### PR TITLE
add logging to chain loading from disk

### DIFF
--- a/chain/default_store.go
+++ b/chain/default_store.go
@@ -122,7 +122,7 @@ func (store *DefaultStore) Load(ctx context.Context) error {
 
 	var genesii types.TipSet
 	err = store.walkChain(ctx, headTs.ToSlice(), func(tips []*types.Block) (cont bool, err error) {
-		if (tips[0].Height % logStatusEvery) == 0 {
+		if logStatusEvery != 0 && (tips[0].Height%logStatusEvery) == 0 {
 			logStore.Infof("load tipset: %s, height: %v", tips[0].Cid().String(), tips[0].Height)
 		}
 		ts, err := types.NewTipSet(tips...)

--- a/chain/default_store.go
+++ b/chain/default_store.go
@@ -104,6 +104,7 @@ func (store *DefaultStore) Load(ctx context.Context) error {
 	}
 	headTs := types.TipSet{}
 	// traverse starting from head to begin loading the chain
+	var startHeight types.Uint64
 	for it := tipCids.Iter(); !it.Complete(); it.Next() {
 		blk, err := store.GetBlock(ctx, it.Value())
 		if err != nil {
@@ -113,10 +114,17 @@ func (store *DefaultStore) Load(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to add validated block to TipSet")
 		}
+		startHeight = blk.Height
 	}
+	logStore.Infof("start loading chain at tipset: %s, height: %d", tipCids.String(), startHeight)
+	// esnures we only produce 10 log messages regardless of the chain height
+	logStatusEvery := startHeight / 10
 
 	var genesii types.TipSet
 	err = store.walkChain(ctx, headTs.ToSlice(), func(tips []*types.Block) (cont bool, err error) {
+		if (tips[0].Height % logStatusEvery) == 0 {
+			logStore.Infof("load tipset: %s, height: %v", tips[0].Cid().String(), tips[0].Height)
+		}
 		ts, err := types.NewTipSet(tips...)
 		if err != nil {
 			return false, err
@@ -150,6 +158,7 @@ func (store *DefaultStore) Load(ctx context.Context) error {
 		return errors.Errorf("expected genesis cid: %s, loaded genesis cid: %s", store.genesis, loadCid)
 	}
 
+	logStore.Infof("finished loading %d tipsets from %s", startHeight, headTs.String())
 	// Set actual head.
 	return store.SetHead(ctx, headTs)
 }


### PR DESCRIPTION
This PR adds logging around the status of loading the chain from disk, example logs produced:
```
13:14:27.994  INFO chain.stor: start loading chain at tipset: { zDPWYqFCvRYC8zKuB9enFLJhzSopGCXBBxR7y15KoerNJDUupEW3 zDPWYqFD6dmjamu4Mw4sRwFkPa7uvKYddWzmZeHE3BSqZXn2ZXSK }, height: 1597 default_store.go:119
13:14:30.374  INFO chain.stor: load tipset: zDPWYqFD4Y8kwX6k7mWyaMKV2Z8JNjRe6dAXvqMJhPuDqQfmA3We, height: 1100 default_store.go:124
13:14:31.296  INFO chain.stor: load tipset: zDPWYqFCraB24f7bfwS3jxYZ7Nd3ZC4fPuPAQ5zRz1M1ZoXLGwoj, height: 900 default_store.go:124
13:14:33.991  INFO chain.stor: load tipset: zDPWYqFD3hTcZQev2D5TpRLMQobmgKTb75BnJZw1LDTCiLFLcTSS, height: 300 default_store.go:124
13:14:34.804  INFO chain.stor: load tipset: zDPWYqFD24Wofr7F3tRTVV1UjtYV3vrCKhRthBc4dsu5CiRAY2QQ, height: 100 default_store.go:124
13:14:35.400  INFO chain.stor: load tipset: zDPWYqFCutuHwRZhGXzji9L4eHeoFxxNCxCruGjWje36aAvbK2XV, height: 0 default_store.go:124
13:14:35.406  INFO chain.stor: complete chain load current tipset: { zDPWYqFCvRYC8zKuB9enFLJhzSopGCXBBxR7y15KoerNJDUupEW3 zDPWYqFD6dmjamu4Mw4sRwFkPa7uvKYddWzmZeHE3BSqZXn2ZXSK } default_store.go:159
```