### PR TITLE
update submodule when installing rust-fil-proofs

### DIFF
--- a/scripts/install-rust-fil-proofs.sh
+++ b/scripts/install-rust-fil-proofs.sh
@@ -55,8 +55,6 @@ install_local() {
     exit 1
   fi
 
-  git submodule update --init --recursive proofs/rust-fil-proofs
-
   pushd proofs/rust-fil-proofs
 
   cargo --version
@@ -77,6 +75,8 @@ install_local() {
   cp proofs/rust-fil-proofs/target/release/libfilecoin_proofs.a ./proofs/lib/
   cp proofs/rust-fil-proofs/target/release/libfilecoin_proofs.pc ./proofs/lib/pkgconfig/
 }
+
+git submodule update --init --recursive proofs/rust-fil-proofs
 
 if [ -z "$FILECOIN_USE_PRECOMPILED_RUST_PROOFS" ]; then
   echo "using local rust-fil-proofs"


### PR DESCRIPTION
fixes: https://github.com/filecoin-project/go-filecoin/issues/2134

just updates the submodule for both local/remote installs