### PR TITLE
don't compile binaries during docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,11 +233,14 @@ jobs:
       - run:
           name: Create linux bundle
           command: ./scripts/build-bundle.sh
+
       - store_artifacts:
           path: "/go/src/github.com/filecoin-project/go-filecoin/filecoin-Linux.tar.gz"
           destination: filecoin-Linux.tar.gz
+
       - store_test_results:
           path: test-results
+
       - persist_to_workspace:
           root: "."
           paths:
@@ -266,6 +269,21 @@ jobs:
           command: |
             ./scripts/publish-release.sh
 
+  build_faucet_and_genesis:
+    docker:
+      - image: circleci/golang:1.11.1
+    working_directory: /go/src/github.com/filecoin-project/go-filecoin
+    resource_class: small
+    steps:
+      - command: |
+          go build -o ./faucet ./tools/faucet/main.go
+          go build -o ./genesis-file-server ./tools/genesis-file-server/main.go
+
+      - persist_to_workspace:
+          root: "."
+          paths:
+            - "faucet"
+            - "genesis-file-server"
 
   build_docker_img:
     docker:
@@ -292,41 +310,50 @@ jobs:
       # The first checkout ensures we have the files needed to restore the cache
       - checkout
 
+      - attach_workspace:
+          at: "."
+
+      - restore_cache:
+          key: v0-proof-params-{{ arch }}-{{ checksum "/tmp/rust-proofs-checksum.txt" }}
+
       # Pull in all submodules (inc. rust-proofs)
       - run: git submodule update --init
 
       - run:
           name: build an image of all binaries
           command: |
+            tar -xf filecoin-Linux.tar.gz
+            ln -s $HOME/filecoin-proof-parameters ./filecoin-proof-parameters
             docker build -t filecoin:all --target=builder .
           no_output_timeout: 20m
-
-      - run:
-          name: build & push image - filecoin
-          command: |
-            export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
-            docker build -f Dockerfile.ci.filecoin --label "version=$SHORT_GIT_SHA" -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA --cache-from filecoin:all .
-            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA
-            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:latest
-            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:latest
 
       - run:
           name: build & push image - genesis file server
           command: |
             export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
             docker build -f Dockerfile.ci.genesis --label "version=$SHORT_GIT_SHA" -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA --cache-from filecoin:all .
-            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA
-            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:latest
-            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:latest
+#            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA
+#            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:latest
+#            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:latest
 
       - run:
           name: build & push image - faucet
           command: |
             export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
             docker build -f Dockerfile.ci.faucet --label "version=$SHORT_GIT_SHA" -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA --cache-from filecoin:all .
-            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA
-            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:latest
-            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:latest
+#            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA
+#            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:latest
+#            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:latest
+
+      - run:
+          name: build & push image - filecoin
+          command: |
+            mv $HOME/filecoin-proof-parameters ./filecoin-proof-parameters
+            export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
+            docker build -f Dockerfile.ci.filecoin --label "version=$SHORT_GIT_SHA" -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA --cache-from filecoin:all .
+#            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA
+#            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:latest
+#            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:latest
 
   trigger_nightly_devnet_deploy:
     docker:
@@ -403,13 +430,19 @@ workflows:
   test_all:
     jobs:
       - build_linux
-      - build_docker_img:
-          requires:
-            - build_linux
+      - build_faucet_and_genesis:
           filters:
             branches:
               only:
                 - master
+      - build_docker_img:
+          requires:
+            - build_linux
+            - build_faucet_and_genesis
+#          filters:
+#            branches:
+#              only:
+#                - master
 
   build_nightly_osx:
     triggers:
@@ -464,9 +497,11 @@ workflows:
                 - master
     jobs:
       - build_linux
+      - build_faucet_and_genesis
       - build_docker_img:
           requires:
             - build_linux
+            - build_faucet_and_genesis
       - trigger_nightly_devnet_deploy:
           requires:
             - build_docker_img
@@ -481,9 +516,8 @@ workflows:
             tags:
               only:
                 - /^devnet-user$/
-      - build_docker_img:
-          requires:
-            - build_linux
+
+      - build_faucet_and_genesis:
           filters:
             branches:
               ignore:
