### PR TITLE
Mark chain as bad if syncing fails

### DIFF
--- a/chain/bad_tipset_cache.go
+++ b/chain/bad_tipset_cache.go
@@ -7,7 +7,10 @@ import (
 )
 
 // badTipSetCache keeps track of bad tipsets that the syncer should not try to
-// download.  Readers and writers grab a lock.
+// download. Readers and writers grab a lock. The purpose of this cache is to
+// prevent a node from having to repeatedly invalidate a block (and its children)
+// in the event that the tipset does not conform to the rules of consensus. Note
+// that the cache is only in-memory, so it is reset whenever the node is restarted.
 // TODO: this needs to be limited.
 type badTipSetCache struct {
 	mu  sync.Mutex

--- a/chain/default_syncer.go
+++ b/chain/default_syncer.go
@@ -371,6 +371,12 @@ func (syncer *DefaultSyncer) HandleNewBlocks(ctx context.Context, blkCids []cid.
 			}
 		}
 		if err = syncer.syncOne(ctx, parent, ts); err != nil {
+			// While `syncOne` can indeed fail for reasons other than consensus,
+			// adding to the badTipSets at this point is the simplest, since we
+			// have access to the chain. If syncOne fails for non-consensus reasons,
+			// there is no assumption that the running node's data is valid at all,
+			// so we don't really lose anything with this simplification.
+			syncer.badTipSets.AddChain(chain[i:])
 			return err
 		}
 		parent = ts


### PR DESCRIPTION
We mark a chain as bad in the event that a syncOne call on a tipset
returns an error.

Part of resolution of #2155 .