### PR TITLE
Feat/log reorgs

### DIFF
--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -157,7 +157,7 @@ func requireSetTestChain(require *require.Assertions, con consensus.Protocol, mo
 }
 
 // loadSyncerFromRepo creates a store and syncer from an existing repo.
-func loadSyncerFromRepo(require *require.Assertions, r repo.Repo) (chain.Syncer, *hamt.CborIpldStore) {
+func loadSyncerFromRepo(require *require.Assertions, r repo.Repo) (*chain.DefaultSyncer, *hamt.CborIpldStore) {
 	powerTable := &testhelpers.TestView{}
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := hamt.NewCborStore()
@@ -172,7 +172,7 @@ func loadSyncerFromRepo(require *require.Assertions, r repo.Repo) (chain.Syncer,
 
 // initSyncTestDefault creates and returns the datastructures (chain store, syncer, etc)
 // needed to run tests.  It also sets the global test variables appropriately.
-func initSyncTestDefault(require *require.Assertions) (chain.Syncer, chain.Store, *hamt.CborIpldStore, repo.Repo) {
+func initSyncTestDefault(require *require.Assertions) (*chain.DefaultSyncer, chain.Store, *hamt.CborIpldStore, repo.Repo) {
 	processor := testhelpers.NewTestProcessor()
 	powerTable := &testhelpers.TestView{}
 	r := repo.NewInMemoryRepo()
@@ -186,7 +186,7 @@ func initSyncTestDefault(require *require.Assertions) (chain.Syncer, chain.Store
 
 // initSyncTestWithPowerTable creates and returns the datastructures (chain store, syncer, etc)
 // needed to run tests.  It also sets the global test variables appropriately.
-func initSyncTestWithPowerTable(require *require.Assertions, powerTable consensus.PowerTableView) (chain.Syncer, chain.Store, *hamt.CborIpldStore, consensus.Protocol) {
+func initSyncTestWithPowerTable(require *require.Assertions, powerTable consensus.PowerTableView) (*chain.DefaultSyncer, chain.Store, *hamt.CborIpldStore, consensus.Protocol) {
 	processor := testhelpers.NewTestProcessor()
 	r := repo.NewInMemoryRepo()
 	bs := bstore.NewBlockstore(r.Datastore())
@@ -198,7 +198,7 @@ func initSyncTestWithPowerTable(require *require.Assertions, powerTable consensu
 	return sync, testchain, cst, con
 }
 
-func initSyncTest(require *require.Assertions, con consensus.Protocol, genFunc func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error), cst *hamt.CborIpldStore, bs bstore.Blockstore, r repo.Repo) (chain.Syncer, chain.Store, *hamt.CborIpldStore, repo.Repo) {
+func initSyncTest(require *require.Assertions, con consensus.Protocol, genFunc func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error), cst *hamt.CborIpldStore, bs bstore.Blockstore, r repo.Repo) (*chain.DefaultSyncer, chain.Store, *hamt.CborIpldStore, repo.Repo) {
 	ctx := context.Background()
 
 	calcGenBlk, err := genFunc(cst, bs) // flushes state

--- a/chain/reorg.go
+++ b/chain/reorg.go
@@ -1,0 +1,24 @@
+package chain
+
+import (
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// IsReorg determines if choosing the end of the newChain as the new head
+// would cause a "reorg" given the current head is at curHead.
+// A reorg occurs when curHead is not a member of newChain AND curHead is not
+// a subset of newChain's head.
+func IsReorg(curHead types.TipSet, newChain []types.TipSet) bool {
+	newHead := newChain[len(newChain)-1]
+	oldSortedSet := curHead.ToSortedCidSet()
+	newSortedSet := newHead.ToSortedCidSet()
+	if (&newSortedSet).Contains(&oldSortedSet) {
+		return false
+	}
+	for _, ancestor := range newChain {
+		if ancestor.Equals(curHead) {
+			return false
+		}
+	}
+	return true
+}

--- a/chain/reorg_test.go
+++ b/chain/reorg_test.go
@@ -1,0 +1,50 @@
+package chain_test
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/go-filecoin/chain"
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	"github.com/filecoin-project/go-filecoin/types"
+
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+)
+
+func TestIsReorg(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	// Only need dummy blocks for this test
+	var reorgGen types.Block
+	reorgGenTS := th.RequireNewTipSet(require, &reorgGen)
+	t.Run("if chain is a fork of another chain, IsReorg is true", func(t *testing.T) {
+		params := chain.FakeChildParams{GenesisCid: reorgGen.Cid(), StateRoot: reorgGen.StateRoot}
+		chn := chain.RequireMkFakeChain(require, reorgGenTS, 10, params)
+		curHead := chn[len(chn)-1]
+
+		params.Nonce = uint64(32)
+		forkChain := chain.RequireMkFakeChain(require, reorgGenTS, 15, params)
+		forkChain = append([]types.TipSet{reorgGenTS}, forkChain...)
+		assert.True(chain.IsReorg(curHead, forkChain))
+	})
+
+	t.Run("if new chain has existing chain as prefix, IsReorg is false", func(t *testing.T) {
+		params := chain.FakeChildParams{GenesisCid: reorgGen.Cid(), StateRoot: reorgGen.StateRoot}
+		chn := chain.RequireMkFakeChain(require, reorgGenTS, 20, params)
+		curHead := chn[10]
+
+		assert.False(chain.IsReorg(curHead, chn))
+	})
+
+	t.Run("if chain has head that is a subset of new chain head, IsReorg is false", func(t *testing.T) {
+		params := chain.FakeChildParams{GenesisCid: reorgGen.Cid(), StateRoot: reorgGen.StateRoot}
+		chn := chain.RequireMkFakeChain(require, reorgGenTS, 10, params)
+		curHead := chn[len(chn)-1]
+		headBlock := curHead.ToSlice()[0]
+		block2 := chain.RequireMkFakeChild(require, chain.FakeChildParams{Parent: chn[len(chn)-2], GenesisCid: reorgGen.Cid(), StateRoot: reorgGen.StateRoot})
+		superset := th.RequireNewTipSet(require, headBlock, block2)
+		chn[len(chn)-1] = superset
+
+		assert.False(chain.IsReorg(curHead, chn))
+	})
+}

--- a/testhelpers/consensus.go
+++ b/testhelpers/consensus.go
@@ -78,7 +78,7 @@ func (tv *TestPowerTableView) HasPower(ctx context.Context, st state.Tree, bstor
 }
 
 // NewValidTestBlockFromTipSet creates a block for when proofs & power table don't need
-// to be correct
+// to be correct.
 func NewValidTestBlockFromTipSet(baseTipSet types.TipSet, stateRootCid cid.Cid, height uint64, minerAddr address.Address) *types.Block {
 	postProof := MakeRandomPoSTProofForTest()
 	ticket := consensus.CreateTicket(postProof, minerAddr)

--- a/types/sorted_cid_set.go
+++ b/types/sorted_cid_set.go
@@ -118,6 +118,16 @@ func (s SortedCidSet) Equals(s2 SortedCidSet) bool {
 	return true
 }
 
+// Contains checks if s2 is a sub-tipset of s
+func (s *SortedCidSet) Contains(s2 *SortedCidSet) bool {
+	for it := s2.Iter(); !it.Complete(); it.Next() {
+		if !s.Has(it.Value()) {
+			return false
+		}
+	}
+	return true
+}
+
 // String returns a string listing the cids in the set.
 func (s SortedCidSet) String() string {
 	out := "{"


### PR DESCRIPTION
In response to #1883, leftover from launch. 

@rkowalick and I verified that this change causes reorg warnings in the log by manually triggering a reorg on a local node by disconnecting and reconnecting to the user net.  

FYI this change is quick and dirty, exposing a function on the defaultSyncer that probably belongs as a private method in order to make testing from outside the chain package possible.  As this method really should be private the tests effectively test a private abstraction which I understand is ugly and bad too.

My understanding is that this is good enough and that good alternatives to make this cleaner (like refactoring the chain syncer + tests OR figuring out a way to make assertions about log output, OR writing up boiler plate to allow test daemons to mine on forks and then asserting on logs that way) are lower priority than other things on my plate.  Furthermore [issues](https://github.com/filecoin-project/go-filecoin/issues/2065) [are](https://github.com/filecoin-project/go-filecoin/issues/2128) [open](https://github.com/filecoin-project/go-filecoin/issues/2116) that cover cleanup.

If this is unacceptably dirty I will slow down and focus efforts here but I think that's more time than this issue deserves.