### PR TITLE
Prevent transient failures of TestGenerateKey

### DIFF
--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -20,7 +20,9 @@ func TestGenerateKey(t *testing.T) {
 	assert.Equal(len(sk), 32)
 
 	msg := make([]byte, 32)
-	msg[0] = 1
+	for i := 0; i < len(msg); i++ {
+		msg[0] = byte(i)
+	}
 
 	digest, err := crypto.Sign(sk, msg)
 	assert.NoError(err)


### PR DESCRIPTION
We make all entries distinct in the byte array used in the test. This
means the shuffle will (practically) always mutate the message in some
way.

Resolves #2217