### PR TITLE
scope submodule update init to relevant subdirectories

### DIFF
--- a/scripts/install-bls-signatures.sh
+++ b/scripts/install-bls-signatures.sh
@@ -12,7 +12,7 @@ install_local() {
     exit 1
   fi
 
-  git submodule update --init --recursive
+  git submodule update --init --recursive bls-signatures
 
   pushd bls-signatures/bls-signatures
 

--- a/scripts/install-bls-signatures.sh
+++ b/scripts/install-bls-signatures.sh
@@ -12,7 +12,7 @@ install_local() {
     exit 1
   fi
 
-  git submodule update --init --recursive bls-signatures
+  git submodule update --init --recursive bls-signatures/bls-signatures
 
   pushd bls-signatures/bls-signatures
 

--- a/scripts/install-rust-fil-proofs.sh
+++ b/scripts/install-rust-fil-proofs.sh
@@ -56,7 +56,7 @@ install_local() {
     exit 1
   fi
 
-  git submodule update --init --recursive rust-fil-proofs
+  git submodule update --init --recursive proofs/rust-fil-proofs
 
   pushd proofs/rust-fil-proofs
 

--- a/scripts/install-rust-fil-proofs.sh
+++ b/scripts/install-rust-fil-proofs.sh
@@ -56,7 +56,7 @@ install_local() {
     exit 1
   fi
 
-  git submodule update --init --recursive
+  git submodule update --init --recursive rust-fil-proofs
 
   pushd proofs/rust-fil-proofs
 


### PR DESCRIPTION
Fixes #2081.

## Why's this PR needed?

The two install scripts `git submodule update init` _all_ submodules instead of the minimum required by the script.