### PR TITLE
Feat/dht command

### DIFF
--- a/commands/dht.go
+++ b/commands/dht.go
@@ -1,0 +1,175 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	cmds "gx/ipfs/QmQtQrtNioesAWtrx8csBvfY37gTe94d6wQ3VikZUjxD39/go-ipfs-cmds"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	pstore "gx/ipfs/QmRhFARzTHcFh8wUxwN5KvyTGq73FLC65EfFAhz8Ng7aGb/go-libp2p-peerstore"
+	notif "gx/ipfs/QmWaDSNoSdSXU9b6udyaq9T8y6LkzMwqWxECznFqvtcTsk/go-libp2p-routing/notifications"
+	cmdkit "gx/ipfs/Qmde5VP1qUkyQXKCfmEUA7bP64V2HAptbJ7phuPp7jXWwg/go-ipfs-cmdkit"
+)
+
+const (
+	dhtVerboseOptionName   = "verbose"
+	numProvidersOptionName = "num-providers"
+)
+
+// Note, most of this is copied directly from go-ipfs (https://github.com/ipfs/go-ipfs/blob/master/core/commands/dht.go).
+// A few simple modifications have been adapted for filecoin.
+var dhtCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline:          "Explore and manipulate the libp2p DHT.",
+		ShortDescription: ``,
+	},
+
+	Subcommands: map[string]*cmds.Command{
+		"findprovs": findProvidersDhtCmd,
+	},
+}
+
+var findProvidersDhtCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline:          "Find peers that can provide a given key's value.",
+		ShortDescription: "Outputs a list of newline-delimited provider Peer IDs for a given key.",
+	},
+	Arguments: []cmdkit.Argument{
+		cmdkit.StringArg("key", true, false, "The key whose provider Peer IDs are output.").EnableStdin(),
+	},
+	Options: []cmdkit.Option{
+		cmdkit.BoolOption(dhtVerboseOptionName, "v", "Print extra information."),
+		cmdkit.IntOption(numProvidersOptionName, "n", "The max number of providers to find.").WithDefault(20),
+	},
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		numProviders, _ := req.Options[numProvidersOptionName].(int)
+		if numProviders < 1 {
+			return fmt.Errorf("number of providers must be greater than 0")
+		}
+
+		c, err := cid.Parse(req.Arguments[0])
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(req.Context, time.Minute)
+		ctx, events := notif.RegisterForQueryEvents(ctx)
+
+		pchan := GetPorcelainAPI(env).NetworkFindProvidersAsync(ctx, c, numProviders)
+
+		go func() {
+			defer cancel()
+			for p := range pchan {
+				np := p
+				// Note that the peer IDs in these Provider
+				// events are the main output of this command.
+				// These results are piped back into the event
+				// system so that they can be read alongside
+				// other routing events which are output in
+				// verbose mode but otherwise filtered.
+				notif.PublishQueryEvent(ctx, &notif.QueryEvent{
+					Type:      notif.Provider,
+					Responses: []*pstore.PeerInfo{&np},
+				})
+			}
+		}()
+		for e := range events {
+			if err := res.Emit(e); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *notif.QueryEvent) error {
+			pfm := pfuncMap{
+				notif.FinalPeer: func(obj *notif.QueryEvent, out io.Writer, verbose bool) {
+					if verbose {
+						fmt.Fprintf(out, "* closest peer %s\n", obj.ID) // nolint: errcheck
+					}
+				},
+				notif.Provider: func(obj *notif.QueryEvent, out io.Writer, verbose bool) {
+					prov := obj.Responses[0]
+					if verbose {
+						fmt.Fprintf(out, "provider: ") // nolint: errcheck
+					}
+					fmt.Fprintf(out, "%s\n", prov.ID.Pretty()) // nolint: errcheck
+					if verbose {
+						for _, a := range prov.Addrs {
+							fmt.Fprintf(out, "\t%s\n", a) // nolint: errcheck
+						}
+					}
+				},
+			}
+
+			verbose, _ := req.Options[dhtVerboseOptionName].(bool)
+			printEvent(out, w, verbose, pfm)
+
+			return nil
+		}),
+	},
+	Type: notif.QueryEvent{},
+}
+
+type printFunc func(obj *notif.QueryEvent, out io.Writer, verbose bool)
+type pfuncMap map[notif.QueryEventType]printFunc
+
+// printEvent writes a libp2p event to a user friendly output on the out writer.
+// Note that this function is only needed to enable the output logging of
+// events that only show up during a "verbose" run. If we choose to eliminate
+// the verbose option this can be removed. However if we keep the verbose option
+// in findprovs and on any other dht subcommands we decide to copy over from
+// ipfs this function will stay needed.
+func printEvent(obj *notif.QueryEvent, out io.Writer, verbose bool, override pfuncMap) {
+	if verbose {
+		fmt.Fprintf(out, "%s: ", time.Now().Format("15:04:05.000")) // nolint: errcheck
+	}
+
+	if override != nil {
+		if pf, ok := override[obj.Type]; ok {
+			pf(obj, out, verbose)
+			return
+		}
+	}
+
+	switch obj.Type {
+	case notif.SendingQuery:
+		if verbose {
+			fmt.Fprintf(out, "* querying %s\n", obj.ID) // nolint: errcheck
+		}
+	case notif.Value:
+		if verbose {
+			fmt.Fprintf(out, "got value: '%s'\n", obj.Extra) // nolint: errcheck
+		} else {
+			fmt.Fprint(out, obj.Extra) // nolint: errcheck
+		}
+	case notif.PeerResponse:
+		if verbose {
+			fmt.Fprintf(out, "* %s says use ", obj.ID) // nolint: errcheck
+			for _, p := range obj.Responses {
+				fmt.Fprintf(out, "%s ", p.ID) // nolint: errcheck
+			}
+			fmt.Fprintln(out) // nolint: errcheck
+		}
+	case notif.QueryError:
+		if verbose {
+			fmt.Fprintf(out, "error: %s\n", obj.Extra) // nolint: errcheck
+		}
+	case notif.DialingPeer:
+		if verbose {
+			fmt.Fprintf(out, "dialing peer: %s\n", obj.ID) // nolint: errcheck
+		}
+	case notif.AddingPeer:
+		if verbose {
+			fmt.Fprintf(out, "adding peer to query: %s\n", obj.ID) // nolint: errcheck
+		}
+	case notif.FinalPeer:
+	default:
+		if verbose {
+			fmt.Fprintf(out, "unrecognized event type: %d\n", obj.Type) // nolint: errcheck
+		}
+	}
+}

