### PR TITLE
integrate go-filecoin with new variable proof-producing generate_post and variable proof-consuming verify_post CGO calls

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -78,9 +78,9 @@ func (t Type) String() string {
 	case SectorID:
 		return "uint64"
 	case CommitmentsMap:
-		return "map[string]Commitments"
+		return "map[string]types.Commitments"
 	case PoStProofs:
-		return "[]PoStProof"
+		return "[]proofs.PoStProof"
 	default:
 		return "<unknown type>"
 	}

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -327,7 +327,7 @@ func TestMinerSubmitPoSt(t *testing.T) {
 
 	// submit post
 	proof := th.MakeRandomPoSTProofForTest()
-	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 8, "submitPoSt", proof[:])
+	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 8, "submitPoSt", []proofs.PoStProof{proof})
 	require.NoError(err)
 	require.NoError(res.ExecutionError)
 	require.Equal(uint8(0), res.Receipt.ExitCode)
@@ -340,7 +340,7 @@ func TestMinerSubmitPoSt(t *testing.T) {
 
 	// fail to submit inside the proving period
 	proof = th.MakeRandomPoSTProofForTest()
-	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 40008, "submitPoSt", proof[:])
+	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 40008, "submitPoSt", []proofs.PoStProof{proof})
 	require.NoError(err)
 	require.EqualError(res.ExecutionError, "submitted PoSt late, need to pay a fee")
 }

--- a/proofs/interface.go
+++ b/proofs/interface.go
@@ -16,7 +16,7 @@ type VerifyPoSTRequest struct {
 	ChallengeSeed PoStChallengeSeed
 	CommRs        []CommR
 	Faults        []uint64
-	Proof         PoStProof
+	Proofs        []PoStProof
 	StoreType     SectorStoreType // used to control sealing/verification performance
 }
 

