### PR TITLE
Initial implementation of outbound message queue, including expiry mechanism

### DIFF
--- a/core/message_queue.go
+++ b/core/message_queue.go
@@ -1,0 +1,132 @@
+package core
+
+import (
+	"sync"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/pkg/errors"
+)
+
+// MessageQueue stores an ordered list of messages (per actor) and enforces that their nonces form a contiguous sequence.
+// Each message is associated with a "stamp" (an opaque integer), and the queue supports expiring any list
+// of messages where the first message has a stamp below some threshold. The relative order of stamps in a queue is
+// not enforced.
+// A message queue is intended to record outbound messages that have been transmitted but not yet appeared in a block,
+// where the stamp could be block height.
+// MessageQueue is safe for concurrent access.
+type MessageQueue struct {
+	lk sync.RWMutex
+	// Message queues keyed by sending actor address, in nonce order
+	queues map[address.Address][]*queuedMessage
+}
+
+type queuedMessage struct {
+	msg   *types.SignedMessage
+	stamp uint64
+}
+
+// NewMessageQueue constructs a new, empty queue.
+func NewMessageQueue() *MessageQueue {
+	return &MessageQueue{
+		queues: make(map[address.Address][]*queuedMessage),
+	}
+}
+
+// Enqueue appends a new message for an address. If the queue already contains any messages for
+// from same address, the new message's nonce must be exactly one greater than the largest nonce
+// present.
+func (mq *MessageQueue) Enqueue(msg *types.SignedMessage, stamp uint64) error {
+	mq.lk.Lock()
+	defer mq.lk.Unlock()
+
+	q := mq.queues[msg.From]
+	if len(q) > 0 {
+		nextNonce := q[len(q)-1].msg.Nonce + 1
+		if msg.Nonce != nextNonce {
+			return errors.Errorf("Invalid nonce %d, expected %d", msg.Nonce, nextNonce)
+		}
+	}
+	mq.queues[msg.From] = append(q, &queuedMessage{msg, stamp})
+	return nil
+}
+
+// RemoveNext removes and returns a single message from the queue, if it bears the expected nonce value, with found = true.
+// Returns found = false if the queue is empty or the expected nonce is less than any in the queue for that address
+// (indicating the message had already been removed).
+// Returns an error if the expected nonce is greater than the smallest in the queue.
+// The caller may wish to check that the returned message is equal to that expected (not just in nonce value).
+func (mq *MessageQueue) RemoveNext(sender address.Address, expectedNonce uint64) (msg *types.SignedMessage, found bool, err error) {
+	mq.lk.Lock()
+	defer mq.lk.Unlock()
+
+	q := mq.queues[sender]
+	if len(q) > 0 {
+		head := q[0]
+		if expectedNonce == uint64(head.msg.Nonce) {
+			mq.queues[sender] = q[1:] // pop the head
+			msg = head.msg
+			found = true
+		} else if expectedNonce > uint64(head.msg.Nonce) {
+			err = errors.Errorf("Next message for %s has nonce %d, expected %d", sender, head.msg.Nonce, expectedNonce)
+		}
+		// else expected nonce was before the head of the queue, already removed
+	}
+	return
+}
+
+// Clear removes all messages for a single sender address.
+func (mq *MessageQueue) Clear(sender address.Address) bool {
+	mq.lk.Lock()
+	defer mq.lk.Unlock()
+
+	q := mq.queues[sender]
+	if len(q) > 0 {
+		mq.queues[sender] = []*queuedMessage{}
+		return true
+	}
+	return false
+}
+
+// ExpireBefore clears the queue of any sender where the first message in the queue has a stamp less than `stamp`.
+// Returns a map containing any expired address queues.
+func (mq *MessageQueue) ExpireBefore(stamp uint64) map[address.Address][]*types.SignedMessage {
+	mq.lk.Lock()
+	defer mq.lk.Unlock()
+
+	expired := make(map[address.Address][]*types.SignedMessage)
+
+	for sender, q := range mq.queues {
+		if len(q) > 0 && q[0].stamp < stamp {
+			for _, m := range q {
+				expired[sender] = append(expired[sender], m.msg)
+			}
+			mq.queues[sender] = []*queuedMessage{}
+		}
+	}
+	return expired
+}
+
+// LargestNonce returns the largest nonce of any message in the queue for an address.
+// If the queue for the address is empty, returns (0, false).
+func (mq *MessageQueue) LargestNonce(sender address.Address) (largest uint64, found bool) {
+	mq.lk.RLock()
+	defer mq.lk.RUnlock()
+	q := mq.queues[sender]
+	if len(q) > 0 {
+		return uint64(q[len(q)-1].msg.Nonce), true
+	}
+	return 0, false
+}
+
+// NextStamp returns the stamp for the next message in the queue for an address, or zero if the
+// queue is empty.
+func (mq *MessageQueue) NextStamp(sender address.Address) uint64 {
+	mq.lk.RLock()
+	defer mq.lk.RUnlock()
+	q := mq.queues[sender]
+	if len(q) > 0 {
+		return q[0].stamp
+	}
+	return 0
+}

