### PR TITLE
add command to track bandwidth usage

### DIFF
--- a/commands/main.go
+++ b/commands/main.go
@@ -113,6 +113,7 @@ NETWORK COMMANDS
   go-filecoin id                     - Show info about the network peers
   go-filecoin ping <peer ID>...      - Send echo request packets to p2p network members
   go-filecoin swarm                  - Interact with the swarm
+  go-filecoin stats                  - Monitor statistics on your network usage
 
 ACTOR COMMANDS
   go-filecoin actor                  - Interact with actors. Actors are built-in smart contracts.
@@ -168,6 +169,7 @@ var rootSubcmdsDaemon = map[string]*cmds.Command{
 	"ping":             pingCmd,
 	"retrieval-client": retrievalClientCmd,
 	"show":             showCmd,
+	"stats":            statsCmd,
 	"swarm":            swarmCmd,
 	"version":          versionCmd,
 	"wallet":           walletCmd,

--- a/commands/stats.go
+++ b/commands/stats.go
@@ -1,0 +1,28 @@
+package commands
+
+import (
+	"gx/ipfs/QmQtQrtNioesAWtrx8csBvfY37gTe94d6wQ3VikZUjxD39/go-ipfs-cmds"
+	"gx/ipfs/QmZZseAa9xcK6tT3YpaShNUAEpyRAoWmUL5ojH3uGNepAc/go-libp2p-metrics"
+	"gx/ipfs/Qmde5VP1qUkyQXKCfmEUA7bP64V2HAptbJ7phuPp7jXWwg/go-ipfs-cmdkit"
+)
+
+var statsCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "View various filecoin node statistics",
+	},
+	Subcommands: map[string]*cmds.Command{
+		"bandwidth": statsBandwidthCmd,
+	},
+}
+
+var statsBandwidthCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "View bandwidth usage metrics",
+	},
+	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+		bandwidthStats := GetPorcelainAPI(env).NetworkGetBandwidthStats()
+
+		return re.Emit(bandwidthStats)
+	},
+	Type: metrics.Stats{},
+}

--- a/commands/stats_daemon_test.go
+++ b/commands/stats_daemon_test.go
@@ -1,0 +1,20 @@
+package commands
+
+import (
+	"testing"
+
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+)
+
+func TestStatsBandwidth(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	d := th.NewDaemon(t).Start()
+	defer d.ShutdownSuccess()
+
+	stats := d.RunSuccess("stats", "bandwidth").ReadStdoutTrimNewlines()
+
+	assert.Equal("{\"TotalIn\":0,\"TotalOut\":0,\"RateIn\":0,\"RateOut\":0}", stats)
+}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -168,7 +168,7 @@ func TestNodeStartMining(t *testing.T) {
 		MsgQueryer:   msg.NewQueryer(minerNode.Repo, minerNode.Wallet, minerNode.ChainReader, minerNode.CborStore(), minerNode.Blockstore),
 		MsgSender:    msg.NewSender(minerNode.Wallet, minerNode.ChainReader, minerNode.MsgPool, validator, minerNode.PorcelainAPI.PubSubPublish),
 		MsgWaiter:    msg.NewWaiter(minerNode.ChainReader, minerNode.Blockstore, minerNode.CborStore()),
-		Network:      ntwk.New(minerNode.Host(), nil, nil, nil),
+		Network:      ntwk.New(minerNode.Host(), nil, nil, nil, nil),
 		SigGetter:    mthdsig.NewGetter(minerNode.ChainReader),
 		Wallet:       wallet.New(walletBackend),
 	})

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -6,6 +6,7 @@ import (
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	pstore "gx/ipfs/QmRhFARzTHcFh8wUxwN5KvyTGq73FLC65EfFAhz8Ng7aGb/go-libp2p-peerstore"
 	"gx/ipfs/QmTu65MVbemtUxJEWgsTtzv9Zv9P8rvmqNA4eG9TrTRGYc/go-libp2p-peer"
+	"gx/ipfs/QmZZseAa9xcK6tT3YpaShNUAEpyRAoWmUL5ojH3uGNepAc/go-libp2p-metrics"
 	logging "gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log"
 
 	"github.com/filecoin-project/go-filecoin/actor"
@@ -175,6 +176,11 @@ func (api *API) PubSubSubscribe(topic string) (pubsub.Subscription, error) {
 // PubSubPublish publishes a message to a topic on the filecoin network
 func (api *API) PubSubPublish(topic string, data []byte) error {
 	return api.network.Publish(topic, data)
+}
+
+// NetworkGetBandwidthStats gets stats on the current bandwidth usage of the network
+func (api *API) NetworkGetBandwidthStats() metrics.Stats {
+	return api.network.GetBandwidthStats()
 }
 
 // NetworkGetPeerID gets the current peer id from Util

--- a/plumbing/ntwk/ntwk.go
+++ b/plumbing/ntwk/ntwk.go
@@ -2,6 +2,7 @@ package ntwk
 
 import (
 	"gx/ipfs/QmTu65MVbemtUxJEWgsTtzv9Zv9P8rvmqNA4eG9TrTRGYc/go-libp2p-peer"
+	"gx/ipfs/QmZZseAa9xcK6tT3YpaShNUAEpyRAoWmUL5ojH3uGNepAc/go-libp2p-metrics"
 	"gx/ipfs/Qmd52WKRSwrBK5gUaJKawryZQ5by6UbNB8KVW2Zy6JtbyW/go-libp2p-host"
 
 	"github.com/filecoin-project/go-filecoin/filnet"
@@ -13,20 +14,33 @@ type Network struct {
 	host host.Host
 	*pubsub.Subscriber
 	*pubsub.Publisher
+	metrics.Reporter
 	*filnet.Router
 }
 
 // New returns a new Network
-func New(host host.Host, publisher *pubsub.Publisher, subscriber *pubsub.Subscriber, router *filnet.Router) *Network {
+func New(
+	host host.Host,
+	publisher *pubsub.Publisher,
+	subscriber *pubsub.Subscriber,
+	router *filnet.Router,
+	reporter metrics.Reporter,
+) *Network {
 	return &Network{
 		host:       host,
-		Subscriber: subscriber,
 		Publisher:  publisher,
+		Reporter:   reporter,
 		Router:     router,
+		Subscriber: subscriber,
 	}
 }
 
 // GetPeerID gets the current peer id from libp2p-host
 func (network *Network) GetPeerID() peer.ID {
 	return network.host.ID()
+}
+
+// GetBandwidthStats gets stats on the current bandwidth usage of the network
+func (network *Network) GetBandwidthStats() metrics.Stats {
+	return network.Reporter.GetBandwidthTotals()
 }


### PR DESCRIPTION
In working on figuring out why filecoin is using such an absurd amount of bandwidth (hint: it rhymes with fee age tree), i wrote this to expose libp2p bandwidth metrics.