### PR TITLE
Add note to README about slow proof parameter download or generation in deps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ cd ${GOPATH}/src/github.com/filecoin-project/go-filecoin
 FILECOIN_USE_PRECOMPILED_RUST_PROOFS=true go run ./build/*.go deps
 ```
 
+Note: The first time you run `deps` can be **slow** as a ~1.6GB parameter file is either downloaded or generated locally in `/tmp/filecoin-proof-parameters`. 
+Have patience; future runs will be faster.
+
 #### Build, Run Tests, and Install
 
 ```sh


### PR DESCRIPTION
I have also updated https://github.com/filecoin-project/go-filecoin/wiki/Getting-Started with a note about runtime generation of these parameters if missing.

Closes #2008.