### PR TITLE
Add mpool show command to show an unmined message detail.

### DIFF
--- a/commands/mpool.go
+++ b/commands/mpool.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io"
+	"strconv"
 
 	"gx/ipfs/QmQtQrtNioesAWtrx8csBvfY37gTe94d6wQ3VikZUjxD39/go-ipfs-cmds"
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
@@ -17,8 +19,9 @@ var mpoolCmd = &cmds.Command{
 		Tagline: "Manage the message pool",
 	},
 	Subcommands: map[string]*cmds.Command{
-		"ls": mpoolLsCmd,
-		"rm": mpoolRemoveCmd,
+		"ls":   mpoolLsCmd,
+		"show": mpoolShowCmd,
+		"rm":   mpoolRemoveCmd,
 	},
 }
 
@@ -47,9 +50,57 @@ var mpoolLsCmd = &cmds.Command{
 				if err != nil {
 					return err
 				}
-				fmt.Fprintln(w, c.String()) // nolint: errcheck
+				_ = PrintString(w, c)
 			}
 			return nil
+		}),
+	},
+}
+
+var mpoolShowCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Show content of an outstanding message",
+	},
+	Arguments: []cmdkit.Argument{
+		cmdkit.StringArg("cid", true, false, "The CID of the message to show"),
+	},
+	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+		msgCid, err := cid.Parse(req.Arguments[0])
+		if err != nil {
+			return errors.Wrap(err, "invalid message cid")
+		}
+
+		msg, ok := GetPorcelainAPI(env).MessagePoolGet(msgCid)
+		if !ok {
+			return fmt.Errorf("message %s not found in pool (already mined?)", msgCid)
+		}
+		return re.Emit(msg)
+	},
+	Type: &types.SignedMessage{},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, msg *types.SignedMessage) error {
+			_, err := fmt.Fprintf(w, `Message Details
+To:        %s
+From:      %s
+Nonce:     %s
+Value:     %s
+Method:    %s
+Params:    %s
+Gas price: %s
+Gas limit: %s
+Signature: %s
+`,
+				msg.To,
+				msg.From,
+				strconv.FormatUint(uint64(msg.Nonce), 10),
+				msg.Value,
+				msg.Method,
+				base64.StdEncoding.EncodeToString(msg.Params),
+				msg.GasPrice.String(),
+				strconv.FormatUint(uint64(msg.GasLimit), 10),
+				base64.StdEncoding.EncodeToString(msg.Signature),
+			)
+			return err
 		}),
 	},
 }

--- a/commands/mpool_daemon_test.go
+++ b/commands/mpool_daemon_test.go
@@ -70,6 +70,40 @@ func TestMpoolLs(t *testing.T) {
 	})
 }
 
+func TestMpoolShow(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	t.Run("shows message", func(t *testing.T) {
+		t.Parallel()
+		d := th.NewDaemon(t, th.KeyFile(fixtures.KeyFilePaths()[0])).Start()
+		defer d.ShutdownSuccess()
+
+		msgCid := d.RunSuccess("message", "send",
+			"--from", fixtures.TestAddresses[0],
+			"--price", "0", "--limit", "300",
+			"--value=10", fixtures.TestAddresses[2],
+		).ReadStdoutTrimNewlines()
+
+		out := d.RunSuccess("mpool", "show", msgCid).ReadStdoutTrimNewlines()
+
+		assert.Contains(out, "From:      "+fixtures.TestAddresses[0])
+		assert.Contains(out, "To:        "+fixtures.TestAddresses[2])
+		assert.Contains(out, "Value:     10")
+	})
+
+	t.Run("fails missing message", func(t *testing.T) {
+		t.Parallel()
+		d := th.NewDaemon(t, th.KeyFile(fixtures.KeyFilePaths()[0])).Start()
+		defer d.ShutdownSuccess()
+
+		const c = "QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw"
+
+		out := d.RunFail("not found", "mpool", "show", c).ReadStderr()
+		assert.Contains(out, c)
+	})
+}
+
 func TestMpoolRm(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)

--- a/core/message_pool.go
+++ b/core/message_pool.go
@@ -56,6 +56,17 @@ func (pool *MessagePool) Pending() []*types.SignedMessage {
 	return out
 }
 
