### PR TITLE
Move core.OrderMessagesByNonce to mining.SelectMessagesForBlock and simplify tests.

### DIFF
--- a/core/message_pool.go
+++ b/core/message_pool.go
@@ -2,14 +2,14 @@ package core
 
 import (
 	"context"
-	"sort"
 	"sync"
 
-	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/types"
 	"gx/ipfs/QmNf3wujpV2Y7Lnj2hy2UrmuX8bhMDStRHbnSLh7Ypf36h/go-hamt-ipld"
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 // MessagePool keeps an unordered, de-duplicated set of Messages and supports removal by CID.
@@ -220,26 +220,6 @@ func UpdateMessagePool(ctx context.Context, pool *MessagePool, store *hamt.CborI
 	}
 
 	return nil
-}
-
-// OrderMessagesByNonce returns the pending messages in the
-// pool ordered such that all messages with the same msg.From
-// occur in Nonce order in the slice.
-// TODO can be smarter here by skipping messages with gaps; see
-//      ethereum's abstraction for example
-// TODO order by time of receipt
-func OrderMessagesByNonce(messages []*types.SignedMessage) []*types.SignedMessage {
-	// TODO this could all be more efficient.
-	byAddress := make(map[address.Address][]*types.SignedMessage)
-	for _, m := range messages {
-		byAddress[m.From] = append(byAddress[m.From], m)
-	}
-	messages = messages[:0]
-	for _, msgs := range byAddress {
-		sort.Slice(msgs, func(i, j int) bool { return msgs[i].Nonce < msgs[j].Nonce })
-		messages = append(messages, msgs...)
-	}
-	return messages
 }
 
 // LargestNonce returns the largest nonce used by a message from address in the pool.

--- a/core/message_pool_test.go
+++ b/core/message_pool_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	hamt "gx/ipfs/QmNf3wujpV2Y7Lnj2hy2UrmuX8bhMDStRHbnSLh7Ypf36h/go-hamt-ipld"
-
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 
@@ -397,61 +396,6 @@ func TestUpdateMessagePool(t *testing.T) {
 
 		UpdateMessagePool(ctx, p, store, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p)
-	})
-}
-
-func TestOrderMessagesByNonce(t *testing.T) {
-	t.Run("Empty pool", func(t *testing.T) {
-		assert := assert.New(t)
-		p := NewMessagePool()
-		ordered := OrderMessagesByNonce(p.Pending())
-		assert.Equal(0, len(ordered))
-	})
-
-	t.Run("Msgs in three orders", func(t *testing.T) {
-		assert := assert.New(t)
-		require := require.New(t)
-		p := NewMessagePool()
-
-		m := types.NewMsgsWithAddrs(9, mockSigner.Addresses)
-
-		// Three in increasing nonce order.
-		m[3].From = m[0].From
-		m[6].From = m[0].From
-		m[0].Nonce = 0
-		m[3].Nonce = 1
-		m[6].Nonce = 20
-
-		// Three in decreasing nonce order.
-		m[4].From = m[1].From
-		m[7].From = m[1].From
-		m[1].Nonce = 15
-		m[4].Nonce = 1
-		m[7].Nonce = 0
-
-		// Three out of order.
-		m[5].From = m[2].From
-		m[8].From = m[2].From
-		m[2].Nonce = 5
-		m[5].Nonce = 7
-		m[8].Nonce = 0
-
-		sm, err := types.SignMsgs(mockSigner, m)
-		require.NoError(err)
-
-		MustAdd(p, sm...)
-
-		ordered := OrderMessagesByNonce(p.Pending())
-		assert.Equal(len(p.Pending()), len(ordered))
-
-		lastSeen := make(map[address.Address]uint64)
-		for _, m := range ordered {
-			last, seen := lastSeen[m.From]
-			if seen {
-				assert.True(last <= uint64(m.Nonce))
-			}
-			lastSeen[m.From] = uint64(m.Nonce)
-		}
 	})
 }
 

--- a/mining/block_generate_test.go
+++ b/mining/block_generate_test.go
@@ -1,0 +1,73 @@
+package mining
+
+import (
+	"testing"
+
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+func TestSelectMessagesForBlock(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var seed = types.GenerateKeyInfoSeed()
+	var ki = types.MustGenerateKeyInfo(10, seed)
+	var mockSigner = types.NewMockSigner(ki)
+
+	a0 := mockSigner.Addresses[0]
+	a1 := mockSigner.Addresses[2]
+	a2 := mockSigner.Addresses[3]
+	to := mockSigner.Addresses[9]
+
+	sign := func(from address.Address, to address.Address, nonce uint64, units uint64, price int64) *types.SignedMessage {
+		msg := types.Message{
+			From:  from,
+			To:    to,
+			Nonce: types.Uint64(nonce),
+		}
+		s, err := types.NewSignedMessage(msg, &mockSigner, types.NewGasPrice(price), types.NewGasUnits(units))
+		require.NoError(err)
+		return s
+	}
+
+	t.Run("empty", func(t *testing.T) {
+		ordered := SelectMessagesForBlock([]*types.SignedMessage{})
+		assert.Equal(0, len(ordered))
+	})
+
+	t.Run("orders by nonce", func(t *testing.T) {
+		msgs := []*types.SignedMessage{
+			// Msgs from a0 are in increasing order.
+			// Msgs from a1 are in decreasing order.
+			// Msgs from a2 are out of order.
+			// Messages from different signers are interleaved.
+			sign(a0, to, 0, 0, 0),
+			sign(a1, to, 15, 0, 0),
+			sign(a2, to, 5, 0, 0),
+
+			sign(a0, to, 1, 0, 0),
+			sign(a1, to, 2, 0, 0),
+			sign(a2, to, 7, 0, 0),
+
+			sign(a0, to, 20, 0, 0),
+			sign(a1, to, 1, 0, 0),
+			sign(a2, to, 1, 0, 0),
+		}
+
+		ordered := SelectMessagesForBlock(msgs)
+		assert.Equal(len(msgs), len(ordered))
+
+		lastFromAddr := make(map[address.Address]uint64)
+		for _, m := range ordered {
+			last, seen := lastFromAddr[m.From]
+			if seen {
+				assert.True(last <= uint64(m.Nonce))
+			}
+			lastFromAddr[m.From] = uint64(m.Nonce)
+		}
+	})
+}


### PR DESCRIPTION
This is a prefactor for work on #1751 ordering by gas price. I've moved OrderMessagesByNonce next to its only caller.

In the long term, we may want to move sophisticated message queueing inside the messages pool, but until performance requires it, let's keep the pool simple.