### PR TITLE
force symlink in copy_groth_params

### DIFF
--- a/scripts/copy-groth-params.sh
+++ b/scripts/copy-groth-params.sh
@@ -9,7 +9,7 @@ copy_groth_params() {
     echo "try rerunning 'go run ./build/*.go deps'"
     exit 1
   fi
-  ln -s ${params_file} params.out
+  ln -sf ${params_file} params.out
   popd
 }
 


### PR DESCRIPTION
currently, if the symlink already exists, it throws an error.
see https://github.com/filecoin-project/go-filecoin/issues/2013