### PR TITLE
Bug/dont connect heartbeat target when empty

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -526,7 +526,7 @@ func (node *Node) Start(ctx context.Context) error {
 	}
 
 	if err := node.setupHeartbeatServices(ctx); err != nil {
-		return err
+		return errors.Wrap(err, "failed to start heartbeat services")
 	}
 
 	return nil
@@ -545,8 +545,10 @@ func (node *Node) setupHeartbeatServices(ctx context.Context) error {
 	}
 
 	// start the primary heartbeat service
-	hbs := metrics.NewHeartbeatService(node.Host(), node.Repo.Config().Heartbeat, node.ChainReader.Head, metrics.WithMinerAddressGetter(mag))
-	go hbs.Start(ctx)
+	if len(node.Repo.Config().Heartbeat.BeatTarget) > 0 {
+		hbs := metrics.NewHeartbeatService(node.Host(), node.Repo.Config().Heartbeat, node.ChainReader.Head, metrics.WithMinerAddressGetter(mag))
+		go hbs.Start(ctx)
+	}
 
 	// check if we want to connect to an alert service. An alerting service is a heartbeat
 	// service that can trigger alerts based on the contents of heatbeats.

--- a/node/node.go
+++ b/node/node.go
@@ -525,6 +525,14 @@ func (node *Node) Start(ctx context.Context) error {
 		node.Bootstrapper.Start(context.Background())
 	}
 
+	if err := node.setupHeartbeatServices(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (node *Node) setupHeartbeatServices(ctx context.Context) error {
 	mag := func() address.Address {
 		addr, err := node.miningAddress()
 		// the only error miningAddress() returns is ErrNoMinerAddress.
@@ -533,9 +541,9 @@ func (node *Node) Start(ctx context.Context) error {
 		if err != nil {
 			return address.Address{}
 		}
-
 		return addr
 	}
+
 	// start the primary heartbeat service
 	hbs := metrics.NewHeartbeatService(node.Host(), node.Repo.Config().Heartbeat, node.ChainReader.Head, metrics.WithMinerAddressGetter(mag))
 	go hbs.Start(ctx)


### PR DESCRIPTION
Based on discussion in https://github.com/filecoin-project/go-filecoin/pull/2117

Check that a non-empty HeartBeat.BeatTarget was set before starting a HeartbeatService