### PR TITLE
Update required go version for filecoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Now install the tools and dependencies listed below. If you have **any problems 
 
 The build process for go-filecoin requires:
 
-- [Go](https://golang.org/doc/install) >= v1.11.2.
+- [Go](https://golang.org/doc/install) >= v1.11.2 AND < 1.12.
   - Installing Go for the first time? We recommend [this tutorial](https://www.ardanlabs.com/blog/2016/05/installing-go-and-your-workspace.html) which includes environment setup.
 - [Rust](https://www.rust-lang.org/) >= v1.31.0 and `cargo`
 - `pkg-config` - used by go-filecoin to handle generating linker flags

--- a/util/version/version.go
+++ b/util/version/version.go
@@ -16,7 +16,7 @@ func Check(version string) bool {
 	minorVersion, _ := strconv.Atoi(pieces[1])
 
 	if minorVersion > 11 {
-		return true
+		return false
 	}
 
 	if minorVersion < 11 {

--- a/util/version/version_test.go
+++ b/util/version/version_test.go
@@ -12,9 +12,11 @@ func TestCheck(t *testing.T) {
 
 	assert.True(version.Check("go1.11.1"))
 	assert.True(version.Check("go1.11.2"))
-	assert.True(version.Check("go1.12"))
-	assert.True(version.Check("go1.12.1"))
-	assert.True(version.Check("go1.12.2"))
+
+	// filecoin currently doesn't work with go 1.12+
+	assert.False(version.Check("go1.12"))
+	assert.False(version.Check("go1.12.1"))
+	assert.False(version.Check("go1.12.2"))
 
 	assert.False(version.Check("go1.11"))
 	assert.False(version.Check("go1.10"))


### PR DESCRIPTION
Filecoin doesn't work with go 1.12 right now: #2167, so we update the
README and version checking code to require the go version to be < 1.12