### PR TITLE
Feat/wallet balance porcelain 1797

### DIFF
--- a/api/address.go
+++ b/api/address.go
@@ -13,8 +13,7 @@ import (
 // Address is the interface that defines methods to manage Filecoin addresses and wallets.
 type Address interface {
 	Addrs() Addrs
-	Balance(ctx context.Context, addr address.Address) (*types.AttoFIL, error)
-	Import(ctx context.Context, d files.Directory) ([]address.Address, error)
+	Import(ctx context.Context, f files.File) ([]address.Address, error)
 	Export(ctx context.Context, addrs []address.Address) ([]*types.KeyInfo, error)
 }
 

--- a/api/address.go
+++ b/api/address.go
@@ -13,7 +13,7 @@ import (
 // Address is the interface that defines methods to manage Filecoin addresses and wallets.
 type Address interface {
 	Addrs() Addrs
-	Import(ctx context.Context, f files.File) ([]address.Address, error)
+	Import(ctx context.Context, f files.Directory) ([]address.Address, error)
 	Export(ctx context.Context, addrs []address.Address) ([]*types.KeyInfo, error)
 }
 

--- a/api/impl/address.go
+++ b/api/impl/address.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/api"
-	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/wallet"
 )
@@ -31,27 +30,6 @@ func newNodeAddress(api *nodeAPI) *nodeAddress {
 
 func (api *nodeAddress) Addrs() api.Addrs {
 	return api.addrs
-}
-
-func (api *nodeAddress) Balance(ctx context.Context, addr address.Address) (*types.AttoFIL, error) {
-	fcn := api.api.node
-
-	tree, err := fcn.ChainReader.LatestState(ctx)
-	if err != nil {
-		return types.ZeroAttoFIL, err
-	}
-
-	act, err := tree.GetActor(ctx, addr)
-	if err != nil {
-		if state.IsActorNotFoundError(err) {
-			// if the account doesn't exit, the balance should be zero
-			return types.NewAttoFILFromFIL(0), nil
-		}
-
-		return types.ZeroAttoFIL, err
-	}
-
-	return act.Balance, nil
 }
 
 type nodeAddrs struct {

--- a/commands/address.go
+++ b/commands/address.go
@@ -123,7 +123,7 @@ var balanceCmd = &cmds.Command{
 			return err
 		}
 
-		balance, err := GetAPI(env).Address().Balance(req.Context, addr)
+		balance, err := GetPorcelainAPI(env).WalletBalance(req.Context, addr)
 		if err != nil {
 			return err
 		}

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -113,8 +113,8 @@ func (api *API) ChainLs(ctx context.Context) <-chan interface{} {
 	return api.chain.BlockHistory(ctx, api.chain.Head())
 }
 
-// ChainGetActorFromLatestState returns an actor from the latest state on the chain
-func (api *API) ChainGetActorFromLatestState(ctx context.Context, addr address.Address) (*actor.Actor, error) {
+// ActorGet returns an actor from the latest state on the chain
+func (api *API) ActorGet(ctx context.Context, addr address.Address) (*actor.Actor, error) {
 	state, err := api.chain.LatestState(ctx)
 	if err != nil {
 		return nil, err

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -8,6 +8,7 @@ import (
 	logging "gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log"
 	"gx/ipfs/QmepvmmYNM6q4RaUiwEikQFhgMFHXg2PLhx2E9iaRd3jmS/go-libp2p-pubsub"
 
+	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/core"
@@ -17,7 +18,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/plumbing/mthdsig"
 	"github.com/filecoin-project/go-filecoin/plumbing/ntwk"
 	"github.com/filecoin-project/go-filecoin/plumbing/ps"
-	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/wallet"
 )
@@ -113,9 +113,13 @@ func (api *API) ChainLs(ctx context.Context) <-chan interface{} {
 	return api.chain.BlockHistory(ctx, api.chain.Head())
 }
 
-// ChainLatestState returns the latest state tree from the chain reader
-func (api *API) ChainLatestState(ctx context.Context) (state.Tree, error) {
-	return api.chain.LatestState(ctx)
+// ChainGetActorFromLatestState returns an actor from the latest state on the chain
+func (api *API) ChainGetActorFromLatestState(ctx context.Context, addr address.Address) (*actor.Actor, error) {
+	state, err := api.chain.LatestState(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return state.GetActor(ctx, addr)
 }
 
 // BlockGet gets a block by CID

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/plumbing/mthdsig"
 	"github.com/filecoin-project/go-filecoin/plumbing/ntwk"
 	"github.com/filecoin-project/go-filecoin/plumbing/ps"
+	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/wallet"
 )
@@ -110,6 +111,11 @@ func (api *API) ChainHead(ctx context.Context) types.TipSet {
 // ChainLs returns a channel of tipsets from head to genesis
 func (api *API) ChainLs(ctx context.Context) <-chan interface{} {
 	return api.chain.BlockHistory(ctx, api.chain.Head())
+}
+
+// ChainLatestState returns the latest state tree from the chain reader
+func (api *API) ChainLatestState(ctx context.Context) (state.Tree, error) {
+	return api.chain.LatestState(ctx)
 }
 
 // BlockGet gets a block by CID

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -131,3 +131,8 @@ func (a *API) MinerPreviewSetPrice(
 func (a *API) GetAndMaybeSetDefaultSenderAddress() (address.Address, error) {
 	return GetAndMaybeSetDefaultSenderAddress(a)
 }
+
+// WalletBalance returns the current balance of the given wallet address.
+func (a *API) WalletBalance(ctx context.Context, address address.Address) (*types.AttoFIL, error) {
+	return WalletBalance(ctx, a, address)
+}

--- a/porcelain/wallet.go
+++ b/porcelain/wallet.go
@@ -9,11 +9,10 @@ import (
 )
 
 type walletPlumbing interface {
-	ChainLs(ctx context.Context) <-chan interface{}
 	ChainLatestState(ctx context.Context) (state.Tree, error)
 }
 
-// WalletBalance gets the current balance of the wallet
+// WalletBalance gets the current balance associated with an address
 func WalletBalance(ctx context.Context, plumbing walletPlumbing, addr address.Address) (*types.AttoFIL, error) {
 	tree, err := plumbing.ChainLatestState(ctx)
 	if err != nil {

--- a/porcelain/wallet.go
+++ b/porcelain/wallet.go
@@ -1,0 +1,34 @@
+package porcelain
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/state"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+type walletPlumbing interface {
+	ChainLs(ctx context.Context) <-chan interface{}
+	ChainLatestState(ctx context.Context) (state.Tree, error)
+}
+
+// WalletBalance gets the current balance of the wallet
+func WalletBalance(ctx context.Context, plumbing walletPlumbing, addr address.Address) (*types.AttoFIL, error) {
+	tree, err := plumbing.ChainLatestState(ctx)
+	if err != nil {
+		return types.ZeroAttoFIL, err
+	}
+
+	act, err := tree.GetActor(ctx, addr)
+	if err != nil {
+		if state.IsActorNotFoundError(err) {
+			// if the account doesn't exit, the balance should be zero
+			return types.NewAttoFILFromFIL(0), nil
+		}
+
+		return types.ZeroAttoFIL, err
+	}
+
+	return act.Balance, nil
+}

--- a/porcelain/wallet.go
+++ b/porcelain/wallet.go
@@ -3,23 +3,19 @@ package porcelain
 import (
 	"context"
 
+	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
 type walletPlumbing interface {
-	ChainLatestState(ctx context.Context) (state.Tree, error)
+	ChainGetActorFromLatestState(ctx context.Context, addr address.Address) (*actor.Actor, error)
 }
 
 // WalletBalance gets the current balance associated with an address
 func WalletBalance(ctx context.Context, plumbing walletPlumbing, addr address.Address) (*types.AttoFIL, error) {
-	tree, err := plumbing.ChainLatestState(ctx)
-	if err != nil {
-		return types.ZeroAttoFIL, err
-	}
-
-	act, err := tree.GetActor(ctx, addr)
+	act, err := plumbing.ChainGetActorFromLatestState(ctx, addr)
 	if err != nil {
 		if state.IsActorNotFoundError(err) {
 			// if the account doesn't exit, the balance should be zero

--- a/porcelain/wallet.go
+++ b/porcelain/wallet.go
@@ -10,12 +10,12 @@ import (
 )
 
 type walletPlumbing interface {
-	ChainGetActorFromLatestState(ctx context.Context, addr address.Address) (*actor.Actor, error)
+	ActorGet(ctx context.Context, addr address.Address) (*actor.Actor, error)
 }
 
 // WalletBalance gets the current balance associated with an address
 func WalletBalance(ctx context.Context, plumbing walletPlumbing, addr address.Address) (*types.AttoFIL, error) {
-	act, err := plumbing.ChainGetActorFromLatestState(ctx, addr)
+	act, err := plumbing.ActorGet(ctx, addr)
 	if err != nil {
 		if state.IsActorNotFoundError(err) {
 			// if the account doesn't exit, the balance should be zero

--- a/porcelain/wallet_test.go
+++ b/porcelain/wallet_test.go
@@ -14,10 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type walletTestPlumbing struct{}
+type walletTestPlumbing struct {
+	balance *types.AttoFIL
+}
 
 func (wtp *walletTestPlumbing) ChainGetActorFromLatestState(ctx context.Context, addr address.Address) (*actor.Actor, error) {
-	testActor := actor.NewActor(cid.Undef, types.NewAttoFILFromFIL(20))
+	testActor := actor.NewActor(cid.Undef, wtp.balance)
 	return testActor, nil
 }
 
@@ -27,9 +29,13 @@ func TestWalletBalance(t *testing.T) {
 		require := require.New(t)
 		ctx := context.Background()
 
-		balance, err := porcelain.WalletBalance(ctx, &walletTestPlumbing{}, address.Address{})
+		expectedBalance := types.NewAttoFILFromFIL(20)
+		plumbing := &walletTestPlumbing{
+			balance: expectedBalance,
+		}
+		balance, err := porcelain.WalletBalance(ctx, plumbing, address.Address{})
 		require.NoError(err)
 
-		assert.Equal(types.NewAttoFILFromFIL(20), balance)
+		assert.Equal(expectedBalance, balance)
 	})
 }

--- a/porcelain/wallet_test.go
+++ b/porcelain/wallet_test.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"gx/ipfs/QmNf3wujpV2Y7Lnj2hy2UrmuX8bhMDStRHbnSLh7Ypf36h/go-hamt-ipld"
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/porcelain"
-	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,14 +16,9 @@ import (
 
 type walletTestPlumbing struct{}
 
-func (wtp *walletTestPlumbing) ChainLatestState(ctx context.Context) (state.Tree, error) {
-	store := hamt.NewCborStore()
-	tree := state.NewEmptyStateTree(store)
-
+func (wtp *walletTestPlumbing) ChainGetActorFromLatestState(ctx context.Context, addr address.Address) (*actor.Actor, error) {
 	testActor := actor.NewActor(cid.Undef, types.NewAttoFILFromFIL(20))
-	tree.SetActor(ctx, address.Address{}, testActor)
-
-	return tree, nil
+	return testActor, nil
 }
 
 func TestWalletBalance(t *testing.T) {

--- a/porcelain/wallet_test.go
+++ b/porcelain/wallet_test.go
@@ -18,7 +18,7 @@ type walletTestPlumbing struct {
 	balance *types.AttoFIL
 }
 
-func (wtp *walletTestPlumbing) ChainGetActorFromLatestState(ctx context.Context, addr address.Address) (*actor.Actor, error) {
+func (wtp *walletTestPlumbing) ActorGet(ctx context.Context, addr address.Address) (*actor.Actor, error) {
 	testActor := actor.NewActor(cid.Undef, wtp.balance)
 	return testActor, nil
 }

--- a/porcelain/wallet_test.go
+++ b/porcelain/wallet_test.go
@@ -1,0 +1,42 @@
+package porcelain_test
+
+import (
+	"context"
+	"testing"
+
+	"gx/ipfs/QmNf3wujpV2Y7Lnj2hy2UrmuX8bhMDStRHbnSLh7Ypf36h/go-hamt-ipld"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+
+	"github.com/filecoin-project/go-filecoin/actor"
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/porcelain"
+	"github.com/filecoin-project/go-filecoin/state"
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type walletTestPlumbing struct{}
+
+func (wtp *walletTestPlumbing) ChainLatestState(ctx context.Context) (state.Tree, error) {
+	store := hamt.NewCborStore()
+	tree := state.NewEmptyStateTree(store)
+
+	testActor := actor.NewActor(cid.Undef, types.NewAttoFILFromFIL(20))
+	tree.SetActor(ctx, address.Address{}, testActor)
+
+	return tree, nil
+}
+
+func TestWalletBalance(t *testing.T) {
+	t.Run("Returns the correct value for wallet balance", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+		ctx := context.Background()
+
+		balance, err := porcelain.WalletBalance(ctx, &walletTestPlumbing{}, address.Address{})
+		require.NoError(err)
+
+		assert.Equal(types.NewAttoFILFromFIL(20), balance)
+	})
+}


### PR DESCRIPTION
# Problem

We don't want the node API to exist, and `Address().Balance()` is a small part of node API.

# Solution

Move `Address().Balance()`'s functionality to a porcelain method so we can move one step closer to killing the node.

Resolves #1797 