### PR TITLE
bump timeouts to accommodate slow osx build container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,7 @@ jobs:
 
       - run:
           name: Test
+          no_output_timeout: 30m
           command: |
             trap "go-junit-report < test-results/go-test-suite/go-test.out > test-results/go-test-suite/go-test-report.xml" EXIT
             go run ./build/*.go test -v 2>&1 | tee test-results/go-test-suite/go-test.out

--- a/build/main.go
+++ b/build/main.go
@@ -319,7 +319,7 @@ func install() {
 func test(args ...string) {
 	log.Println("Testing...")
 
-	runCmd(cmd(fmt.Sprintf("go test -parallel 8 ./... %s", strings.Join(args, " "))))
+	runCmd(cmd(fmt.Sprintf("go test -timeout 30m -parallel 8 ./... %s", strings.Join(args, " "))))
 }
 
 func main() {


### PR DESCRIPTION
Fixes #1911 

## What's in this PR?

- bump CircleCI timeout to 30m
- bump `go test` timeout to 30m

## Why's this PR needed?

CircleCI runs Linux builds in `xlarge` class containers. CircleCI runs OSX builds in `medium` class containers. Seal performance in the `medium` class is approximately 4x worse (slower) than `xlarge`.

To prevent tests from timing out and failing the build, we need to bump both `go test` timeout and the CircleCI no-output timeout.

## Performance Deltas

Here are some timing metrics from our OSX build:

```
--- PASS: TestSectorBuilder (1489.22s)
    --- PASS: TestSectorBuilder/concurrent_AddPiece_and_SealAllStagedSectors (595.14s)
    --- PASS: TestSectorBuilder/concurrent_writes (483.24s)
    --- PASS: TestSectorBuilder/add,_seal,_verify,_and_read_user_piece-bytes (121.69s)
    --- PASS: TestSectorBuilder/sector_builder_resumes_polling_for_staged_sectors_even_after_a_restart (175.63s)
    --- PASS: TestSectorBuilder/proof-of-spacetime_generation_and_verification (113.52s)
```

and, for comparison, Linux:

```
--- PASS: TestSectorBuilder (359.19s)
    --- PASS: TestSectorBuilder/concurrent_AddPiece_and_SealAllStagedSectors (102.05s)
    --- PASS: TestSectorBuilder/concurrent_writes (119.05s)
    --- PASS: TestSectorBuilder/add,_seal,_verify,_and_read_user_piece-bytes (43.05s)
    --- PASS: TestSectorBuilder/sector_builder_resumes_polling_for_staged_sectors_even_after_a_restart (64.02s)
    --- PASS: TestSectorBuilder/proof-of-spacetime_generation_and_verification (31.02s)
```