### PR TITLE
PoSt generation and verification should use same challenge seed

### DIFF
--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -28,10 +28,6 @@ func init() {
 // MaximumPublicKeySize is a limit on how big a public key can be.
 const MaximumPublicKeySize = 100
 
-// LookbackParameter is the protocol parameter defining how many blocks in the
-// past to look back to sample randomness values.
-const LookbackParameter = 3
-
 // ProvingPeriodBlocks defines how long a proving period is for.
 // TODO: what is an actual workable value? currently set very high to avoid race conditions in test.
 // https://github.com/filecoin-project/go-filecoin/issues/966
@@ -734,60 +730,4 @@ func currentProvingPeriodPoStChallengeSeed(ctx exec.VMContext, state State) (pro
 	copy(seed[:], bytes)
 
 	return seed, nil
-}
-
-// SampleChainRandomness produces a slice of random bytes sampled from a TipSet
-// in the provided slice of TipSets at a given height (minus lookback). This
-// function assumes that the tipSets slice is sorted and that the genesis block
-// is at the end of the list.
-
-// SampleChainRandomness is useful for things like PoSt challenge seed
-// generation.
-func SampleChainRandomness(sampleHeight *types.BlockHeight, tipSetsDescBlockHeight []types.TipSet) ([]byte, error) {
-	sampleIndex := -1
-	tipSetsLen := len(tipSetsDescBlockHeight)
-	lastIdxInTipSets := tipSetsLen - 1
-
-	for i := 0; i < tipSetsLen; i++ {
-		height, err := tipSetsDescBlockHeight[i].Height()
-		if err != nil {
-			return nil, xerrors.Wrap(err, "error obtaining tip set height")
-		}
-
-		if types.NewBlockHeight(height).Equal(sampleHeight) {
-			sampleIndex = i
-			break
-		}
-	}
-
-	// Produce an error if no tip set exists in `tipSetsDescBlockHeight` with
-	// block height `sampleHeight`.
-	if sampleIndex == -1 {
-		return nil, xerrors.Errorf("sample height out of range: %s", sampleHeight)
-	}
-
-	// If looking backwards in time Lookback-number of tip sets from the tip set
-	// with `sampleHeight` would put us farther back in time than the genesis
-	// block, choose the last block in `tipSetsDescBlockHeight` for sampling. If
-	// this block isn't the genesis block (because of some programmer error),
-	// produce an error.
-	//
-	// TODO: security, spec, bootstrap implications.
-	// See issue https://github.com/filecoin-project/go-filecoin/issues/1872
-	lookbackIdx := sampleIndex + LookbackParameter
-	if lookbackIdx > lastIdxInTipSets {
-		leastHeightInChain, err := tipSetsDescBlockHeight[lastIdxInTipSets].Height()
-		if err != nil {
-			return nil, xerrors.Wrap(err, "error obtaining tip set height")
-		}
-
-		if leastHeightInChain == uint64(0) {
-			lookbackIdx = lastIdxInTipSets
-		} else {
-			errMsg := "lookbackIdx=%d does not correspond to genesis block (leastHeightInChain=%d)"
-			return nil, xerrors.Errorf(errMsg, lookbackIdx, leastHeightInChain)
-		}
-	}
-
-	return tipSetsDescBlockHeight[lookbackIdx].MinTicket()
 }

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -753,6 +753,10 @@ func (ma *Actor) currentProvingPeriodPoStChallengeSeed(ctx exec.VMContext) (proo
 // If no TipSet exists with the provided height (sampleHeight), we instead
 // sample the genesis block.
 func SampleChainRandomness(sampleHeight *types.BlockHeight, tipSetCh <-chan interface{}) ([]byte, error) {
+	// EDGE CASE: for now if ancestors includes the genesis block we take
+	// randomness from the genesis block.
+	// TODO: security, spec, bootstrap implications.
+	// See issue https://github.com/filecoin-project/go-filecoin/issues/1872
 	sampleHeight = sampleHeight.Sub(types.NewBlockHeight(LookbackParameter))
 	if sampleHeight.LessThan(types.NewBlockHeight(0)) {
 		sampleHeight = types.NewBlockHeight(0)

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -737,51 +737,57 @@ func currentProvingPeriodPoStChallengeSeed(ctx exec.VMContext, state State) (pro
 }
 
 // SampleChainRandomness produces a slice of random bytes sampled from a TipSet
-// in the blockchain at a given height (minus lookback). This is useful for
-// things like PoSt challenge seed generation.
-//
-// If no TipSet exists with the provided height (sampleHeight), we instead
-// sample the genesis block.
-func SampleChainRandomness(sampleHeight *types.BlockHeight, tipSetCh <-chan interface{}) ([]byte, error) {
-	// EDGE CASE: for now if ancestors includes the genesis block we take
-	// randomness from the genesis block.
-	// TODO: security, spec, bootstrap implications.
-	// See issue https://github.com/filecoin-project/go-filecoin/issues/1872
-	sampleHeight = sampleHeight.Sub(types.NewBlockHeight(LookbackParameter))
-	if sampleHeight.LessThan(types.NewBlockHeight(0)) {
-		sampleHeight = types.NewBlockHeight(0)
-	}
+// in the provided slice of TipSets at a given height (minus lookback). This
+// function assumes that the tipSets slice is sorted and that the genesis block
+// is at the end of the list.
 
-	var sampleTipSet *types.TipSet
+// SampleChainRandomness is useful for things like PoSt challenge seed
+// generation.
+func SampleChainRandomness(sampleHeight *types.BlockHeight, tipSetsDescBlockHeight []types.TipSet) ([]byte, error) {
+	sampleIndex := -1
+	tipSetsLen := len(tipSetsDescBlockHeight)
+	lastIdxInTipSets := tipSetsLen - 1
 
-Loop:
-	for raw := range tipSetCh {
-		switch v := raw.(type) {
-		case error:
-			return nil, xerrors.Wrap(v, "error walking chain")
-		case types.TipSet:
-			height, err := v.Height()
-			if err != nil {
-				return nil, xerrors.Wrap(err, "error obtaining tip set height")
-			}
+	for i := 0; i < tipSetsLen; i++ {
+		height, err := tipSetsDescBlockHeight[i].Height()
+		if err != nil {
+			return nil, xerrors.Wrap(err, "error obtaining tip set height")
+		}
 
-			if sampleHeight.Equal(types.NewBlockHeight(height)) {
-				sampleTipSet = &v
-				break Loop
-			}
-		default:
-			return nil, xerrors.New("unexpected type")
+		if types.NewBlockHeight(height).Equal(sampleHeight) {
+			sampleIndex = i
+			break
 		}
 	}
 
-	if sampleTipSet == nil {
-		return nil, xerrors.Errorf("found no tip set in chain with height %s", sampleHeight)
+	// Produce an error if no tip set exists in `tipSetsDescBlockHeight` with
+	// block height `sampleHeight`.
+	if sampleIndex == -1 {
+		return nil, xerrors.Errorf("sample height out of range: %s", sampleHeight)
 	}
 
-	ticket, err := sampleTipSet.MinTicket()
-	if err != nil {
-		return nil, xerrors.Wrap(err, "error obtaining tip set (min) ticket")
+	// If looking backwards in time Lookback-number of tip sets from the tip set
+	// with `sampleHeight` would put us farther back in time than the genesis
+	// block, choose the last block in `tipSetsDescBlockHeight` for sampling. If
+	// this block isn't the genesis block (because of some programmer error),
+	// produce an error.
+	//
+	// TODO: security, spec, bootstrap implications.
+	// See issue https://github.com/filecoin-project/go-filecoin/issues/1872
+	lookbackIdx := sampleIndex + LookbackParameter
+	if lookbackIdx > lastIdxInTipSets {
+		leastHeightInChain, err := tipSetsDescBlockHeight[lastIdxInTipSets].Height()
+		if err != nil {
+			return nil, xerrors.Wrap(err, "error obtaining tip set height")
+		}
+
+		if leastHeightInChain == uint64(0) {
+			lookbackIdx = lastIdxInTipSets
+		} else {
+			errMsg := "lookbackIdx=%d does not correspond to genesis block (leastHeightInChain=%d)"
+			return nil, xerrors.Errorf(errMsg, lookbackIdx, leastHeightInChain)
+		}
 	}
 
-	return ticket, nil
+	return tipSetsDescBlockHeight[lookbackIdx].MinTicket()
 }

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -647,6 +647,14 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, postProofs []proofs.PoStProof) (
 			return nil, Errors[ErrCallerUnauthorized]
 		}
 
+		// Check if we submitted it in time
+		provingPeriodEnd := state.ProvingPeriodStart.Add(ProvingPeriodBlocks)
+		if ctx.BlockHeight().GreaterThan(provingPeriodEnd) {
+			// Not great.
+			// TODO: charge penalty
+			return nil, errors.NewRevertErrorf("submitted PoSt late, need to pay a fee")
+		}
+
 		// reach in to actor storage to grab comm-r for each committed sector
 		var commRs []proofs.CommR
 		for _, v := range state.SectorCommitments {
@@ -684,17 +692,9 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, postProofs []proofs.PoStProof) (
 			return nil, Errors[ErrInvalidPoSt]
 		}
 
-		// Check if we submitted it in time
-		provingPeriodEnd := state.ProvingPeriodStart.Add(ProvingPeriodBlocks)
-
-		if ctx.BlockHeight().LessEqual(provingPeriodEnd) {
-			state.ProvingPeriodStart = provingPeriodEnd
-			state.LastPoSt = ctx.BlockHeight()
-		} else {
-			// Not great.
-			// TODO: charge penalty
-			return nil, errors.NewRevertErrorf("submitted PoSt late, need to pay a fee")
-		}
+		// transition to the next proving period
+		state.ProvingPeriodStart = provingPeriodEnd
+		state.LastPoSt = ctx.BlockHeight()
 
 		return nil, nil
 	})

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -671,9 +671,9 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, postProofs []proofs.PoStProof) (
 			sectorStoreType = proofs.Test
 		}
 
-		seed, err := ma.currentProvingPeriodPoStChallengeSeed(ctx)
+		seed, err := currentProvingPeriodPoStChallengeSeed(ctx, state)
 		if err != nil {
-			return nil, errors.RevertErrorWrap(err, "failed to sample chain for challenge seed")
+			return nil, errors.FaultErrorWrap(err, "failed to sample chain for challenge seed")
 		}
 
 		req := proofs.VerifyPoSTRequest{
@@ -724,17 +724,7 @@ func (ma *Actor) GetProvingPeriodStart(ctx exec.VMContext) (*types.BlockHeight, 
 	return state.ProvingPeriodStart, 0, nil
 }
 
-func (ma *Actor) currentProvingPeriodPoStChallengeSeed(ctx exec.VMContext) (proofs.PoStChallengeSeed, error) {
-	chunk, err := ctx.ReadStorage()
-	if err != nil {
-		return proofs.PoStChallengeSeed{}, err
-	}
-
-	var state State
-	if err := actor.UnmarshalStorage(chunk, &state); err != nil {
-		return proofs.PoStChallengeSeed{}, err
-	}
-
+func currentProvingPeriodPoStChallengeSeed(ctx exec.VMContext, state State) (proofs.PoStChallengeSeed, error) {
 	bytes, err := ctx.SampleChainRandomness(state.ProvingPeriodStart)
 	if err != nil {
 		return proofs.PoStChallengeSeed{}, err

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -3,7 +3,6 @@ package miner_test
 import (
 	"context"
 	"math/big"
-	"strconv"
 	"testing"
 
 	peer "gx/ipfs/QmTu65MVbemtUxJEWgsTtzv9Zv9P8rvmqNA4eG9TrTRGYc/go-libp2p-peer"
@@ -311,7 +310,7 @@ func TestMinerSubmitPoSt(t *testing.T) {
 	ctx := context.Background()
 	st, vms := core.CreateStorages(ctx, t)
 
-	ancestors := requireAncestors(t, 10)
+	ancestors := th.RequireTipSetChain(t, 10)
 
 	origPid := th.RequireRandomPeerID()
 	minerAddr := createTestMiner(assert.New(t), st, vms, address.TestAddress, []byte("my public key"), origPid)
@@ -346,22 +345,4 @@ func TestMinerSubmitPoSt(t *testing.T) {
 	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 40008, "submitPoSt", ancestors, []proofs.PoStProof{proof})
 	require.NoError(err)
 	require.EqualError(res.ExecutionError, "submitted PoSt late, need to pay a fee")
-}
-
-func requireAncestors(t *testing.T, length int) []types.TipSet {
-	require := require.New(t)
-
-	var ancestors []types.TipSet
-	head := types.NewBlockForTest(nil, uint64(0))
-	head.Ticket = []byte(strconv.Itoa(0))
-	for i := 0; i < length; i++ {
-		ancestors = append(ancestors, types.RequireNewTipSet(require, head))
-		newBlock := types.NewBlockForTest(head, uint64(0))
-		newBlock.Ticket = []byte(strconv.Itoa(i + 1))
-		head = newBlock
-	}
-
-	ancestors = append(ancestors, types.RequireNewTipSet(require, head))
-
-	return ancestors
 }

--- a/api/impl/mining.go
+++ b/api/impl/mining.go
@@ -4,12 +4,12 @@ import (
 	"context"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
-	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/mining"
 	"github.com/filecoin-project/go-filecoin/node"
+	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 )
@@ -71,7 +71,7 @@ func (api *nodeMining) Once(ctx context.Context) (*types.Block, error) {
 	blockSignerAddr := blockSignerAddrIf.(address.Address)
 
 	getAncestors := func(ctx context.Context, ts types.TipSet, newBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
-		return chain.GetRecentAncestors(ctx, ts, nd.ChainReader, newBlockHeight, consensus.AncestorRoundsNeeded, miner.LookbackParameter)
+		return chain.GetRecentAncestors(ctx, ts, nd.ChainReader, newBlockHeight, consensus.AncestorRoundsNeeded, sampling.LookbackParameter)
 	}
 	worker := mining.NewDefaultWorker(nd.MsgPool, getState, getWeight, getAncestors, consensus.NewDefaultProcessor(),
 		nd.PowerTable, nd.Blockstore, nd.CborStore(), miningAddr, miningOwnerAddr, blockSignerAddr, nd.Wallet, blockTime)

--- a/api/impl/mining.go
+++ b/api/impl/mining.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/consensus"
@@ -70,7 +71,7 @@ func (api *nodeMining) Once(ctx context.Context) (*types.Block, error) {
 	blockSignerAddr := blockSignerAddrIf.(address.Address)
 
 	getAncestors := func(ctx context.Context, ts types.TipSet, newBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
-		return chain.GetRecentAncestors(ctx, ts, nd.ChainReader, newBlockHeight, consensus.AncestorRoundsNeeded, consensus.LookBackParameter)
+		return chain.GetRecentAncestors(ctx, ts, nd.ChainReader, newBlockHeight, consensus.AncestorRoundsNeeded, miner.LookbackParameter)
 	}
 	worker := mining.NewDefaultWorker(nd.MsgPool, getState, getWeight, getAncestors, consensus.NewDefaultProcessor(),
 		nd.PowerTable, nd.Blockstore, nd.CborStore(), miningAddr, miningOwnerAddr, blockSignerAddr, nd.Wallet, blockTime)

--- a/chain/default_store.go
+++ b/chain/default_store.go
@@ -17,9 +17,7 @@ import (
 	"gx/ipfs/QmdbxjQWogRCHRaxhhGnYdT1oQJzL9GdqSKzCdqWr85AP2/pubsub"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
-	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/repo"
-	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 )
@@ -419,12 +417,6 @@ func (store *DefaultStore) BlockHistory(ctx context.Context, start types.TipSet)
 		}
 	}()
 	return out
-}
-
-// GetRecentAncestors returns (at most) `LookbackParameter`-number of ancestors
-// of the `TipSet` with height `descendantBlockHeight` from the store.
-func (store *DefaultStore) GetRecentAncestors(ctx context.Context, descendantBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
-	return GetRecentAncestors(ctx, store.head, store, descendantBlockHeight, consensus.AncestorRoundsNeeded, sampling.LookbackParameter)
 }
 
 // walkChain walks backward through the chain, starting at tips, invoking cb() at each height.

--- a/chain/default_store.go
+++ b/chain/default_store.go
@@ -17,9 +17,9 @@ import (
 	"gx/ipfs/QmdbxjQWogRCHRaxhhGnYdT1oQJzL9GdqSKzCdqWr85AP2/pubsub"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
-	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/repo"
+	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 )
@@ -424,7 +424,7 @@ func (store *DefaultStore) BlockHistory(ctx context.Context, start types.TipSet)
 // GetRecentAncestors returns (at most) `LookbackParameter`-number of ancestors
 // of the `TipSet` with height `descendantBlockHeight` from the store.
 func (store *DefaultStore) GetRecentAncestors(ctx context.Context, descendantBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
-	return GetRecentAncestors(ctx, store.head, store, descendantBlockHeight, consensus.AncestorRoundsNeeded, miner.LookbackParameter)
+	return GetRecentAncestors(ctx, store.head, store, descendantBlockHeight, consensus.AncestorRoundsNeeded, sampling.LookbackParameter)
 }
 
 // walkChain walks backward through the chain, starting at tips, invoking cb() at each height.

--- a/chain/default_store.go
+++ b/chain/default_store.go
@@ -17,6 +17,8 @@ import (
 	"gx/ipfs/QmdbxjQWogRCHRaxhhGnYdT1oQJzL9GdqSKzCdqWr85AP2/pubsub"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
+	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
@@ -417,6 +419,12 @@ func (store *DefaultStore) BlockHistory(ctx context.Context, start types.TipSet)
 		}
 	}()
 	return out
+}
+
+// GetRecentAncestors returns (at most) `LookbackParameter`-number of ancestors
+// of the `TipSet` with height `descendantBlockHeight` from the store.
+func (store *DefaultStore) GetRecentAncestors(ctx context.Context, descendantBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
+	return GetRecentAncestors(ctx, store.head, store, descendantBlockHeight, consensus.AncestorRoundsNeeded, miner.LookbackParameter)
 }
 
 // walkChain walks backward through the chain, starting at tips, invoking cb() at each height.

--- a/chain/default_syncer.go
+++ b/chain/default_syncer.go
@@ -11,8 +11,8 @@ import (
 	logging "gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
-	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 )
@@ -208,7 +208,7 @@ func (syncer *DefaultSyncer) syncOne(ctx context.Context, parent, next types.Tip
 		return err
 	}
 	newBlockHeight := types.NewBlockHeight(h)
-	ancestors, err := GetRecentAncestors(ctx, parent, syncer.chainStore, newBlockHeight, consensus.AncestorRoundsNeeded, miner.LookbackParameter)
+	ancestors, err := GetRecentAncestors(ctx, parent, syncer.chainStore, newBlockHeight, consensus.AncestorRoundsNeeded, sampling.LookbackParameter)
 	if err != nil {
 		return err
 	}

--- a/chain/default_syncer.go
+++ b/chain/default_syncer.go
@@ -11,6 +11,7 @@ import (
 	logging "gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
@@ -207,7 +208,7 @@ func (syncer *DefaultSyncer) syncOne(ctx context.Context, parent, next types.Tip
 		return err
 	}
 	newBlockHeight := types.NewBlockHeight(h)
-	ancestors, err := GetRecentAncestors(ctx, parent, syncer.chainStore, newBlockHeight, consensus.AncestorRoundsNeeded, consensus.LookBackParameter)
+	ancestors, err := GetRecentAncestors(ctx, parent, syncer.chainStore, newBlockHeight, consensus.AncestorRoundsNeeded, miner.LookbackParameter)
 	if err != nil {
 		return err
 	}

--- a/chain/get_ancestors.go
+++ b/chain/get_ancestors.go
@@ -5,8 +5,16 @@ import (
 
 	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
 
+	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/types"
 )
+
+// GetRecentAncestorsOfHeaviestChain returns the ancestors of a `TipSet` with
+// height `descendantBlockHeight` in the heaviest chain.
+func GetRecentAncestorsOfHeaviestChain(ctx context.Context, chainReader ReadStore, descendantBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
+	return GetRecentAncestors(ctx, chainReader.Head(), chainReader, descendantBlockHeight, consensus.AncestorRoundsNeeded, sampling.LookbackParameter)
+}
 
 // GetRecentAncestors returns the ancestors of base as a slice of TipSets.
 //

--- a/chain/store.go
+++ b/chain/store.go
@@ -41,6 +41,11 @@ type ReadStore interface {
 	LatestState(ctx context.Context) (state.Tree, error)
 
 	BlockHistory(ctx context.Context, tips types.TipSet) <-chan interface{}
+
+	// GetRecentAncestors returns the recent ancestors of the `TipSet` with
+	// height `descendantBlockHeight`.
+	GetRecentAncestors(ctx context.Context, descendantBlockHeight *types.BlockHeight) ([]types.TipSet, error)
+
 	GenesisCid() cid.Cid
 }
 

--- a/chain/store.go
+++ b/chain/store.go
@@ -42,10 +42,6 @@ type ReadStore interface {
 
 	BlockHistory(ctx context.Context, tips types.TipSet) <-chan interface{}
 
-	// GetRecentAncestors returns the recent ancestors of the `TipSet` with
-	// height `descendantBlockHeight`.
-	GetRecentAncestors(ctx context.Context, descendantBlockHeight *types.BlockHeight) ([]types.TipSet, error)
-
 	GenesisCid() cid.Cid
 }
 

--- a/consensus/expected.go
+++ b/consensus/expected.go
@@ -54,10 +54,6 @@ const ECV uint64 = 10
 // ECPrM is the power ratio magnitude defined in the EC spec.
 const ECPrM uint64 = 100
 
-// LookBackParameter is the protocol parameter defining how many blocks in the
-// past to look back to sample randomness values.
-const LookBackParameter = 3
-
 // AncestorRoundsNeeded is the number of rounds of the ancestor chain needed
 // to process all state transitions.
 var AncestorRoundsNeeded = miner.ProvingPeriodBlocks.Add(miner.GracePeriodBlocks)

--- a/consensus/processor.go
+++ b/consensus/processor.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
@@ -474,7 +475,7 @@ func (p *DefaultProcessor) attemptApplyMessage(ctx context.Context, st *state.Ca
 		GasTracker:  gasTracker,
 		BlockHeight: bh,
 		Ancestors:   ancestors,
-		LookBack:    LookBackParameter,
+		LookBack:    miner.LookbackParameter,
 	}
 	vmCtx := vm.NewVMContext(vmCtxParams)
 

--- a/consensus/processor.go
+++ b/consensus/processor.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
-	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
@@ -475,7 +474,6 @@ func (p *DefaultProcessor) attemptApplyMessage(ctx context.Context, st *state.Ca
 		GasTracker:  gasTracker,
 		BlockHeight: bh,
 		Ancestors:   ancestors,
-		LookBack:    miner.LookbackParameter,
 	}
 	vmCtx := vm.NewVMContext(vmCtxParams)
 

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -74,6 +74,7 @@ type VMContext interface {
 	BlockHeight() *types.BlockHeight
 	IsFromAccountActor() bool
 	Charge(cost types.GasUnits) error
+	SampleChainRandomness(sampleHeight *types.BlockHeight) ([]byte, error)
 
 	CreateNewActor(addr address.Address, code cid.Cid, initalizationParams interface{}) error
 

--- a/node/node.go
+++ b/node/node.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/storagemarket"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
@@ -805,7 +806,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 			return node.Consensus.Weight(ctx, ts, pSt)
 		}
 		getAncestors := func(ctx context.Context, ts types.TipSet, newBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
-			return chain.GetRecentAncestors(ctx, ts, node.ChainReader, newBlockHeight, consensus.AncestorRoundsNeeded, consensus.LookBackParameter)
+			return chain.GetRecentAncestors(ctx, ts, node.ChainReader, newBlockHeight, consensus.AncestorRoundsNeeded, miner.LookbackParameter)
 		}
 		processor := consensus.NewDefaultProcessor()
 		worker := mining.NewDefaultWorker(node.MsgPool, getState, getWeight, getAncestors, processor, node.PowerTable,

--- a/node/node.go
+++ b/node/node.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
-	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/storagemarket"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
@@ -63,6 +62,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/protocol/retrieval"
 	"github.com/filecoin-project/go-filecoin/protocol/storage"
 	"github.com/filecoin-project/go-filecoin/repo"
+	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	vmErrors "github.com/filecoin-project/go-filecoin/vm/errors"
@@ -806,7 +806,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 			return node.Consensus.Weight(ctx, ts, pSt)
 		}
 		getAncestors := func(ctx context.Context, ts types.TipSet, newBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
-			return chain.GetRecentAncestors(ctx, ts, node.ChainReader, newBlockHeight, consensus.AncestorRoundsNeeded, miner.LookbackParameter)
+			return chain.GetRecentAncestors(ctx, ts, node.ChainReader, newBlockHeight, consensus.AncestorRoundsNeeded, sampling.LookbackParameter)
 		}
 		processor := consensus.NewDefaultProcessor()
 		worker := mining.NewDefaultWorker(node.MsgPool, getState, getWeight, getAncestors, processor, node.PowerTable,

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -108,6 +108,12 @@ func (api *API) ChainHead(ctx context.Context) types.TipSet {
 	return api.chain.Head()
 }
 
+// GetRecentAncestors returns the recent ancestors of the `TipSet` with height
+// `descendantBlockHeight`.
+func (api *API) GetRecentAncestors(ctx context.Context, descendantBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
+	return api.chain.GetRecentAncestors(ctx, descendantBlockHeight)
+}
+
 // ChainLs returns a channel of tipsets from head to genesis
 func (api *API) ChainLs(ctx context.Context) <-chan interface{} {
 	return api.chain.BlockHistory(ctx, api.chain.Head())

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -108,10 +108,10 @@ func (api *API) ChainHead(ctx context.Context) types.TipSet {
 	return api.chain.Head()
 }
 
-// GetRecentAncestors returns the recent ancestors of the `TipSet` with height
-// `descendantBlockHeight`.
-func (api *API) GetRecentAncestors(ctx context.Context, descendantBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
-	return api.chain.GetRecentAncestors(ctx, descendantBlockHeight)
+// GetRecentAncestorsOfHeaviestChain returns the recent ancestors of the
+// `TipSet` with height `descendantBlockHeight` in the heaviest chain.
+func (api *API) GetRecentAncestorsOfHeaviestChain(ctx context.Context, descendantBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
+	return chain.GetRecentAncestorsOfHeaviestChain(ctx, api.chain, descendantBlockHeight)
 }
 
 // ChainLs returns a channel of tipsets from head to genesis

--- a/plumbing/msg/waiter.go
+++ b/plumbing/msg/waiter.go
@@ -11,9 +11,9 @@ import (
 	logging "gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
-	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
@@ -159,7 +159,7 @@ func (w *Waiter) receiptFromTipSet(ctx context.Context, msgCid cid.Cid, ts types
 		return nil, err
 	}
 	tsBlockHeight := types.NewBlockHeight(tsHeight)
-	ancestors, err := chain.GetRecentAncestors(ctx, tsas.TipSet, w.chainReader, tsBlockHeight, consensus.AncestorRoundsNeeded, miner.LookbackParameter)
+	ancestors, err := chain.GetRecentAncestors(ctx, tsas.TipSet, w.chainReader, tsBlockHeight, consensus.AncestorRoundsNeeded, sampling.LookbackParameter)
 	if err != nil {
 		return nil, err
 	}

--- a/plumbing/msg/waiter.go
+++ b/plumbing/msg/waiter.go
@@ -11,6 +11,7 @@ import (
 	logging "gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/state"
@@ -158,7 +159,7 @@ func (w *Waiter) receiptFromTipSet(ctx context.Context, msgCid cid.Cid, ts types
 		return nil, err
 	}
 	tsBlockHeight := types.NewBlockHeight(tsHeight)
-	ancestors, err := chain.GetRecentAncestors(ctx, tsas.TipSet, w.chainReader, tsBlockHeight, consensus.AncestorRoundsNeeded, consensus.LookBackParameter)
+	ancestors, err := chain.GetRecentAncestors(ctx, tsas.TipSet, w.chainReader, tsBlockHeight, consensus.AncestorRoundsNeeded, miner.LookbackParameter)
 	if err != nil {
 		return nil, err
 	}

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -53,6 +53,13 @@ func (a *API) CreatePayments(ctx context.Context, config CreatePaymentsParams) (
 	return CreatePayments(ctx, a, config)
 }
 
+// SampleChainRandomness produces a slice of random bytes sampled from a TipSet
+// in the blockchain at a given height, useful for things like PoSt challenge seed
+// generation.
+func (a *API) SampleChainRandomness(ctx context.Context, sampleHeight *types.BlockHeight) ([]byte, error) {
+	return SampleChainRandomness(ctx, a, sampleHeight)
+}
+
 // DealGet returns a single deal matching a given cid or an error
 func (a *API) DealGet(proposalCid cid.Cid) *storagedeal.Deal {
 	return DealGet(a, proposalCid)

--- a/porcelain/chain.go
+++ b/porcelain/chain.go
@@ -14,7 +14,7 @@ type chBlockHeightPlumbing interface {
 }
 
 type chSampleRandomnessPlumbing interface {
-	GetRecentAncestors(ctx context.Context, descendantBlockHeight *types.BlockHeight) ([]types.TipSet, error)
+	GetRecentAncestorsOfHeaviestChain(ctx context.Context, descendantBlockHeight *types.BlockHeight) ([]types.TipSet, error)
 }
 
 // ChainBlockHeight determines the current block height
@@ -37,7 +37,7 @@ func ChainBlockHeight(ctx context.Context, plumbing chBlockHeightPlumbing) (*typ
 
 // SampleChainRandomness samples randomness from the chain at the given height.
 func SampleChainRandomness(ctx context.Context, plumbing chSampleRandomnessPlumbing, sampleHeight *types.BlockHeight) ([]byte, error) {
-	tipSetBuffer, err := plumbing.GetRecentAncestors(ctx, sampleHeight)
+	tipSetBuffer, err := plumbing.GetRecentAncestorsOfHeaviestChain(ctx, sampleHeight)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get recent ancestors")
 	}

--- a/porcelain/chain.go
+++ b/porcelain/chain.go
@@ -2,7 +2,10 @@ package porcelain
 
 import (
 	"context"
-	"errors"
+
+	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
+
+	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -26,4 +29,50 @@ func ChainBlockHeight(ctx context.Context, plumbing chPlumbing) (*types.BlockHei
 		return nil, err
 	}
 	return types.NewBlockHeight(currentHeight), nil
+}
+
+// SampleChainRandomness produces a slice of random bytes sampled from a TipSet
+// in the blockchain at a given height (minus lookback). This is useful for
+// things like PoSt challenge seed generation.
+//
+// If no TipSet exists with the provided height (sampleHeight), we instead
+// sample the genesis block.
+func SampleChainRandomness(ctx context.Context, plumbing chPlumbing, sampleHeight *types.BlockHeight) ([]byte, error) {
+	sampleHeight = sampleHeight.Sub(types.NewBlockHeight(miner.LookbackParameter))
+	if sampleHeight.LessThan(types.NewBlockHeight(0)) {
+		sampleHeight = types.NewBlockHeight(0)
+	}
+
+	var sampleTipSet *types.TipSet
+
+Loop:
+	for raw := range plumbing.ChainLs(ctx) {
+		switch v := raw.(type) {
+		case error:
+			return nil, errors.Wrap(v, "error walking chain")
+		case types.TipSet:
+			height, err := v.Height()
+			if err != nil {
+				return nil, errors.Wrap(err, "error obtaining tip set height")
+			}
+
+			if sampleHeight.Equal(types.NewBlockHeight(height)) {
+				sampleTipSet = &v
+				break Loop
+			}
+		default:
+			return nil, errors.New("unexpected type")
+		}
+	}
+
+	if sampleTipSet == nil {
+		return nil, errors.Errorf("found no tip set in chain with height %s", sampleHeight)
+	}
+
+	ticket, err := sampleTipSet.MinTicket()
+	if err != nil {
+		return nil, errors.Wrap(err, "error obtaining tip set (min) ticket")
+	}
+
+	return ticket, nil
 }

--- a/porcelain/chain.go
+++ b/porcelain/chain.go
@@ -5,7 +5,7 @@ import (
 
 	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
+	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -42,5 +42,5 @@ func SampleChainRandomness(ctx context.Context, plumbing chSampleRandomnessPlumb
 		return nil, errors.Wrap(err, "failed to get recent ancestors")
 	}
 
-	return miner.SampleChainRandomness(sampleHeight, tipSetBuffer)
+	return sampling.SampleChainRandomness(sampleHeight, tipSetBuffer)
 }

--- a/porcelain/chain.go
+++ b/porcelain/chain.go
@@ -31,48 +31,7 @@ func ChainBlockHeight(ctx context.Context, plumbing chPlumbing) (*types.BlockHei
 	return types.NewBlockHeight(currentHeight), nil
 }
 
-// SampleChainRandomness produces a slice of random bytes sampled from a TipSet
-// in the blockchain at a given height (minus lookback). This is useful for
-// things like PoSt challenge seed generation.
-//
-// If no TipSet exists with the provided height (sampleHeight), we instead
-// sample the genesis block.
+// SampleChainRandomness samples randomness from the chain at the given height.
 func SampleChainRandomness(ctx context.Context, plumbing chPlumbing, sampleHeight *types.BlockHeight) ([]byte, error) {
-	sampleHeight = sampleHeight.Sub(types.NewBlockHeight(miner.LookbackParameter))
-	if sampleHeight.LessThan(types.NewBlockHeight(0)) {
-		sampleHeight = types.NewBlockHeight(0)
-	}
-
-	var sampleTipSet *types.TipSet
-
-Loop:
-	for raw := range plumbing.ChainLs(ctx) {
-		switch v := raw.(type) {
-		case error:
-			return nil, errors.Wrap(v, "error walking chain")
-		case types.TipSet:
-			height, err := v.Height()
-			if err != nil {
-				return nil, errors.Wrap(err, "error obtaining tip set height")
-			}
-
-			if sampleHeight.Equal(types.NewBlockHeight(height)) {
-				sampleTipSet = &v
-				break Loop
-			}
-		default:
-			return nil, errors.New("unexpected type")
-		}
-	}
-
-	if sampleTipSet == nil {
-		return nil, errors.Errorf("found no tip set in chain with height %s", sampleHeight)
-	}
-
-	ticket, err := sampleTipSet.MinTicket()
-	if err != nil {
-		return nil, errors.Wrap(err, "error obtaining tip set (min) ticket")
-	}
-
-	return ticket, nil
+	return miner.SampleChainRandomness(sampleHeight, plumbing.ChainLs(ctx))
 }

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -2,12 +2,10 @@ package storage
 
 import (
 	"context"
+	"crypto/rand"
 	"testing"
 
-	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
-
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 
@@ -18,6 +16,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/plumbing/cfg"
 	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
 	"github.com/filecoin-project/go-filecoin/repo"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -362,6 +361,15 @@ type minerTestPorcelain struct {
 	deals         map[cid.Cid]*storagedeal.Deal
 
 	require *require.Assertions
+}
+
+func (mtp *minerTestPorcelain) SampleChainRandomness(ctx context.Context, sampleHeight *types.BlockHeight) ([]byte, error) {
+	bytes := make([]byte, 42)
+	if _, err := rand.Read(bytes); err != nil {
+		panic(err)
+	}
+
+	return bytes, nil
 }
 
 func newMinerTestPorcelain(require *require.Assertions) *minerTestPorcelain {

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -5,9 +5,9 @@ import (
 	"crypto/rand"
 	"testing"
 
-	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
@@ -15,8 +15,8 @@ import (
 	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/plumbing/cfg"
 	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
-	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
+	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 

--- a/sampling/chain_randomness.go
+++ b/sampling/chain_randomness.go
@@ -1,0 +1,67 @@
+package sampling
+
+import (
+	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
+
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// LookbackParameter is the protocol parameter defining how many blocks in the
+// past to look back to sample randomness values.
+const LookbackParameter = 3
+
+// SampleChainRandomness produces a slice of random bytes sampled from a TipSet
+// in the provided slice of TipSets at a given height (minus lookback). This
+// function assumes that the tipSets slice is sorted and that the genesis block
+// is at the end of the list.
+//
+// SampleChainRandomness is useful for things like PoSt challenge seed
+// generation.
+func SampleChainRandomness(sampleHeight *types.BlockHeight, tipSetsDescBlockHeight []types.TipSet) ([]byte, error) {
+	sampleIndex := -1
+	tipSetsLen := len(tipSetsDescBlockHeight)
+	lastIdxInTipSets := tipSetsLen - 1
+
+	for i := 0; i < tipSetsLen; i++ {
+		height, err := tipSetsDescBlockHeight[i].Height()
+		if err != nil {
+			return nil, errors.Wrap(err, "error obtaining tip set height")
+		}
+
+		if types.NewBlockHeight(height).Equal(sampleHeight) {
+			sampleIndex = i
+			break
+		}
+	}
+
+	// Produce an error if no tip set exists in `tipSetsDescBlockHeight` with
+	// block height `sampleHeight`.
+	if sampleIndex == -1 {
+		return nil, errors.Errorf("sample height out of range: %s", sampleHeight)
+	}
+
+	// If looking backwards in time Lookback-number of tip sets from the tip set
+	// with `sampleHeight` would put us farther back in time than the genesis
+	// block, choose the last block in `tipSetsDescBlockHeight` for sampling. If
+	// this block isn't the genesis block (because of some programmer error),
+	// produce an error.
+	//
+	// TODO: security, spec, bootstrap implications.
+	// See issue https://github.com/filecoin-project/go-filecoin/issues/1872
+	lookbackIdx := sampleIndex + LookbackParameter
+	if lookbackIdx > lastIdxInTipSets {
+		leastHeightInChain, err := tipSetsDescBlockHeight[lastIdxInTipSets].Height()
+		if err != nil {
+			return nil, errors.Wrap(err, "error obtaining tip set height")
+		}
+
+		if leastHeightInChain == uint64(0) {
+			lookbackIdx = lastIdxInTipSets
+		} else {
+			errMsg := "lookbackIdx=%d does not correspond to genesis block (leastHeightInChain=%d)"
+			return nil, errors.Errorf(errMsg, lookbackIdx, leastHeightInChain)
+		}
+	}
+
+	return tipSetsDescBlockHeight[lookbackIdx].MinTicket()
+}

--- a/sampling/chain_randomness.go
+++ b/sampling/chain_randomness.go
@@ -10,20 +10,20 @@ import (
 // past to look back to sample randomness values.
 const LookbackParameter = 3
 
-// SampleChainRandomness produces a slice of random bytes sampled from a TipSet
-// in the provided slice of TipSets at a given height (minus lookback). This
-// function assumes that the tipSets slice is sorted and that the genesis block
-// is at the end of the list.
+// SampleChainRandomness produces a slice of random bytes sampled from a tip set
+// in the provided slice of tip sets at a given height (minus lookback). This
+// function assumes that the tip set slice is sorted by block height in
+// descending order.
 //
 // SampleChainRandomness is useful for things like PoSt challenge seed
 // generation.
-func SampleChainRandomness(sampleHeight *types.BlockHeight, tipSetsDescBlockHeight []types.TipSet) ([]byte, error) {
+func SampleChainRandomness(sampleHeight *types.BlockHeight, tipSetsSortedByBlockHeightDescending []types.TipSet) ([]byte, error) {
 	sampleIndex := -1
-	tipSetsLen := len(tipSetsDescBlockHeight)
+	tipSetsLen := len(tipSetsSortedByBlockHeightDescending)
 	lastIdxInTipSets := tipSetsLen - 1
 
 	for i := 0; i < tipSetsLen; i++ {
-		height, err := tipSetsDescBlockHeight[i].Height()
+		height, err := tipSetsSortedByBlockHeightDescending[i].Height()
 		if err != nil {
 			return nil, errors.Wrap(err, "error obtaining tip set height")
 		}
@@ -34,23 +34,23 @@ func SampleChainRandomness(sampleHeight *types.BlockHeight, tipSetsDescBlockHeig
 		}
 	}
 
-	// Produce an error if no tip set exists in `tipSetsDescBlockHeight` with
+	// Produce an error if no tip set exists in `tipSetsSortedByBlockHeightDescending` with
 	// block height `sampleHeight`.
 	if sampleIndex == -1 {
 		return nil, errors.Errorf("sample height out of range: %s", sampleHeight)
 	}
 
-	// If looking backwards in time Lookback-number of tip sets from the tip set
-	// with `sampleHeight` would put us farther back in time than the genesis
-	// block, choose the last block in `tipSetsDescBlockHeight` for sampling. If
-	// this block isn't the genesis block (because of some programmer error),
-	// produce an error.
+	// If looking backwards in time `Lookback`-number of tip sets from the tip
+	// set with `sampleHeight` would put us farther back in time than the lowest
+	// height tip set in the slice, then check to see if the lowest height tip
+	// set is the genesis block. If it is, use its randomness. If not, produce
+	// an error.
 	//
 	// TODO: security, spec, bootstrap implications.
 	// See issue https://github.com/filecoin-project/go-filecoin/issues/1872
 	lookbackIdx := sampleIndex + LookbackParameter
 	if lookbackIdx > lastIdxInTipSets {
-		leastHeightInChain, err := tipSetsDescBlockHeight[lastIdxInTipSets].Height()
+		leastHeightInChain, err := tipSetsSortedByBlockHeightDescending[lastIdxInTipSets].Height()
 		if err != nil {
 			return nil, errors.Wrap(err, "error obtaining tip set height")
 		}
@@ -58,10 +58,10 @@ func SampleChainRandomness(sampleHeight *types.BlockHeight, tipSetsDescBlockHeig
 		if leastHeightInChain == uint64(0) {
 			lookbackIdx = lastIdxInTipSets
 		} else {
-			errMsg := "lookbackIdx=%d does not correspond to genesis block (leastHeightInChain=%d)"
+			errMsg := "sample height out of range: lookbackIdx=%d, lastHeightInChain=%d"
 			return nil, errors.Errorf(errMsg, lookbackIdx, leastHeightInChain)
 		}
 	}
 
-	return tipSetsDescBlockHeight[lookbackIdx].MinTicket()
+	return tipSetsSortedByBlockHeightDescending[lookbackIdx].MinTicket()
 }

--- a/sampling/chain_randomness_test.go
+++ b/sampling/chain_randomness_test.go
@@ -1,0 +1,105 @@
+package sampling_test
+
+import (
+	"strconv"
+	"testing"
+
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/sampling"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+func TestSamplingChainRandomness(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	// set a tripwire
+	require.Equal(sampling.LookbackParameter, 3, "these tests assume LookbackParameter=3")
+
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+		chain := requireTipSetChain(t, 20)
+
+		r, err := sampling.SampleChainRandomness(types.NewBlockHeight(uint64(20)), chain)
+		assert.NoError(err)
+		assert.Equal([]byte(strconv.Itoa(17)), r)
+
+		r, err = sampling.SampleChainRandomness(types.NewBlockHeight(uint64(3)), chain)
+		assert.NoError(err)
+		assert.Equal([]byte(strconv.Itoa(0)), r)
+
+		r, err = sampling.SampleChainRandomness(types.NewBlockHeight(uint64(10)), chain)
+		assert.NoError(err)
+		assert.Equal([]byte(strconv.Itoa(7)), r)
+	})
+
+	t.Run("faults with height out of range", func(t *testing.T) {
+		t.Parallel()
+		chain := requireTipSetChain(t, 20)
+
+		// edit chain to include null blocks at heights 21 through 24
+		baseBlock := chain[1].ToSlice()[0]
+		afterNull := types.NewBlockForTest(baseBlock, uint64(0))
+		afterNull.Height += types.Uint64(uint64(5))
+		afterNull.Ticket = []byte(strconv.Itoa(int(afterNull.Height)))
+		chain = append([]types.TipSet{types.RequireNewTipSet(require, afterNull)}, chain...)
+
+		// ancestor block heights:
+		//
+		// 25 20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
+		//
+		// no tip set with height 30 exists in ancestors
+		_, err := sampling.SampleChainRandomness(types.NewBlockHeight(uint64(30)), chain)
+		assert.Error(err)
+	})
+
+	t.Run("faults with lookback out of range", func(t *testing.T) {
+		t.Parallel()
+		chain := requireTipSetChain(t, 20)[:5]
+
+		// ancestor block heights:
+		//
+		// 20, 19, 18, 17, 16
+		//
+		// going back in time by `LookbackParameter`-number of tip sets from
+		// block height 17 does not find us the genesis block
+		_, err := sampling.SampleChainRandomness(types.NewBlockHeight(uint64(17)), chain)
+		assert.Error(err)
+	})
+
+	t.Run("falls back to genesis block", func(t *testing.T) {
+		t.Parallel()
+		chain := requireTipSetChain(t, 5)
+
+		// ancestor block heights:
+		//
+		// 5, 3, 2, 1, 0
+		//
+		// going back in time by `LookbackParameter`-number of tip sets from 1
+		// would put us into the negative - so fall back to genesis block
+		r, err := sampling.SampleChainRandomness(types.NewBlockHeight(uint64(1)), chain)
+		assert.NoError(err)
+		assert.Equal([]byte(strconv.Itoa(0)), r)
+	})
+}
+
+func requireTipSetChain(t *testing.T, numTipSets int) []types.TipSet {
+	require := require.New(t)
+
+	var tipSetsDescBlockHeight []types.TipSet
+	// setup ancestor chain
+	head := types.NewBlockForTest(nil, uint64(0))
+	head.Ticket = []byte(strconv.Itoa(0))
+	for i := 0; i < numTipSets; i++ {
+		tipSetsDescBlockHeight = append([]types.TipSet{types.RequireNewTipSet(require, head)}, tipSetsDescBlockHeight...)
+		newBlock := types.NewBlockForTest(head, uint64(0))
+		newBlock.Ticket = []byte(strconv.Itoa(i + 1))
+		head = newBlock
+	}
+
+	tipSetsDescBlockHeight = append([]types.TipSet{types.RequireNewTipSet(require, head)}, tipSetsDescBlockHeight...)
+
+	return tipSetsDescBlockHeight
+}

--- a/testhelpers/mining.go
+++ b/testhelpers/mining.go
@@ -3,6 +3,8 @@ package testhelpers
 import (
 	"crypto/rand"
 	"math/big"
+	"strconv"
+	"testing"
 	"time"
 
 	"gx/ipfs/QmTu65MVbemtUxJEWgsTtzv9Zv9P8rvmqNA4eG9TrTRGYc/go-libp2p-peer"
@@ -10,6 +12,8 @@ import (
 	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/types"
+
+	"github.com/stretchr/testify/require"
 )
 
 // BlockTimeTest is the block time used by workers during testing
@@ -48,4 +52,23 @@ func MakeRandomBytes(size int) []byte {
 	}
 
 	return comm
+}
+
+func RequireTipSetChain(t *testing.T, numTipSets int) []types.TipSet {
+	require := require.New(t)
+
+	var tipSetsDescBlockHeight []types.TipSet
+	// setup ancestor chain
+	head := types.NewBlockForTest(nil, uint64(0))
+	head.Ticket = []byte(strconv.Itoa(0))
+	for i := 0; i < numTipSets; i++ {
+		tipSetsDescBlockHeight = append([]types.TipSet{types.RequireNewTipSet(require, head)}, tipSetsDescBlockHeight...)
+		newBlock := types.NewBlockForTest(head, uint64(0))
+		newBlock.Ticket = []byte(strconv.Itoa(i + 1))
+		head = newBlock
+	}
+
+	tipSetsDescBlockHeight = append([]types.TipSet{types.RequireNewTipSet(require, head)}, tipSetsDescBlockHeight...)
+
+	return tipSetsDescBlockHeight
 }

--- a/testhelpers/mining.go
+++ b/testhelpers/mining.go
@@ -7,13 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 	"gx/ipfs/QmTu65MVbemtUxJEWgsTtzv9Zv9P8rvmqNA4eG9TrTRGYc/go-libp2p-peer"
 
 	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/types"
-
-	"github.com/stretchr/testify/require"
 )
 
 // BlockTimeTest is the block time used by workers during testing
@@ -54,6 +53,8 @@ func MakeRandomBytes(size int) []byte {
 	return comm
 }
 
+// RequireTipSetChain produces a chain of TipSet of the requested length. The
+// TipSet with greatest height will be at the front of the returned slice.
 func RequireTipSetChain(t *testing.T, numTipSets int) []types.TipSet {
 	require := require.New(t)
 

--- a/vm/context.go
+++ b/vm/context.go
@@ -9,9 +9,9 @@ import (
 	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
-	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/exec"
+	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm/errors"
@@ -243,7 +243,7 @@ func (ctx *Context) CreateNewActor(addr address.Address, code cid.Cid, initializ
 // SampleChainRandomness samples randomness from a block's ancestors at the
 // given height.
 func (ctx *Context) SampleChainRandomness(sampleHeight *types.BlockHeight) ([]byte, error) {
-	return miner.SampleChainRandomness(sampleHeight, ctx.ancestors)
+	return sampling.SampleChainRandomness(sampleHeight, ctx.ancestors)
 }
 
 // Dependency injection setup.

--- a/vm/context.go
+++ b/vm/context.go
@@ -252,6 +252,7 @@ func (ctx *Context) SampleChainRandomness(sampleHeight *types.BlockHeight) ([]by
 		for _, val := range ctx.ancestors {
 			ancestorCh <- val
 		}
+		close(ancestorCh)
 	}()
 
 	bytes, err := miner.SampleChainRandomness(sampleHeight, ancestorCh)

--- a/vm/context.go
+++ b/vm/context.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/abi"

--- a/vm/context.go
+++ b/vm/context.go
@@ -5,13 +5,12 @@ import (
 	"context"
 	"encoding/binary"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
-
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/state"
@@ -248,14 +247,19 @@ func (ctx *Context) CreateNewActor(addr address.Address, code cid.Cid, initializ
 // SampleChainRandomness samples randomness from a block's ancestors at the
 // given height.
 func (ctx *Context) SampleChainRandomness(sampleHeight *types.BlockHeight) ([]byte, error) {
-	ch := make(chan interface{})
+	ancestorCh := make(chan interface{})
 	go func() {
 		for _, val := range ctx.ancestors {
-			ch <- val
+			ancestorCh <- val
 		}
 	}()
 
-	return miner.SampleChainRandomness(sampleHeight, ch)
+	bytes, err := miner.SampleChainRandomness(sampleHeight, ancestorCh)
+	if err != nil {
+		return nil, errors.FaultErrorWrap(err, "failed to sample randomness from chain")
+	}
+
+	return bytes, nil
 }
 
 // Dependency injection setup.

--- a/vm/context.go
+++ b/vm/context.go
@@ -243,20 +243,7 @@ func (ctx *Context) CreateNewActor(addr address.Address, code cid.Cid, initializ
 // SampleChainRandomness samples randomness from a block's ancestors at the
 // given height.
 func (ctx *Context) SampleChainRandomness(sampleHeight *types.BlockHeight) ([]byte, error) {
-	ancestorCh := make(chan interface{})
-	go func() {
-		for _, val := range ctx.ancestors {
-			ancestorCh <- val
-		}
-		close(ancestorCh)
-	}()
-
-	bytes, err := miner.SampleChainRandomness(sampleHeight, ancestorCh)
-	if err != nil {
-		return nil, errors.FaultErrorWrap(err, "failed to sample randomness from chain")
-	}
-
-	return bytes, nil
+	return miner.SampleChainRandomness(sampleHeight, ctx.ancestors)
 }
 
 // Dependency injection setup.

--- a/vm/context.go
+++ b/vm/context.go
@@ -46,7 +46,6 @@ type NewContextParams struct {
 	GasTracker  *GasTracker
 	BlockHeight *types.BlockHeight
 	Ancestors   []types.TipSet
-	LookBack    int
 }
 
 // NewVMContext returns an initialized context.
@@ -60,7 +59,6 @@ func NewVMContext(params NewContextParams) *Context {
 		gasTracker:  params.GasTracker,
 		blockHeight: params.BlockHeight,
 		ancestors:   params.Ancestors,
-		lookBack:    params.LookBack,
 		deps:        makeDeps(params.State),
 	}
 }

--- a/vm/context.go
+++ b/vm/context.go
@@ -29,7 +29,6 @@ type Context struct {
 	gasTracker  *GasTracker
 	blockHeight *types.BlockHeight
 	ancestors   []types.TipSet
-	lookBack    int
 
 	deps *deps // Inject external dependencies so we can unit test robustly.
 }

--- a/vm/context_test.go
+++ b/vm/context_test.go
@@ -340,10 +340,16 @@ func TestVMContextRand(t *testing.T) {
 			Ancestors: modAncestors,
 		}
 
+		// ancestor block heights:
+		//
+		// 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 25
 		ctx := NewVMContext(vmCtxParams)
-		_, err := ctx.SampleChainRandomness(types.NewBlockHeight(uint64(22))) // null block here
+
+		// 24 - lookback = 22 ... no such tip set in ancestors (null block)
+		_, err := ctx.SampleChainRandomness(types.NewBlockHeight(uint64(24)))
 		assert.Error(err)
 
+		// 30 - lookback = 28 ... no such tip set in ancestors
 		_, err = ctx.SampleChainRandomness(types.NewBlockHeight(uint64(30))) // ancestors all lower height
 		assert.Error(err)
 	})

--- a/vm/context_test.go
+++ b/vm/context_test.go
@@ -18,9 +18,9 @@ import (
 	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
-	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/exec"
+	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm/errors"
@@ -312,7 +312,7 @@ func TestVMContextRand(t *testing.T) {
 	tipSetsDescBlockHeight = append([]types.TipSet{types.RequireNewTipSet(require, head)}, tipSetsDescBlockHeight...)
 
 	// set a tripwire
-	require.Equal(miner.LookbackParameter, 3, "these tests assume LookbackParameter=3")
+	require.Equal(sampling.LookbackParameter, 3, "these tests assume LookbackParameter=3")
 
 	t.Run("happy path", func(t *testing.T) {
 		ctx := NewVMContext(NewContextParams{

--- a/vm/context_test.go
+++ b/vm/context_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/state"
@@ -298,23 +299,25 @@ func TestVMContextIsAccountActor(t *testing.T) {
 func TestVMContextRand(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	var ancestors []types.TipSet
+	var tipSetsDescBlockHeight []types.TipSet
 	// setup ancestor chain
 	head := types.NewBlockForTest(nil, uint64(0))
 	head.Ticket = []byte(strconv.Itoa(0))
 	for i := 0; i < 20; i++ {
-		ancestors = append(ancestors, types.RequireNewTipSet(require, head))
+		tipSetsDescBlockHeight = append([]types.TipSet{types.RequireNewTipSet(require, head)}, tipSetsDescBlockHeight...)
 		newBlock := types.NewBlockForTest(head, uint64(0))
 		newBlock.Ticket = []byte(strconv.Itoa(i + 1))
 		head = newBlock
 	}
-	ancestors = append(ancestors, types.RequireNewTipSet(require, head))
+	tipSetsDescBlockHeight = append([]types.TipSet{types.RequireNewTipSet(require, head)}, tipSetsDescBlockHeight...)
+
+	// set a tripwire
+	require.Equal(miner.LookbackParameter, 3, "these tests assume LookbackParameter=3")
 
 	t.Run("happy path", func(t *testing.T) {
-		vmCtxParams := NewContextParams{
-			Ancestors: ancestors,
-		}
-		ctx := NewVMContext(vmCtxParams)
+		ctx := NewVMContext(NewContextParams{
+			Ancestors: tipSetsDescBlockHeight,
+		})
 
 		r, err := ctx.SampleChainRandomness(types.NewBlockHeight(uint64(20)))
 		assert.NoError(err)
@@ -330,47 +333,46 @@ func TestVMContextRand(t *testing.T) {
 	})
 
 	t.Run("faults with height out of range", func(t *testing.T) {
-		// edit ancestors to include null blocks
-		baseBlock := ancestors[len(ancestors)-2].ToSlice()[0]
+		// edit `tipSetsDescBlockHeight` to include null blocks at heights 21
+		// through 24
+		baseBlock := tipSetsDescBlockHeight[1].ToSlice()[0]
 		afterNull := types.NewBlockForTest(baseBlock, uint64(0))
 		afterNull.Height += types.Uint64(uint64(5))
 		afterNull.Ticket = []byte(strconv.Itoa(int(afterNull.Height)))
-		modAncestors := append(ancestors[:len(ancestors)-1], types.RequireNewTipSet(require, afterNull))
-		vmCtxParams := NewContextParams{
-			Ancestors: modAncestors,
-		}
+		modAncestors := append([]types.TipSet{types.RequireNewTipSet(require, afterNull)}, tipSetsDescBlockHeight...)
 
 		// ancestor block heights:
 		//
-		// 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 25
-		ctx := NewVMContext(vmCtxParams)
+		// 25 20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
+		ctx := NewVMContext(NewContextParams{
+			Ancestors: modAncestors,
+		})
 
-		// 24 - lookback = 22 ... no such tip set in ancestors (null block)
-		_, err := ctx.SampleChainRandomness(types.NewBlockHeight(uint64(24)))
-		assert.Error(err)
-
-		// 30 - lookback = 28 ... no such tip set in ancestors
-		_, err = ctx.SampleChainRandomness(types.NewBlockHeight(uint64(30))) // ancestors all lower height
+		// no tip set with height 30 exists in ancestors
+		_, err := ctx.SampleChainRandomness(types.NewBlockHeight(uint64(30)))
 		assert.Error(err)
 	})
 
 	t.Run("faults with lookback out of range", func(t *testing.T) {
-		modAncestors := ancestors[5:]
-		vmCtxParams := NewContextParams{
-			Ancestors: modAncestors,
-		}
+		// ancestor block heights:
+		//
+		// 25 20
+		ctx := NewVMContext(NewContextParams{
+			Ancestors: tipSetsDescBlockHeight[:5],
+		})
 
-		ctx := NewVMContext(vmCtxParams)
-		_, err := ctx.SampleChainRandomness(types.NewBlockHeight(uint64(5))) // lookback height lower than all ancestors
+		// going back in time by `LookbackParameter`-number of tip sets from
+		// block height 25 does not find us the genesis block
+		_, err := ctx.SampleChainRandomness(types.NewBlockHeight(uint64(25)))
 		assert.Error(err)
 	})
 
-	t.Run("truncated to genesis", func(t *testing.T) {
+	t.Run("falls back to genesis block", func(t *testing.T) {
 		vmCtxParams := NewContextParams{
-			Ancestors: ancestors,
+			Ancestors: tipSetsDescBlockHeight,
 		}
 		ctx := NewVMContext(vmCtxParams)
-		r, err := ctx.SampleChainRandomness(types.NewBlockHeight(uint64(1))) // lookback height lower than all ancestors
+		r, err := ctx.SampleChainRandomness(types.NewBlockHeight(uint64(1))) // lookback height lower than all tipSetsDescBlockHeight
 		assert.NoError(err)
 		assert.Equal([]byte(strconv.Itoa(0)), r)
 	})

--- a/vm/context_test.go
+++ b/vm/context_test.go
@@ -313,7 +313,6 @@ func TestVMContextRand(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		vmCtxParams := NewContextParams{
 			Ancestors: ancestors,
-			LookBack:  3,
 		}
 		ctx := NewVMContext(vmCtxParams)
 
@@ -339,7 +338,6 @@ func TestVMContextRand(t *testing.T) {
 		modAncestors := append(ancestors[:len(ancestors)-1], types.RequireNewTipSet(require, afterNull))
 		vmCtxParams := NewContextParams{
 			Ancestors: modAncestors,
-			LookBack:  3,
 		}
 
 		ctx := NewVMContext(vmCtxParams)
@@ -354,7 +352,6 @@ func TestVMContextRand(t *testing.T) {
 		modAncestors := ancestors[5:]
 		vmCtxParams := NewContextParams{
 			Ancestors: modAncestors,
-			LookBack:  3,
 		}
 
 		ctx := NewVMContext(vmCtxParams)
@@ -365,7 +362,6 @@ func TestVMContextRand(t *testing.T) {
 	t.Run("truncated to genesis", func(t *testing.T) {
 		vmCtxParams := NewContextParams{
 			Ancestors: ancestors,
-			LookBack:  3,
 		}
 		ctx := NewVMContext(vmCtxParams)
 		r, err := ctx.SampleChainRandomness(types.NewBlockHeight(uint64(1))) // lookback height lower than all ancestors

--- a/vm/context_test.go
+++ b/vm/context_test.go
@@ -317,15 +317,15 @@ func TestVMContextRand(t *testing.T) {
 		}
 		ctx := NewVMContext(vmCtxParams)
 
-		r, err := ctx.Rand(types.NewBlockHeight(uint64(20)))
+		r, err := ctx.SampleChainRandomness(types.NewBlockHeight(uint64(20)))
 		assert.NoError(err)
 		assert.Equal([]byte(strconv.Itoa(17)), r)
 
-		r, err = ctx.Rand(types.NewBlockHeight(uint64(3)))
+		r, err = ctx.SampleChainRandomness(types.NewBlockHeight(uint64(3)))
 		assert.NoError(err)
 		assert.Equal([]byte(strconv.Itoa(0)), r)
 
-		r, err = ctx.Rand(types.NewBlockHeight(uint64(10)))
+		r, err = ctx.SampleChainRandomness(types.NewBlockHeight(uint64(10)))
 		assert.NoError(err)
 		assert.Equal([]byte(strconv.Itoa(7)), r)
 	})
@@ -343,10 +343,10 @@ func TestVMContextRand(t *testing.T) {
 		}
 
 		ctx := NewVMContext(vmCtxParams)
-		_, err := ctx.Rand(types.NewBlockHeight(uint64(22))) // null block here
+		_, err := ctx.SampleChainRandomness(types.NewBlockHeight(uint64(22))) // null block here
 		assert.Error(err)
 
-		_, err = ctx.Rand(types.NewBlockHeight(uint64(30))) // ancestors all lower height
+		_, err = ctx.SampleChainRandomness(types.NewBlockHeight(uint64(30))) // ancestors all lower height
 		assert.Error(err)
 	})
 
@@ -358,7 +358,7 @@ func TestVMContextRand(t *testing.T) {
 		}
 
 		ctx := NewVMContext(vmCtxParams)
-		_, err := ctx.Rand(types.NewBlockHeight(uint64(5))) // lookback height lower than all ancestors
+		_, err := ctx.SampleChainRandomness(types.NewBlockHeight(uint64(5))) // lookback height lower than all ancestors
 		assert.Error(err)
 	})
 
@@ -368,7 +368,7 @@ func TestVMContextRand(t *testing.T) {
 			LookBack:  3,
 		}
 		ctx := NewVMContext(vmCtxParams)
-		r, err := ctx.Rand(types.NewBlockHeight(uint64(1))) // lookback height lower than all ancestors
+		r, err := ctx.SampleChainRandomness(types.NewBlockHeight(uint64(1))) // lookback height lower than all ancestors
 		assert.NoError(err)
 		assert.Equal([]byte(strconv.Itoa(0)), r)
 	})


### PR DESCRIPTION
Fixes #1996 

Fixes #1302 

## Why is this PR needed?

- PoSt generation and verification require a challenge seed
- challenge seed must be created from shared source of randomness (blockchain)
- we need some way to sample randomness from seed from both inside and outside state machine

## What's in this PR?

- provide mechanism for sampling chain randomness from outside state machine (for PoSt generation)
- use chain randomness to generate challenge seed for PoSt verification and generation

## Controversial Stuff

- Lookback parameter was once a field on the VM context. It isn't anymore. It's not clear to me why it was both a package variable `LookbackParameter` and also part of the VM context. I can be convinced to put it back to the way that it was.
- If chain randomness sampling height minus lookback results in a null block, we fault. *It's not clear to me what to do in this scenario.*