### PR TITLE
Remove unused mockMineMode arg and simplify integration test genesis and node init.

### DIFF
--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -559,7 +559,7 @@ func requireGenesis(ctx context.Context, t *testing.T, targetAddresses ...addres
 	vms := vm.NewStorageMap(bs)
 
 	cst := hamt.NewCborStore()
-	blk, err := consensus.InitGenesis(cst, bs)
+	blk, err := consensus.DefaultGenesis(cst, bs)
 	require.NoError(err)
 
 	st, err := state.LoadStateTree(ctx, cst, blk.StateRoot, builtin.Actors)

--- a/api/impl/actor_test.go
+++ b/api/impl/actor_test.go
@@ -54,7 +54,7 @@ func TestActorLs(t *testing.T) {
 
 		nd := node.MakeOfflineNode(t)
 
-		genBlock, err := consensus.InitGenesis(nd.CborStore(), nd.Blockstore)
+		genBlock, err := consensus.DefaultGenesis(nd.CborStore(), nd.Blockstore)
 		require.NoError(err)
 		b1 := types.NewBlockForTest(genBlock, 1)
 		ts := testhelpers.RequireNewTipSet(require, b1)

--- a/api/impl/daemon.go
+++ b/api/impl/daemon.go
@@ -78,7 +78,7 @@ func (nd *nodeDaemon) Init(ctx context.Context, opts ...api.DaemonInitOpt) error
 		} // else err may be set and returned as normal
 	}()
 
