### PR TITLE
Make sure defer daemon.ShutdownSuccess() is paired with every call to Start()

### DIFF
--- a/commands/daemon_daemon_test.go
+++ b/commands/daemon_daemon_test.go
@@ -47,7 +47,9 @@ func TestDaemonCORS(t *testing.T) {
 	t.Run("default allowed origins work", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
+
 		td := th.NewDaemon(t).Start()
+		defer td.ShutdownSuccess()
 
 		maddr, err := ma.NewMultiaddr(td.CmdAddr())
 		assert.NoError(err)
@@ -89,6 +91,7 @@ func TestDaemonCORS(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 		td := th.NewDaemon(t).Start()
+		defer td.ShutdownSuccess()
 
 		maddr, err := ma.NewMultiaddr(td.CmdAddr())
 		assert.NoError(err)


### PR DESCRIPTION
# Problem 
Closes #1972:  daemon zombies after test runs

# Solution
Make sure defer daemon.ShutdownSuccess() is paired with every call to Start() -- turns out there were two that did not, and what do you know, two stray processes are left behind after each test run.
