### PR TITLE
 Plumb message validator to sender and validate outgoing messages before adding them to mpool.

### DIFF
--- a/commands/message_daemon_test.go
+++ b/commands/message_daemon_test.go
@@ -38,11 +38,10 @@ func TestMessageSend(t *testing.T) {
 	)
 
 	t.Log("[success] with from")
-	defaultaddr := d.GetDefaultAddress()
 	d.RunSuccess("message", "send",
 		"--from", fixtures.TestAddresses[0],
 		"--price", "0", "--limit", "300",
-		defaultaddr,
+		fixtures.TestAddresses[1],
 	)
 
 	t.Log("[success] with from and value")

--- a/node/message_propagate_test.go
+++ b/node/message_propagate_test.go
@@ -2,70 +2,88 @@ package node
 
 import (
 	"context"
-	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
 	"testing"
 	"time"
 
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/consensus"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/filecoin-project/go-filecoin/wallet"
 )
 
+// TestMessagePropagation is a high level check that messages are propagated between message
+// pools of connected ndoes.
 func TestMessagePropagation(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	require := require.New(t)
 
-	nodes := MakeNodesUnstarted(t, 5, false)
+	// Generate a key and install an account actor at genesis which will be able to send messages.
+	ki := types.MustGenerateKeyInfo(1, types.GenerateKeyInfoSeed())[0]
+	senderAddress, err := ki.Address()
+	require.NoError(err)
+	genesis := consensus.MakeGenesisFunc(
+		consensus.ActorAccount(senderAddress, types.NewAttoFILFromFIL(100)),
+	)
+
+	// Initialize the first node to be the message sender.
+	senderNodeOpts := TestNodeOptions{
+		GenesisFunc: genesis,
+		ConfigOpts:  DefaultTestingConfig(),
+		InitOpts: []InitOpt{
+			DefaultWalletAddressOpt(senderAddress),
+		},
+	}
+	sender := GenNode(t, &senderNodeOpts)
+
+	// Give the sender the private key so it can sign messages.
+	// Note: this is an ugly hack around the Wallet lacking a mutable interface.
+	err = sender.Wallet.Backends(wallet.DSBackendType)[0].(*wallet.DSBackend).ImportKey(&ki)
+	require.NoError(err)
+
+	// Initialize other nodes to receive the message.
+	receiverCount := 2
+	receivers := MakeNodesUnstartedWithGif(t, receiverCount, false, genesis)
+
+	nodes := append([]*Node{sender}, receivers...)
 	StartNodes(t, nodes)
 	defer StopNodes(nodes)
+
+	// Connect nodes in series
 	connect(t, nodes[0], nodes[1])
 	connect(t, nodes[1], nodes[2])
-	connect(t, nodes[2], nodes[3])
-	connect(t, nodes[3], nodes[4])
-
 	// Wait for network connection notifications to propagate
 	time.Sleep(time.Millisecond * 50)
 
 	require.Equal(0, len(nodes[0].MsgPool.Pending()))
 	require.Equal(0, len(nodes[1].MsgPool.Pending()))
 	require.Equal(0, len(nodes[2].MsgPool.Pending()))
-	require.Equal(0, len(nodes[3].MsgPool.Pending()))
-	require.Equal(0, len(nodes[4].MsgPool.Pending()))
 
-	nd0Addr, err := nodes[0].NewAddress()
-	require.NoError(err)
-
-	gasPrice := types.NewGasPrice(0)
-	gasLimit := types.NewGasUnits(0)
-
-	t.Run("Make sure new message makes it to every node message pool and is correctly propagated", func(t *testing.T) {
-		_, err = nodes[0].PorcelainAPI.MessageSendWithDefaultAddress(
+	t.Run("message propagates", func(t *testing.T) {
+		_, err = sender.PorcelainAPI.MessageSendWithDefaultAddress(
 			ctx,
-			nd0Addr,
+			senderAddress,
 			address.NetworkAddress,
-			types.NewAttoFILFromFIL(123),
-			gasPrice,
-			gasLimit,
+			types.NewAttoFILFromFIL(1),
+			types.NewGasPrice(0),
+			types.NewGasUnits(0),
 			"foo",
-			[]byte{},
 		)
 		require.NoError(err)
 
-		var msgs0, msgs1, msgs2, msgs3, msgs4 []*types.SignedMessage
 		require.NoError(th.WaitForIt(50, 100*time.Millisecond, func() (bool, error) {
-			msgs0 = nodes[0].MsgPool.Pending()
-			msgs1 = nodes[1].MsgPool.Pending()
-			msgs2 = nodes[2].MsgPool.Pending()
-			msgs3 = nodes[3].MsgPool.Pending()
-			msgs4 = nodes[4].MsgPool.Pending()
-			return len(msgs0) == 1 && len(msgs1) == 1 && len(msgs2) == 1 && len(msgs3) == 1 && len(msgs4) == 1, nil
+			return len(nodes[0].MsgPool.Pending()) == 1 &&
+				len(nodes[1].MsgPool.Pending()) == 1 &&
+				len(nodes[2].MsgPool.Pending()) == 1, nil
 		}), "failed to propagate messages")
 
-		assert.True(t, msgs0[0].Message.Method == "foo")
-		assert.True(t, msgs4[0].Message.Method == "foo")
+		assert.True(t, nodes[0].MsgPool.Pending()[0].Message.Method == "foo")
+		assert.True(t, nodes[1].MsgPool.Pending()[0].Message.Method == "foo")
+		assert.True(t, nodes[2].MsgPool.Pending()[0].Message.Method == "foo")
 	})
 }

--- a/node/node.go
+++ b/node/node.go
@@ -407,7 +407,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 		MsgPool:      msgPool,
 		MsgPreviewer: msg.NewPreviewer(fcWallet, chainReader, &cstOffline, bs),
 		MsgQueryer:   msg.NewQueryer(nc.Repo, fcWallet, chainReader, &cstOffline, bs),
-		MsgSender:    msg.NewSender(nc.Repo, fcWallet, chainReader, msgPool, fsub.Publish),
+		MsgSender:    msg.NewSender(fcWallet, chainReader, msgPool, consensus.NewOutboundMessageValidator(), fsub.Publish),
 		MsgWaiter:    msg.NewWaiter(chainReader, bs, &cstOffline),
 		Network:      ntwk.New(peerHost, pubsub.NewPublisher(fsub), pubsub.NewSubscriber(fsub)),
 		SigGetter:    mthdsig.NewGetter(chainReader),

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"gx/ipfs/QmRhFARzTHcFh8wUxwN5KvyTGq73FLC65EfFAhz8Ng7aGb/go-libp2p-peerstore"
-
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/config"
@@ -29,6 +27,7 @@ import (
 
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+	"gx/ipfs/QmRhFARzTHcFh8wUxwN5KvyTGq73FLC65EfFAhz8Ng7aGb/go-libp2p-peerstore"
 )
 
 var seed = types.GenerateKeyInfoSeed()
@@ -157,6 +156,7 @@ func TestNodeStartMining(t *testing.T) {
 	minerNode := MakeNodeWithChainSeed(t, seed, []ConfigOpt{}, PeerKeyOpt(PeerKeys[0]), AutoSealIntervalSecondsOpt(1))
 
 	walletBackend, _ := wallet.NewDSBackend(minerNode.Repo.WalletDatastore())
+	validator := consensus.NewDefaultMessageValidator()
 
 	// TODO we need a principled way to construct an API that can be used both by node and by
 	// tests. It should enable selective replacement of dependencies.
@@ -166,7 +166,7 @@ func TestNodeStartMining(t *testing.T) {
 		MsgPool:      nil,
 		MsgPreviewer: msg.NewPreviewer(minerNode.Wallet, minerNode.ChainReader, minerNode.CborStore(), minerNode.Blockstore),
 		MsgQueryer:   msg.NewQueryer(minerNode.Repo, minerNode.Wallet, minerNode.ChainReader, minerNode.CborStore(), minerNode.Blockstore),
-		MsgSender:    msg.NewSender(minerNode.Repo, minerNode.Wallet, minerNode.ChainReader, minerNode.MsgPool, minerNode.PorcelainAPI.PubSubPublish),
+		MsgSender:    msg.NewSender(minerNode.Wallet, minerNode.ChainReader, minerNode.MsgPool, validator, minerNode.PorcelainAPI.PubSubPublish),
 		MsgWaiter:    msg.NewWaiter(minerNode.ChainReader, minerNode.Blockstore, minerNode.CborStore()),
 		Network:      ntwk.New(minerNode.Host(), nil, nil),
 		SigGetter:    mthdsig.NewGetter(minerNode.ChainReader),

--- a/plumbing/msg/testing.go
+++ b/plumbing/msg/testing.go
@@ -23,11 +23,7 @@ type commonDeps struct {
 	cst        *hamt.CborIpldStore
 }
 
-func requireCommonDeps(require *require.Assertions) *commonDeps { //nolint: deadcode
-	return requireCommonDepsWithGif(require, consensus.DefaultGenesis)
-}
-
-func requireCommonDepsWithGif(require *require.Assertions, gif consensus.GenesisInitFunc) *commonDeps {
+func requiredCommonDeps(require *require.Assertions, gif consensus.GenesisInitFunc) *commonDeps { // nolint: deadcode
 	r := repo.NewInMemoryRepo()
 	bs := bstore.NewBlockstore(r.Datastore())
 	return requireCommonDepsWithGifAndBlockstore(require, gif, r, bs)

--- a/plumbing/msg/waiter_test.go
+++ b/plumbing/msg/waiter_test.go
@@ -6,16 +6,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/go-filecoin/testhelpers"
-
 	"gx/ipfs/QmNf3wujpV2Y7Lnj2hy2UrmuX8bhMDStRHbnSLh7Ypf36h/go-hamt-ipld"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/core"
+	"github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
-	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
-	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 )
 
 var seed = types.GenerateKeyInfoSeed()
@@ -46,12 +45,12 @@ type smsgs []*types.SignedMessage
 type smsgsSet [][]*types.SignedMessage
 
 func setupTest(require *require.Assertions) (*hamt.CborIpldStore, *chain.DefaultStore, *Waiter) {
-	d := requireCommonDeps(require)
+	d := requiredCommonDeps(require, consensus.DefaultGenesis)
 	return d.cst, d.chainStore, NewWaiter(d.chainStore, d.blockstore, d.cst)
 }
 
 func setupTestWithGif(require *require.Assertions, gif consensus.GenesisInitFunc) (*hamt.CborIpldStore, *chain.DefaultStore, *Waiter) {
-	d := requireCommonDepsWithGif(require, gif)
+	d := requiredCommonDeps(require, gif)
 	return d.cst, d.chainStore, NewWaiter(d.chainStore, d.blockstore, d.cst)
 }
 


### PR DESCRIPTION
This is most of the work for #1934 (there are some cases the validator doesn't yet check).

I intend to rebase on #2136 and #2138 before merging, resolving some duplicated actor loading.