-	gif := consensus.InitGenesis
+	gif := consensus.DefaultGenesis
 
 	var initopts []node.InitOpt
 	if cfg.PeerKeyFile != "" {

--- a/api/impl/id_test.go
+++ b/api/impl/id_test.go
@@ -38,7 +38,7 @@ func TestIdOutput(t *testing.T) {
 	r := repo.NewInMemoryRepo()
 	r.Config().Swarm.Address = "/ip4/0.0.0.0/tcp/0"
 
-	err := node.Init(ctx, r, consensus.InitGenesis)
+	err := node.Init(ctx, r, consensus.DefaultGenesis)
 	assert.NoError(err)
 
 	// define repo option

--- a/api/impl/ping_test.go
+++ b/api/impl/ping_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 	pstore "gx/ipfs/QmRhFARzTHcFh8wUxwN5KvyTGq73FLC65EfFAhz8Ng7aGb/go-libp2p-peerstore"
 
 	"github.com/filecoin-project/go-filecoin/api"
 	"github.com/filecoin-project/go-filecoin/node"
-	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 )
 
 func TestPing(t *testing.T) {
@@ -18,7 +18,8 @@ func TestPing(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
 
-	nodes := node.MakeNodesStarted(t, 2, false, true)
+	nodes := node.MakeNodesUnstarted(t, 2, false)
+	node.StartNodes(t, nodes)
 	api0 := New(nodes[0])
 	p1 := nodes[1].Host().ID()
 	pi1 := pstore.PeerInfo{

--- a/commands/env_test.go
+++ b/commands/env_test.go
@@ -20,7 +20,7 @@ func TestEnv(t *testing.T) {
 	r := repo.NewInMemoryRepo()
 	r.Config().Swarm.Address = "/ip4/0.0.0.0/tcp/0"
 
-	err := node.Init(ctx, r, consensus.InitGenesis)
+	err := node.Init(ctx, r, consensus.DefaultGenesis)
 	assert.NoError(err)
 
 	opts, err := node.OptionsFromRepo(r)

--- a/consensus/expected_test.go
+++ b/consensus/expected_test.go
@@ -47,7 +47,7 @@ func TestExpected_NewValidTipSet(t *testing.T) {
 
 	t.Run("NewValidTipSet returns a tipset + nil (no errors) when valid blocks", func(t *testing.T) {
 
-		genesisBlock, err := consensus.InitGenesis(cistore, bstore)
+		genesisBlock, err := consensus.DefaultGenesis(cistore, bstore)
 		require.NoError(err)
 
 		exp := consensus.NewExpected(cistore, bstore, consensus.NewDefaultProcessor(), ptv, genesisBlock.Cid(), verifier)
@@ -124,7 +124,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 	ctx := context.Background()
 
 	cistore, bstore, verifier := setupCborBlockstoreProofs()
-	genesisBlock, err := consensus.InitGenesis(cistore, bstore)
+	genesisBlock, err := consensus.DefaultGenesis(cistore, bstore)
 	require.NoError(err)
 
 	t.Run("passes the validateMining section when given valid mining blocks", func(t *testing.T) {

--- a/consensus/genesis.go
+++ b/consensus/genesis.go
@@ -90,8 +90,8 @@ func NewEmptyConfig() *Config {
 	}
 }
 
-// MakeGenesisFunc is a method used to define a custom genesis function
-func MakeGenesisFunc(opts ...GenOption) func(cst *hamt.CborIpldStore, bs blockstore.Blockstore) (*types.Block, error) {
+// MakeGenesisFunc returns a genesis function configured by a set of options.
+func MakeGenesisFunc(opts ...GenOption) GenesisInitFunc {
 	return func(cst *hamt.CborIpldStore, bs blockstore.Blockstore) (*types.Block, error) {
 		ctx := context.Background()
 		st := state.NewEmptyStateTreeWithActors(cst, builtin.Actors)
@@ -175,8 +175,8 @@ func MakeGenesisFunc(opts ...GenOption) func(cst *hamt.CborIpldStore, bs blockst
 	}
 }
 
-// InitGenesis is the default function to create the genesis block.
-func InitGenesis(cst *hamt.CborIpldStore, bs blockstore.Blockstore) (*types.Block, error) {
+// DefaultGenesis creates a genesis block with default accounts and actors installed.
+func DefaultGenesis(cst *hamt.CborIpldStore, bs blockstore.Blockstore) (*types.Block, error) {
 	return MakeGenesisFunc()(cst, bs)
 }
 

--- a/core/testing.go
+++ b/core/testing.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"gx/ipfs/QmNf3wujpV2Y7Lnj2hy2UrmuX8bhMDStRHbnSLh7Ypf36h/go-hamt-ipld"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	"gx/ipfs/QmRu7tiRnFk9mMPpVECQTBQJqXtmG132jJxA1w9A7TtpBz/go-ipfs-blockstore"
 	"gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
@@ -19,8 +20,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
-
-	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 )
 
 // MustGetNonce returns the next nonce for an actor at an address or panics.
@@ -131,7 +130,7 @@ func CreateStorages(ctx context.Context, t *testing.T) (state.Tree, vm.StorageMa
 	cst := hamt.NewCborStore()
 	d := datastore.NewMapDatastore()
 	bs := blockstore.NewBlockstore(d)
-	blk, err := consensus.InitGenesis(cst, bs)
+	blk, err := consensus.DefaultGenesis(cst, bs)
 	require.NoError(t, err)
 
 	st, err := state.LoadStateTree(ctx, cst, blk.StateRoot, builtin.Actors)

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -2,19 +2,19 @@ package node
 
 import (
 	"context"
-	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/state"
-	"github.com/filecoin-project/go-filecoin/testhelpers"
 	"testing"
 	"time"
 
-	"gx/ipfs/QmRhFARzTHcFh8wUxwN5KvyTGq73FLC65EfFAhz8Ng7aGb/go-libp2p-peerstore"
-
-	"github.com/filecoin-project/go-filecoin/consensus"
-	"github.com/filecoin-project/go-filecoin/protocol/storage"
-	"github.com/filecoin-project/go-filecoin/types"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+	"gx/ipfs/QmRhFARzTHcFh8wUxwN5KvyTGq73FLC65EfFAhz8Ng7aGb/go-libp2p-peerstore"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/protocol/storage"
+	"github.com/filecoin-project/go-filecoin/state"
+	"github.com/filecoin-project/go-filecoin/testhelpers"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 func connect(t *testing.T, nd1, nd2 *Node) {
@@ -29,21 +29,6 @@ func connect(t *testing.T, nd1, nd2 *Node) {
 	}
 }
 
-func stopNodes(nds []*Node) {
-	for _, nd := range nds {
-		nd.Stop(context.Background())
-	}
-}
-
-func startNodes(t *testing.T, nds []*Node) {
-	t.Helper()
-	for _, nd := range nds {
-		if err := nd.Start(context.Background()); err != nil {
-			t.Fatal(err)
-		}
-	}
-}
-
 func TestBlockPropsManyNodes(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -52,8 +37,8 @@ func TestBlockPropsManyNodes(t *testing.T) {
 
 	numNodes := 4
 	minerAddr, nodes := makeNodes(ctx, t, assert, numNodes)
-	startNodes(t, nodes)
-	defer stopNodes(nodes)
+	StartNodes(t, nodes)
+	defer StopNodes(nodes)
 
 	minerNode := nodes[0]
 
@@ -102,8 +87,8 @@ func TestChainSync(t *testing.T) {
 	assert := assert.New(t)
 
 	minerAddr, nodes := makeNodes(ctx, t, assert, 2)
-	startNodes(t, nodes)
-	defer stopNodes(nodes)
+	StartNodes(t, nodes)
+	defer StopNodes(nodes)
 
 	baseTS := nodes[0].ChainReader.Head()
 

--- a/node/init.go
+++ b/node/init.go
@@ -58,8 +58,6 @@ func Init(ctx context.Context, r repo.Repo, gen consensus.GenesisInitFunc, opts 
 		o(cfg)
 	}
 
-	// TODO(ipfs): make the blockstore and blockservice have the same interfaces
-	// so that this becomes less painful
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
 

--- a/node/message_propagate_test.go
+++ b/node/message_propagate_test.go
@@ -19,9 +19,9 @@ func TestMessagePropagation(t *testing.T) {
 	defer cancel()
 	require := require.New(t)
 
-	nodes := MakeNodesUnstarted(t, 5, false, true)
-	startNodes(t, nodes)
-	defer stopNodes(nodes)
+	nodes := MakeNodesUnstarted(t, 5, false)
+	StartNodes(t, nodes)
+	defer StopNodes(nodes)
 	connect(t, nodes[0], nodes[1])
 	connect(t, nodes[1], nodes[2])
 	connect(t, nodes[2], nodes[3])

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -39,7 +39,7 @@ func TestNodeConstruct(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	nd := MakeNodesUnstarted(t, 1, false, true)[0]
+	nd := MakeNodesUnstarted(t, 1, false)[0]
 	assert.NotNil(nd.Host)
 
 	nd.Stop(context.Background())
@@ -50,7 +50,7 @@ func TestNodeNetworking(t *testing.T) {
 	ctx := context.Background()
 	assert := assert.New(t)
 
-	nds := MakeNodesUnstarted(t, 2, false, true)
+	nds := MakeNodesUnstarted(t, 2, false)
 	nd1, nd2 := nds[0], nds[1]
 
 	pinfo := peerstore.PeerInfo{
@@ -76,7 +76,7 @@ func TestConnectsToBootstrapNodes(t *testing.T) {
 		r := repo.NewInMemoryRepo()
 		r.Config().Swarm.Address = "/ip4/0.0.0.0/tcp/0"
 
-		require.NoError(Init(ctx, r, consensus.InitGenesis))
+		require.NoError(Init(ctx, r, consensus.DefaultGenesis))
 		r.Config().Bootstrap.Addresses = []string{}
 		opts, err := OptionsFromRepo(r)
 		require.NoError(err)
@@ -93,7 +93,8 @@ func TestConnectsToBootstrapNodes(t *testing.T) {
 		ctx := context.Background()
 
 		// These are two bootstrap nodes we'll connect to.
-		nds := MakeNodesStarted(t, 2, false, true)
+		nds := MakeNodesUnstarted(t, 2, false)
+		StartNodes(t, nds)
 		nd1, nd2 := nds[0], nds[1]
 
 		// Gotta be a better way to do this?
@@ -104,7 +105,7 @@ func TestConnectsToBootstrapNodes(t *testing.T) {
 		r := repo.NewInMemoryRepo()
 		r.Config().Swarm.Address = "/ip4/0.0.0.0/tcp/0"
 
-		require.NoError(Init(ctx, r, consensus.InitGenesis))
+		require.NoError(Init(ctx, r, consensus.DefaultGenesis))
 		r.Config().Bootstrap.Addresses = []string{peer1, peer2}
 		opts, err := OptionsFromRepo(r)
 		require.NoError(err)
@@ -294,7 +295,7 @@ func TestUpdateMessagePool(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := context.Background()
-	node := MakeNodesUnstarted(t, 1, true, false)[0]
+	node := MakeNodesUnstarted(t, 1, true)[0]
 	chainForTest, ok := node.ChainReader.(chain.Store)
 	require.True(ok)
 
@@ -341,7 +342,7 @@ func TestOptionWithError(t *testing.T) {
 	ctx := context.Background()
 	assert := assert.New(t)
 	r := repo.NewInMemoryRepo()
-	assert.NoError(Init(ctx, r, consensus.InitGenesis))
+	assert.NoError(Init(ctx, r, consensus.DefaultGenesis))
 
 	opts, err := OptionsFromRepo(r)
 	assert.NoError(err)
@@ -410,7 +411,7 @@ func TestNodeConfig(t *testing.T) {
 		ConfigOpts:  configOptions,
 		InitOpts:    initOpts,
 		OfflineMode: true,
-		GenesisFunc: consensus.InitGenesis,
+		GenesisFunc: consensus.DefaultGenesis,
 	}
 
 	n := GenNode(t, &tno)

--- a/plumbing/msg/testing.go
+++ b/plumbing/msg/testing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	hamt "gx/ipfs/QmNf3wujpV2Y7Lnj2hy2UrmuX8bhMDStRHbnSLh7Ypf36h/go-hamt-ipld"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 	bstore "gx/ipfs/QmRu7tiRnFk9mMPpVECQTBQJqXtmG132jJxA1w9A7TtpBz/go-ipfs-blockstore"
 	offline "gx/ipfs/QmSz8kAe2JCKp2dWSG8gHSWnwSmne8YfRXTeK5HBmc9L7t/go-ipfs-exchange-offline"
 	bserv "gx/ipfs/QmZsGVGCqMCNzHLNMB6q4F6yyvomqf1VxwhJwSfgo1NGaF/go-blockservice"
@@ -12,7 +13,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/wallet"
-	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 )
 
 type commonDeps struct {
@@ -24,7 +24,7 @@ type commonDeps struct {
 }
 
 func requireCommonDeps(require *require.Assertions) *commonDeps { //nolint: deadcode
-	return requireCommonDepsWithGif(require, consensus.InitGenesis)
+	return requireCommonDepsWithGif(require, consensus.DefaultGenesis)
 }
 
 func requireCommonDepsWithGif(require *require.Assertions, gif consensus.GenesisInitFunc) *commonDeps {


### PR DESCRIPTION
- The mockMineMode arg to MakeNodesUnstarted was always true, or could be set true (it installs a fake proof verifier).
- Removed MakeNodesStarted in favour of moving an existing StartNodes where it could be reused.
- Renamed InitGenesis to DefaultGenesis after I finally understood what it did.

This is prework to some more complicated in-process integration test setup I need for #2139.