### PR TITLE
Bug/docker build gen gen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,6 +340,10 @@ jobs:
       - run: git submodule update --init
 
       - run:
+          name: Generate fixtures
+          command: go build -o ./gengen/gengen ./gengen
+
+      - run:
           name: build an image of all binaries
           command: |
             docker build -t filecoin:all --target=base --file Dockerfile.ci.base .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,6 +251,7 @@ jobs:
           paths:
             - "filecoin-Linux.tar.gz"
             - "gengen/gengen"
+            - "fixtures"
 
   publish_release:
     docker:
@@ -338,10 +339,6 @@ jobs:
 
       # Pull in all submodules (inc. rust-fil-proofs)
       - run: git submodule update --init
-
-      - run:
-          name: Generate fixtures
-          command: go build -o ./gengen/gengen ./gengen
 
       - run:
           name: build an image of all binaries

--- a/Dockerfile.ci.genesis
+++ b/Dockerfile.ci.genesis
@@ -3,6 +3,7 @@ MAINTAINER Filecoin Dev Team
 
 # Get the binary, entrypoint script, and TLS CAs from the build container.
 COPY genesis-file-server /usr/local/bin/genesis-file-server
+COPY fixtures/* /data/
 COPY --from=filecoin:all /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=filecoin:all /tmp/tini /sbin/tini
 COPY --from=filecoin:all /etc/ssl/certs /etc/ssl/certs


### PR DESCRIPTION
Generates and adds missing fixtures in CI.

Copies fixtures to `genesis` image, to remedy error encountered in nightly devnet deploy
```sh
cp: can't stat '/data/genesis.car': No such file or directory
```

The proper fixtures will also get added to `filecoin` image without any additional changes to Dockerfile.ci.filecoin