--- a/commands/main.go
+++ b/commands/main.go
@@ -109,6 +109,7 @@ VIEW DATA STRUCTURES
 
 NETWORK COMMANDS
   go-filecoin bootstrap              - Interact with bootstrap addresses
+  go-filecoin dht                    - Interact with the dht
   go-filecoin id                     - Show info about the network peers
   go-filecoin ping <peer ID>...      - Send echo request packets to p2p network members
   go-filecoin swarm                  - Interact with the swarm
@@ -156,6 +157,7 @@ var rootSubcmdsDaemon = map[string]*cmds.Command{
 	"config":           configCmd,
 	"client":           clientCmd,
 	"dag":              dagCmd,
+	"dht":              dhtCmd,
 	"id":               idCmd,
 	"log":              logCmd,
 	"message":          msgCmd,

--- a/filnet/router.go
+++ b/filnet/router.go
@@ -1,0 +1,41 @@
+package filnet
+
+import (
+	"context"
+
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	pstore "gx/ipfs/QmRhFARzTHcFh8wUxwN5KvyTGq73FLC65EfFAhz8Ng7aGb/go-libp2p-peerstore"
+	routing "gx/ipfs/QmWaDSNoSdSXU9b6udyaq9T8y6LkzMwqWxECznFqvtcTsk/go-libp2p-routing"
+)
+
+// This struct wraps the filecoin nodes router.  This router is a
+// go-libp2p-routing.IpfsRouting interface that provides both PeerRouting,
+// ContentRouting and a Bootstrap init process. Filecoin nodes in online mode
+// use a go-libp2p-kad-dht DHT to satisfy this interface. Nodes run the
+// Bootstrap function to join the DHT on start up. The PeerRouting functionality
+// enables filecoin nodes to lookup the network addresses of their peers given a
+// peerID.  The ContentRouting functionality enables peers to provide and
+// discover providers of network services. This is currently used by the
+// auto-relay feature in the filecoin network to allow nodes to advertise
+// themselves as relay nodes and discover other relay nodes.
+//
+// The IpfsRouting interface and its DHT instantiation also carries ValueStore
+// functionality for using the DHT as a key value store.  Filecoin nodes do
+// not currently use this functionality.
+
+// Router exposes the methods on the internal filecoin router that are needed
+// by the system plumbing API.
+type Router struct {
+	routing routing.IpfsRouting
+}
+
+// NewRouter builds a new router.
+func NewRouter(r routing.IpfsRouting) *Router {
+	return &Router{routing: r}
+}
+
+// FindProvidersAsync searches for and returns peers who are able to provide a
+// given key.
+func (r *Router) FindProvidersAsync(ctx context.Context, key cid.Cid, count int) <-chan pstore.PeerInfo {
+	return r.routing.FindProvidersAsync(ctx, key, count)
+}

--- a/node/node.go
+++ b/node/node.go
@@ -409,7 +409,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 		MsgQueryer:   msg.NewQueryer(nc.Repo, fcWallet, chainReader, &cstOffline, bs),
 		MsgSender:    msg.NewSender(fcWallet, chainReader, msgPool, consensus.NewOutboundMessageValidator(), fsub.Publish),
 		MsgWaiter:    msg.NewWaiter(chainReader, bs, &cstOffline),
-		Network:      ntwk.New(peerHost, pubsub.NewPublisher(fsub), pubsub.NewSubscriber(fsub)),
+		Network:      ntwk.New(peerHost, pubsub.NewPublisher(fsub), pubsub.NewSubscriber(fsub), filnet.NewRouter(router)),
 		SigGetter:    mthdsig.NewGetter(chainReader),
 		Wallet:       fcWallet,
 	}))

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -168,7 +168,7 @@ func TestNodeStartMining(t *testing.T) {
 		MsgQueryer:   msg.NewQueryer(minerNode.Repo, minerNode.Wallet, minerNode.ChainReader, minerNode.CborStore(), minerNode.Blockstore),
 		MsgSender:    msg.NewSender(minerNode.Wallet, minerNode.ChainReader, minerNode.MsgPool, validator, minerNode.PorcelainAPI.PubSubPublish),
 		MsgWaiter:    msg.NewWaiter(minerNode.ChainReader, minerNode.Blockstore, minerNode.CborStore()),
-		Network:      ntwk.New(minerNode.Host(), nil, nil),
+		Network:      ntwk.New(minerNode.Host(), nil, nil, nil),
 		SigGetter:    mthdsig.NewGetter(minerNode.ChainReader),
 		Wallet:       wallet.New(walletBackend),
 	})

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	pstore "gx/ipfs/QmRhFARzTHcFh8wUxwN5KvyTGq73FLC65EfFAhz8Ng7aGb/go-libp2p-peerstore"
 	"gx/ipfs/QmTu65MVbemtUxJEWgsTtzv9Zv9P8rvmqNA4eG9TrTRGYc/go-libp2p-peer"
 	logging "gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log"
 
