### PR TITLE
force params.out symlink to filecoin-proof-parameters

### DIFF
--- a/Dockerfile.ci.filecoin
+++ b/Dockerfile.ci.filecoin
@@ -15,7 +15,7 @@ COPY --from=filecoin:all /tmp/tini /sbin/tini
 COPY --from=filecoin:all /tmp/jq /usr/local/bin/jq
 COPY --from=filecoin:all /etc/ssl/certs /etc/ssl/certs
 
-RUN ln -s /tmp/filecoin-proof-parameters/v9-zigzag-proof-of-replication-52431242c129794fe51d373ae29953f2ff52abd94c78756e318ce45f3e4946d8 /tmp/filecoin-proof-parameters/params.out
+RUN ln -sf /tmp/filecoin-proof-parameters/v9-zigzag-proof-of-replication-52431242c129794fe51d373ae29953f2ff52abd94c78756e318ce45f3e4946d8 /tmp/filecoin-proof-parameters/params.out
 # This shared lib (part of glibc) doesn't seem to be included with busybox.
 COPY --from=filecoin:all /lib/x86_64-linux-gnu/libdl-2.24.so /lib/libdl.so.2
 COPY --from=filecoin:all /lib/x86_64-linux-gnu/librt.so.1 /lib/librt.so.1


### PR DESCRIPTION
prevents docker build from throwing an error if symlink already exists.
also see https://github.com/filecoin-project/go-filecoin/issues/2013