### PR TITLE
use paramfetch before paramcache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ tools/faucet/faucet
 tools/aggregator/aggregator
 tools/genesis-file-server/genesis-file-server
 proofs/misc/parameters.json
-proofs/bin/paramfetch
 proofs/bin/paramcache
 proofs/bin/paramfetch
 proofs/include/libfilecoin_proofs.h

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ fixtures/genesis.car
 tools/faucet/faucet
 tools/aggregator/aggregator
 tools/genesis-file-server/genesis-file-server
+proofs/misc/parameters.json
+proofs/bin/paramfetch
 proofs/bin/paramcache
 proofs/bin/paramfetch
 proofs/include/libfilecoin_proofs.h

--- a/build/main.go
+++ b/build/main.go
@@ -130,6 +130,7 @@ func deps() {
 		cmd("go get -u github.com/pmezard/go-difflib/difflib"),
 		cmd("./scripts/install-rust-proofs.sh"),
 		cmd("./scripts/install-bls-signatures.sh"),
+		cmdWithDir("./proofs/misc/", "../bin/paramfetch fetch --all"),
 		cmd("./proofs/bin/paramcache"),
 		cmd("./scripts/copy-groth-params.sh"),
 	}
@@ -152,6 +153,7 @@ func smartdeps() {
 		cmd("gometalinter --install"),
 		cmd("./scripts/install-rust-proofs.sh"),
 		cmd("./scripts/install-bls-signatures.sh"),
+		cmdWithDir("./proofs/misc/", "../bin/paramfetch fetch --all"),
 		cmd("./proofs/bin/paramcache"),
 		cmd("./scripts/copy-groth-params.sh"),
 	}

--- a/build/main.go
+++ b/build/main.go
@@ -130,7 +130,7 @@ func deps() {
 		cmd("go get -u github.com/pmezard/go-difflib/difflib"),
 		cmd("./scripts/install-rust-proofs.sh"),
 		cmd("./scripts/install-bls-signatures.sh"),
-		cmdWithDir("./proofs/misc/", "../bin/paramfetch fetch --all"),
+		cmd("./proofs/bin/paramfetch fetch --all --json=./proofs/misc/parameters.json"),
 		cmd("./proofs/bin/paramcache"),
 		cmd("./scripts/copy-groth-params.sh"),
 	}
@@ -153,7 +153,7 @@ func smartdeps() {
 		cmd("gometalinter --install"),
 		cmd("./scripts/install-rust-proofs.sh"),
 		cmd("./scripts/install-bls-signatures.sh"),
-		cmdWithDir("./proofs/misc/", "../bin/paramfetch fetch --all"),
+		cmd("./proofs/bin/paramfetch fetch --all --json=./proofs/misc/parameters.json"),
 		cmd("./proofs/bin/paramcache"),
 		cmd("./scripts/copy-groth-params.sh"),
 	}

--- a/scripts/install-rust-proofs.sh
+++ b/scripts/install-rust-proofs.sh
@@ -40,6 +40,7 @@ install_precompiled() {
   mkdir -p proofs/bin
   mkdir -p proofs/include
   mkdir -p proofs/lib/pkgconfig
+  mkdir -p proofs/misc
 
   tar -C proofs -xzf /tmp/${TAR_NAME}.tar.gz
 }
@@ -64,8 +65,11 @@ install_local() {
   mkdir -p proofs/bin
   mkdir -p proofs/include
   mkdir -p proofs/lib/pkgconfig
+  mkdir -p proofs/misc
 
+  cp proofs/rust-proofs/parameters.json ./proofs/misc/
   cp proofs/rust-proofs/target/release/paramcache ./proofs/bin/
+  cp proofs/rust-proofs/target/release/paramfetch ./proofs/bin/
   cp proofs/rust-proofs/target/release/libfilecoin_proofs.h ./proofs/include/
   cp proofs/rust-proofs/target/release/libfilecoin_proofs.a ./proofs/lib/
   cp proofs/rust-proofs/target/release/libfilecoin_proofs.pc ./proofs/lib/pkgconfig/


### PR DESCRIPTION
has `deps` use `paramfetch` to pull any predefined parameters from ipfs before generating any missing ones with `paramcache`