### PR TITLE
Miner payment management

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/protocol/storage"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -28,8 +28,8 @@ type Ask struct {
 type Client interface {
 	Cat(ctx context.Context, c cid.Cid) (uio.DagReader, error)
 	ImportData(ctx context.Context, data io.Reader) (ipld.Node, error)
-	ProposeStorageDeal(ctx context.Context, data cid.Cid, miner address.Address, ask uint64, duration uint64, allowDuplicates bool) (*storage.DealResponse, error)
-	QueryStorageDeal(ctx context.Context, prop cid.Cid) (*storage.DealResponse, error)
+	ProposeStorageDeal(ctx context.Context, data cid.Cid, miner address.Address, ask uint64, duration uint64, allowDuplicates bool) (*storagedeal.Response, error)
+	QueryStorageDeal(ctx context.Context, prop cid.Cid) (*storagedeal.Response, error)
 	ListAsks(ctx context.Context) (<-chan Ask, error)
 	Payments(ctx context.Context, dealCid cid.Cid) ([]*paymentbroker.PaymentVoucher, error)
 }

--- a/api/impl/client.go
+++ b/api/impl/client.go
@@ -21,7 +21,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	mapi "github.com/filecoin-project/go-filecoin/api"
-	"github.com/filecoin-project/go-filecoin/protocol/storage"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -63,11 +63,11 @@ func (api *nodeClient) ImportData(ctx context.Context, data io.Reader) (ipld.Nod
 	return nd, bufds.Commit()
 }
 
-func (api *nodeClient) ProposeStorageDeal(ctx context.Context, data cid.Cid, miner address.Address, askid uint64, duration uint64, allowDuplicates bool) (*storage.DealResponse, error) {
+func (api *nodeClient) ProposeStorageDeal(ctx context.Context, data cid.Cid, miner address.Address, askid uint64, duration uint64, allowDuplicates bool) (*storagedeal.Response, error) {
 	return api.api.node.StorageMinerClient.ProposeDeal(ctx, miner, data, askid, duration, allowDuplicates)
 }
 
-func (api *nodeClient) QueryStorageDeal(ctx context.Context, prop cid.Cid) (*storage.DealResponse, error) {
+func (api *nodeClient) QueryStorageDeal(ctx context.Context, prop cid.Cid) (*storagedeal.Response, error) {
 	return api.api.node.StorageMinerClient.QueryDeal(ctx, prop)
 }
 

--- a/commands/client.go
+++ b/commands/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/api"
-	"github.com/filecoin-project/go-filecoin/protocol/storage"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 )
 
 var clientCmd = &cmds.Command{
@@ -152,9 +152,9 @@ be 2, 1 hour would be 120, and 1 day would be 2880.
 
 		return re.Emit(resp)
 	},
-	Type: storage.DealResponse{},
+	Type: storagedeal.Response{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, resp *storage.DealResponse) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, resp *storagedeal.Response) error {
 			fmt.Fprintf(w, "State:   %s\n", resp.State.String())       // nolint: errcheck
 			fmt.Fprintf(w, "Message: %s\n", resp.Message)              // nolint: errcheck
 			fmt.Fprintf(w, "DealID:  %s\n", resp.ProposalCid.String()) // nolint: errcheck
@@ -188,9 +188,9 @@ format is specified with the --enc flag.
 
 		return re.Emit(resp)
 	},