--- a/proofs/sectorbuilder/interface.go
+++ b/proofs/sectorbuilder/interface.go
@@ -47,11 +47,11 @@ type SectorBuilder interface {
 	// which will fit into a newly-provisioned staged sector.
 	GetMaxUserBytesPerStagedSector() (uint64, error)
 
-	// GeneratePoST creates a proof-of-spacetime for the replicas managed by
+	// GeneratePoSt creates a proof-of-spacetime for the replicas managed by
 	// the SectorBuilder. Its output includes the proof-of-spacetime proof which
 	// is posted to the blockchain along with any faults. The proof can be
 	// verified by the VerifyPoSt method on the Verifier interface.
-	GeneratePoST(GeneratePoSTRequest) (GeneratePoSTResponse, error)
+	GeneratePoSt(GeneratePoStRequest) (GeneratePoStResponse, error)
 
 	// Close signals that this SectorBuilder is no longer in use. SectorBuilder
 	// metadata will not be deleted when Close is called; an equivalent
@@ -89,14 +89,14 @@ type SealedSectorMetadata struct {
 	SectorID  uint64
 }
 
-// GeneratePoSTRequest represents a request to generate a proof-of-spacetime.
-type GeneratePoSTRequest struct {
+// GeneratePoStRequest represents a request to generate a proof-of-spacetime.
+type GeneratePoStRequest struct {
 	CommRs        []proofs.CommR
 	ChallengeSeed proofs.PoStChallengeSeed
 }
 
-// GeneratePoSTResponse contains PoST proof and any faults that may have occurred.
-type GeneratePoSTResponse struct {
+// GeneratePoStResponse contains PoST proof and any faults that may have occurred.
+type GeneratePoStResponse struct {
 	Faults []uint64
-	Proof  proofs.PoStProof
+	Proofs []proofs.PoStProof
 }

--- a/proofs/sectorbuilder/rustsectorbuilder.go
+++ b/proofs/sectorbuilder/rustsectorbuilder.go
@@ -347,6 +347,10 @@ func goPoStProofs(src *C.uint8_t, size C.size_t) ([]proofs.PoStProof, error) {
 	chunkSize := int(proofs.PoStBytesLen)
 	arrSize := int(size)
 
+	if src == nil {
+		return []proofs.PoStProof{}, nil
+	}
+
 	if arrSize%chunkSize != 0 {
 		msg := "PoSt proof array invalid size (arrSize=%d % PoStBytesLen=%d != 0)"
 		return nil, errors.Errorf(msg, arrSize, proofs.PoStBytesLen)

--- a/proofs/sectorbuilder/rustsectorbuilder.go
+++ b/proofs/sectorbuilder/rustsectorbuilder.go
@@ -357,14 +357,15 @@ func goPoStProofs(src *C.uint8_t, size C.size_t) ([]proofs.PoStProof, error) {
 	}
 
 	out := make([]proofs.PoStProof, arrSize/chunkSize)
-	tmp := make([]byte, size)
 
-	if src != nil {
-		copy(tmp, (*(*[1 << 30]byte)(unsafe.Pointer(src)))[:size:size])
+	// Create a slice from a pointer to an array on the C heap by slicing to
+	// the appropriate size. We can then copy from this slice into the Go heap.
+	//
+	// https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
+	tmp := (*(*[1 << 30]byte)(unsafe.Pointer(src)))[:size:size]
 
-		for i := 0; i < len(out); i++ {
-			copy(out[i][:], tmp[i*chunkSize:(i+1)*chunkSize])
-		}
+	for i := 0; i < len(out); i++ {
+		copy(out[i][:], tmp[i*chunkSize:(i+1)*chunkSize])
 	}
 
 	return out, nil

--- a/proofs/sectorbuilder/testing/interface_test.go
+++ b/proofs/sectorbuilder/testing/interface_test.go
@@ -311,7 +311,7 @@ func TestSectorBuilder(t *testing.T) {
 			challengeSeed := proofs.PoStChallengeSeed{1, 2, 3}
 
 			// generate a proof-of-spacetime
-			gres, gerr := h.SectorBuilder.GeneratePoST(sectorbuilder.GeneratePoSTRequest{
+			gres, gerr := h.SectorBuilder.GeneratePoSt(sectorbuilder.GeneratePoStRequest{
 				CommRs:        []proofs.CommR{val.SealingResult.CommR},
 				ChallengeSeed: challengeSeed,
 			})
@@ -319,7 +319,7 @@ func TestSectorBuilder(t *testing.T) {
 
 			// TODO: Replace these hard-coded values (in rust-fil-proofs) with an
 			// end-to-end PoST test over a small number of replica commitments
-			require.Equal(t, "00101010", fmt.Sprintf("%08b", gres.Proof[0]))
+			require.Equal(t, "00101010", fmt.Sprintf("%08b", gres.Proofs[0][0]))
 			require.Equal(t, 1, len(gres.Faults))
 			require.Equal(t, uint64(0), gres.Faults[0])
 
@@ -328,7 +328,7 @@ func TestSectorBuilder(t *testing.T) {
 				ChallengeSeed: proofs.PoStChallengeSeed{},
 				CommRs:        []proofs.CommR{val.SealingResult.CommR},
 				Faults:        gres.Faults,
-				Proof:         gres.Proof,
+				Proofs:        gres.Proofs,
 				StoreType:     proofs.Test,
 			})
 

--- a/proofs/types.go
+++ b/proofs/types.go
@@ -1,7 +1,7 @@
 package proofs
 
-// SnarkBytesLen is the length of the Proof of SpaceTime proof.
-const SnarkBytesLen uint = 192
+// PoStBytesLen is the length of the Proof of SpaceTime proof.
+const PoStBytesLen uint = 192
 
 // SealBytesLen is the length of the proof of Seal Proof of Replication.
 const SealBytesLen uint = 384
@@ -13,7 +13,7 @@ const PoStChallengeSeedBytesLen uint = 32
 const CommitmentBytesLen uint = 32
 
 // PoStProof is the byte representation of the Proof of SpaceTime proof
-type PoStProof [SnarkBytesLen]byte
+type PoStProof [PoStBytesLen]byte
 
 // SealProof is the byte representation of the Seal Proof of Replication
 type SealProof [SealBytesLen]byte

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -723,17 +723,17 @@ func (sm *Miner) getProvingPeriodStart() (*types.BlockHeight, error) {
 // generatePoSt creates the required PoSt, given a list of sector ids and
 // matching seeds. It returns the Snark Proof for the PoSt, and a list of
 // sectors that faulted, if there were any faults.
-func (sm *Miner) generatePoSt(commRs []proofs.CommR, challenge proofs.PoStChallengeSeed) (proofs.PoStProof, []uint64, error) {
-	req := sectorbuilder.GeneratePoSTRequest{
+func (sm *Miner) generatePoSt(commRs []proofs.CommR, challenge proofs.PoStChallengeSeed) ([]proofs.PoStProof, []uint64, error) {
+	req := sectorbuilder.GeneratePoStRequest{
 		CommRs:        commRs,
 		ChallengeSeed: challenge,
 	}
-	res, err := sm.node.SectorBuilder().GeneratePoST(req)
+	res, err := sm.node.SectorBuilder().GeneratePoSt(req)
 	if err != nil {
-		return proofs.PoStProof{}, nil, errors.Wrap(err, "failed to generate PoSt")
+		return nil, nil, errors.Wrap(err, "failed to generate PoSt")
 	}
 
-	return res.Proof, res.Faults, nil
+	return res.Proofs, res.Faults, nil
 }
 
 func (sm *Miner) submitPoSt(start, end *types.BlockHeight, inputs []generatePostInput) {

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -748,7 +748,7 @@ func (sm *Miner) submitPoSt(start, end *types.BlockHeight, inputs []generatePost
 		commRs[i] = input.commR
 	}
 
-	proof, faults, err := sm.generatePoSt(commRs, seed)
+	proofs, faults, err := sm.generatePoSt(commRs, seed)
 	if err != nil {
 		log.Errorf("failed to generate PoSts: %s", err)
 		return
@@ -784,7 +784,7 @@ func (sm *Miner) submitPoSt(start, end *types.BlockHeight, inputs []generatePost
 	gasPrice := types.NewGasPrice(submitPostGasPrice)
 	gasLimit := types.NewGasUnits(submitPostGasLimit)
 
-	_, err = sm.porcelainAPI.MessageSend(ctx, sm.minerOwnerAddr, sm.minerAddr, types.ZeroAttoFIL, gasPrice, gasLimit, "submitPoSt", proof[:])
+	_, err = sm.porcelainAPI.MessageSend(ctx, sm.minerOwnerAddr, sm.minerAddr, types.ZeroAttoFIL, gasPrice, gasLimit, "submitPoSt", proofs)
 	if err != nil {
 		log.Errorf("failed to submit PoSt: %s", err)
 		return

--- a/testhelpers/consensus.go
+++ b/testhelpers/consensus.go
@@ -2,6 +2,11 @@ package testhelpers
 
 import (
 	"context"
+
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+	cid "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmRu7tiRnFk9mMPpVECQTBQJqXtmG132jJxA1w9A7TtpBz/go-ipfs-blockstore"
+
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/consensus"
@@ -9,9 +14,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
-	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
-	cid "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-	"gx/ipfs/QmRu7tiRnFk9mMPpVECQTBQJqXtmG132jJxA1w9A7TtpBz/go-ipfs-blockstore"
 
 	"testing"
 )


### PR DESCRIPTION
This PR fixes the go-filecoin side of [this rust-fil-proofs issue](https://github.com/filecoin-project/rust-fil-proofs/issues/505).

## What's in this PR?

- modify go-filecoin to conform to [the spec](https://github.com/filecoin-project/specs/blob/master/actors.md#submitpost), which shows `submitPoSt` message receiving multiple PoSt proofs
- modify `generate_post` and `verify_post` CGO calls to return/accept variable number of PoSt proofs