### PR TITLE
exclude test from PR limit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Check out the [Go-Filecoin code overview](CODEWALK.md) for a brief tour of the c
 
 ### Pull Requests
 
-- Try to keep PRs small, no more than 400 lines or 8 files.
+- Try to keep PRs small, no more than 400 lines or 8 files excluding new test code.
 - Always squash commits.
 - For now, you'll need to request write access (via chat) to create a PR because CircleCI doesn't play well with private branches. Once we open source this repo, forking is preferred.
 - Committers should merge their own PRs after Approval, because they have the most context.


### PR DESCRIPTION
### Problem

We limit the the length of PRs to 400 lines in our contributing guide. This is good because reviewing long PRs is burdensome to reviewers and slows progress. It is also bad because it disincentivizes testing. If a PR requires say 350 lines worth of non-test changes, I can either pull out and figure out how to break up the work, or undertest and get it through under the limit.

### Solution

Exclude new tests from this limit. New test code is easier to review and we don't want any barriers to contributing to our test suite.