@@ -491,6 +525,19 @@ workflows:
             tags:
               only:
                 - /^devnet-user$/
+
+      - build_docker_img:
+          requires:
+            - build_linux
+            - build_faucet_and_genesis
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^devnet-user$/
+
       - trigger_user_devnet_deploy:
           requires:
             - build_docker_img

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,8 +354,8 @@ jobs:
             export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
             docker build -f Dockerfile.ci.genesis --label "version=$SHORT_GIT_SHA" -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA --cache-from filecoin:all .
             docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA
-#            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:latest
-#            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:latest
+            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:latest
+            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:latest
 
       - run:
           name: build & push image - faucet
@@ -363,8 +363,8 @@ jobs:
             export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
             docker build -f Dockerfile.ci.faucet --label "version=$SHORT_GIT_SHA" -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA --cache-from filecoin:all .
             docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA
-#            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:latest
-#            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:latest
+            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:latest
+            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:latest
 
       - run:
           name: build & push image - filecoin
@@ -374,8 +374,8 @@ jobs:
             export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
             docker build -f Dockerfile.ci.filecoin --label "version=$SHORT_GIT_SHA" -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA --cache-from filecoin:all .
             docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA
-#            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:latest
-#            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:latest
+            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:latest
+            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:latest
 
   trigger_nightly_devnet_deploy:
     docker:
@@ -455,18 +455,18 @@ workflows:
       - build_faucet_and_genesis:
           requires:
             - build_linux
-#          filters:
-#            branches:
-#              only:
-#                - master
+          filters:
+            branches:
+              only:
+                - master
       - build_docker_img:
           requires:
             - build_linux
             - build_faucet_and_genesis
-#          filters:
-#            branches:
-#              only:
-#                - master
+          filters:
+            branches:
+              only:
+                - master
 
   build_nightly_osx:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,8 +345,7 @@ jobs:
       - run:
           name: build an image of all binaries
           command: |
-            tar -xf filecoin-Linux.tar.gz
-            docker build -t filecoin:all --target=builder .
+            docker build -t filecoin:all --target=base --file Dockerfile.ci.base .
           no_output_timeout: 20m
 
       - run:
@@ -354,7 +353,7 @@ jobs:
           command: |
             export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
             docker build -f Dockerfile.ci.genesis --label "version=$SHORT_GIT_SHA" -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA --cache-from filecoin:all .
-#            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA
+            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA
 #            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:latest
 #            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:latest
 
@@ -363,17 +362,18 @@ jobs:
           command: |
             export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
             docker build -f Dockerfile.ci.faucet --label "version=$SHORT_GIT_SHA" -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA --cache-from filecoin:all .
-#            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA
+            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA
 #            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:latest
 #            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:latest
 
       - run:
           name: build & push image - filecoin
           command: |
+            tar -xf filecoin-Linux.tar.gz
             mv $HOME/filecoin-proof-parameters ./filecoin-proof-parameters
             export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
             docker build -f Dockerfile.ci.filecoin --label "version=$SHORT_GIT_SHA" -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA --cache-from filecoin:all .
-#            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA
+            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA
 #            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:latest
 #            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:latest
 
@@ -521,7 +521,9 @@ workflows:
                 - master
     jobs:
       - build_linux
-      - build_faucet_and_genesis
+      - build_faucet_and_genesis:
+          requires:
+            - build_linux
       - build_docker_img:
           requires:
             - build_linux
@@ -542,6 +544,8 @@ workflows:
                 - /^devnet-user$/
 
       - build_faucet_and_genesis:
+          requires:
+            - build_linux
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,7 @@ jobs:
           root: "."
           paths:
             - "filecoin-Linux.tar.gz"
+            - "gengen/gengen"
 
   publish_release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,6 +308,7 @@ jobs:
     docker:
       - image: circleci/golang:latest
     resource_class: xlarge
+    working_directory: "~/docker_build"
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -344,7 +345,6 @@ jobs:
           name: build an image of all binaries
           command: |
             tar -xf filecoin-Linux.tar.gz
