### PR TITLE
Fix race in TestMessagePoolWait.

### DIFF
--- a/plumbing/ps/testing.go
+++ b/plumbing/ps/testing.go
@@ -17,10 +17,10 @@ type FakeSubscription struct {
 }
 
 // NewFakeSubscription builds a new fake subscription to a topic.
-func NewFakeSubscription(topic string) *FakeSubscription {
+func NewFakeSubscription(topic string, bufSize int) *FakeSubscription {
 	sub := &FakeSubscription{
 		topic:       topic,
-		pending:     make(chan *pubsub.Message),
+		pending:     make(chan *pubsub.Message, bufSize),
 		awaitCancel: sync.WaitGroup{},
 	}
 	sub.awaitCancel.Add(1)

--- a/porcelain/mpool_test.go
+++ b/porcelain/mpool_test.go
@@ -7,33 +7,37 @@ import (
 
 	"gx/ipfs/QmepvmmYNM6q4RaUiwEikQFhgMFHXg2PLhx2E9iaRd3jmS/go-libp2p-pubsub"
 
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+
 	"github.com/filecoin-project/go-filecoin/plumbing/msg"
 	"github.com/filecoin-project/go-filecoin/plumbing/ps"
 	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type fakeMpoolWaitPlumbing struct {
-	pending []*types.SignedMessage
-	subCh   chan *ps.FakeSubscription // Receives subscription as is it opened
+	pending            []*types.SignedMessage
+	subscription       *ps.FakeSubscription // Receives subscription as is it opened
+	afterPendingCalled func()               // Invoked after each call to MessagePoolPending
 }
 
-func newFakeMpoolWaitPlumbing() *fakeMpoolWaitPlumbing {
+func newFakeMpoolWaitPlumbing(onPendingCalled func()) *fakeMpoolWaitPlumbing {
 	return &fakeMpoolWaitPlumbing{
-		subCh: make(chan *ps.FakeSubscription, 1),
+		afterPendingCalled: onPendingCalled,
 	}
 }
 
 func (plumbing *fakeMpoolWaitPlumbing) MessagePoolPending() []*types.SignedMessage {
+	if plumbing.afterPendingCalled != nil {
+		defer plumbing.afterPendingCalled()
+	}
 	return plumbing.pending
 }
 
 func (plumbing *fakeMpoolWaitPlumbing) PubSubSubscribe(topic string, opts ...pubsub.SubOpt) (ps.Subscription, error) {
-	subscription := ps.NewFakeSubscription(msg.Topic)
-	plumbing.subCh <- subscription
-	close(plumbing.subCh)
+	subscription := ps.NewFakeSubscription(msg.Topic, 1)
+	plumbing.subscription = subscription
 	return subscription, nil
 }
 
@@ -46,7 +50,7 @@ func TestMessagePoolWait(t *testing.T) {
 
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
-		plumbing := newFakeMpoolWaitPlumbing()
+		plumbing := newFakeMpoolWaitPlumbing(nil)
 		msgs, e := porcelain.MessagePoolWait(context.Background(), plumbing, 0)
 		require.NoError(e)
 		assert.Equal(0, len(msgs))
@@ -54,7 +58,7 @@ func TestMessagePoolWait(t *testing.T) {
 
 	t.Run("returns immediates", func(t *testing.T) {
 		t.Parallel()
-		plumbing := newFakeMpoolWaitPlumbing()
+		plumbing := newFakeMpoolWaitPlumbing(nil)
 		plumbing.pending = types.NewSignedMsgs(3, signer)
 
 		msgs, e := porcelain.MessagePoolWait(context.Background(), plumbing, 3)
@@ -64,33 +68,65 @@ func TestMessagePoolWait(t *testing.T) {
 
 	t.Run("waits", func(t *testing.T) {
 		t.Parallel()
-		plumbing := newFakeMpoolWaitPlumbing()
 
-		wg := sync.WaitGroup{}
-		wg.Add(2)
+		var plumbing *fakeMpoolWaitPlumbing
+		callCount := 0
 
-		// Waits for subscription to be requested, then posts a message
-		go func() {
-			sub := <-plumbing.subCh
-			// First pubsub message doesn't affect the message pool.
-			// The waiter must wait longer.
-			sub.Post(nil)
+		// This callback to the MessagePoolPending plumbing orchestrates the appearance of
+		// pending messages and notifications on the pubsub subscription.
+		handlePendingCalled := func() {
+			if callCount == 0 {
+				// The first call is checking for the fast path; do nothing.
+			} else if callCount == 1 {
+				// Pubsub subscribed but not yet waited.
+				// Bump the pubsub but *don't* add to message pool; the waiter must wait longer.
+				plumbing.subscription.Post(nil)
+			} else if callCount == 2 {
+				// First pubsub bump processed.
+				// Add a message to the pool then bump pubsub again.
+				plumbing.pending = types.NewSignedMsgs(1, signer)
+				plumbing.subscription.Post(nil)
+			}
+			callCount += 1
+		}
 
-			// Add a message to the pool then bump the pubsub again.
-			plumbing.pending = types.NewSignedMsgs(1, signer)
-			sub.Post(nil)
+		plumbing = newFakeMpoolWaitPlumbing(handlePendingCalled)
+		finished := assertMessagePoolWaitAsync(plumbing, 1, require, assert)
 
-			sub.AwaitCancellation()
-			defer wg.Done()
-		}()
-
-		go func() {
-			msgs, e := porcelain.MessagePoolWait(context.Background(), plumbing, 1)
-			require.NoError(e)
-			assert.Equal(1, len(msgs))
-			defer wg.Done()
-		}()
-
-		wg.Wait()
+		finished.Wait()
+		plumbing.subscription.AwaitCancellation()
 	})
+
+	t.Run("message races pubsub", func(t *testing.T) {
+		t.Parallel()
+
+		var plumbing *fakeMpoolWaitPlumbing
+
+		handlePendingCalled := func() {
+			// The first call is checking for the fast path. It returns empty, but
+			// then a message appears, racing the pubsub subscription.
+			plumbing.pending = types.NewSignedMsgs(1, signer)
+		}
+
+		plumbing = newFakeMpoolWaitPlumbing(handlePendingCalled)
+		finished := assertMessagePoolWaitAsync(plumbing, 1, require, assert)
+
+		finished.Wait()
+		plumbing.subscription.AwaitCancellation()
+	})
+}
+
+// assertMessagePoolWaitAsync waits for msgCount messages asynchronously
+func assertMessagePoolWaitAsync(plumbing *fakeMpoolWaitPlumbing, msgCount uint, require *require.Assertions, assert *assert.Assertions) *sync.WaitGroup {
+	finished := sync.WaitGroup{}
+	finished.Add(1)
+
+	go func() {
+		msgs, e := porcelain.MessagePoolWait(context.Background(), plumbing, msgCount)
+		require.NoError(e)
+		assert.Equal(msgCount, uint(len(msgs)))
+		defer finished.Done()
+	}()
+
+	return &finished
 }


### PR DESCRIPTION
Inspired by @travisperson's [patch](https://gist.github.com/travisperson/58535622ee84517fb4b5cb77495ef9f0). This resolves a race to post the second pubsub message (to an unbuffered channel) against inspection of `MessagePoolPending` and polling the first message from that channel. Also adds another test exercising a second possible interleaving.

Closes #2059. Obviates #2088.

@acruikshank please commandeer/merge immediately so we can un-flake the tests if this looks ok to you. cc @phritz in case you want to review and merge before AC starts work.