+// Get retrieves a message from the pool by CID.
+func (pool *MessagePool) Get(c cid.Cid) (value *types.SignedMessage, ok bool) {
+	pool.lk.Lock()
+	defer pool.lk.Unlock()
+	value, ok = pool.pending[c]
+	if ok && value == nil {
+		panic("Found nil message for CID " + c.String())
+	}
+	return
+}
+
 // Remove removes the message by CID from the pending pool.
 func (pool *MessagePool) Remove(c cid.Cid) {
 	pool.lk.Lock()

--- a/core/message_pool_test.go
+++ b/core/message_pool_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	hamt "gx/ipfs/QmNf3wujpV2Y7Lnj2hy2UrmuX8bhMDStRHbnSLh7Ypf36h/go-hamt-ipld"
+	"gx/ipfs/QmNf3wujpV2Y7Lnj2hy2UrmuX8bhMDStRHbnSLh7Ypf36h/go-hamt-ipld"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 
@@ -32,12 +32,23 @@ func TestMessagePoolAddRemove(t *testing.T) {
 	assert.NoError(err)
 
 	assert.Len(pool.Pending(), 0)
+	m, ok := pool.Get(c1)
+	assert.Nil(m)
+	assert.False(ok)
+
 	_, err = pool.Add(msg1)
 	assert.NoError(err)
 	assert.Len(pool.Pending(), 1)
 	_, err = pool.Add(msg2)
 	assert.NoError(err)
 	assert.Len(pool.Pending(), 2)
+
+	m, ok = pool.Get(c1)
+	assert.Equal(msg1, m)
+	assert.True(ok)
+	m, ok = pool.Get(c2)
+	assert.Equal(msg2, m)
+	assert.True(ok)
 
 	pool.Remove(c1)
 	assert.Len(pool.Pending(), 1)
@@ -55,6 +66,11 @@ func TestMessagePoolAddBadSignature(t *testing.T) {
 	c, err := pool.Add(smsg)
 	assert.False(c.Defined())
 	assert.Error(err)
+
+	c, _ = smsg.Cid()
+	m, ok := pool.Get(c)
+	assert.Nil(m)
+	assert.False(ok)
 }
 
 func TestMessagePoolDedup(t *testing.T) {

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -120,12 +120,17 @@ func (api *API) BlockGet(ctx context.Context, id cid.Cid) (*types.Block, error) 
 	return api.chain.GetBlock(ctx, id)
 }
 
-// MessagePoolPending lists messages un-mined in the pool
+// MessagePoolPending lists messages in the pool.
 func (api *API) MessagePoolPending() []*types.SignedMessage {
 	return api.msgPool.Pending()
 }
 
-// MessagePoolRemove removes a message from the message pool
+// MessagePoolGet fetches a message from the pool.
+func (api *API) MessagePoolGet(cid cid.Cid) (value *types.SignedMessage, ok bool) {
+	return api.msgPool.Get(cid)
+}
+
+// MessagePoolRemove removes a message from the message pool.
 func (api *API) MessagePoolRemove(cid cid.Cid) {
 	api.msgPool.Remove(cid)
 }


### PR DESCRIPTION
I emulated the output format from `block show`.

```Message Details
To:        fcqp606qfk5gwmq6ac24g4mhv3cr8zzf67vqkpulh
From:      fcq6k3r52n89c0m0nd8sm8cf27srpgephkqkrc9nj
Nonce:     102
Value:     100000
Method:    createChannel
Params:    glYAANrn4y/rt8o+bnah3odFEv661KJWQ+KXAg==
Gas price: 0
Gas limit: 300
Signature: Pzn2NWyHjcO7gc4denBVC64nBb/n7otlEmyyC2g1vHJhM3yufdVl07FmCugC4mQihu5302vxU3SPU3eBDKI5xgA=

Message Details
To:        fcq423mk77skf2tg2542ku6skje9859ecu3z7dmha
From:      fcqunwslgsaa52xuqxlxvpx4km8h2erprz9trc4l3
Nonce:     2
Value:     0
Method:
Params:
Gas price: 1000
Gas limit: 1000
Signature: U3V2tqwZfa5KxH//GdapekmG5icglvddij7S0yR20iVGWGMfbo3hpo8LVbwJcmXe9sj+jpI5bvZSzon427alGgE=
```
Params are "too hard" to decode here without more work. My understanding is that decoding them requires knowledge of the expected schema–it's not self-describing.

Closes #1933 (see also #2053).