### PR TITLE
docs: Add dual license

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
   ],
   "gxVersion": "0.12.1",
   "language": "go",
-  "license": "(MIT OR APACHE)",
+  "license": "(MIT OR APACHE-2.0)",
   "name": "go-filecoin",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
   "subtoolRequired": true,

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
   ],
   "gxVersion": "0.12.1",
   "language": "go",
-  "license": "",
+  "license": "(MIT OR APACHE)",
   "name": "go-filecoin",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
   "subtoolRequired": true,


### PR DESCRIPTION
Missing it in the manifest. Not sure if this is how GX reads it (cc @whyrusleeping), but I'm going off of [this example from @kemitchell](https://www.npmjs.com/package/dual-licensed-package).