-            ln -s $HOME/filecoin-proof-parameters ./filecoin-proof-parameters
             docker build -t filecoin:all --target=builder .
           no_output_timeout: 20m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
 version: 2
 
+definitions:
+  steps:
+    - run: &rust_proofs_checksum
+        name: generate rust proofs checksum
+        command: git rev-parse @:./proofs/rust-proofs > /tmp/rust-proofs-checksum.txt
+
 jobs:
   build_macos:
     macos:
@@ -21,8 +27,7 @@ jobs:
       - run:
           name: Update submodules
           command: git submodule update --init
-      - run:
-          command: git rev-parse @:./proofs/rust-proofs > /tmp/rust-proofs-checksum.txt
+      - run: *rust_proofs_checksum
       - restore_cache:
           key: v5-go-deps-{{ arch }}-{{ checksum  "~/go/src/github.com/filecoin-project/go-filecoin/build/main.go" }}-{{ checksum "~/go/src/github.com/filecoin-project/go-filecoin/package.json" }}-{{ checksum "/tmp/rust-proofs-checksum.txt" }}
 
@@ -142,7 +147,7 @@ jobs:
       - run: git submodule update --init
 
       # Save the Git SHA of the rust-proofs submodule so that we can use it when creating a cache key
-      - run: git rev-parse @:./proofs/rust-proofs > /tmp/rust-proofs-checksum.txt
+      - run: *rust_proofs_checksum
 
       - restore_cache:
           keys:
@@ -275,9 +280,21 @@ jobs:
     working_directory: /go/src/github.com/filecoin-project/go-filecoin
     resource_class: small
     steps:
-      - command: |
-          go build -o ./faucet ./tools/faucet/main.go
-          go build -o ./genesis-file-server ./tools/genesis-file-server/main.go
+      - add_ssh_keys:
+          fingerprints:
+            - "1e:73:c5:15:75:e0:e4:98:54:3c:2b:9e:e8:94:14:2e"
+
+      - restore_cache:
+          keys:
+            - v5-go-deps-{{ .Branch }}-{{ arch }}-{{ checksum  "build/main.go" }}-{{ checksum "package.json" }}-{{ checksum "/tmp/rust-proofs-checksum.txt" }}
+            - v5-go-deps-{{ arch }}-{{ checksum  "build/main.go" }}-{{ checksum "package.json" }}-{{ checksum "/tmp/rust-proofs-checksum.txt" }}
+
+      - checkout
+      - run:
+          name: build faucet and genesis-file-server
+          command: |
+            go build -o ./faucet ./tools/faucet/main.go
+            go build -o ./genesis-file-server ./tools/genesis-file-server/main.go
 
       - persist_to_workspace:
           root: "."
@@ -309,6 +326,8 @@ jobs:
 
       # The first checkout ensures we have the files needed to restore the cache
       - checkout
+
+      - run: *rust_proofs_checksum
 
       - attach_workspace:
           at: "."
@@ -430,11 +449,11 @@ workflows:
   test_all:
     jobs:
       - build_linux
-      - build_faucet_and_genesis:
-          filters:
-            branches:
-              only:
-                - master
+      - build_faucet_and_genesis
+#          filters:
+#            branches:
+#              only:
+#                - master
       - build_docker_img:
           requires:
             - build_linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,8 @@ jobs:
           fingerprints:
             - "1e:73:c5:15:75:e0:e4:98:54:3c:2b:9e:e8:94:14:2e"
 
+      - checkout
+      - run: *rust_proofs_checksum
       - restore_cache:
           keys:
             - v5-go-deps-{{ .Branch }}-{{ arch }}-{{ checksum  "build/main.go" }}-{{ checksum "package.json" }}-{{ checksum "/tmp/rust-proofs-checksum.txt" }}
@@ -449,7 +451,9 @@ workflows:
   test_all:
     jobs:
       - build_linux