-	Type: storage.DealResponse{},
+	Type: storagedeal.Response{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, resp *storage.DealResponse) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, resp *storagedeal.Response) error {
 			fmt.Fprintf(w, "Status: %s\n", resp.State.String()) // nolint: errcheck
 			fmt.Fprintf(w, "Message: %s\n", resp.Message)       // nolint: errcheck
 			return nil

--- a/commands/client_daemon_test.go
+++ b/commands/client_daemon_test.go
@@ -100,7 +100,7 @@ func TestDuplicateDeals(t *testing.T) {
 
 	t.Run("propose a duplicate deal _WITHOUT_ the '--allow-duplicates' flag", func(t *testing.T) {
 		proposeDealOutput := client.Run("client", "propose-storage-deal", fixtures.TestMiners[0], dataCid, "0", "5").ReadStderr()
-		expectedError := fmt.Sprintf("Error: %s", storage.Errors[storage.ErrDupicateDeal].Error())
+		expectedError := fmt.Sprintf("Error: %s", storage.Errors[storage.ErrDuplicateDeal].Error())
 		assert.Equal(expectedError, proposeDealOutput)
 	})
 }

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -36,7 +36,7 @@ func TestBlockPropsManyNodes(t *testing.T) {
 	assert := assert.New(t)
 
 	numNodes := 4
-	minerAddr, nodes := makeNodes(ctx, t, assert, numNodes)
+	minerAddr, nodes := makeNodes(t, assert, numNodes)
 	StartNodes(t, nodes)
 	defer StopNodes(nodes)
 
@@ -86,7 +86,7 @@ func TestChainSync(t *testing.T) {
 	ctx := context.Background()
 	assert := assert.New(t)
 
-	minerAddr, nodes := makeNodes(ctx, t, assert, 2)
+	minerAddr, nodes := makeNodes(t, assert, 2)
 	StartNodes(t, nodes)
 	defer StopNodes(nodes)
 
@@ -128,7 +128,7 @@ func (r *zeroRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr a
 }
 
 // makeNodes makes at least two nodes, a miner and a client; numNodes is the total wanted
-func makeNodes(ctx context.Context, t *testing.T, assertions *assert.Assertions, numNodes int) (address.Address, []*Node) {
+func makeNodes(t *testing.T, assertions *assert.Assertions, numNodes int) (address.Address, []*Node) {
 	seed := MakeChainSeed(t, TestGenCfg)
 	configOpts := []ConfigOpt{RewarderConfigOption(&zeroRewarder{})}
 	minerNode := MakeNodeWithChainSeed(t, seed, configOpts,
@@ -137,7 +137,7 @@ func makeNodes(ctx context.Context, t *testing.T, assertions *assert.Assertions,
 	)
 	seed.GiveKey(t, minerNode, 0)
 	mineraddr, minerOwnerAddr := seed.GiveMiner(t, minerNode, 0)
-	_, err := storage.NewMiner(ctx, mineraddr, minerOwnerAddr, minerNode, minerNode.Repo.DealsDatastore(), minerNode.PorcelainAPI)
+	_, err := storage.NewMiner(mineraddr, minerOwnerAddr, minerNode, minerNode.Repo.DealsDatastore(), minerNode.PorcelainAPI)
 	assertions.NoError(err)
 
 	nodes := []*Node{minerNode}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/plumbing/msg"
 	"github.com/filecoin-project/go-filecoin/plumbing/mthdsig"
 	"github.com/filecoin-project/go-filecoin/plumbing/ntwk"
+	"github.com/filecoin-project/go-filecoin/plumbing/strgdls"
 	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/protocol/storage"
@@ -171,12 +172,13 @@ func TestNodeStartMining(t *testing.T) {
 		Network:      ntwk.New(minerNode.Host(), nil, nil, nil, nil),
 		SigGetter:    mthdsig.NewGetter(minerNode.ChainReader),
 		Wallet:       wallet.New(walletBackend),
+		Deals:        strgdls.New(minerNode.Repo.DealsDatastore()),
 	})
 	porcelainAPI := porcelain.New(plumbingAPI)
 
 	seed.GiveKey(t, minerNode, 0)
 	mineraddr, minerOwnerAddr := seed.GiveMiner(t, minerNode, 0)
-	_, err := storage.NewMiner(ctx, mineraddr, minerOwnerAddr, minerNode, minerNode.Repo.DealsDatastore(), porcelainAPI)
+	_, err := storage.NewMiner(mineraddr, minerOwnerAddr, minerNode, minerNode.Repo.DealsDatastore(), porcelainAPI)
 	assert.NoError(err)
 
 	assert.NoError(minerNode.Start(ctx))
@@ -429,7 +431,6 @@ func TestNodeConfig(t *testing.T) {
 }
 
 func TestNode_getMinerOwnerPubKey(t *testing.T) {
-	ctx := context.Background()
 	seed := MakeChainSeed(t, TestGenCfg)
 	configOpts := []ConfigOpt{RewarderConfigOption(&zeroRewarder{})}
 	tnode := MakeNodeWithChainSeed(t, seed, configOpts,
@@ -438,7 +439,7 @@ func TestNode_getMinerOwnerPubKey(t *testing.T) {
 	)
 	seed.GiveKey(t, tnode, 0)
 	mineraddr, minerOwnerAddr := seed.GiveMiner(t, tnode, 0)
-	_, err := storage.NewMiner(ctx, mineraddr, minerOwnerAddr, tnode, tnode.Repo.DealsDatastore(), tnode.PorcelainAPI)
+	_, err := storage.NewMiner(mineraddr, minerOwnerAddr, tnode, tnode.Repo.DealsDatastore(), tnode.PorcelainAPI)
 	assert.NoError(t, err)
 
 	// it hasn't yet been saved to the MinerConfig; simulates incomplete CreateMiner, or no miner for the node

--- a/plumbing/strgdls/store.go
+++ b/plumbing/strgdls/store.go
@@ -1,0 +1,60 @@
+package strgdls
+
+import (
+	"gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
+	"gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/query"
+	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
+	cbor "gx/ipfs/QmcZLyosDwMKdB6NLRsiss9HXzDPhVhhRtPy67JFKTDQDX/go-ipld-cbor"
+
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
+	"github.com/filecoin-project/go-filecoin/repo"
+)
+
+// Store is plumbing implementation querying deals
+type Store struct {
+	dealsDs repo.Datastore
+}
+
+// StorageDealPrefix is the datastore prefix for storage deals
+const StorageDealPrefix = "storagedeals"
+
+// New returns a new Store.
+func New(dealsDatastore repo.Datastore) *Store {
+	return &Store{dealsDs: dealsDatastore}
+}
+
+// Ls returns a slice of deals matching the given query, with a possible error
+func (store *Store) Ls() ([]*storagedeal.Deal, error) {
+	var deals []*storagedeal.Deal
+
+	results, err := store.dealsDs.Query(query.Query{Prefix: "/" + StorageDealPrefix})
+	if err != nil {
+		return deals, errors.Wrap(err, "failed to query deals from datastore")
+	}
+	for entry := range results.Next() {
+		var storageDeal storagedeal.Deal
+		if err := cbor.DecodeInto(entry.Value, &storageDeal); err != nil {
+			return deals, errors.Wrap(err, "failed to unmarshal deals from datastore")
+		}
+		deals = append(deals, &storageDeal)
+	}
+
+	return deals, nil
+}
+
+// Put puts the deal into the datastore
+func (store *Store) Put(storageDeal *storagedeal.Deal) error {
+	proposalCid := storageDeal.Response.ProposalCid
+	datum, err := cbor.DumpObject(storageDeal)
+	if err != nil {
+		return errors.Wrap(err, "could not marshal storageDeal")
+	}
+
+	key := datastore.KeyWithNamespaces([]string{StorageDealPrefix, proposalCid.String()})
+	err = store.dealsDs.Put(key, datum)
+	if err != nil {
+		return errors.Wrap(err, "could not save storage deal to disk")
+	}
+
+	return nil
+}

--- a/plumbing/strgdls/store_test.go
+++ b/plumbing/strgdls/store_test.go
@@ -1,0 +1,89 @@
+package strgdls_test
+
+import (
+	"github.com/stretchr/testify/require"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+	"testing"
+
+	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/plumbing/strgdls"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
+	"github.com/filecoin-project/go-filecoin/repo"
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/filecoin-project/go-filecoin/util/convert"
+)
+
+func TestDealStoreRoundTrip(t *testing.T) {
+	addressMaker := address.NewForTestGetter()
+
+	store := strgdls.New(repo.NewInMemoryRepo().DealsDs)
+	minerAddr := addressMaker()
+	pieceRefCid, err := convert.ToCid("pieceRef")
+	require.NoError(t, err)
+	size := types.NewBytesAmount(12)
+	totalPrice := types.NewAttoFILFromFIL(13)
+	duration := uint64(23)
+	channelID := *types.NewChannelID(19)
+	channelMessageCid, err := convert.ToCid(&types.Message{})
+	require.NoError(t, err)
+	clientAddr := addressMaker()
+	validAt := types.NewBlockHeight(231)
+	responseMessage := "Success!"
+
+	payment := storagedeal.PaymentInfo{PayChActor: addressMaker(),
+		Payer:         addressMaker(),
+		Channel:       &channelID,
+		ChannelMsgCid: &channelMessageCid,
+		Vouchers: []*paymentbroker.PaymentVoucher{{
+			Channel: channelID,
+			Payer:   clientAddr,
+			Target:  minerAddr,
+			Amount:  *totalPrice,
+			ValidAt: *validAt,
+		}}}
+
+	proposal := &storagedeal.Proposal{
+		PieceRef:     pieceRefCid,
+		Size:         size,
+		TotalPrice:   totalPrice,
+		Duration:     duration,
+		MinerAddress: minerAddr,
+		Payment:      payment,
+	}
+
+	proposalCid, err := convert.ToCid(proposal)
+	require.NoError(t, err)
+
+	storageDeal := &storagedeal.Deal{
+		Miner:    minerAddr,
+		Proposal: proposal,
+		Response: &storagedeal.Response{
+			State:       storagedeal.Accepted,
+			Message:     responseMessage,
+			ProposalCid: proposalCid,
+			ProofInfo:   &storagedeal.ProofInfo{},
+			Signature:   []byte("signature"),
+		},
+	}
+
+	require.NoError(t, store.Put(storageDeal))
+	deals, err := store.Ls()
+	require.NoError(t, err)
+
+	retrievedDeal := deals[0]
+
+	assert.Equal(t, minerAddr, retrievedDeal.Miner)
+
+	assert.Equal(t, pieceRefCid, retrievedDeal.Proposal.PieceRef)
+	assert.Equal(t, size, retrievedDeal.Proposal.Size)
+	assert.Equal(t, totalPrice, retrievedDeal.Proposal.TotalPrice)
+	assert.Equal(t, duration, retrievedDeal.Proposal.Duration)
+	assert.Equal(t, minerAddr, retrievedDeal.Proposal.MinerAddress)
+
+	assert.Equal(t, channelID, retrievedDeal.Proposal.Payment.Vouchers[0].Channel)
+	assert.Equal(t, clientAddr, retrievedDeal.Proposal.Payment.Vouchers[0].Payer)
+	assert.Equal(t, minerAddr, retrievedDeal.Proposal.Payment.Vouchers[0].Target)
+	assert.Equal(t, *totalPrice, retrievedDeal.Proposal.Payment.Vouchers[0].Amount)
+	assert.Equal(t, *validAt, retrievedDeal.Proposal.Payment.Vouchers[0].ValidAt)
+}

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/plumbing"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -50,6 +51,11 @@ func (a *API) ChainBlockHeight(ctx context.Context) (*types.BlockHeight, error) 
 // CreatePayments establishes a payment channel and create multiple payments against it
 func (a *API) CreatePayments(ctx context.Context, config CreatePaymentsParams) (*CreatePaymentsReturn, error) {
 	return CreatePayments(ctx, a, config)
+}
+
+// DealGet returns a single deal matching a given cid or an error
+func (a *API) DealGet(proposalCid cid.Cid) *storagedeal.Deal {
+	return DealGet(a, proposalCid)
 }
 
 // MessagePoolWait waits for the message pool to have at least messageCount unmined messages.

--- a/porcelain/storagedeals.go
+++ b/porcelain/storagedeals.go
@@ -1,0 +1,25 @@
+package porcelain
+
+import (
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
+)
+
+type strgdlsPlumbing interface {
+	DealsLs() ([]*storagedeal.Deal, error)
+}
+
+// DealGet returns a single deal matching a given cid or an error
+func DealGet(plumbing strgdlsPlumbing, dealCid cid.Cid) *storagedeal.Deal {
+	deals, err := plumbing.DealsLs()
+	if err != nil {
+		return nil
+	}
+	for _, storageDeal := range deals {
+		if storageDeal.Response.ProposalCid == dealCid {
+			return storageDeal
+		}
+	}
+	return nil
+}

--- a/protocol/storage/storage_protocol_test.go
+++ b/protocol/storage/storage_protocol_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
-	. "github.com/filecoin-project/go-filecoin/protocol/storage"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/types"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 )
@@ -20,7 +20,7 @@ func TestSerializeProposal(t *testing.T) {
 
 	ag := address.NewForTestGetter()
 	cg := types.NewCidForTestGetter()
-	p := &DealProposal{}
+	p := &storagedeal.Proposal{}
 	p.Size = types.NewBytesAmount(5)
 	cmc := cg()
 	p.Payment.ChannelMsgCid = &cmc
@@ -39,6 +39,6 @@ func TestSerializeProposal(t *testing.T) {
 	chunk, err := cbor.DumpObject(p)
 	require.NoError(err)
 
-	err = cbor.DecodeInto(chunk, &DealProposal{})
+	err = cbor.DecodeInto(chunk, &storagedeal.Proposal{})
 	require.NoError(err)
 }

--- a/protocol/storage/storagedeal/state.go
+++ b/protocol/storage/storagedeal/state.go
@@ -1,13 +1,15 @@
-package storage
+package storagedeal
 
-import "fmt"
+import (
+	"fmt"
+)
 
-// DealState signifies the state of a deal
-type DealState int
+// State signifies the state of a deal
+type State int
 
 const (
 	// Unknown signifies an unknown negotiation
-	Unknown = DealState(iota)
+	Unknown = State(iota)
 
 	// Rejected means the deal was rejected for some reason
 	Rejected
@@ -32,7 +34,7 @@ const (
 	Staged
 )
 
-func (s DealState) String() string {
+func (s State) String() string {
 	switch s {
 	case Unknown:
 		return "unknown"

--- a/tools/fast/action_client.go
+++ b/tools/fast/action_client.go
@@ -7,7 +7,7 @@ import (
 	"io"
 
 	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/protocol/storage"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 
 	"gx/ipfs/QmQmhotPUzVrMEWNK3x1R5jQ5ZHWyL7tVUrmRPjrBrvyCb/go-ipfs-files"
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
@@ -36,9 +36,9 @@ func (f *Filecoin) ClientImport(ctx context.Context, data files.File) (cid.Cid, 
 
 // ClientProposeStorageDeal runs the client propose-storage-deal command against the filecoin process.
 func (f *Filecoin) ClientProposeStorageDeal(ctx context.Context, data cid.Cid,
-	miner address.Address, ask uint64, duration uint64, allowDuplicates bool) (*storage.DealResponse, error) {
+	miner address.Address, ask uint64, duration uint64, allowDuplicates bool) (*storagedeal.Response, error) {
 
-	var out storage.DealResponse
+	var out storagedeal.Response
 	sData := data.String()
 	sMiner := miner.String()
 	sAsk := fmt.Sprintf("%d", ask)
@@ -51,8 +51,8 @@ func (f *Filecoin) ClientProposeStorageDeal(ctx context.Context, data cid.Cid,
 }
 
 // ClientQueryStorageDeal runs the client query-storage-deal command against the filecoin process.
-func (f *Filecoin) ClientQueryStorageDeal(ctx context.Context, prop cid.Cid) (*storage.DealResponse, error) {
-	var out storage.DealResponse
+func (f *Filecoin) ClientQueryStorageDeal(ctx context.Context, prop cid.Cid) (*storagedeal.Response, error) {
+	var out storagedeal.Response
 
 	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "client", "query-storage-deal", prop.String()); err != nil {
 		return nil, err

--- a/tools/fast/series/series_importandstore.go
+++ b/tools/fast/series/series_importandstore.go
@@ -2,19 +2,19 @@ package series
 
 import (
 	"context"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 
 	"gx/ipfs/QmQmhotPUzVrMEWNK3x1R5jQ5ZHWyL7tVUrmRPjrBrvyCb/go-ipfs-files"
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/api"
-	"github.com/filecoin-project/go-filecoin/protocol/storage"
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 )
 
 // ImportAndStore imports the `data` to the `client`, and proposes a storage
 // deal using the provided `ask`, returning the cid of the import and the
 // created deal.
-func ImportAndStore(ctx context.Context, client *fast.Filecoin, ask api.Ask, data files.File) (cid.Cid, *storage.DealResponse, error) {
+func ImportAndStore(ctx context.Context, client *fast.Filecoin, ask api.Ask, data files.File) (cid.Cid, *storagedeal.Response, error) {
 	// Client neeeds to import the data
 	dcid, err := client.ClientImport(ctx, data)
 	if err != nil {

--- a/tools/fast/series/series_waitfordealstate.go
+++ b/tools/fast/series/series_waitfordealstate.go
@@ -2,15 +2,15 @@ package series
 
 import (
 	"context"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"time"
 
-	"github.com/filecoin-project/go-filecoin/protocol/storage"
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 )
 
 // WaitForDealState will query the storage deal until its state matches the
 // passed in `state`, or the context is canceled.
-func WaitForDealState(ctx context.Context, client *fast.Filecoin, deal *storage.DealResponse, state storage.DealState) error {
+func WaitForDealState(ctx context.Context, client *fast.Filecoin, deal *storagedeal.Response, state storagedeal.State) error {
 	for {
 		// Client waits around for the deal to be sealed
 		dr, err := client.ClientQueryStorageDeal(ctx, deal.ProposalCid)

--- a/tools/fast/tests/retrieval_test.go
+++ b/tools/fast/tests/retrieval_test.go
@@ -13,7 +13,7 @@ import (
 
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 
-	"github.com/filecoin-project/go-filecoin/protocol/storage"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 	"github.com/filecoin-project/go-filecoin/tools/fast/series"
@@ -130,11 +130,11 @@ func TestRetrieval(t *testing.T) {
 	// the imported data, and the deal which was created
 	data := []byte("Hello World!")
 	dataReader := bytes.NewReader(data)
-	dcid, deal, err := series.ImportAndStore(ctx, client, ask, files.NewReaderFile(dataReader))
+	dcid, storageDeal, err := series.ImportAndStore(ctx, client, ask, files.NewReaderFile(dataReader))
 	require.NoError(err)
 
 	// Wait for the deal to be posted
-	err = series.WaitForDealState(ctx, client, deal, storage.Posted)
+	err = series.WaitForDealState(ctx, client, storageDeal, storagedeal.Posted)
 	require.NoError(err)
 
 	// Retrieve the stored piece of data


### PR DESCRIPTION
We coalesce the the storage of storage deals for both storage miners and storage clients into a single datastore with a single namespace. This allows easy querying of storage deals, regardless of whether one is a miner or client. This also easily allows a miner to obtain vouchers for storage deals that have been successfully executed, thus enabling miner payments with minimal hoop-jumping.

Resolves #1433 