--- a/core/message_queue_test.go
+++ b/core/message_queue_test.go
@@ -1,0 +1,295 @@
+package core_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/core"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+func TestMessageQueue(t *testing.T) {
+	t.Parallel() // Individual tests share msgSeq so not parallel (but quick)
+	assert := assert.New(t)
+	require := require.New(t)
+
+	keys := types.MustGenerateKeyInfo(3, types.GenerateKeyInfoSeed())
+	addresses := make([]address.Address, len(keys))
+	signer := types.NewMockSigner(keys)
+	msgSeq := 0
+	gasPrice := *types.ZeroAttoFIL
+	gasUnits := types.NewGasUnits(0)
+
+	for i, key := range keys {
+		addr, _ := key.Address()
+		addresses[i] = addr
+	}
+
+	alice := addresses[0]
+	bob := addresses[1]
+	require.NotEqual(alice, bob)
+
+	// Creates a new message with specified sender and nonce
+	newMessage := func(from address.Address, nonce uint64) *types.SignedMessage {
+		seq := msgSeq
+		msgSeq++
+		msg := types.NewMessage(
+			from,
+			address.NewMainnet([]byte("destination")),
+			nonce,
+			types.NewAttoFILFromFIL(0),
+			"method"+fmt.Sprintf("%d", seq),
+			[]byte("params"))
+		signed, err := types.NewSignedMessage(*msg, signer, gasPrice, gasUnits)
+		require.NoError(err)
+		return signed
+	}
+
+	mustEnqueue := func(q *core.MessageQueue, msg *types.SignedMessage, stamp uint64) {
+		err := q.Enqueue(msg, stamp)
+		require.NoError(err)
+	}
+
+	mustRemoveNext := func(q *core.MessageQueue, sender address.Address, expected uint64) *types.SignedMessage {
+		msg, found, e := q.RemoveNext(sender, expected)
+		require.True(found)
+		require.NoError(e)
+		return msg
+	}
+
+	assertLargestNonce := func(q *core.MessageQueue, sender address.Address, expected uint64) {
+		largest, found := q.LargestNonce(sender)
+		assert.True(found, "no messages")
+		assert.Equal(expected, largest)
+	}
+
+	assertNoNonce := func(q *core.MessageQueue, sender address.Address) {
+		_, found := q.LargestNonce(sender)
+		assert.False(found, "unexpected messages")
+	}
+
+	t.Run("empty queue", func(t *testing.T) {
+		q := core.NewMessageQueue()
+		msg, found, err := q.RemoveNext(alice, 0)
+		assert.Nil(msg)
+		assert.False(found)
+		assert.NoError(err)
+
+		assert.Empty(q.ExpireBefore(math.MaxUint64))
+
+		nonce, found := q.LargestNonce(alice)
+		assert.False(found)
+		assert.Zero(nonce)
+
+		assert.Equal(uint64(0), q.NextStamp(alice))
+	})
+
+	t.Run("add and remove sequence", func(t *testing.T) {
+		msgs := []*types.SignedMessage{
+			newMessage(alice, 0),
+			newMessage(alice, 1),
+			newMessage(alice, 2),
+		}
+
+		q := core.NewMessageQueue()
+		mustEnqueue(q, msgs[0], 0)
+		mustEnqueue(q, msgs[1], 0)
+		mustEnqueue(q, msgs[2], 0)
+
+		msg := mustRemoveNext(q, alice, 0)
+		assert.Equal(msgs[0], msg)
+
+		_, found, err := q.RemoveNext(alice, 0) // Remove first message again
+		assert.False(found)
+		assert.NoError(err)
+
+		msg = mustRemoveNext(q, alice, 1)
+		assert.Equal(msgs[1], msg)
+
+		_, found, err = q.RemoveNext(alice, 0) // Remove first message yet again
+		assert.False(found)
+		assert.NoError(err)
+
+		msg = mustRemoveNext(q, alice, 2)
+		assert.Equal(msgs[2], msg)
+	})
+
+	t.Run("invalid nonce sequence", func(t *testing.T) {
+		msgs := []*types.SignedMessage{
+			newMessage(alice, 0),
+			newMessage(alice, 1),
+			newMessage(alice, 2),
+			newMessage(alice, 3),
+		}
+
+		q := core.NewMessageQueue()
+		mustEnqueue(q, msgs[1], 0)
+
+		err := q.Enqueue(msgs[0], 0) // Prior to existing
+		assert.Error(err)
+
+		err = q.Enqueue(msgs[1], 0) // Equal to existing
+		assert.Error(err)
+
+		err = q.Enqueue(msgs[3], 0) // Gap after existing
+		assert.Error(err)
+	})
+
+	t.Run("invalid remove sequence", func(t *testing.T) {
+		msgs := []*types.SignedMessage{
+			newMessage(alice, 10),
+			newMessage(alice, 11),
+		}
+
+		q := core.NewMessageQueue()
+		mustEnqueue(q, msgs[0], 0)
+		mustEnqueue(q, msgs[1], 0)
+
+		msg, found, err := q.RemoveNext(alice, 9) // Prior to head
+		assert.Nil(msg)
+		assert.False(found)
+		require.NoError(err)
+
+		msg, found, err = q.RemoveNext(alice, 11) // After head
+		assert.False(found)
+		assert.Nil(msg)
+		assert.Error(err)
+	})
+
+	t.Run("largest nonce", func(t *testing.T) {
+		msgs := []*types.SignedMessage{
+			newMessage(alice, 0),
+			newMessage(alice, 1),
+			newMessage(alice, 2),
+			newMessage(alice, 3),
+		}
+		q := core.NewMessageQueue()
+		mustEnqueue(q, msgs[0], 0)
+		assertLargestNonce(q, alice, 0)
+		mustEnqueue(q, msgs[1], 0)
+		assertLargestNonce(q, alice, 1)
+		mustEnqueue(q, msgs[2], 0)
+		assertLargestNonce(q, alice, 2)
+
+		mustRemoveNext(q, alice, 0)
+		assertLargestNonce(q, alice, 2)
+
+		mustEnqueue(q, msgs[3], 0)
+		assertLargestNonce(q, alice, 3)
+
+		mustRemoveNext(q, alice, 1)
+		mustRemoveNext(q, alice, 2)
+		assertLargestNonce(q, alice, 3)
+
+		mustRemoveNext(q, alice, 3) // clears queue
+		assertNoNonce(q, alice)
+	})
+
+	t.Run("clear", func(t *testing.T) {
+		msgs := []*types.SignedMessage{
+			newMessage(alice, 0),
+			newMessage(alice, 1),
+			newMessage(alice, 2),
+		}
+
+		q := core.NewMessageQueue()
+		mustEnqueue(q, msgs[1], 0)
+		mustEnqueue(q, msgs[2], 0)
+		assertLargestNonce(q, alice, 2)
+		q.Clear(alice)
+		assertNoNonce(q, alice)
+
+		mustEnqueue(q, msgs[0], 0)
+		mustEnqueue(q, msgs[1], 0)
+		assertLargestNonce(q, alice, 1)
+	})
+
+	t.Run("independent addresses", func(t *testing.T) {
+		fromAlice := []*types.SignedMessage{
+			newMessage(alice, 0),
+			newMessage(alice, 1),
+			newMessage(alice, 2),
+		}
+		fromBob := []*types.SignedMessage{
+			newMessage(bob, 10),
+			newMessage(bob, 11),
+			newMessage(bob, 12),
+		}
+		q := core.NewMessageQueue()
+
+		mustEnqueue(q, fromAlice[0], 0)
+		assertNoNonce(q, bob)
+
+		mustEnqueue(q, fromBob[0], 0)
+		assertLargestNonce(q, alice, 0)
+		assertLargestNonce(q, bob, 10)
+
+		mustEnqueue(q, fromBob[1], 0)
+		mustEnqueue(q, fromBob[2], 0)
+		assertLargestNonce(q, bob, 12)
+
+		mustEnqueue(q, fromAlice[1], 0)
+		mustEnqueue(q, fromAlice[2], 0)
+		assertLargestNonce(q, alice, 2)
+
+		msg := mustRemoveNext(q, alice, 0)
+		assert.Equal(fromAlice[0], msg)
+
+		msg = mustRemoveNext(q, bob, 10)
+		assert.Equal(fromBob[0], msg)
+
+		q.Clear(bob)
+		assertLargestNonce(q, alice, 2)
+		assertNoNonce(q, bob)
+	})
+
+	t.Run("expire before stamp", func(t *testing.T) {
+		fromAlice := []*types.SignedMessage{
+			newMessage(alice, 0),
+			newMessage(alice, 1),
+		}
+		fromBob := []*types.SignedMessage{
+			newMessage(bob, 10),
+			newMessage(bob, 11),
+		}
+		q := core.NewMessageQueue()
+
+		mustEnqueue(q, fromAlice[0], 100)
+		mustEnqueue(q, fromAlice[1], 101)
+		mustEnqueue(q, fromBob[0], 200)
+		mustEnqueue(q, fromBob[1], 201)
+
+		assert.Equal(uint64(100), q.NextStamp(alice))
+		assert.Equal(uint64(200), q.NextStamp(bob))
+
+		expired := q.ExpireBefore(0)
+		assert.Empty(expired)
+
+		expired = q.ExpireBefore(100)
+		assert.Empty(expired)
+
+		// Alice's whole queue expires as soon as the first one does
+		expired = q.ExpireBefore(101)
+		assert.Equal(map[address.Address][]*types.SignedMessage{
+			alice: {fromAlice[0], fromAlice[1]},
+		}, expired)
+
+		assert.Equal(uint64(0), q.NextStamp(alice))
+		assertNoNonce(q, alice)
+		assert.Equal(uint64(200), q.NextStamp(bob))
+		assertLargestNonce(q, bob, 11)
+
+		expired = q.ExpireBefore(300)
+		assert.Equal(map[address.Address][]*types.SignedMessage{
+			bob: {fromBob[0], fromBob[1]},
+		}, expired)
+
+		assert.Equal(uint64(0), q.NextStamp(bob))
+		assertNoNonce(q, bob)
+	})
+}


### PR DESCRIPTION
This is the core of #2146.

This is not yet integrated into the message sender plumbing, which will provide values for chain height,
or chain syncing, which will remove/expire messages.