-      - build_faucet_and_genesis
+      - build_faucet_and_genesis:
+          requires:
+            - build_linux
 #          filters:
 #            branches:
 #              only:

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ COPY --from=builder $SRC_DIR/bin/devnet_start /usr/local/bin/devnet_start
 COPY --from=builder $SRC_DIR/bin/node_restart /usr/local/bin/node_restart
 COPY --from=builder $SRC_DIR/gengen/gengen /usr/local/bin/gengen
 COPY --from=builder $SRC_DIR/fixtures/* /data/
-COPY --from=builder $SRC_DIR/filecoin-proof-parameters /tmp/filecoin-proof-parameters/
 COPY --from=builder /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=builder /tmp/tini /sbin/tini
 COPY --from=builder /tmp/jq /usr/local/bin/jq

--- a/Dockerfile.ci.base
+++ b/Dockerfile.ci.base
@@ -1,0 +1,27 @@
+FROM debian:stretch-20190204-slim AS builder
+MAINTAINER Filecoin Dev Team
+
+RUN apt-get update && apt-get install -y ca-certificates file sudo git build-essential wget
+
+# This docker file is a modified version of
+# https://github.com/ipfs/go-ipfs/blob/master/Dockerfile
+# Thanks Lars :)
+
+# Get su-exec, a very minimal tool for dropping privileges,
+# and tini, a very minimal init daemon for containers
+ENV SUEXEC_VERSION v0.2
+ENV TINI_VERSION v0.16.1
+RUN set -x \
+&& cd /tmp \
+&& git clone https://github.com/ncopa/su-exec.git \
+&& cd su-exec \
+&& git checkout -q $SUEXEC_VERSION \
+&& make \
+&& cd /tmp \
+&& wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini \
+&& chmod +x tini
+
+# need jq for parsing genesis output
+RUN cd /tmp \
+&& wget -q -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+&& chmod +x jq

--- a/Dockerfile.ci.base
+++ b/Dockerfile.ci.base
@@ -1,4 +1,4 @@
-FROM debian:stretch-20190204-slim AS builder
+FROM debian:stretch-20190204-slim AS base
 MAINTAINER Filecoin Dev Team
 
 RUN apt-get update && apt-get install -y ca-certificates file sudo git build-essential wget

--- a/Dockerfile.ci.faucet
+++ b/Dockerfile.ci.faucet
@@ -2,8 +2,7 @@ FROM busybox:1-glibc
 MAINTAINER Filecoin Dev Team
 
 # Get the binary, entrypoint script, and TLS CAs from the build container.
-ENV SRC_DIR /go/src/github.com/filecoin-project/go-filecoin
-COPY --from=filecoin:all $SRC_DIR/faucet /usr/local/bin/faucet
+COPY faucet /usr/local/bin/faucet
 COPY --from=filecoin:all /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=filecoin:all /tmp/tini /sbin/tini
 COPY --from=filecoin:all /etc/ssl/certs /etc/ssl/certs

--- a/Dockerfile.ci.filecoin
+++ b/Dockerfile.ci.filecoin
@@ -3,7 +3,7 @@ MAINTAINER Filecoin Dev Team
 
 # Get the filecoin binary, entrypoint script, and TLS CAs from the build container.
 ENV SRC_DIR /go/src/github.com/filecoin-project/go-filecoin
-COPY --from=filecoin:all $SRC_DIR/filecoin-proof-parameters/* /tmp/filecoin-proof-parameters/
+COPY $SRC_DIR/filecoin-proof-parameters/* /tmp/filecoin-proof-parameters/
 COPY --from=filecoin:all $SRC_DIR/go-filecoin /usr/local/bin/go-filecoin
 COPY --from=filecoin:all $SRC_DIR/bin/container_daemon /usr/local/bin/start_filecoin
 COPY --from=filecoin:all $SRC_DIR/bin/devnet_start /usr/local/bin/devnet_start

--- a/Dockerfile.ci.filecoin
+++ b/Dockerfile.ci.filecoin
@@ -3,13 +3,13 @@ MAINTAINER Filecoin Dev Team
 
 # Get the filecoin binary, entrypoint script, and TLS CAs from the build container.
 ENV SRC_DIR /go/src/github.com/filecoin-project/go-filecoin
-COPY $SRC_DIR/filecoin-proof-parameters/* /tmp/filecoin-proof-parameters/
-COPY --from=filecoin:all $SRC_DIR/go-filecoin /usr/local/bin/go-filecoin
-COPY --from=filecoin:all $SRC_DIR/bin/container_daemon /usr/local/bin/start_filecoin
-COPY --from=filecoin:all $SRC_DIR/bin/devnet_start /usr/local/bin/devnet_start
-COPY --from=filecoin:all $SRC_DIR/bin/node_restart /usr/local/bin/node_restart
-COPY --from=filecoin:all $SRC_DIR/gengen/gengen /usr/local/bin/gengen
-COPY --from=filecoin:all $SRC_DIR/fixtures/* /data/
+COPY filecoin-proof-parameters /tmp/filecoin-proof-parameters
+COPY filecoin/go-filecoin /usr/local/bin/go-filecoin
+COPY bin/container_daemon /usr/local/bin/start_filecoin
+COPY bin/devnet_start /usr/local/bin/devnet_start
+COPY bin/node_restart /usr/local/bin/node_restart
+COPY fixtures/* /data/
+COPY gengen/gengen /usr/local/bin/gengen
 COPY --from=filecoin:all /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=filecoin:all /tmp/tini /sbin/tini
 COPY --from=filecoin:all /tmp/jq /usr/local/bin/jq

--- a/Dockerfile.ci.filecoin
+++ b/Dockerfile.ci.filecoin
@@ -3,6 +3,7 @@ MAINTAINER Filecoin Dev Team
 
 # Get the filecoin binary, entrypoint script, and TLS CAs from the build container.
 ENV SRC_DIR /go/src/github.com/filecoin-project/go-filecoin
+COPY --from=filecoin:all $SRC_DIR/filecoin-proof-parameters/* /tmp/filecoin-proof-parameters/
 COPY --from=filecoin:all $SRC_DIR/go-filecoin /usr/local/bin/go-filecoin
 COPY --from=filecoin:all $SRC_DIR/bin/container_daemon /usr/local/bin/start_filecoin
 COPY --from=filecoin:all $SRC_DIR/bin/devnet_start /usr/local/bin/devnet_start
@@ -11,7 +12,6 @@ COPY --from=filecoin:all $SRC_DIR/gengen/gengen /usr/local/bin/gengen
 COPY --from=filecoin:all $SRC_DIR/fixtures/* /data/
 COPY --from=filecoin:all /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=filecoin:all /tmp/tini /sbin/tini
-COPY --from=filecoin:all /tmp/filecoin-proof-parameters/v9-zigzag-* /tmp/filecoin-proof-parameters/
 COPY --from=filecoin:all /tmp/jq /usr/local/bin/jq
 COPY --from=filecoin:all /etc/ssl/certs /etc/ssl/certs
 

--- a/Dockerfile.ci.genesis
+++ b/Dockerfile.ci.genesis
@@ -2,8 +2,7 @@ FROM busybox:1-glibc
 MAINTAINER Filecoin Dev Team
 
 # Get the binary, entrypoint script, and TLS CAs from the build container.
-ENV SRC_DIR /go/src/github.com/filecoin-project/go-filecoin
-COPY --from=filecoin:all $SRC_DIR/genesis-file-server /usr/local/bin/genesis-file-server
+COPY genesis-file-server /usr/local/bin/genesis-file-server
 COPY --from=filecoin:all /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=filecoin:all /tmp/tini /sbin/tini
 COPY --from=filecoin:all /etc/ssl/certs /etc/ssl/certs


### PR DESCRIPTION
* add an extra step in circle config to generate faucet and genesis-file-server and persist to workspace
* attach workspace and param cache to build_docker_img
* COPY binaries and params to docker image
* build go-filecoin container last to avoid adding params to faucet and genesis-file-server docker context
* make build_docker_img dependent on build_faucet_and_genesis
* remove rust dependencies from base docker image

the intention of these changes is to speed up the docker build time and make the docker image smaller

-----

this should be tested before merging by removing the branch filtering on `build_faucet_and_genesis` and `build_docker_img` jobs of `test_all` workflow, and commenting out the docker pushing and tagging steps

a second test would be to trigger a test devnet deploy