### PR TITLE
Part 1/3 Tickets --> Signed tickets #1054

### DIFF
--- a/api/impl/mining.go
+++ b/api/impl/mining.go
@@ -54,10 +54,13 @@ func (api *nodeMining) Once(ctx context.Context) (*types.Block, error) {
 		}
 		return nd.Consensus.Weight(ctx, ts, pSt)
 	}
+
 	getAncestors := func(ctx context.Context, ts types.TipSet, newBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
 		return chain.GetRecentAncestors(ctx, ts, nd.ChainReader, newBlockHeight, consensus.AncestorRoundsNeeded, consensus.LookBackParameter)
 	}
-	worker := mining.NewDefaultWorker(nd.MsgPool, getState, getWeight, getAncestors, consensus.NewDefaultProcessor(), nd.PowerTable, nd.Blockstore, nd.CborStore(), miningAddr, blockTime)
+	worker := mining.NewDefaultWorker(nd.MsgPool, getState, getWeight, getAncestors, consensus.NewDefaultProcessor(),
+		nd.PowerTable, nd.Blockstore, nd.CborStore(), miningAddr, nd.MiningSignerAddress(), nd.Wallet, blockTime)
+
 
 	res, err := mining.MineOnce(ctx, worker, mineDelay, ts)
 	if err != nil {

--- a/api/impl/mining.go
+++ b/api/impl/mining.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
-	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/mining"
 	"github.com/filecoin-project/go-filecoin/node"
@@ -53,12 +53,11 @@ func (api *nodeMining) Once(ctx context.Context) (*types.Block, error) {
 		return nd.Consensus.Weight(ctx, ts, pSt)
 	}
 
-	miningAddr := miningAddrIf.(address.Address)
-
 	miningAddrIf, err := nd.PorcelainAPI.ConfigGet("mining.minerAddress")
 	if err != nil {
 		return nil, err
 	}
+	miningAddr := miningAddrIf.(address.Address)
 
 	blockSignerAddrIf, err := nd.PorcelainAPI.ConfigGet("mining.blockSignerAddress")
 	if err != nil {
@@ -71,7 +70,6 @@ func (api *nodeMining) Once(ctx context.Context) (*types.Block, error) {
 	}
 	worker := mining.NewDefaultWorker(nd.MsgPool, getState, getWeight, getAncestors, consensus.NewDefaultProcessor(),
 		nd.PowerTable, nd.Blockstore, nd.CborStore(), miningAddr, blockSignerAddr, nd.Wallet, blockTime)
-
 
 	res, err := mining.MineOnce(ctx, worker, mineDelay, ts)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -101,6 +101,7 @@ func newDefaultBootstrapConfig() *BootstrapConfig {
 // MiningConfig holds all configuration options related to mining.
 type MiningConfig struct {
 	MinerAddress            address.Address `json:"minerAddress"`
+	SignerAddress           address.Address `json:"signerAddress"`
 	AutoSealIntervalSeconds uint            `json:"autoSealIntervalSeconds"`
 	StoragePrice            *types.AttoFIL  `json:"storagePrice"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -101,7 +101,7 @@ func newDefaultBootstrapConfig() *BootstrapConfig {
 // MiningConfig holds all configuration options related to mining.
 type MiningConfig struct {
 	MinerAddress            address.Address `json:"minerAddress"`
-	SignerAddress           address.Address `json:"signerAddress"`
+	BlockSignerAddress      address.Address `json:"blockSignerAddress"`
 	AutoSealIntervalSeconds uint            `json:"autoSealIntervalSeconds"`
 	StoragePrice            *types.AttoFIL  `json:"storagePrice"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -65,7 +65,7 @@ func TestWriteFile(t *testing.T) {
 	},
 	"mining": {
 		"minerAddress": "",
-		"signerAddress": "",
+		"blockSignerAddress": "",
 		"autoSealIntervalSeconds": 120,
 		"storagePrice": "0"
 	},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -65,6 +65,7 @@ func TestWriteFile(t *testing.T) {
 	},
 	"mining": {
 		"minerAddress": "",
+		"signerAddress": "",
 		"autoSealIntervalSeconds": 120,
 		"storagePrice": "0"
 	},

--- a/mining/worker.go
+++ b/mining/worker.go
@@ -68,7 +68,7 @@ type MessageApplier interface {
 // DefaultWorker runs a mining job.
 type DefaultWorker struct {
 	createPoSTFunc  DoSomeWorkFunc
-	minerAddr       address.Address // TODO: needs to be a key in the near future
+	minerAddr       address.Address
 	blockSignerAddr address.Address
 	blockSigner     types.Signer
 	// consensus things

--- a/mining/worker.go
+++ b/mining/worker.go
@@ -112,9 +112,11 @@ func NewDefaultWorker(messagePool *core.MessagePool,
 		blockSigner,
 		bt,
 		func() {})
+
 	// TODO: create real PoST.
 	// https://github.com/filecoin-project/go-filecoin/issues/1791
 	w.createPoSTFunc = w.fakeCreatePoST
+
 	return w
 }
 
@@ -133,17 +135,17 @@ func NewDefaultWorkerWithDeps(messagePool *core.MessagePool,
 	bt time.Duration,
 	createPoST DoSomeWorkFunc) *DefaultWorker {
 	return &DefaultWorker{
-		getStateTree: getStateTree,
-		getWeight:    getWeight,
-		getAncestors: getAncestors,
-		messagePool:  messagePool,
-		processor:    processor,
-		powerTable:   powerTable,
-		blockstore:   bs,
-		cstore:       cst,
+		getStateTree:    getStateTree,
+		getWeight:       getWeight,
+		getAncestors:    getAncestors,
+		messagePool:     messagePool,
+		processor:       processor,
+		powerTable:      powerTable,
+		blockstore:      bs,
+		cstore:          cst,
 		createPoSTFunc:  createPoST,
-		minerAddr:    miner,
-		blockTime:    bt,
+		minerAddr:       miner,
+		blockTime:       bt,
 		blockSignerAddr: blockSignerAddr,
 		blockSigner:     blockSigner,
 	}

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -5,6 +5,11 @@ import (
 	"errors"
 	"testing"
 
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmRXf2uUSdGSunRJsM9wXSUNVwLUGCY3So5fAs7h2CBJVf/go-hamt-ipld"
+	"gx/ipfs/QmS2aqUZLJp8kF1ihE5rvDGE5LvmKDPnx32w9Z1BW9xLV5/go-ipfs-blockstore"
+	"gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,11 +22,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/state"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
-
-	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-	"gx/ipfs/QmRXf2uUSdGSunRJsM9wXSUNVwLUGCY3So5fAs7h2CBJVf/go-hamt-ipld"
-	"gx/ipfs/QmS2aqUZLJp8kF1ihE5rvDGE5LvmKDPnx32w9Z1BW9xLV5/go-ipfs-blockstore"
-	"gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore"
 )
 
 func Test_Mine(t *testing.T) {

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -1,20 +1,22 @@
-package mining
+package mining_test
 
 import (
 	"context"
 	"errors"
-	"github.com/filecoin-project/go-filecoin/proofs"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/core"
+	"github.com/filecoin-project/go-filecoin/mining"
+	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/state"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	"gx/ipfs/QmRXf2uUSdGSunRJsM9wXSUNVwLUGCY3So5fAs7h2CBJVf/go-hamt-ipld"
@@ -25,13 +27,19 @@ import (
 func Test_Mine(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+
+	var doSomeWorkCalled = false
+	CreatePoSTFunc := func() { doSomeWorkCalled = true }
+
+	mockSigner, blockSignerAddr := setupSigner()
+
 	newCid := types.NewCidForTestGetter()
 	stateRoot := newCid()
 	baseBlock := &types.Block{Height: 2, StateRoot: stateRoot}
 	tipSet := th.RequireNewTipSet(require, baseBlock)
 	ctx, cancel := context.WithCancel(context.Background())
 
-	st, pool, addrs, cst, bs := sharedSetup(t)
+	st, pool, addrs, cst, bs := sharedSetup(t, mockSigner)
 	getStateTree := func(c context.Context, ts types.TipSet) (state.Tree, error) {
 		return st, nil
 	}
@@ -39,13 +47,19 @@ func Test_Mine(t *testing.T) {
 		return nil, nil
 	}
 
+	minerOwnerAddr := addrs[3]
+
 	// Success case. TODO: this case isn't testing much.  Testing w.Mine
 	// further needs a lot more attention.
 	worker := NewDefaultWorker(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(), NewTestPowerTableView(1), bs, cst, addrs[3], th.BlockTimeTest)
 
-	outCh := make(chan Output)
-	doSomeWorkCalled := false
-	worker.createPoST = func() { doSomeWorkCalled = true }
+	// Success case.
+	// TODO: this case isn't testing much.  Testing w.Mine further needs a lot more attention.
+	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(),
+		mining.NewTestPowerTableView(1), bs, cst, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest,
+		CreatePoSTFunc)
+
+	outCh := make(chan mining.Output)
 	go worker.Mine(ctx, tipSet, 0, outCh)
 	r := <-outCh
 	assert.NoError(r.Err)
@@ -53,10 +67,10 @@ func Test_Mine(t *testing.T) {
 	cancel()
 	// Block generation fails.
 	ctx, cancel = context.WithCancel(context.Background())
-	worker = NewDefaultWorker(pool, makeExplodingGetStateTree(st), getWeightTest, getAncestors, th.NewTestProcessor(), NewTestPowerTableView(1), bs, cst, addrs[3], th.BlockTimeTest)
-	outCh = make(chan Output)
+	worker = mining.NewDefaultWorkerWithDeps(pool, makeExplodingGetStateTree(st), getWeightTest, getAncestors, th.NewTestProcessor(),
+		mining.NewTestPowerTableView(1), bs, cst, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+	outCh = make(chan mining.Output)
 	doSomeWorkCalled = false
-	worker.createPoST = func() { doSomeWorkCalled = true }
 	go worker.Mine(ctx, tipSet, 0, outCh)
 	r = <-outCh
 	assert.Error(r.Err)
@@ -65,10 +79,10 @@ func Test_Mine(t *testing.T) {
 
 	// Sent empty tipset
 	ctx, cancel = context.WithCancel(context.Background())
-	worker = NewDefaultWorker(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(), NewTestPowerTableView(1), bs, cst, addrs[3], th.BlockTimeTest)
-	outCh = make(chan Output)
+	worker = mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(),
+		mining.NewTestPowerTableView(1), bs, cst, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+	outCh = make(chan mining.Output)
 	doSomeWorkCalled = false
-	worker.createPoST = func() { doSomeWorkCalled = true }
 	input := types.TipSet{}
 	go worker.Mine(ctx, input, 0, outCh)
 	r = <-outCh
@@ -76,10 +90,6 @@ func Test_Mine(t *testing.T) {
 	assert.False(doSomeWorkCalled)
 	cancel()
 }
-
-var seed = types.GenerateKeyInfoSeed()
-var ki = types.MustGenerateKeyInfo(10, seed)
-var mockSigner = types.NewMockSigner(ki)
 
 func TestGenerate(t *testing.T) {
 	// TODO use core.FakeActor for state/contract tests for generate:
@@ -95,8 +105,11 @@ func sharedSetupInitial() (*hamt.CborIpldStore, *core.MessagePool, cid.Cid) {
 	return cst, pool, fakeActorCodeCid
 }
 
-func sharedSetup(t *testing.T) (state.Tree, *core.MessagePool, []address.Address, *hamt.CborIpldStore, blockstore.Blockstore) {
+func sharedSetup(t *testing.T, mockSigner types.MockSigner) (
+	state.Tree, *core.MessagePool, []address.Address, *hamt.CborIpldStore, blockstore.Blockstore) {
+
 	require := require.New(t)
+
 	cst, pool, fakeActorCodeCid := sharedSetupInitial()
 	vms := th.VMStorage()
 	d := datastore.NewMapDatastore()
@@ -129,6 +142,7 @@ func TestApplyMessagesForSuccessTempAndPermFailures(t *testing.T) {
 	require := require.New(t)
 	vms := th.VMStorage()
 
+	mockSigner, _ := setupSigner()
 	cst, _, fakeActorCodeCid := sharedSetupInitial()
 
 	// Stick two fake actors in the state tree so they can talk.
@@ -183,17 +197,24 @@ func TestApplyMessagesForSuccessTempAndPermFailures(t *testing.T) {
 func TestGenerateMultiBlockTipSet(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-
 	ctx := context.Background()
+
+	CreatePoSTFunc := func() {}
+
+	mockSigner, blockSignerAddr := setupSigner()
 	newCid := types.NewCidForTestGetter()
-	st, pool, addrs, cst, bs := sharedSetup(t)
+	st, pool, addrs, cst, bs := sharedSetup(t, mockSigner)
 	getStateTree := func(c context.Context, ts types.TipSet) (state.Tree, error) {
 		return st, nil
 	}
 	getAncestors := func(ctx context.Context, ts types.TipSet, newBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
 		return nil, nil
 	}
-	worker := NewDefaultWorker(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(), &th.TestView{}, bs, cst, addrs[3], th.BlockTimeTest)
+
+	minerOwnerAddr := addrs[3]
+
+	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(),
+		&th.TestView{}, bs, cst, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest)
 
 	parents := types.NewSortedCidSet(newCid())
 	stateRoot := newCid()
@@ -222,10 +243,12 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 func TestGeneratePoolBlockResults(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	CreatePoSTFunc := func() {}
 
 	ctx := context.Background()
+	mockSigner, blockSignerAddr := setupSigner()
 	newCid := types.NewCidForTestGetter()
-	st, pool, addrs, cst, bs := sharedSetup(t)
+	st, pool, addrs, cst, bs := sharedSetup(t, mockSigner)
 
 	getStateTree := func(c context.Context, ts types.TipSet) (state.Tree, error) {
 		return st, nil
@@ -233,7 +256,8 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 	getAncestors := func(ctx context.Context, ts types.TipSet, newBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
 		return nil, nil
 	}
-	worker := NewDefaultWorker(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(), &th.TestView{}, bs, cst, addrs[3], th.BlockTimeTest)
+	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(),
+		&th.TestView{}, bs, cst, addrs[3], blockSignerAddr, mockSigner, th.BlockTimeTest)
 
 	// addr3 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
 	msg1 := types.NewMessage(addrs[2], addrs[0], 0, nil, "", nil)
@@ -282,10 +306,13 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
+	CreatePoSTFunc := func() {}
+
 	ctx := context.Background()
+	mockSigner, blockSignerAddr := setupSigner()
 	newCid := types.NewCidForTestGetter()
 
-	st, pool, addrs, cst, bs := sharedSetup(t)
+	st, pool, addrs, cst, bs := sharedSetup(t, mockSigner)
 
 	getStateTree := func(c context.Context, ts types.TipSet) (state.Tree, error) {
 		return st, nil
@@ -293,7 +320,9 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 	getAncestors := func(ctx context.Context, ts types.TipSet, newBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
 		return nil, nil
 	}
-	worker := NewDefaultWorker(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(), &th.TestView{}, bs, cst, addrs[3], th.BlockTimeTest)
+	minerOwnerAddr := addrs[3]
+	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(),
+		&th.TestView{}, bs, cst, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
 
 	h := types.Uint64(100)
 	w := types.Uint64(1000)
@@ -308,31 +337,35 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 	assert.NoError(err)
 
 	assert.Equal(h+1, blk.Height)
-	assert.Equal(addrs[3], blk.Miner)
+	assert.Equal(minerOwnerAddr, blk.Miner)
 
 	blk, err = worker.Generate(ctx, baseTipSet, nil, proofs.PoStProof{}, 1)
 	assert.NoError(err)
 
 	assert.Equal(h+2, blk.Height)
 	assert.Equal(w+10.0, blk.ParentWeight)
-	assert.Equal(addrs[3], blk.Miner)
+	assert.Equal(minerOwnerAddr, blk.Miner)
 }
 
 func TestGenerateWithoutMessages(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
+	CreatePoSTFunc := func() {}
+
 	ctx := context.Background()
+	mockSigner, blockSignerAddr := setupSigner()
 	newCid := types.NewCidForTestGetter()
 
-	st, pool, addrs, cst, bs := sharedSetup(t)
+	st, pool, addrs, cst, bs := sharedSetup(t, mockSigner)
 	getStateTree := func(c context.Context, ts types.TipSet) (state.Tree, error) {
 		return st, nil
 	}
 	getAncestors := func(ctx context.Context, ts types.TipSet, newBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
 		return nil, nil
 	}
-	worker := NewDefaultWorker(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(), &th.TestView{}, bs, cst, addrs[3], th.BlockTimeTest)
+	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getAncestors, getWeightTest, consensus.NewDefaultProcessor(),
+		&th.TestView{}, bs, cst, addrs[3], blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
 
 	assert.Len(pool.Pending(), 0)
 	baseBlock := types.Block{
@@ -353,14 +386,21 @@ func TestGenerateWithoutMessages(t *testing.T) {
 func TestGenerateError(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+
+	CreatePoSTFunc := func() {}
+
 	ctx := context.Background()
+	mockSigner, blockSignerAddr := setupSigner()
 	newCid := types.NewCidForTestGetter()
 
-	st, pool, addrs, cst, bs := sharedSetup(t)
+	st, pool, addrs, cst, bs := sharedSetup(t, mockSigner)
+
 	getAncestors := func(ctx context.Context, ts types.TipSet, newBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
 		return nil, nil
 	}
-	worker := NewDefaultWorker(pool, makeExplodingGetStateTree(st), getWeightTest, getAncestors, consensus.NewDefaultProcessor(), &th.TestView{}, bs, cst, addrs[3], th.BlockTimeTest)
+	worker := mining.NewDefaultWorkerWithDeps(pool, makeExplodingGetStateTree(st), getWeightTest, getAncestors,
+		consensus.NewDefaultProcessor(),
+		&th.TestView{}, bs, cst, addrs[3], blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
 
 	// This is actually okay and should result in a receipt
 	msg := types.NewMessage(addrs[0], addrs[1], 0, nil, "", nil)
@@ -383,20 +423,20 @@ func TestGenerateError(t *testing.T) {
 	assert.Len(pool.Pending(), 1) // No messages are removed from the pool.
 }
 
-type StateTreeForTest struct {
+type stateTreeForTest struct {
 	state.Tree
 	TestFlush func(ctx context.Context) (cid.Cid, error)
 }
 
-func WrapStateTreeForTest(st state.Tree) *StateTreeForTest {
-	stt := StateTreeForTest{
+func wrapStateTreeForTest(st state.Tree) *stateTreeForTest {
+	stt := stateTreeForTest{
 		st,
 		st.Flush,
 	}
 	return &stt
 }
 
-func (st *StateTreeForTest) Flush(ctx context.Context) (cid.Cid, error) {
+func (st *stateTreeForTest) Flush(ctx context.Context) (cid.Cid, error) {
 	return st.TestFlush(ctx)
 }
 
@@ -410,11 +450,19 @@ func getWeightTest(c context.Context, ts types.TipSet) (uint64, error) {
 
 func makeExplodingGetStateTree(st state.Tree) func(context.Context, types.TipSet) (state.Tree, error) {
 	return func(c context.Context, ts types.TipSet) (state.Tree, error) {
-		stt := WrapStateTreeForTest(st)
+		stt := wrapStateTreeForTest(st)
 		stt.TestFlush = func(ctx context.Context) (cid.Cid, error) {
 			return cid.Undef, errors.New("boom no flush")
 		}
 
 		return stt, nil
 	}
+}
+
+func setupSigner() (types.MockSigner, address.Address) {
+	seed := types.GenerateKeyInfoSeed()
+	ki := types.MustGenerateKeyInfo(10, seed)
+	mockSigner := types.NewMockSigner(ki)
+	blockSignerAddr := mockSigner.Addresses[len(mockSigner.Addresses)-1]
+	return mockSigner, blockSignerAddr
 }

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -49,10 +49,6 @@ func Test_Mine(t *testing.T) {
 
 	minerOwnerAddr := addrs[3]
 
-	// Success case. TODO: this case isn't testing much.  Testing w.Mine
-	// further needs a lot more attention.
-	worker := NewDefaultWorker(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(), NewTestPowerTableView(1), bs, cst, addrs[3], th.BlockTimeTest)
-
 	// Success case.
 	// TODO: this case isn't testing much.  Testing w.Mine further needs a lot more attention.
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(),
@@ -214,7 +210,7 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 	minerOwnerAddr := addrs[3]
 
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(),
-		&th.TestView{}, bs, cst, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest)
+		&th.TestView{}, bs, cst, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
 
 	parents := types.NewSortedCidSet(newCid())
 	stateRoot := newCid()
@@ -257,7 +253,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		return nil, nil
 	}
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(),
-		&th.TestView{}, bs, cst, addrs[3], blockSignerAddr, mockSigner, th.BlockTimeTest)
+		&th.TestView{}, bs, cst, addrs[3], blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
 
 	// addr3 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
 	msg1 := types.NewMessage(addrs[2], addrs[0], 0, nil, "", nil)
@@ -364,7 +360,7 @@ func TestGenerateWithoutMessages(t *testing.T) {
 	getAncestors := func(ctx context.Context, ts types.TipSet, newBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
 		return nil, nil
 	}
-	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getAncestors, getWeightTest, consensus.NewDefaultProcessor(),
+	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(),
 		&th.TestView{}, bs, cst, addrs[3], blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
 
 	assert.Len(pool.Pending(), 0)

--- a/node/node.go
+++ b/node/node.go
@@ -796,7 +796,6 @@ func (node *Node) StartMining(ctx context.Context) error {
 			return chain.GetRecentAncestors(ctx, ts, node.ChainReader, newBlockHeight, consensus.AncestorRoundsNeeded, consensus.LookBackParameter)
 		}
 		processor := consensus.NewDefaultProcessor()
-		// add signingAddr and signer to params
 		worker := mining.NewDefaultWorker(node.MsgPool, getState, getWeight, getAncestors, processor, node.PowerTable,
 			node.Blockstore, node.CborStore(), minerAddr, minerSigningAddress, node.Wallet, blockTime)
 		node.MiningScheduler = mining.NewScheduler(worker, mineDelay, node.ChainReader.Head)
@@ -1003,8 +1002,6 @@ func (node *Node) CreateMiner(ctx context.Context, accountAddr address.Address, 
 	if err != nil {
 		return nil, err
 	}
-	smsgCid, err := node.PorcelainAPI.MessageSend(ctx, accountAddr, address.StorageMarketAddress, collateral, gasPrice,
-		gasLimit, "createMiner", big.NewInt(int64(pledge)), pubKey, pid)
 
 	smsgCid, err := node.PorcelainAPI.MessageSendWithDefaultAddress(
 		ctx,
@@ -1015,7 +1012,7 @@ func (node *Node) CreateMiner(ctx context.Context, accountAddr address.Address, 
 		gasLimit,
 		"createMiner",
 		big.NewInt(int64(pledge)),
-		pubkey,
+		pubKey,
 		pid,
 	)
 	if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -990,9 +990,6 @@ func (node *Node) NewAddress() (address.Address, error) {
 //       See https://github.com/filecoin-project/go-filecoin/issues/1843
 func (node *Node) CreateMiner(ctx context.Context, accountAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, pledge uint64, pid libp2ppeer.ID, collateral *types.AttoFIL) (_ *address.Address, err error) {
 
-	hbc := node.Repo.Config().Heartbeat
-	log.Errorf("Current heartbeatconfig: %v", *hbc)
-
 	// Only create a miner if we don't already have one.
 	if _, err := node.miningAddress(); err != ErrNoMinerAddress {
 		return nil, fmt.Errorf("can only have one miner per node")

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -427,22 +427,7 @@ func TestNodeConfig(t *testing.T) {
 	}, cfg.Swarm)
 }
 
-func TestNode_GenerateNewKeyInfo(t *testing.T) {
-	tnode := MakeNodesUnstarted(t, 1, true, true)[0]
-	ki, err := tnode.GenerateNewKeyInfo()
-	require.NoError(t, err)
-	assert.NotNil(t, ki)
-
-	pkey, err := ki.PublicKey()
-	require.NoError(t, err)
-	assert.NotNil(t, pkey)
-
-	addr, err := ki.Address()
-	require.NoError(t, err)
-	assert.NotNil(t, addr)
-}
-
-func TestNode_GetMinerOwnerPubKey(t *testing.T) {
+func TestNode_getMinerOwnerPubKey(t *testing.T) {
 	ctx := context.Background()
 	seed := MakeChainSeed(t, TestGenCfg)
 	configOpts := []ConfigOpt{RewarderConfigOption(&zeroRewarder{})}
@@ -456,14 +441,14 @@ func TestNode_GetMinerOwnerPubKey(t *testing.T) {
 	assert.NoError(t, err)
 
 	// it hasn't yet been saved to the MinerConfig; simulates incomplete CreateMiner, or no miner for the node
-	pkey, err := tnode.GetMinerOwnerPubKey()
+	pkey, err := tnode.getMinerActorPubKey()
 	assert.NoError(t, err)
 	assert.Nil(t, pkey)
 
 	err = tnode.saveMinerConfig(minerOwnerAddr, address.Address{})
 	assert.NoError(t, err)
 
-	pkey, err = tnode.GetMinerOwnerPubKey()
+	pkey, err = tnode.getMinerActorPubKey()
 	assert.NoError(t, err)
 	assert.NotNil(t, pkey)
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -432,9 +432,11 @@ func TestNode_GenerateNewKeyInfo(t *testing.T) {
 	ki, err := tnode.GenerateNewKeyInfo()
 	require.NoError(t, err)
 	assert.NotNil(t, ki)
+
 	pkey, err := ki.PublicKey()
 	require.NoError(t, err)
 	assert.NotNil(t, pkey)
+
 	addr, err := ki.Address()
 	require.NoError(t, err)
 	assert.NotNil(t, addr)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -452,7 +452,7 @@ func TestNode_GetMinerOwnerPubKey(t *testing.T) {
 	)
 	seed.GiveKey(t, tnode, 0)
 	mineraddr, minerOwnerAddr := seed.GiveMiner(t, tnode, 0)
-	_, err := storage.NewMiner(ctx, mineraddr, minerOwnerAddr, tnode, tnode.Repo.DealsDatastore(), tnode.PlumbingAPI)
+	_, err := storage.NewMiner(ctx, mineraddr, minerOwnerAddr, tnode, tnode.Repo.DealsDatastore(), tnode.PorcelainAPI)
 	assert.NoError(t, err)
 
 	// it hasn't yet been saved to the MinerConfig; simulates incomplete CreateMiner, or no miner for the node

--- a/node/testing.go
+++ b/node/testing.go
@@ -16,21 +16,16 @@ import (
 	"gx/ipfs/QmYZwey1thDTynSrvd6qQkX24UpTka6TFhQ2v569UpoqxD/go-ipfs-exchange-offline"
 	ds "gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/gengen/util"
-	"github.com/filecoin-project/go-filecoin/lookup"
-	"github.com/filecoin-project/go-filecoin/mining"
-	"github.com/filecoin-project/go-filecoin/plumbing"
-	"github.com/filecoin-project/go-filecoin/plumbing/cfg"
-	"github.com/filecoin-project/go-filecoin/plumbing/msg"
 	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/wallet"
-	"github.com/stretchr/testify/require"
 )
 
 // ChainSeed is a generalized struct for configuring node
@@ -240,10 +235,7 @@ func configureFakeVerifier(cfo []ConfigOpt) []ConfigOpt {
 // created, which is bad information to need to rely on in tests.
 func resetNodeGen(node *Node, gif consensus.GenesisInitFunc) error { // nolint: deadcode
 	ctx := context.Background()
-	newGenBlk, err := gif(node.CborStore(), node.Blockstore)
-	if err != nil {
-		return err
-	}
+
 	getStateTree := func(ctx context.Context, ts types.TipSet) (state.Tree, error) {
 		return getStateFromKey(ctx, ts.String())
 	}

--- a/repo/fsrepo_test.go
+++ b/repo/fsrepo_test.go
@@ -46,6 +46,7 @@ const (
 	},
 	"mining": {
 		"minerAddress": "",
+		"signerAddress": "",
 		"autoSealIntervalSeconds": 120,
 		"storagePrice": "0"
 	},

--- a/repo/fsrepo_test.go
+++ b/repo/fsrepo_test.go
@@ -46,7 +46,7 @@ const (
 	},
 	"mining": {
 		"minerAddress": "",
-		"signerAddress": "",
+		"blockSignerAddress": "",
 		"autoSealIntervalSeconds": 120,
 		"storagePrice": "0"
 	},

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -130,3 +130,40 @@ func NewAddress(w *Wallet) (address.Address, error) {
 	backend := (backends[0]).(*DSBackend)
 	return backend.NewAddress()
 }
+
+// GetPubKeyForAddress returns the public key in the keystore associated with
+// the given address.
+func (w *Wallet) GetPubKeyForAddress(addr address.Address) ([]byte, error) {
+	info, err := w.keyInfoForAddr(addr)
+	if err != nil {
+		return nil, err
+	}
+	pubkey, err := info.PublicKey()
+	if err != nil {
+		return nil, err
+	}
+	return pubkey, nil
+}
+
+// NewKeyInfo creates a new KeyInfo struct in the wallet backend and returns it
+func (w *Wallet) NewKeyInfo() (*types.KeyInfo, error) {
+	newAddr, err := NewAddress(w)
+	if err != nil {
+		return &types.KeyInfo{}, err
+	}
+
+	return w.keyInfoForAddr(newAddr)
+}
+
+func (w *Wallet) keyInfoForAddr(addr address.Address) (*types.KeyInfo, error) {
+	backend, err := w.Find(addr)
+	if err != nil {
+		return &types.KeyInfo{}, err
+	}
+
+	info, err := backend.GetKeyInfo(addr)
+	if err != nil {
+		return &types.KeyInfo{}, err
+	}
+	return info, nil
+}


### PR DESCRIPTION
Part 1 of 3 for #1054 

1. In node.CreateMiner, generate a public/private key pair.  This will be the keypair for signing blocks and tickets. Store it in node.Wallet.  Alter the node's Mining config to store the block signer address so the keyinfo can be used.

    This assumes that there will be only one block miner;  if a subsequent call to CreateMiner is performed, right now it will simply generate a new key pair and overwrite the old one. I think this should be fine (?) since we will be publishing the minerAddress and its public key for verification in the block -- just not with this PR.

1. Add two parameters for a mining DefaultWorker struct and instantiation:
    * `blockSigningAddr address.Address`  -- this will be the address for the keypair generated above
    * `blockSigner types.Signer` -- this will be node.Wallet

Last, get all the code and tests working again.  This DOES NOT change how tickets are created; only the information available to a worker is changed.  This is to limit the size of the PRs to something manageable.

Additionally there is some clerical type stuff - killing a TODO-snake with a rename, and a small refactor of mining_test.

**PART 2** will consist of generating the ticket as a signature of the hashed Proof.   *Ticket validation will be temporarily disabled* until Part 3, because changing this generation will break a bunch of other things anyway, although not the protocol.

**PART 3** will consist of validating the ticket.  This will reinstate ticket validation, although it will this time do so in accordance with the spec, i.e., check that the ticket is a valid signature over the block proof, using the block public key.  This will break protocol since currently the public key is not part of blocks.  It'll cause some complicated issues with testing too, since now we can't generate a winning ticket so easily.