### PR TITLE
Make private key output consistent

### DIFF
--- a/commands/address.go
+++ b/commands/address.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io"
 
@@ -212,7 +213,8 @@ var walletExportCmd = &cmds.Command{
 				if err != nil {
 					return err
 				}
-				_, err = fmt.Fprintf(w, "Address:\t%s\nPrivateKey:\t%x\nCurve:\t\t%s\n\n", a.String(), k.PrivateKey, k.Curve)
+				privateKeyInBase64 := base64.StdEncoding.EncodeToString(k.PrivateKey)
+				_, err = fmt.Fprintf(w, "Address:\t%s\nPrivateKey:\t%s\nCurve:\t\t%s\n\n", a.String(), privateKeyInBase64, k.Curve)
 				if err != nil {
 					return err
 				}

--- a/commands/address_daemon_test.go
+++ b/commands/address_daemon_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -139,4 +140,21 @@ func TestWalletExportImportRoundTrip(t *testing.T) {
 	maybeAddr := d.RunSuccess("wallet", "import", wf.Name()).ReadStdoutTrimNewlines()
 	assert.Equal(dw, maybeAddr)
 
+}
+
+func TestWalletExportPrivateKeyConsistentDisplay(t *testing.T) {
+	assert := assert.New(t)
+
+	d := th.NewDaemon(t).Start()
+	defer d.ShutdownSuccess()
+
+	dw := d.RunSuccess("address", "ls").ReadStdoutTrimNewlines()
+
+	exportText := d.RunSuccess("wallet", "export", dw).ReadStdoutTrimNewlines()
+	exportTextPrivateKeyLine := strings.Split(exportText, "\n")[1]
+	exportTextPrivateKey := strings.Split(exportTextPrivateKeyLine, "\t")[1]
+
+	exportJSON := d.RunSuccess("wallet", "export", dw, "--enc=json").ReadStdoutTrimNewlines()
+
+	assert.Contains(exportJSON, exportTextPrivateKey)
 }


### PR DESCRIPTION
Resolves #2004 

The `wallet export` command with `--enc=json` will still only return the private key and the curve used, since this command is designed to write files suitable for consumption by the `wallet import` command, and isn't really designed for human use.

The `wallet export` command with no encoding specified will still return address, private key, and curve, but the private key will have the same output format as the one used for `--enc=json`.

Some examples:

```
$ ./go-filecoin wallet export fcqtu6574lys8nwsc39h4vpa4k0v7vnyj0xzzhsue
Address:	fcqtu6574lys8nwsc39h4vpa4k0v7vnyj0xzzhsue
PrivateKey:	ehfp0DiWZBqlYK4oBVUIBoAVIPJok4e/SVb5RPpL57E=
Curve:		secp256k1
```
and

```
$ ./go-filecoin wallet export fcqtu6574lys8nwsc39h4vpa4k0v7vnyj0xzzhsue --enc=json | json_pp
{
   "KeyInfo" : [
      {
         "privateKey" : "ehfp0DiWZBqlYK4oBVUIBoAVIPJok4e/SVb5RPpL57E=",
         "curve" : "secp256k1"
      }
   ]
}
```