### PR TITLE
add level and ls command to log

### DIFF
--- a/commands/log.go
+++ b/commands/log.go
@@ -1,9 +1,21 @@
 package commands
 
 import (
+	"fmt"
+	"io"
+
 	"gx/ipfs/QmQtQrtNioesAWtrx8csBvfY37gTe94d6wQ3VikZUjxD39/go-ipfs-cmds"
+	logging "gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log"
 	"gx/ipfs/Qmde5VP1qUkyQXKCfmEUA7bP64V2HAptbJ7phuPp7jXWwg/go-ipfs-cmdkit"
 )
+
+var loglogger = logging.Logger("commands/log")
+
+// Golang os.Args overrides * and replaces the character argument with
+// an array which includes every file in the user's CWD. As a
+// workaround, we use 'all' instead. The util library still uses * so
+// we convert it at this step.
+var logAllKeyword = "all"
 
 var logCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
@@ -15,7 +27,9 @@ output of a running daemon.
 	},
 
 	Subcommands: map[string]*cmds.Command{
-		"tail": logTailCmd,
+		"tail":  logTailCmd,
+		"level": logLevelCmd,
+		"ls":    logLsCmd,
 	},
 }
 
@@ -30,5 +44,71 @@ Outputs event log messages (not other log messages) as they are generated.
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		r := GetAPI(env).Log().Tail(req.Context)
 		return re.Emit(r)
+	},
+}
+
+var logLevelCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Change the logging level.",
+		ShortDescription: `
+Change the verbosity of one or all subsystems log output. This does not affect
+the event log.
+`,
+	},
+
+	Arguments: []cmdkit.Argument{
+		// TODO use a different keyword for 'all' because all can theoretically
+		// clash with a subsystem name
+		cmdkit.StringArg("subsystem", true, false, fmt.Sprintf("The subsystem logging identifier. Use '%s' for all subsystems.", logAllKeyword)),
+		cmdkit.StringArg("level", true, false, `The log level, with 'debug' the most verbose and 'critical' the least verbose.
+			One of: debug, info, warning, error, critical.
+		`),
+	},
+
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		args := req.Arguments
+		subsystem, level := args[0], args[1]
+
+		if subsystem == logAllKeyword {
+			subsystem = "*"
+		}
+
+		if err := logging.SetLogLevel(subsystem, level); err != nil {
+			return err
+		}
+
+		s := fmt.Sprintf("Changed log level of '%s' to '%s'", subsystem, level)
+		loglogger.Info(s)
+
+		return cmds.EmitOnce(res, s)
+	},
+	Type: string(""),
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out string) error {
+			_, err := fmt.Fprint(w, out)
+			return err
+		}),
+	},
+}
+
+var logLsCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "List the logging subsystems.",
+		ShortDescription: `
+'go-filecoin log ls' is a utility command used to list the logging
+subsystems of a running daemon.
+`,
+	},
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		return cmds.EmitOnce(res, logging.GetSubsystems())
+	},
+	Type: []string{},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, list []string) error {
+			for _, s := range list {
+				fmt.Fprintln(w, s) // nolint: errcheck
+			}
+			return nil
+		}),
 	},
 }


### PR DESCRIPTION
This PR add commands:
```
  go-filecoin log level <subsystem> <level> - Change the logging level.
  go-filecoin log ls                        - List the logging subsystems.
```
Prior art here: https://github.com/ipfs/go-ipfs/blob/master/core/commands/log.go