### PR TITLE
Use bitswap sessions for block fetching

### DIFF
--- a/chain/store.go
+++ b/chain/store.go
@@ -67,7 +67,7 @@ type Store interface {
 	HasTipSetAndStatesWithParentsAndHeight(ctx context.Context, pTsKey string, h uint64) bool
 
 	// GetBlocks gets several blocks by cid. In the future there is caching here
-	GetBlocks(ctx context.Context, ids types.SortedCidSet) ([]*types.Block, error)
+	GetBlocks(ctx context.Context, cids types.SortedCidSet) ([]*types.Block, error)
 	// HasAllBlocks indicates whether the blocks are in the store.
 	HasAllBlocks(ctx context.Context, cs []cid.Cid) bool
 	HasBlock(ctx context.Context, c cid.Cid) bool

--- a/net/bootstrap.go
+++ b/net/bootstrap.go
@@ -14,7 +14,7 @@ import (
 	host "gx/ipfs/Qmd52WKRSwrBK5gUaJKawryZQ5by6UbNB8KVW2Zy6JtbyW/go-libp2p-host"
 )
 
-var log = logging.Logger("bootstrap")
+var logBootstrap = logging.Logger("net.bootstrap")
 
 // Bootstrapper attempts to keep the p2p host connected to the filecoin network
 // by keeping a minimum threshold of connections. If the threshold isn't met it
@@ -110,7 +110,7 @@ func (b *Bootstrapper) bootstrap(currentPeers []peer.ID) {
 			b.dhtBootStarted = true
 			err := b.r.Bootstrap(b.ctx)
 			if err != nil {
-				log.Warningf("got error trying to bootstrap DHT: %s. Peer discovery may suffer.", err.Error())
+				logBootstrap.Warningf("got error trying to bootstrap DHT: %s. Peer discovery may suffer.", err.Error())
 			}
 		}
 		cancel()
@@ -127,7 +127,7 @@ func (b *Bootstrapper) bootstrap(currentPeers []peer.ID) {
 		wg.Add(1)
 		go func() {
 			if err := b.h.Connect(ctx, pinfo); err != nil {
-				log.Errorf("got error trying to connect to bootstrap node %+v: %s", pinfo, err.Error())
+				logBootstrap.Errorf("got error trying to connect to bootstrap node %+v: %s", pinfo, err.Error())
 			}
 			wg.Done()
 		}()
@@ -136,7 +136,7 @@ func (b *Bootstrapper) bootstrap(currentPeers []peer.ID) {
 			return
 		}
 	}
-	log.Warningf("not enough bootstrap nodes to maintain %d connections (current connections: %d)", b.MinPeerThreshold, len(currentPeers))
+	logBootstrap.Warningf("not enough bootstrap nodes to maintain %d connections (current connections: %d)", b.MinPeerThreshold, len(currentPeers))
 }
 
 func hasPID(pids []peer.ID, pid peer.ID) bool {

--- a/net/fetcher.go
+++ b/net/fetcher.go
@@ -1,0 +1,57 @@
+package net
+
+import (
+	"context"
+	"fmt"
+
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
+	"gx/ipfs/QmWoXtvgC8inqFkAATB7cp2Dax7XBi9VDvSg9RCCZufmRk/go-block-format"
+	bserv "gx/ipfs/QmZsGVGCqMCNzHLNMB6q4F6yyvomqf1VxwhJwSfgo1NGaF/go-blockservice"
+
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// Fetcher is used to fetch data over the network.  It is implemented with
+// a persistent bitswap session on a networked blockservice.
+type Fetcher struct {
+	// session is a bitswap session that enables efficient transfer.
+	session *bserv.Session
+}
+
+// NewFetcher returns a Fetcher wired up to the input BlockService and a newly
+// initialized persistent session of the block service.
+func NewFetcher(ctx context.Context, bsrv bserv.BlockService) *Fetcher {
+	return &Fetcher{
+		session: bserv.NewSession(ctx, bsrv),
+	}
+}
+
+// GetBlocks fetches the blocks with the given cids from the network using the
+// Fetcher's bitswap session.
+func (f *Fetcher) GetBlocks(ctx context.Context, cids []cid.Cid) ([]*types.Block, error) {
+	var unsanitized []blocks.Block
+	for b := range f.session.GetBlocks(ctx, cids) {
+		unsanitized = append(unsanitized, b)
+	}
+
+	if len(unsanitized) < len(cids) {
+		var err error
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = errors.Wrap(ctxErr, "failed to fetch all requested blocks")
+		} else {
+			err = errors.New("failed to fetch all requested blocks")
+		}
+		return nil, err
+	}
+
+	var blocks []*types.Block
+	for _, u := range unsanitized {
+		block, err := types.DecodeBlock(u.RawData())
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("fetched data (cid %s) was not a block", u.Cid().String()))
+		}
+		blocks = append(blocks, block)
+	}
+	return blocks, nil
+}

