### PR TITLE
Allow actors with undefined code to send messages.

### DIFF
--- a/actor/actor.go
+++ b/actor/actor.go
@@ -31,7 +31,8 @@ func init() {
 //
 // Not safe for concurrent access.
 type Actor struct {
-	// Code is a CID of the VM code for this actor's implementation (or a constant for actors implemented in Go code)
+	// Code is a CID of the VM code for this actor's implementation (or a constant for actors implemented in Go code).
+	// Code may be nil for an uninitialized actor (which exists because it has received a balance).
 	Code cid.Cid `refmt:",omitempty"`
 	// Head is the CID of the root of the actor's state tree.
 	Head cid.Cid `refmt:",omitempty"`

--- a/actor/builtin/account/account.go
+++ b/actor/builtin/account/account.go
@@ -1,6 +1,8 @@
 package account
 
 import (
+	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
+
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/types"
@@ -24,6 +26,9 @@ func NewActor(balance *types.AttoFIL) (*actor.Actor, error) {
 
 // UpgradeActor converts the given actor to an account actor, leaving its balance and nonce in place.
 func UpgradeActor(act *actor.Actor) error {
+	if act.Code.Defined() {
+		return errors.Errorf("Can't upgrade non-empty actor with code %s", act.Code)
+	}
 	act.Code = types.AccountActorCodeCid
 	return nil
 }

--- a/consensus/processor.go
+++ b/consensus/processor.go
@@ -439,20 +439,20 @@ func (p *DefaultProcessor) attemptApplyMessage(ctx context.Context, st *state.Ca
 		return nil, errors.FaultErrorWrapf(err, "failed to get From actor %s", msg.From)
 	}
 
-	// processing an external message from an empty actor upgrades it to an account actor.
-	if !fromActor.Code.Defined() {
-		err := account.UpgradeActor(fromActor)
-		if err != nil {
-			return nil, errors.FaultErrorWrap(err, "failed to upgrade empty actor")
-		}
-	}
-
 	err = p.signedMessageValidator.Validate(ctx, msg, fromActor)
 	if err != nil {
 		return &types.MessageReceipt{
 			ExitCode:   errors.CodeError(err),
 			GasAttoFIL: types.ZeroAttoFIL,
 		}, err
+	}
+
+	// Processing an external message from an empty actor upgrades it to an account actor.
+	if !fromActor.Code.Defined() {
+		err := account.UpgradeActor(fromActor)
+		if err != nil {
+			return nil, errors.FaultErrorWrap(err, "failed to upgrade empty actor")
+		}
 	}
 
 	toActor, err := st.GetOrCreateActor(ctx, msg.To, func() (*actor.Actor, error) {

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -44,12 +44,13 @@ func (v *defaultMessageValidator) Validate(ctx context.Context, msg *types.Signe
 		return errSelfSend
 	}
 
-	// sender must be an account actor.
-	if !fromActor.Code.Equals(types.AccountActorCodeCid) {
+	// Sender must be an account actor, or a undefined actor which will be upgraded to an account actor
+	// when the message is processed.
+	if fromActor.Code.Defined() && !fromActor.Code.Equals(types.AccountActorCodeCid) {
 		return errNonAccountActor
 	}
 
-	// avoid processing messages for actors that cannot pay.
+	// Avoid processing messages for actors that cannot pay.
 	if !canCoverGasLimit(msg, fromActor) {
 		log.Info("Insufficient funds to cover gas limit: ", fromActor, msg)
 		return errInsufficientGas


### PR DESCRIPTION
An empty actor may be initialised by sending FIL to an address. The actor is not recognized as
an account actor until a message is sent from it's address, at which point it is transparently
upgraded in processing. This change updates the validation logic to reflect that.

I re-ordered the validation and upgrade blocks in the processor to exercise the code. This PR is unfortunately not accompanied by a regression test, which is a bit difficult to construct. I intend to follow up with some plumbing such that an in-process integration test (c.f. `message_propagate_test`) can mine a block and we can test the sequence of sending FIL to a new address, then a message from that address.

Fixes #2184.