### PR TITLE
point to Cargo 1.31.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The build process for go-filecoin requires:
 
 - [Go](https://golang.org/doc/install) >= v1.11.2. 
   - Installing Go for the first time? We recommend [this tutorial](https://www.ardanlabs.com/blog/2016/05/installing-go-and-your-workspace.html) which includes environment setup.
-- [Rust](https://www.rust-lang.org/) >= v1.29.0 and `cargo`  
+- [Rust](https://www.rust-lang.org/) >= v1.31.0 and `cargo`
 - `pkg-config` - used by go-filecoin to handle generating linker flags
   - Mac OS devs can install through brew `brew install pkg-config`
   


### PR DESCRIPTION
Fixes #1949 

## Problem Description

The `rust-toolchain` file (https://github.com/filecoin-project/rust-proofs/blob/master/rust-toolchain) contains `nightly-2018-12-06`.

The `nightly-2018-12-06` version corresponds to Rust 1.31.0 (https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1310-2018-12-06).

The `install-rust-proofs.sh` script invokes `cargo`, which should read the contents of `rust-toolchain` file to download and install the appropriate version of Cargo, Rust, and so forth. It doesn't appear to be the case that this is working in @markwylde 's environment.

## What's in this PR?

This PR updates the readme to point to the version of Cargo required by `nightly-2018-12-06`. This PR is a stopgap. We need to figure out why the `rust-toolchain` file was not used when @markwylde built rust-proofs.