### PR TITLE
Add RAM Requirements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See [KNOWN_ISSUES](https://github.com/filecoin-project/go-filecoin/blob/master/K
 
 ### System Requirements
 
-Filecoin can build and run on most Linux and MacOS systems. Windows is not yet supported.
+Filecoin can build and run on most Linux and MacOS systems with at least 8GB of RAM. Windows is not yet supported.
 
 <!--
 ### Install from Release Binary


### PR DESCRIPTION
Some community users running filecoin on AWS instances with 4GB of RAM notice that the daemon will run out of memory. Upping the memory to 8GB resolves the problem, so we are adding this in as a system requirement.