--- a/net/fetcher_test.go
+++ b/net/fetcher_test.go
@@ -1,0 +1,81 @@
+package net_test
+
+import (
+	"context"
+	"testing"
+
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	ipld "gx/ipfs/QmRL22E4paat7ky7vx9MLpR97JHHbFPrg3ytFQw6qp1y1s/go-ipld-format"
+	bstore "gx/ipfs/QmRu7tiRnFk9mMPpVECQTBQJqXtmG132jJxA1w9A7TtpBz/go-ipfs-blockstore"
+	"gx/ipfs/QmSz8kAe2JCKp2dWSG8gHSWnwSmne8YfRXTeK5HBmc9L7t/go-ipfs-exchange-offline"
+	"gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
+	dss "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/sync"
+	bserv "gx/ipfs/QmZsGVGCqMCNzHLNMB6q4F6yyvomqf1VxwhJwSfgo1NGaF/go-blockservice"
+
+	"github.com/filecoin-project/go-filecoin/net"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+func requireBlockStorePut(require *require.Assertions, bs bstore.Blockstore, data ipld.Node) {
+	err := bs.Put(data)
+	require.NoError(err)
+}
+
+func TestFetchHappyPath(t *testing.T) {
+	require := require.New(t)
+	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
+	fetcher := net.NewFetcher(context.Background(), bserv.New(bs, offline.Exchange(bs)))
+	block1 := types.NewBlockForTest(nil, uint64(0))
+	block2 := types.NewBlockForTest(nil, uint64(1))
+	block3 := types.NewBlockForTest(nil, uint64(3))
+
+	requireBlockStorePut(require, bs, block1.ToNode())
+	requireBlockStorePut(require, bs, block2.ToNode())
+	requireBlockStorePut(require, bs, block3.ToNode())
+	originalCids := types.NewSortedCidSet(block1.Cid(), block2.Cid(), block3.Cid())
+
+	fetchedBlocks, err := fetcher.GetBlocks(context.Background(), originalCids.ToSlice())
+	require.NoError(err)
+	require.Equal(3, len(fetchedBlocks))
+	fetchedCids := types.NewSortedCidSet(
+		fetchedBlocks[0].Cid(),
+		fetchedBlocks[1].Cid(),
+		fetchedBlocks[2].Cid(),
+	)
+
+	require.True(originalCids.Equals(fetchedCids))
+}
+
+func TestFetchNoBlockFails(t *testing.T) {
+	require := require.New(t)
+	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
+	fetcher := net.NewFetcher(context.Background(), bserv.New(bs, offline.Exchange(bs)))
+	block1 := types.NewBlockForTest(nil, uint64(0))
+	block2 := types.NewBlockForTest(nil, uint64(1))
+
+	// do not add block2 to the bstore
+	requireBlockStorePut(require, bs, block1.ToNode())
+	cids := types.NewSortedCidSet(block1.Cid(), block2.Cid())
+
+	blocks, err := fetcher.GetBlocks(context.Background(), cids.ToSlice())
+	require.Error(err)
+	require.Nil(blocks)
+}
+
+func TestFetchNotBlockFormat(t *testing.T) {
+	require := require.New(t)
+	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
+	fetcher := net.NewFetcher(context.Background(), bserv.New(bs, offline.Exchange(bs)))
+	notABlock := types.NewMsgs(1)[0]
+	notABlockObj, err := notABlock.ToNode()
+	require.NoError(err)
+
+	requireBlockStorePut(require, bs, notABlockObj)
+	notABlockCid, err := notABlock.Cid()
+	require.NoError(err)
+
+	blocks, err := fetcher.GetBlocks(context.Background(), []cid.Cid{notABlockCid})
+	require.Error(err)
+	require.Nil(blocks)
+}

--- a/net/testing.go
+++ b/net/testing.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"testing"
 
 	ma "gx/ipfs/QmNTCey11oxhb1AxDnQBRHtdhap6Ctud872NjAYPYYXPuc/go-multiaddr"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	pstore "gx/ipfs/QmRhFARzTHcFh8wUxwN5KvyTGq73FLC65EfFAhz8Ng7aGb/go-libp2p-peerstore"
 	inet "gx/ipfs/QmTGxDz2CjBucFzPNTiWwzQmTWdrBnzqbqrMucDYMsjuPb/go-libp2p-net"
 	peer "gx/ipfs/QmTu65MVbemtUxJEWgsTtzv9Zv9P8rvmqNA4eG9TrTRGYc/go-libp2p-peer"
@@ -15,6 +17,8 @@ import (
 	ifconnmgr "gx/ipfs/QmcCk4LZRJPAKuwY9dusFea7LckELZgo5HagErTbm39o38/go-libp2p-interface-connmgr"
 	host "gx/ipfs/Qmd52WKRSwrBK5gUaJKawryZQ5by6UbNB8KVW2Zy6JtbyW/go-libp2p-host"
 	mh "gx/ipfs/QmerPMzPk1mJVowm8KgmoknWa4yCYvvugMPsgWmDNUvDLW/go-multihash"
+
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 // RandPeerID is a libp2p random peer ID generator.
@@ -86,3 +90,37 @@ func (fd *fakeDialer) Conns() []inet.Conn              { panic("not implemented"
 func (fd *fakeDialer) ConnsToPeer(peer.ID) []inet.Conn { panic("not implemented") }
 func (fd *fakeDialer) Notify(inet.Notifiee)            { panic("not implemented") }
 func (fd *fakeDialer) StopNotify(inet.Notifiee)        { panic("not implemented") }
+
+// TestFetcher is an object with the same method set as Fetcher plus a method
+// for adding blocks to the source.  It is used to implement an object that
+// behaves like Fetcher but does not go to the network for use in tests.
+type TestFetcher struct {
+	sourceBlocks map[string]*types.Block // sourceBlocks maps block cid strings to blocks.
+}
+
+// NewTestFetcher returns a TestFetcher with no source blocks.
+func NewTestFetcher() *TestFetcher {
+	return &TestFetcher{
+		sourceBlocks: make(map[string]*types.Block),
+	}
+}
+
+// AddSourceBlocks adds the input blocks to the fetcher source.
+func (f *TestFetcher) AddSourceBlocks(blocks ...*types.Block) {
+	for _, block := range blocks {
+		f.sourceBlocks[block.Cid().String()] = block
+	}
+}
+
+// GetBlocks returns any blocks in the source with matching cids.
+func (f *TestFetcher) GetBlocks(ctx context.Context, cids []cid.Cid) ([]*types.Block, error) {
+	var ret []*types.Block
+	for _, c := range cids {
+		if block, ok := f.sourceBlocks[c.String()]; ok {
+			ret = append(ret, block)
+		} else {
+			return nil, fmt.Errorf("failed to fetch block: %s", c.String())
+		}
+	}
+	return ret, nil
+}

--- a/node/block.go
+++ b/node/block.go
@@ -18,7 +18,7 @@ func (node *Node) AddNewBlock(ctx context.Context, b *types.Block) (err error) {
 	// Put block in storage wired to an exchange so this node and other
 	// nodes can fetch it.
 	log.Debugf("putting block in bitswap exchange: %s", b.Cid().String())
-	blkCid, err := node.OnlineStore.Put(ctx, b)
+	blkCid, err := node.cborStore.Put(ctx, b)
 	if err != nil {
 		return errors.Wrap(err, "could not add new block to online storage")
 	}

--- a/protocol/block/api.go
+++ b/protocol/block/api.go
@@ -28,7 +28,6 @@ type apiDeps struct {
 	addNewBlockFunc   func(context.Context, *types.Block) (err error)
 	blockStore        blockstore.Blockstore
 	cBorStore         *hamt.CborIpldStore
-	onlineStore       *hamt.CborIpldStore
 	chainReader       chain.ReadStore
 	consensusProtocol consensus.Protocol
 	blockTime         time.Duration
@@ -46,7 +45,7 @@ type apiDeps struct {
 func New(
 	addNewBlockFunc func(context.Context, *types.Block) (err error),
 	bstore blockstore.Blockstore,
-	cborStore, onlineStore *hamt.CborIpldStore,
+	cborStore *hamt.CborIpldStore,
 	chainReader chain.ReadStore,
 	con consensus.Protocol,
 	blockTime, blockMineDelay time.Duration,
@@ -62,7 +61,6 @@ func New(
 		addNewBlockFunc:   addNewBlockFunc,
 		blockStore:        bstore,
 		cBorStore:         cborStore,
-		onlineStore:       onlineStore,
 		chainReader:       chainReader,
 		consensusProtocol: con,
 		blockTime:         blockTime,

--- a/protocol/block/api_test.go
+++ b/protocol/block/api_test.go
@@ -62,7 +62,7 @@ func newAPI(t *testing.T, assert *ast.Assertions) (bapi.API, *node.Node) {
 	return bapi.New(
 		nd.AddNewBlock,
 		nd.Blockstore,
-		nd.CborStore(), nd.OnlineStore,
+		nd.CborStore(),
 		nd.ChainReader,
 		nd.Consensus,
 		bt, md,

--- a/types/message.go
+++ b/types/message.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	ipld "gx/ipfs/QmRL22E4paat7ky7vx9MLpR97JHHbFPrg3ytFQw6qp1y1s/go-ipld-format"
 	errPkg "gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
 	cbor "gx/ipfs/QmcZLyosDwMKdB6NLRsiss9HXzDPhVhhRtPy67JFKTDQDX/go-ipld-cbor"
 
@@ -48,10 +49,21 @@ func (msg *Message) Marshal() ([]byte, error) {
 	return cbor.DumpObject(msg)
 }
 
+// ToNode converts the Message to an IPLD node.
+func (msg *Message) ToNode() (ipld.Node, error) {
+	// Use 32 byte / 256 bit digest.
+	obj, err := cbor.WrapObject(msg, DefaultHashFunction, -1)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
 // Cid returns the canonical CID for the message.
 // TODO: can we avoid returning an error?
 func (msg *Message) Cid() (cid.Cid, error) {
-	obj, err := cbor.WrapObject(msg, DefaultHashFunction, -1)
+	obj, err := msg.ToNode()
 	if err != nil {
 		return cid.Undef, errPkg.Wrap(err, "failed to marshal to cbor")
 	}


### PR DESCRIPTION
did some refactoring and cleanup on the chain sync/store code to make it use bitswap sessions.

As currently written in master, we request every block from every person we are connected to, resulting in an obscene amount of bandwidth overhead. We need to fix that ASAP.

This PR improves it a bit, further improvements may be needed.