### PR TITLE
Pay miner owner instead of miner

### DIFF
--- a/api/impl/mining.go
+++ b/api/impl/mining.go
@@ -58,6 +58,10 @@ func (api *nodeMining) Once(ctx context.Context) (*types.Block, error) {
 		return nil, err
 	}
 	miningAddr := miningAddrIf.(address.Address)
+	miningOwnerAddr, err := nd.PorcelainAPI.MinerGetOwnerAddress(ctx, miningAddr)
+	if err != nil {
+		return nil, err
+	}
 
 	blockSignerAddrIf, err := nd.PorcelainAPI.ConfigGet("mining.blockSignerAddress")
 	if err != nil {
@@ -69,7 +73,7 @@ func (api *nodeMining) Once(ctx context.Context) (*types.Block, error) {
 		return chain.GetRecentAncestors(ctx, ts, nd.ChainReader, newBlockHeight, consensus.AncestorRoundsNeeded, consensus.LookBackParameter)
 	}
 	worker := mining.NewDefaultWorker(nd.MsgPool, getState, getWeight, getAncestors, consensus.NewDefaultProcessor(),
-		nd.PowerTable, nd.Blockstore, nd.CborStore(), miningAddr, blockSignerAddr, nd.Wallet, blockTime)
+		nd.PowerTable, nd.Blockstore, nd.CborStore(), miningAddr, miningOwnerAddr, blockSignerAddr, nd.Wallet, blockTime)
 
 	res, err := mining.MineOnce(ctx, worker, mineDelay, ts)
 	if err != nil {

--- a/chain/default_store_test.go
+++ b/chain/default_store_test.go
@@ -28,7 +28,7 @@ func initStoreTest(ctx context.Context, require *require.Assertions) {
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := hamt.NewCborStore()
 	con := consensus.NewExpected(cst, bs, testhelpers.NewTestProcessor(), powerTable, genCid, proofs.NewFakeVerifier(true, nil))
-	initSyncTest(require, con, consensus.InitGenesis, cst, bs, r)
+	initSyncTest(require, con, initGenesis, cst, bs, r)
 	requireSetTestChain(require, con, true)
 }
 
@@ -303,7 +303,7 @@ func TestLatestState(t *testing.T) {
 
 	// Call init genesis again to load genesis state into cbor store.
 	// This is required for the chain to access the state in the cbor store.
-	_, err = consensus.InitGenesis(cst, bs)
+	_, err = initGenesis(cst, bs)
 	require.NoError(err)
 
 	assertSetHead(assert, chain, genTS)

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -94,13 +94,12 @@ func MkFakeChildCore(parent types.TipSet,
 
 	pIDs := parent.ToSortedCidSet()
 
-	newBlock := th.NewValidTestBlockFromTipSet(parent, height, minerAddress)
+	newBlock := th.NewValidTestBlockFromTipSet(parent, stateRoot, height, minerAddress)
 
 	// Override fake values with our values
 	newBlock.Parents = pIDs
 	newBlock.ParentWeight = types.Uint64(w)
 	newBlock.Nonce = types.Uint64(nonce)
-	newBlock.StateRoot = stateRoot
 
 	return newBlock, nil
 }

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -333,7 +333,7 @@ func TestMinerCreateChargesGas(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	miningMinerAddr, err := address.NewFromString(fixtures.TestMiners[0])
+	miningMinerOwnerAddr, err := address.NewFromString(fixtures.TestAddresses[0])
 	require.NoError(err)
 
 	d1 := th.NewDaemon(t, th.WithMiner(fixtures.TestMiners[0]), th.KeyFile(fixtures.KeyFilePaths()[2])).Start()
@@ -343,8 +343,8 @@ func TestMinerCreateChargesGas(t *testing.T) {
 	d1.ConnectSuccess(d)
 	var wg sync.WaitGroup
 
-	// make sure the FIL shows up in the MinerAccount
-	startingBalance := queryBalance(t, d, miningMinerAddr)
+	// make sure the FIL shows up in the MinerOwnerAccount
+	startingBalance := queryBalance(t, d, miningMinerOwnerAddr)
 
 	wg.Add(1)
 	go func() {
@@ -362,7 +362,7 @@ func TestMinerCreateChargesGas(t *testing.T) {
 	expectedPrice := types.NewAttoFILFromFIL(333)
 	expectedGasCost := big.NewInt(100)
 	expectedBalance := expectedBlockReward.Add(expectedPrice.MulBigInt(expectedGasCost))
-	newBalance := queryBalance(t, d, miningMinerAddr)
+	newBalance := queryBalance(t, d, miningMinerOwnerAddr)
 	assert.Equal(expectedBalance.String(), newBalance.Sub(startingBalance).String())
 }
 

--- a/commands/mining_daemon_test.go
+++ b/commands/mining_daemon_test.go
@@ -23,7 +23,7 @@ func TestMiningGenBlock(t *testing.T) {
 	d := th.NewDaemon(t, th.WithMiner(fixtures.TestMiners[0]), th.KeyFile(fixtures.KeyFilePaths()[0])).Start()
 	defer d.ShutdownSuccess()
 
-	addr := fixtures.TestMiners[0]
+	addr := fixtures.TestAddresses[0]
 
 	s := d.RunSuccess("wallet", "balance", addr)
 	beforeBalance := parseInt(assert, s.ReadStdout())
@@ -34,5 +34,5 @@ func TestMiningGenBlock(t *testing.T) {
 	afterBalance := parseInt(assert, s.ReadStdout())
 	sum := new(big.Int)
 
-	assert.True(sum.Add(beforeBalance, big.NewInt(1000)).Cmp(afterBalance) == 0)
+	assert.Equal(sum.Add(beforeBalance, big.NewInt(1000)), afterBalance)
 }

--- a/commands/payment_channel_daemon_test.go
+++ b/commands/payment_channel_daemon_test.go
@@ -68,7 +68,7 @@ func TestPaymentChannelLs(t *testing.T) {
 	t.Run("Works with default payer", func(t *testing.T) {
 		t.Parallel()
 
-		payer, err := address.NewFromString(fixtures.TestAddresses[0])
+		payer, err := address.NewFromString(fixtures.TestAddresses[2])
 		require.NoError(err)
 		target, err := address.NewFromString(fixtures.TestAddresses[1])
 		require.NoError(err)
@@ -86,7 +86,7 @@ func TestPaymentChannelLs(t *testing.T) {
 	t.Run("Works with specified payer", func(t *testing.T) {
 		t.Parallel()
 
-		payer, err := address.NewFromString(fixtures.TestAddresses[0])
+		payer, err := address.NewFromString(fixtures.TestAddresses[2])
 		require.NoError(err)
 		target, err := address.NewFromString(fixtures.TestAddresses[1])
 		require.NoError(err)
@@ -108,7 +108,7 @@ func TestPaymentChannelLs(t *testing.T) {
 	t.Run("Notifies when channels not found", func(t *testing.T) {
 		t.Parallel()
 
-		payer, err := address.NewFromString(fixtures.TestAddresses[0])
+		payer, err := address.NewFromString(fixtures.TestAddresses[2])
 		require.NoError(err)
 		target, err := address.NewFromString(fixtures.TestAddresses[1])
 		require.NoError(err)
@@ -128,7 +128,7 @@ func TestPaymentChannelVoucherSuccess(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	payer, err := address.NewFromString(fixtures.TestAddresses[0])
+	payer, err := address.NewFromString(fixtures.TestAddresses[2])
 	require.NoError(err)
 	target, err := address.NewFromString(fixtures.TestAddresses[1])
 	require.NoError(err)
@@ -149,7 +149,7 @@ func TestPaymentChannelRedeemSuccess(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	payer, err := address.NewFromString(fixtures.TestAddresses[0])
+	payer, err := address.NewFromString(fixtures.TestAddresses[2])
 	require.NoError(err)
 	target, err := address.NewFromString(fixtures.TestAddresses[1])
 	require.NoError(err)
@@ -182,7 +182,7 @@ func TestPaymentChannelRedeemTooEarlyFails(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	payer, err := address.NewFromString(fixtures.TestAddresses[0])
+	payer, err := address.NewFromString(fixtures.TestAddresses[2])
 	require.NoError(err)
 	target, err := address.NewFromString(fixtures.TestAddresses[1])
 	require.NoError(err)
@@ -217,7 +217,7 @@ func TestPaymentChannelReclaimSuccess(t *testing.T) {
 	require := require.New(t)
 
 	// Initial Balance 10,000
-	payer, err := address.NewFromString(fixtures.TestAddresses[0])
+	payer, err := address.NewFromString(fixtures.TestAddresses[2])
 	require.NoError(err)
 	// Initial Balance 50,000
 	target, err := address.NewFromString(fixtures.TestAddresses[1])
@@ -266,7 +266,7 @@ func TestPaymentChannelCloseSuccess(t *testing.T) {
 	require := require.New(t)
 
 	// Initial Balance 10,000,000
-	payerA, err := address.NewFromString(fixtures.TestAddresses[0])
+	payerA, err := address.NewFromString(fixtures.TestAddresses[2])
 	require.NoError(err)
 
 	// Initial Balance 10,000,000
@@ -312,7 +312,7 @@ func TestPaymentChannelExtendSuccess(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	payer, err := address.NewFromString(fixtures.TestAddresses[0])
+	payer, err := address.NewFromString(fixtures.TestAddresses[2])
 	require.NoError(err)
 	target, err := address.NewFromString(fixtures.TestAddresses[1])
 	require.NoError(err)
@@ -342,7 +342,7 @@ func daemonTestWithPaymentChannel(t *testing.T, payerAddress *address.Address, t
 	d := th.NewDaemon(
 		t,
 		th.WithMiner(fixtures.TestMiners[0]),
-		th.KeyFile(fixtures.KeyFilePaths()[0]),
+		th.KeyFile(fixtures.KeyFilePaths()[2]),
 	).Start()
 	defer d.ShutdownSuccess()
 

--- a/consensus/processor_test.go
+++ b/consensus/processor_test.go
@@ -52,15 +52,18 @@ func TestProcessBlockSuccess(t *testing.T) {
 
 	toAddr := newAddress()
 	minerAddr := newAddress()
+	minerOwnerAddr := newAddress()
 	fromAddr := mockSigner.Addresses[0] // fromAddr needs to be known by signer
 	fromAct := th.RequireNewAccountActor(require, types.NewAttoFILFromFIL(10000))
+	vms := th.VMStorage()
+	minerActor := th.RequireNewMinerActor(require, vms, minerAddr, minerOwnerAddr, []byte{}, 10, th.RequireRandomPeerID(), types.ZeroAttoFIL)
 	stCid, st := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
 		address.NetworkAddress: th.RequireNewAccountActor(require, types.NewAttoFILFromFIL(startingNetworkBalance)),
-		minerAddr:              th.RequireNewAccountActor(require, types.ZeroAttoFIL),
+		minerAddr:              minerActor,
+		minerOwnerAddr:         th.RequireNewAccountActor(require, types.ZeroAttoFIL),
 		fromAddr:               fromAct,
 	})
 
-	vms := th.VMStorage()
 	msg := types.NewMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(550), "", nil)
 	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
@@ -83,10 +86,12 @@ func TestProcessBlockSuccess(t *testing.T) {
 	expectedNetworkBalance := types.NewAttoFILFromFIL(startingNetworkBalance).Sub(blockRewardAmount)
 	expStCid, _ := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
 		address.NetworkAddress: th.RequireNewAccountActor(require, expectedNetworkBalance),
-		minerAddr:              th.RequireNewAccountActor(require, blockRewardAmount),
+		minerAddr:              minerActor,
+		minerOwnerAddr:         th.RequireNewAccountActor(require, blockRewardAmount),
 		fromAddr:               expAct1,
 		toAddr:                 expAct2,
 	})
+
 	assert.True(expStCid.Equals(gotStCid))
 }
 
@@ -97,7 +102,6 @@ func TestProcessTipSetSuccess(t *testing.T) {
 	newAddress := address.NewForTestGetter()
 	ctx := context.Background()
 	cst := hamt.NewCborStore()
-	vms := th.VMStorage()
 
 	startingNetworkBalance := types.NewAttoFILFromFIL(1000000)
 	minerAddr := newAddress()
@@ -110,11 +114,15 @@ func TestProcessTipSetSuccess(t *testing.T) {
 
 	fromAddr1Act := th.RequireNewAccountActor(require, types.NewAttoFILFromFIL(10000))
 	fromAddr2Act := th.RequireNewAccountActor(require, types.NewAttoFILFromFIL(10000))
-	stCid, st := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
+	_, st := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
 		address.NetworkAddress: th.RequireNewAccountActor(require, startingNetworkBalance),
 		fromAddr1:              fromAddr1Act,
 		fromAddr2:              fromAddr2Act,
 	})
+
+	vms := th.VMStorage()
+	minerOwner := address.MakeTestAddress("mo")
+	stCid, miner := mustCreateMiner(ctx, require, st, vms, minerAddr, minerOwner)
 
 	msg1 := types.NewMessage(fromAddr1, toAddr, 0, types.NewAttoFILFromFIL(550), "", nil)
 	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
@@ -151,7 +159,8 @@ func TestProcessTipSetSuccess(t *testing.T) {
 	expectedNetworkBalance := startingNetworkBalance.Sub(twoBlockRewards)
 	expStCid, _ := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
 		address.NetworkAddress: th.RequireNewAccountActor(require, expectedNetworkBalance),
-		minerAddr:              th.RequireNewEmptyActor(require, twoBlockRewards),
+		minerAddr:              miner,
+		minerOwner:             th.RequireNewEmptyActor(require, twoBlockRewards),
 		fromAddr1:              expAct1,
 		fromAddr2:              expAct2,
 		toAddr:                 expAct3,
@@ -169,16 +178,19 @@ func TestProcessTipsConflicts(t *testing.T) {
 
 	ctx := context.Background()
 	cst := hamt.NewCborStore()
-	vms := th.VMStorage()
 	ki := types.MustGenerateKeyInfo(2, types.GenerateKeyInfoSeed())
 	mockSigner := types.NewMockSigner(ki)
 
 	fromAddr, toAddr := mockSigner.Addresses[0], mockSigner.Addresses[1]
 	act1 := th.RequireNewAccountActor(require, types.NewAttoFILFromFIL(1000))
-	stCid, st := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
+	_, st := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
 		address.NetworkAddress: th.RequireNewAccountActor(require, startingNetworkBalance),
 		fromAddr:               act1,
 	})
+
+	vms := th.VMStorage()
+	minerOwner := address.MakeTestAddress("mo")
+	stCid, miner := mustCreateMiner(ctx, require, st, vms, minerAddr, minerOwner)
 
 	msg1 := types.NewMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(501), "", nil)
 	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
@@ -215,7 +227,8 @@ func TestProcessTipsConflicts(t *testing.T) {
 	expectedNetworkBalance := startingNetworkBalance.Sub(twoBlockRewards)
 	expStCid, _ := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
 		address.NetworkAddress: th.RequireNewAccountActor(require, expectedNetworkBalance),
-		minerAddr:              th.RequireNewEmptyActor(require, twoBlockRewards),
+		minerOwner:             th.RequireNewEmptyActor(require, twoBlockRewards),
+		minerAddr:              miner,
 		fromAddr:               expAct1,
 		toAddr:                 expAct2,
 	})
@@ -235,12 +248,16 @@ func TestProcessBlockBadMsgSig(t *testing.T) {
 	toAddr := newAddress()
 	fromAddr := mockSigner.Addresses[0] // fromAddr needs to be known by signer
 	fromAct := th.RequireNewAccountActor(require, types.NewAttoFILFromFIL(10000))
-	stCid, st := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
+	_, st := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
 		address.NetworkAddress: th.RequireNewAccountActor(require, types.NewAttoFILFromFIL(100000)),
 		fromAddr:               fromAct,
 	})
 
 	vms := th.VMStorage()
+	minerAddr := address.MakeTestAddress("miner")
+	minerOwner := address.MakeTestAddress("mo")
+	stCid, _ := mustCreateMiner(ctx, require, st, vms, minerAddr, minerOwner)
+
 	msg := types.NewMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(550), "", nil)
 	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
@@ -250,6 +267,7 @@ func TestProcessBlockBadMsgSig(t *testing.T) {
 	blk := &types.Block{
 		Height:    20,
 		StateRoot: stCid,
+		Miner:     minerAddr,
 		Messages:  []*types.SignedMessage{smsg},
 	}
 	results, err := NewDefaultProcessor().ProcessBlock(ctx, st, vms, blk, nil)
@@ -266,11 +284,12 @@ func TestProcessBlockReward(t *testing.T) {
 	ctx := context.Background()
 	cst := hamt.NewCborStore()
 
+	minerAddr := newAddress()
 	minerOwnerAddr := newAddress()
 	minerBalance := types.NewAttoFILFromFIL(10000)
 	ownerAct := th.RequireNewAccountActor(require, minerBalance)
 	networkAct := th.RequireNewAccountActor(require, types.NewAttoFILFromFIL(100000000000))
-	stCid, st := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
+	_, st := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
 		minerOwnerAddr: ownerAct,
 		// TODO: get rid of this ugly hack as soon once we have
 		// sustainable reward support (i.e. anything but setting
@@ -279,8 +298,10 @@ func TestProcessBlockReward(t *testing.T) {
 	})
 
 	vms := th.VMStorage()
+	stCid, _ := mustCreateMiner(ctx, require, st, vms, minerAddr, minerOwnerAddr)
+
 	blk := &types.Block{
-		Miner:     minerOwnerAddr,
+		Miner:     minerAddr,
 		Height:    20,
 		StateRoot: stCid,
 		Messages:  []*types.SignedMessage{},
@@ -306,7 +327,7 @@ func TestProcessBlockVMErrors(t *testing.T) {
 
 	newAddress := address.NewForTestGetter()
 	startingNetworkBalance := types.NewAttoFILFromFIL(1000000)
-	minerAddr := newAddress()
+	minerAddr, minerOwnerAddr := newAddress(), newAddress()
 
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.NewCidForTestGetter()()
@@ -321,11 +342,14 @@ func TestProcessBlockVMErrors(t *testing.T) {
 	fromAddr, toAddr := mockSigner.Addresses[0], mockSigner.Addresses[1]
 
 	act1, act2 := th.RequireNewEmptyActor(require, types.NewAttoFILFromFIL(0)), th.RequireNewFakeActor(require, vms, toAddr, fakeActorCodeCid)
-	stCid, st := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
+	_, st := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
 		address.NetworkAddress: th.RequireNewAccountActor(require, startingNetworkBalance),
 		fromAddr:               act1,
 		toAddr:                 act2,
 	})
+
+	stCid, miner := mustCreateMiner(ctx, require, st, vms, minerAddr, minerOwnerAddr)
+
 	msg := types.NewMessage(fromAddr, toAddr, 0, nil, "returnRevertError", nil)
 	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
@@ -354,7 +378,8 @@ func TestProcessBlockVMErrors(t *testing.T) {
 	blockRewardAmount := NewDefaultBlockRewarder().BlockRewardAmount()
 	expectedStCid, _ := th.RequireMakeStateTree(require, cst, map[address.Address]*actor.Actor{
 		address.NetworkAddress: th.RequireNewAccountActor(require, startingNetworkBalance.Sub(blockRewardAmount)),
-		minerAddr:              th.RequireNewEmptyActor(require, blockRewardAmount),
+		minerOwnerAddr:         th.RequireNewEmptyActor(require, blockRewardAmount),
+		minerAddr:              miner,
 		fromAddr:               expectedAct1,
 		toAddr:                 expectedAct2,
 	})
@@ -1073,4 +1098,12 @@ func mustSetup2Actors(t *testing.T, balance1 *types.AttoFIL, balance2 *types.Att
 		addr2: act2,
 	})
 	return addr1, act1, addr2, act2, st, mockSigner
+}
+
+func mustCreateMiner(ctx context.Context, require *require.Assertions, st state.Tree, vms vm.StorageMap, minerAddr, minerOwner address.Address) (cid.Cid, *actor.Actor) {
+	miner := th.RequireNewMinerActor(require, vms, minerAddr, minerOwner, []byte{}, 1000, th.RequireRandomPeerID(), types.ZeroAttoFIL)
+	st.SetActor(ctx, minerAddr, miner)
+	stCid, err := st.Flush(ctx)
+	require.NoError(err)
+	return stCid, miner
 }

--- a/mining/block_generate.go
+++ b/mining/block_generate.go
@@ -58,7 +58,7 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 	messages := mq.Drain()
 
 	vms := vm.NewStorageMap(w.blockstore)
-	res, err := w.processor.ApplyMessagesAndPayRewards(ctx, stateTree, vms, messages, w.minerAddr, types.NewBlockHeight(blockHeight), ancestors)
+	res, err := w.processor.ApplyMessagesAndPayRewards(ctx, stateTree, vms, messages, w.minerOwnerAddr, types.NewBlockHeight(blockHeight), ancestors)
 	if err != nil {
 		return nil, errors.Wrap(err, "generate apply messages")
 	}

--- a/mining/worker.go
+++ b/mining/worker.go
@@ -70,15 +70,17 @@ type MessageSource interface {
 // A MessageApplier processes all the messages in a message pool.
 type MessageApplier interface {
 	// ApplyMessagesAndPayRewards applies all state transitions related to a set of messages.
-	ApplyMessagesAndPayRewards(ctx context.Context, st state.Tree, vms vm.StorageMap, messages []*types.SignedMessage, minerAddr address.Address, bh *types.BlockHeight, ancestors []types.TipSet) (consensus.ApplyMessagesResponse, error)
+	ApplyMessagesAndPayRewards(ctx context.Context, st state.Tree, vms vm.StorageMap, messages []*types.SignedMessage, minerOwnerAddr address.Address, bh *types.BlockHeight, ancestors []types.TipSet) (consensus.ApplyMessagesResponse, error)
 }
 
 // DefaultWorker runs a mining job.
 type DefaultWorker struct {
 	createPoSTFunc  DoSomeWorkFunc
 	minerAddr       address.Address
+	minerOwnerAddr  address.Address
 	blockSignerAddr address.Address
 	blockSigner     types.Signer
+
 	// consensus things
 	getStateTree GetStateTree
 	getWeight    GetWeight
@@ -103,6 +105,7 @@ func NewDefaultWorker(messageSource MessageSource,
 	bs blockstore.Blockstore,
 	cst *hamt.CborIpldStore,
 	miner address.Address,
+	minerOwner address.Address,
 	blockSignerAddr address.Address,
 	blockSigner types.Signer,
 	bt time.Duration) *DefaultWorker {
@@ -116,6 +119,7 @@ func NewDefaultWorker(messageSource MessageSource,
 		bs,
 		cst,
 		miner,
+		minerOwner,
 		blockSignerAddr,
 		blockSigner,
 		bt,
@@ -138,6 +142,7 @@ func NewDefaultWorkerWithDeps(messageSource MessageSource,
 	bs blockstore.Blockstore,
 	cst *hamt.CborIpldStore,
 	miner address.Address,
+	minerOwner address.Address,
 	blockSignerAddr address.Address,
 	blockSigner types.Signer,
 	bt time.Duration,
@@ -153,6 +158,7 @@ func NewDefaultWorkerWithDeps(messageSource MessageSource,
 		cstore:          cst,
 		createPoSTFunc:  createPoST,
 		minerAddr:       miner,
+		minerOwnerAddr:  minerOwner,
 		blockTime:       bt,
 		blockSignerAddr: blockSignerAddr,
 		blockSigner:     blockSigner,

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -106,9 +106,12 @@ func TestChainSync(t *testing.T) {
 	defer stopNodes(nodes)
 
 	baseTS := nodes[0].ChainReader.Head()
-	nextBlk1 := testhelpers.NewValidTestBlockFromTipSet(baseTS, 1, minerAddr)
-	nextBlk2 := testhelpers.NewValidTestBlockFromTipSet(baseTS, 2, minerAddr)
-	nextBlk3 := testhelpers.NewValidTestBlockFromTipSet(baseTS, 3, minerAddr)
+
+	stateRoot := baseTS.ToSlice()[0].StateRoot
+
+	nextBlk1 := testhelpers.NewValidTestBlockFromTipSet(baseTS, stateRoot, 1, minerAddr)
+	nextBlk2 := testhelpers.NewValidTestBlockFromTipSet(baseTS, stateRoot, 2, minerAddr)
+	nextBlk3 := testhelpers.NewValidTestBlockFromTipSet(baseTS, stateRoot, 3, minerAddr)
 
 	assert.NoError(nodes[0].AddNewBlock(ctx, nextBlk1))
 	assert.NoError(nodes[0].AddNewBlock(ctx, nextBlk2))

--- a/node/node.go
+++ b/node/node.go
@@ -793,7 +793,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 		}
 		processor := consensus.NewDefaultProcessor()
 		worker := mining.NewDefaultWorker(node.MsgPool, getState, getWeight, getAncestors, processor, node.PowerTable,
-			node.Blockstore, node.CborStore(), minerAddr, minerSigningAddress, node.Wallet, blockTime)
+			node.Blockstore, node.CborStore(), minerAddr, minerOwnerAddr, minerSigningAddress, node.Wallet, blockTime)
 		node.MiningScheduler = mining.NewScheduler(worker, mineDelay, node.ChainReader.Head)
 	}
 

--- a/plumbing/msg/waiter_test.go
+++ b/plumbing/msg/waiter_test.go
@@ -131,10 +131,15 @@ func TestWaitConflicting(t *testing.T) {
 	ctx := context.Background()
 
 	addr1, addr2, addr3 := mockSigner.Addresses[0], mockSigner.Addresses[1], mockSigner.Addresses[2]
+
+	// create a valid miner
+	minerAddr := mockSigner.Addresses[3]
+
 	testGen := consensus.MakeGenesisFunc(
 		consensus.ActorAccount(addr1, types.NewAttoFILFromFIL(10000)),
 		consensus.ActorAccount(addr2, types.NewAttoFILFromFIL(0)),
 		consensus.ActorAccount(addr3, types.NewAttoFILFromFIL(0)),
+		consensus.MinerActor(minerAddr, addr3, []byte{}, 1000, testhelpers.RequireRandomPeerID(), types.ZeroAttoFIL),
 	)
 	cst, chainStore, waiter := setupTestWithGif(require, testGen)
 
@@ -155,7 +160,7 @@ func TestWaitConflicting(t *testing.T) {
 
 	b1 := chain.RequireMkFakeChild(require,
 		chain.FakeChildParams{
-			Parent: baseTS, GenesisCid: chainStore.GenesisCid(), StateRoot: baseBlock.StateRoot})
+			Parent: baseTS, GenesisCid: chainStore.GenesisCid(), StateRoot: baseBlock.StateRoot, MinerAddr: minerAddr})
 	b1.Messages = []*types.SignedMessage{sm1}
 	b1.Ticket = []byte{0} // block 1 comes first in message application
 	core.MustPut(cst, b1)
@@ -163,7 +168,7 @@ func TestWaitConflicting(t *testing.T) {
 	b2 := chain.RequireMkFakeChild(require,
 		chain.FakeChildParams{
 			Parent: baseTS, GenesisCid: chainStore.GenesisCid(),
-			StateRoot: baseBlock.StateRoot, Nonce: uint64(1)})
+			StateRoot: baseBlock.StateRoot, Nonce: uint64(1), MinerAddr: minerAddr})
 	b2.Messages = []*types.SignedMessage{sm2}
 	b2.Ticket = []byte{1}
 	core.MustPut(cst, b2)

--- a/porcelain/wallet_test.go
+++ b/porcelain/wallet_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 )
 
 type walletTestPlumbing struct {

--- a/testhelpers/consensus.go
+++ b/testhelpers/consensus.go
@@ -10,7 +10,9 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+	cid "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	"gx/ipfs/QmRu7tiRnFk9mMPpVECQTBQJqXtmG132jJxA1w9A7TtpBz/go-ipfs-blockstore"
+
 	"testing"
 )
 
@@ -77,12 +79,9 @@ func (tv *TestPowerTableView) HasPower(ctx context.Context, st state.Tree, bstor
 
 // NewValidTestBlockFromTipSet creates a block for when proofs & power table don't need
 // to be correct
-func NewValidTestBlockFromTipSet(baseTipSet types.TipSet, height uint64, minerAddr address.Address) *types.Block {
+func NewValidTestBlockFromTipSet(baseTipSet types.TipSet, stateRootCid cid.Cid, height uint64, minerAddr address.Address) *types.Block {
 	postProof := MakeRandomPoSTProofForTest()
 	ticket := consensus.CreateTicket(postProof, minerAddr)
-
-	baseTsBlock := baseTipSet.ToSlice()[0]
-	stateRoot := baseTsBlock.StateRoot
 
 	return &types.Block{
 		Miner:        minerAddr,
@@ -91,7 +90,7 @@ func NewValidTestBlockFromTipSet(baseTipSet types.TipSet, height uint64, minerAd
 		ParentWeight: types.Uint64(10000 * height),
 		Height:       types.Uint64(height),
 		Nonce:        types.Uint64(height),
-		StateRoot:    stateRoot,
+		StateRoot:    stateRootCid,
 		Proof:        postProof,
 	}
 }
@@ -158,19 +157,19 @@ func ApplyTestMessage(st state.Tree, store vm.StorageMap, msg *types.Message, bh
 
 // ApplyTestMessageWithGas uses the TestBlockRewarder but the default SignedMessageValidator
 func ApplyTestMessageWithGas(st state.Tree, store vm.StorageMap, msg *types.Message, bh *types.BlockHeight, signer *types.MockSigner,
-	gasPrice types.AttoFIL, gasLimit types.GasUnits, minerAddr address.Address) (*consensus.ApplicationResult, error) {
+	gasPrice types.AttoFIL, gasLimit types.GasUnits, minerOwner address.Address) (*consensus.ApplicationResult, error) {
 
 	smsg, err := types.NewSignedMessage(*msg, signer, gasPrice, gasLimit)
 	if err != nil {
 		panic(err)
 	}
 	applier := consensus.NewConfiguredProcessor(consensus.NewDefaultMessageValidator(), consensus.NewDefaultBlockRewarder())
-	return newMessageApplier(smsg, applier, st, store, bh, minerAddr)
+	return newMessageApplier(smsg, applier, st, store, bh, minerOwner)
 }
 
 func newMessageApplier(smsg *types.SignedMessage, processor *consensus.DefaultProcessor, st state.Tree, storageMap vm.StorageMap,
-	bh *types.BlockHeight, minerAddr address.Address) (*consensus.ApplicationResult, error) {
-	amr, err := processor.ApplyMessagesAndPayRewards(context.Background(), st, storageMap, []*types.SignedMessage{smsg}, minerAddr, bh, nil)
+	bh *types.BlockHeight, minerOwner address.Address) (*consensus.ApplicationResult, error) {
+	amr, err := processor.ApplyMessagesAndPayRewards(context.Background(), st, storageMap, []*types.SignedMessage{smsg}, minerOwner, bh, nil)
 
 	if len(amr.Results) > 0 {
 		return amr.Results[0], err

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -60,8 +60,8 @@ func RequireNewMinerActor(require *require.Assertions, vms vm.StorageMap, addr a
 	storage := vms.NewStorage(addr, act)
 	initializerData := miner.NewState(owner, key, big.NewInt(int64(pledge)), pid, coll)
 	err := (&miner.Actor{}).InitializeState(storage, initializerData)
-	require.NoError(storage.Flush())
 	require.NoError(err)
+	require.NoError(storage.Flush())
 	return act
 }
 


### PR DESCRIPTION
closes #1844

### Problem

For some time now, we have been paying block rewards and gas payments to the miner actor. These payments should be going to the account actor listed as the miner actor's owner.

### Solution

This PR switches the address to which the processor directs payments to that of the miner's owner.

The major complication with this is that blocks contain only the miner's address. The miner owner must be queried from the miner actor. This has the additional complication that all test code that attempts to validate a block must have an actor with an owner in state for the miner address specified in the block. Most of the changes in this PR are related to that.