### PR TITLE
Revert "rust: stop install script if anything fails"

### DIFF
--- a/scripts/install-rust-fil-proofs.sh
+++ b/scripts/install-rust-fil-proofs.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -e
 
 install_precompiled() {
   RELEASE_SHA1=`git rev-parse @:./proofs/rust-fil-proofs`


### PR DESCRIPTION
Closes https://github.com/filecoin-project/go-filecoin/issues/2083.

(Stopping the script is the right thing to do but I need to be more careful in checking how does that interact with the rest of the setup. Doing a quick revert now to unblock @laser, a better solution can be figured out later.)