### PR TITLE
Remove github token from install-rust-proofs.sh and change default README instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,11 @@ tools/faucet/faucet
 tools/aggregator/aggregator
 tools/genesis-file-server/genesis-file-server
 proofs/bin/paramcache
+proofs/bin/paramfetch
 proofs/include/libfilecoin_proofs.h
 proofs/lib/libfilecoin_proofs.a
 proofs/lib/pkgconfig/libfilecoin_proofs.pc
+proofs/misc/
 bls-signatures/include/libbls_signatures.h
 bls-signatures/lib/libbls_signatures.a
 bls-signatures/lib/pkgconfig/libbls_signatures.pc

--- a/README.md
+++ b/README.md
@@ -90,21 +90,21 @@ Due to our use of `cgo`, you'll need a C compiler to build go-filecoin whether y
 #### Install Dependencies
 
 `go-filecoin` depends on some proofs code written in Rust, housed in the
-[rust-proofs](https://github.com/filecoin-project/rust-proofs) repo and consumed as a submodule. You will need to have `rust` and `cargo` installed.
+[rust-proofs](https://github.com/filecoin-project/rust-proofs) repo and consumed as a submodule. You will need to have `cargo` installed.
 
 go-filecoin's dependencies are managed by [gx][2]; this project is not "go gettable." To install gx, gometalinter, and
-other build and test dependencies, run:
+other build and test dependencies (with precompiled proofs, recommended), run:
 
 ```sh
 cd ${GOPATH}/src/github.com/filecoin-project/go-filecoin
-go run ./build/*.go deps
+FILECOIN_USE_PRECOMPILED_RUST_PROOFS=true go run ./build/*.go deps
 ```
 
 #### Build, Run Tests, and Install
 
 ```sh
-# First, build the binary (with precompiled proofs, recommended)
-FILECOIN_USE_PRECOMPILED_RUST_PROOFS=true go run ./build/*.go build
+# First, build the binary
+go run ./build/*.go build
 
 # Install go-filecoin to ${GOPATH}/bin (necessary for tests)
 go run ./build/*.go install

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ go run ./build/*.go deps
 #### Build, Run Tests, and Install
 
 ```sh
-# First, build the binary...
-go run ./build/*.go build
+# First, build the binary (with precompiled proofs, recommended)
+FILECOIN_USE_PRECOMPILED_RUST_PROOFS=true go run ./build/*.go build
 
 # Install go-filecoin to ${GOPATH}/bin (necessary for tests)
 go run ./build/*.go install

--- a/scripts/install-rust-proofs.sh
+++ b/scripts/install-rust-proofs.sh
@@ -5,16 +5,7 @@ install_precompiled() {
   RELEASE_NAME="rust-proofs-`uname`"
   RELEASE_TAG="${RELEASE_SHA1:0:16}"
 
-  if [ -z $GITHUB_TOKEN ]; then
-    echo "\$GITHUB_TOKEN not set"
-    return 1
-  fi
-
-  RELEASE_RESPONSE=`
-    curl \
-      --header "Authorization: token $GITHUB_TOKEN" \
-      "https://api.github.com/repos/filecoin-project/rust-proofs/releases/tags/$RELEASE_TAG"
-  `
+  RELEASE_RESPONSE=`curl "https://api.github.com/repos/filecoin-project/rust-proofs/releases/tags/$RELEASE_TAG"`
 
   RELEASE_ID=`echo $RELEASE_RESPONSE | jq '.id'`
 
@@ -29,7 +20,6 @@ install_precompiled() {
 
   ASSET_URL=`curl \
       --head \
-      --header "Authorization: token $GITHUB_TOKEN" \
       --header "Accept:application/octet-stream" \
       --location \
       --output /dev/null \


### PR DESCRIPTION
Remove the need for a github token in install-rust-proofs.sh, since the
repository is now open and the token is no longer needed.

Resolves #1981