@@ -179,6 +180,11 @@ func (api *API) PubSubPublish(topic string, data []byte) error {
 // NetworkGetPeerID gets the current peer id from Util
 func (api *API) NetworkGetPeerID() peer.ID {
 	return api.network.GetPeerID()
+}
+
+// NetworkFindProvidersAsync issues a findProviders query to the filecoin network content router.
+func (api *API) NetworkFindProvidersAsync(ctx context.Context, key cid.Cid, count int) <-chan pstore.PeerInfo {
+	return api.network.FindProvidersAsync(ctx, key, count)
 }
 
 // SignBytes uses private key information associated with the given address to sign the given bytes.

--- a/plumbing/ntwk/ntwk.go
+++ b/plumbing/ntwk/ntwk.go
@@ -4,6 +4,7 @@ import (
 	"gx/ipfs/QmTu65MVbemtUxJEWgsTtzv9Zv9P8rvmqNA4eG9TrTRGYc/go-libp2p-peer"
 	"gx/ipfs/Qmd52WKRSwrBK5gUaJKawryZQ5by6UbNB8KVW2Zy6JtbyW/go-libp2p-host"
 
+	"github.com/filecoin-project/go-filecoin/filnet"
 	"github.com/filecoin-project/go-filecoin/pubsub"
 )
 
@@ -12,14 +13,16 @@ type Network struct {
 	host host.Host
 	*pubsub.Subscriber
 	*pubsub.Publisher
+	*filnet.Router
 }
 
 // New returns a new Network
-func New(host host.Host, publisher *pubsub.Publisher, subscriber *pubsub.Subscriber) *Network {
+func New(host host.Host, publisher *pubsub.Publisher, subscriber *pubsub.Subscriber, router *filnet.Router) *Network {
 	return &Network{
 		host:       host,
 		Subscriber: subscriber,
 		Publisher:  publisher,
+		Router:     router,
 	}
 }
 

--- a/testhelpers/commands.go
+++ b/testhelpers/commands.go
@@ -102,6 +102,7 @@ type TestDaemon struct {
 	keyFiles         []string
 	withMiner        string
 	autoSealInterval string
+	isRelay          bool
 
 	firstRun bool
 	init     bool
@@ -730,6 +731,11 @@ func WithMiner(m string) func(*TestDaemon) {
 	}
 }
 
+// IsRelay starts the daemon with the --is-relay option.
+func IsRelay(td *TestDaemon) {
+	td.isRelay = true
+}
+
 // NewDaemon creates a new `TestDaemon`, using the passed in configuration options.
 func NewDaemon(t *testing.T, options ...func(*TestDaemon)) *TestDaemon {
 	t.Helper()
@@ -756,7 +762,6 @@ func NewDaemon(t *testing.T, options ...func(*TestDaemon)) *TestDaemon {
 	}
 
 	repoDirFlag := fmt.Sprintf("--repodir=%s", td.repoDir)
-	blockTimeFlag := fmt.Sprintf("--block-time=%s", BlockTimeTest)
 
 	// build command options
 	initopts := []string{repoDirFlag}
@@ -801,8 +806,13 @@ func NewDaemon(t *testing.T, options ...func(*TestDaemon)) *TestDaemon {
 
 	swarmListenFlag := fmt.Sprintf("--swarmlisten=%s", td.swarmAddr)
 	cmdAPIAddrFlag := fmt.Sprintf("--cmdapiaddr=%s", td.cmdAddr)
+	blockTimeFlag := fmt.Sprintf("--block-time=%s", BlockTimeTest)
 
 	td.daemonArgs = []string{filecoinBin, "daemon", repoDirFlag, cmdAPIAddrFlag, swarmListenFlag, blockTimeFlag}
+
+	if td.isRelay {
+		td.daemonArgs = append(td.daemonArgs, "--is-relay")
+	}
 
 	return td
 }


### PR DESCRIPTION
First of the subcommands referenced from #1997 

I'm adding in only one subcommand right now to make sure that other people are on board with some of the decisions I've made in this one that would apply to the others subcommands.

Check this out commit by commit and take a look at the initial comments for things that may need changing.

--edit--
One more note, the cid corresponding to the relay service is `zb2rhZ6FpTqFZyiAtpQFRKmybPMjq5A7oPHfmD5WeBko5kRAo` (the namespace tag "/libp2p/relay" is hashed with [this function](https://github.com/libp2p/go-libp2p-discovery/blob/master/routing.go#L64) )  When connecting to the test cluster with a daemon built on this branch I correctly see that the 5 bootstrap peers are providing the relay service using the `findprovs` command!

```
$ go-filecoin dht findprovs zb2rhZ6FpTqFZyiAtpQFRKmybPMjq5A7oPHfmD5WeBko5kRAo
QmXq6XEYeEmUzBFuuKbVEGgxEpVD4xbSkG2Rhek6zkFMp4
QmXhxqTKzBKHA5FcMuiKZv8YaMPwpbKGXHRVZcFB2DX9XY
QmZGDLdQLUTi7uYTNavKwCd7SBc5KMfxzWxAyvqRQvwuiV
QmZRnwmCjyNHgeNDiyT8mXRtGhP6uSzgHtrozc42crmVbg
Qmd6xrWYHsxivfakYRy6MszTpuAiEoFbgE1LWw4EvwBpp4
```