### PR TITLE
follow `install-rust-proofs.sh` curl redirect

### DIFF
--- a/scripts/install-rust-proofs.sh
+++ b/scripts/install-rust-proofs.sh
@@ -6,7 +6,10 @@ install_precompiled() {
   RELEASE_NAME="rust-proofs-`uname`"
   RELEASE_TAG="${RELEASE_SHA1:0:16}"
 
-  RELEASE_RESPONSE=`curl "https://api.github.com/repos/filecoin-project/rust-proofs/releases/tags/$RELEASE_TAG"`
+  RELEASE_RESPONSE=`curl \
+    --location \
+    "https://api.github.com/repos/filecoin-project/rust-fil-proofs/releases/tags/$RELEASE_TAG"
+  `
 
   RELEASE_ID=`echo $RELEASE_RESPONSE | jq '.id'`
 


### PR DESCRIPTION
resolves: https://github.com/filecoin-project/go-filecoin/issues/2062

the `rust-proofs` rename to `rust-fil-proofs` causes a redirect for the initial curl to `    "https://api.github.com/repos/filecoin-project/rust-proofs/releases/tags/$RELEASE_TAG"
`

changed the repo name and added a `--location` to that curl anyways for the unlikely chance the repo name changes again