### PR TITLE
correctly export wallet data

### DIFF
--- a/api/address.go
+++ b/api/address.go
@@ -13,7 +13,7 @@ import (
 // Address is the interface that defines methods to manage Filecoin addresses and wallets.
 type Address interface {
 	Addrs() Addrs
-	Import(ctx context.Context, f files.Directory) ([]address.Address, error)
+	Import(ctx context.Context, f files.File) ([]address.Address, error)
 	Export(ctx context.Context, addrs []address.Address) ([]*types.KeyInfo, error)
 }
 

--- a/api/impl/address.go
+++ b/api/impl/address.go
@@ -32,6 +32,11 @@ func (api *nodeAddress) Addrs() api.Addrs {
 	return api.addrs
 }
 
+// WalletSerializeResult is the type wallet export and import return and expect.
+type WalletSerializeResult struct {
+	KeyInfo []*types.KeyInfo
+}
+
 type nodeAddrs struct {
 	api *nodeAPI
 }
@@ -115,13 +120,8 @@ func (api *nodeAddress) Export(ctx context.Context, addrs []address.Address) ([]
 	return out, nil
 }
 
-// WalletImportResult is the structure used to hold imported wallet data.
-type WalletImportResult struct {
-	KeyInfo []*types.KeyInfo
-}
-
 func parseKeyInfos(f files.File) ([]*types.KeyInfo, error) {
-	var wir *WalletImportResult
+	var wir *WalletSerializeResult
 	if err := json.NewDecoder(f).Decode(&wir); err != nil {
 		return nil, err
 	}

--- a/commands/address.go
+++ b/commands/address.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"gx/ipfs/QmQmhotPUzVrMEWNK3x1R5jQ5ZHWyL7tVUrmRPjrBrvyCb/go-ipfs-files"
 	"gx/ipfs/QmQtQrtNioesAWtrx8csBvfY37gTe94d6wQ3VikZUjxD39/go-ipfs-cmds"
 	"gx/ipfs/Qmde5VP1qUkyQXKCfmEUA7bP64V2HAptbJ7phuPp7jXWwg/go-ipfs-cmdkit"
 
@@ -142,7 +143,17 @@ var walletImportCmd = &cmds.Command{
 		cmdkit.FileArg("walletFile", true, false, "File containing wallet data to import").EnableStdin(),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
-		addrs, err := GetAPI(env).Address().Import(req.Context, req.Files)
+		iter := req.Files.Entries()
+		if !iter.Next() {
+			return fmt.Errorf("no file given: %s", iter.Err())
+		}
+
+		fi, ok := iter.Node().(files.File)
+		if !ok {
+			return fmt.Errorf("given file was not a files.File")
+		}
+
+		addrs, err := GetAPI(env).Address().Import(req.Context, fi)
 		if err != nil {
 			return err
 		}

--- a/commands/address.go
+++ b/commands/address.go
@@ -9,6 +9,7 @@ import (
 	"gx/ipfs/Qmde5VP1qUkyQXKCfmEUA7bP64V2HAptbJ7phuPp7jXWwg/go-ipfs-cmdkit"
 
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/api/impl"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -179,11 +180,6 @@ var walletImportCmd = &cmds.Command{
 	},
 }
 
-// WalletExportResult is the resut of running the wallet export command.
-type WalletExportResult struct {
-	KeyInfo []*types.KeyInfo
-}
-
 var walletExportCmd = &cmds.Command{
 	Arguments: []cmdkit.Argument{
 		cmdkit.StringArg("addresses", true, true, "Addresses of keys to export").EnableStdin(),
@@ -203,14 +199,14 @@ var walletExportCmd = &cmds.Command{
 			return err
 		}
 
-		var klr WalletExportResult
+		var klr impl.WalletSerializeResult
 		klr.KeyInfo = append(klr.KeyInfo, kis...)
 
 		return re.Emit(klr)
 	},
-	Type: &WalletExportResult{},
+	Type: &impl.WalletSerializeResult{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, klr *WalletExportResult) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, klr *impl.WalletSerializeResult) error {
 			for _, k := range klr.KeyInfo {
 				a, err := k.Address()
 				if err != nil {

--- a/gengen/main.go
+++ b/gengen/main.go
@@ -27,7 +27,7 @@ func writeKey(ki *types.KeyInfo, name string, jsonout bool) error {
 	}
 	defer fi.Close() // nolint: errcheck
 
-	var wir fcapi.WalletImportResult
+	var wir fcapi.WalletSerializeResult
 	wir.KeyInfo = append(wir.KeyInfo, ki)
 
 	return json.NewEncoder(fi).Encode(wir)

--- a/gengen/main.go
+++ b/gengen/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	fcapi "github.com/filecoin-project/go-filecoin/api/impl"
 	gengen "github.com/filecoin-project/go-filecoin/gengen/util"
 	"github.com/filecoin-project/go-filecoin/types"
 )
@@ -26,7 +27,10 @@ func writeKey(ki *types.KeyInfo, name string, jsonout bool) error {
 	}
 	defer fi.Close() // nolint: errcheck
 
-	return json.NewEncoder(fi).Encode(ki)
+	var wir fcapi.WalletImportResult
+	wir.KeyInfo = append(wir.KeyInfo, ki)
+
+	return json.NewEncoder(fi).Encode(wir)
 }
 
 /* gengen takes as input a json encoded 'Genesis Config'

--- a/testhelpers/iptbtester/genesis.go
+++ b/testhelpers/iptbtester/genesis.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"testing"
 
+	fcapi "github.com/filecoin-project/go-filecoin/api/impl"
 	gengen "github.com/filecoin-project/go-filecoin/gengen/util"
 )
 
@@ -55,12 +56,13 @@ func MustGenerateGenesis(t *testing.T, funds int64, dir string) *GenesisInfo {
 		t.Fatal(err)
 	}
 
-	key := info.Keys[0]
-	if err := json.NewEncoder(keyfile).Encode(key); err != nil {
+	var wsr fcapi.WalletSerializeResult
+	wsr.KeyInfo = append(wsr.KeyInfo, info.Keys[0])
+	if err := json.NewEncoder(keyfile).Encode(wsr); err != nil {
 		t.Fatal(err)
 	}
 
-	walletAddr, err := key.Address()
+	walletAddr, err := info.Keys[0].Address()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/fast/action_wallet.go
+++ b/tools/fast/action_wallet.go
@@ -7,6 +7,7 @@ import (
 	"gx/ipfs/QmQmhotPUzVrMEWNK3x1R5jQ5ZHWyL7tVUrmRPjrBrvyCb/go-ipfs-files"
 
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/api/impl"
 	"github.com/filecoin-project/go-filecoin/commands"
 	"github.com/filecoin-project/go-filecoin/types"
 )
@@ -45,7 +46,7 @@ func (f *Filecoin) WalletImport(ctx context.Context, file files.File) ([]address
 // WalletExport run the wallet export command against the filecoin process.
 func (f *Filecoin) WalletExport(ctx context.Context, addrs []address.Address) ([]*types.KeyInfo, error) {
 	// the command returns an KeyInfoListResult
-	var klr commands.WalletExportResult
+	var klr impl.WalletSerializeResult
 	// we expect to interact with an array of KeyInfo(s)
 	var out []*types.KeyInfo
 	var sAddrs []string


### PR DESCRIPTION
### Whats this?

This PR aligns the type `go-filecoin wallet export --enc=json` returns and the type `go-filecoin wallet import` expects. 

#2024 was caused by the `export` command returning:
`{"privateKey":"xVHXgLfpcJ6kisQONRelKHA5DuY+cpIvTTK9K3utxDI=","curve":"secp256k1"}`

And the `import` command expexting:
`{"KeyInfo":[{"privateKey":"xVHXgLfpcJ6kisQONRelKHA5DuY+cpIvTTK9K3utxDI=","curve":"secp256k1"}]}`

closes #2024