### PR TITLE
Remove redundant error return from KeyInfo.Address()

### DIFF
--- a/api/address.go
+++ b/api/address.go
@@ -19,7 +19,7 @@ type Address interface {
 
 // Addrs is the interface that defines method to interact with addresses.
 type Addrs interface {
-	New(ctx context.Context) (address.Address, error)
+	New(ctx context.Context) address.Address
 	Ls(ctx context.Context) ([]address.Address, error)
 	Lookup(ctx context.Context, addr address.Address) (peer.ID, error)
 }

--- a/api/impl/address.go
+++ b/api/impl/address.go
@@ -45,7 +45,7 @@ func newNodeAddrs(api *nodeAPI) *nodeAddrs {
 	return &nodeAddrs{api: api}
 }
 
-func (api *nodeAddrs) New(ctx context.Context) (address.Address, error) {
+func (api *nodeAddrs) New(ctx context.Context) address.Address {
 	return api.api.node.NewAddress()
 }
 
@@ -91,11 +91,7 @@ func (api *nodeAddress) Import(ctx context.Context, f files.File) ([]address.Add
 			return nil, err
 		}
 
-		a, err := ki.Address()
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, a)
+		out = append(out, ki.Address())
 	}
 	return out, nil
 }

--- a/commands/address.go
+++ b/commands/address.go
@@ -48,10 +48,7 @@ type AddressLsResult struct {
 
 var addrsNewCmd = &cmds.Command{
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
-		addr, err := GetAPI(env).Address().Addrs().New(req.Context)
-		if err != nil {
-			return err
-		}
+		addr := GetAPI(env).Address().Addrs().New(req.Context)
 		return re.Emit(&addressResult{addr.String()})
 	},
 	Type: &addressResult{},
@@ -209,12 +206,9 @@ var walletExportCmd = &cmds.Command{
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, klr *impl.WalletSerializeResult) error {
 			for _, k := range klr.KeyInfo {
-				a, err := k.Address()
-				if err != nil {
-					return err
-				}
+				a := k.Address()
 				privateKeyInBase64 := base64.StdEncoding.EncodeToString(k.PrivateKey)
-				_, err = fmt.Fprintf(w, "Address:\t%s\nPrivateKey:\t%s\nCurve:\t\t%s\n\n", a.String(), privateKeyInBase64, k.Curve)
+				_, err := fmt.Fprintf(w, "Address:\t%s\nPrivateKey:\t%s\nCurve:\t\t%s\n\n", a.String(), privateKeyInBase64, k.Curve)
 				if err != nil {
 					return err
 				}

--- a/fixtures/constants.go
+++ b/fixtures/constants.go
@@ -77,10 +77,7 @@ func init() {
 
 	for _, key := range keys {
 		info := details.Keys[key]
-		addr, err := info.Address()
-		if err != nil {
-			panic(err)
-		}
+		addr := info.Address()
 		TestAddresses = append(TestAddresses, addr.String())
 		testKeys = append(testKeys, fmt.Sprintf("%d.key", key))
 	}

--- a/gengen/main.go
+++ b/gengen/main.go
@@ -13,10 +13,7 @@ import (
 )
 
 func writeKey(ki *types.KeyInfo, name string, jsonout bool) error {
-	addr, err := ki.Address()
-	if err != nil {
-		return err
-	}
+	addr := ki.Address()
 	if !jsonout {
 		fmt.Fprintf(os.Stderr, "key: %s - %s\n", name, addr.String())                                                          // nolint: errcheck
 		fmt.Fprintf(os.Stderr, "run 'go-filecoin wallet import ./%s.key' to add private key for %[1]s to your wallet\n", name) // nolint: errcheck

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -182,11 +182,6 @@ func setupPrealloc(st state.Tree, keys []*types.KeyInfo, prealloc []string) erro
 	for i, v := range prealloc {
 		ki := keys[i]
 
-		addr, err := ki.Address()
-		if err != nil {
-			return err
-		}
-
 		valint, err := strconv.ParseUint(v, 10, 64)
 		if err != nil {
 			return err
@@ -196,7 +191,7 @@ func setupPrealloc(st state.Tree, keys []*types.KeyInfo, prealloc []string) erro
 		if err != nil {
 			return err
 		}
-		if err := st.SetActor(context.Background(), addr, act); err != nil {
+		if err := st.SetActor(context.Background(), ki.Address(), act); err != nil {
 			return err
 		}
 	}
@@ -214,10 +209,7 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 	ctx := context.Background()
 
 	for _, m := range miners {
-		addr, err := keys[m.Owner].Address()
-		if err != nil {
-			return nil, err
-		}
+		addr := keys[m.Owner].Address()
 
 		var pid peer.ID
 		if m.PeerID != "" {
@@ -236,7 +228,7 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 		}
 
 		// give collateral to account actor
-		_, err = applyMessageDirect(ctx, st, sm, address.NetworkAddress, addr, types.NewAttoFILFromFIL(100000), "")
+		_, err := applyMessageDirect(ctx, st, sm, address.NetworkAddress, addr, types.NewAttoFILFromFIL(100000), "")
 		if err != nil {
 			return nil, err
 		}

--- a/node/init.go
+++ b/node/init.go
@@ -126,10 +126,5 @@ func newAddress(r repo.Repo) (address.Address, error) {
 		return address.Address{}, errors.Wrap(err, "failed to set up wallet backend")
 	}
 
-	addr, err := backend.NewAddress()
-	if err != nil {
-		return address.Address{}, errors.Wrap(err, "failed to create address")
-	}
-
-	return addr, err
+	return backend.NewAddress(), nil
 }

--- a/node/message_propagate_test.go
+++ b/node/message_propagate_test.go
@@ -25,8 +25,7 @@ func TestMessagePropagation(t *testing.T) {
 
 	// Generate a key and install an account actor at genesis which will be able to send messages.
 	ki := types.MustGenerateKeyInfo(1, types.GenerateKeyInfoSeed())[0]
-	senderAddress, err := ki.Address()
-	require.NoError(err)
+	senderAddress := ki.Address()
 	genesis := consensus.MakeGenesisFunc(
 		consensus.ActorAccount(senderAddress, types.NewAttoFILFromFIL(100)),
 	)
@@ -43,7 +42,7 @@ func TestMessagePropagation(t *testing.T) {
 
 	// Give the sender the private key so it can sign messages.
 	// Note: this is an ugly hack around the Wallet lacking a mutable interface.
-	err = sender.Wallet.Backends(wallet.DSBackendType)[0].(*wallet.DSBackend).ImportKey(&ki)
+	err := sender.Wallet.Backends(wallet.DSBackendType)[0].(*wallet.DSBackend).ImportKey(&ki)
 	require.NoError(err)
 
 	// Initialize other nodes to receive the message.

--- a/node/node.go
+++ b/node/node.go
@@ -990,7 +990,7 @@ func (node *Node) StopMining(ctx context.Context) {
 }
 
 // NewAddress creates a new account address on the default wallet backend.
-func (node *Node) NewAddress() (address.Address, error) {
+func (node *Node) NewAddress() address.Address {
 	return wallet.NewAddress(node.Wallet)
 }
 

--- a/node/testing.go
+++ b/node/testing.go
@@ -100,10 +100,7 @@ func (cs *ChainSeed) GiveKey(t *testing.T, nd *Node, key int) address.Address {
 	kinfo := cs.info.Keys[key]
 	require.NoError(t, dsb.ImportKey(kinfo))
 
-	addr, err := kinfo.Address()
-	require.NoError(t, err)
-
-	return addr
+	return kinfo.Address()
 }
 
 // GiveMiner gives the specified miner to the node. Returns the address and the owner addresss
@@ -115,9 +112,7 @@ func (cs *ChainSeed) GiveMiner(t *testing.T, nd *Node, which int) (address.Addre
 	cfg.Mining.MinerAddress = m.Address
 	require.NoError(t, nd.Repo.ReplaceConfig(cfg))
 
-	ownerAddr, err := cs.info.Keys[m.Owner].Address()
-	require.NoError(t, err)
-
+	ownerAddr := cs.info.Keys[m.Owner].Address()
 	return m.Address, ownerAddr
 }
 
@@ -125,13 +120,7 @@ func (cs *ChainSeed) GiveMiner(t *testing.T, nd *Node, which int) (address.Addre
 func (cs *ChainSeed) Addr(t *testing.T, key int) address.Address {
 	t.Helper()
 	k := cs.info.Keys[key]
-
-	a, err := k.Address()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return a
+	return k.Address()
 }
 
 // MakeNodeWithChainSeed makes a single node with the given chain seed, and some init options

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -224,6 +224,6 @@ func (api *API) WalletFind(address address.Address) (wallet.Backend, error) {
 }
 
 // WalletNewAddress generates a new wallet address
-func (api *API) WalletNewAddress() (address.Address, error) {
+func (api *API) WalletNewAddress() address.Address {
 	return wallet.NewAddress(api.wallet)
 }

--- a/plumbing/msg/sender_test.go
+++ b/plumbing/msg/sender_test.go
@@ -199,16 +199,14 @@ func (v nullValidator) Validate(ctx context.Context, msg *types.SignedMessage, f
 func setupSendTest(require *require.Assertions) (*wallet.Wallet, *chain.DefaultStore, *core.MessagePool) {
 	// Install an account actor in the genesis block.
 	ki := types.MustGenerateKeyInfo(1, types.GenerateKeyInfoSeed())[0]
-	addr, err := ki.Address()
-	require.NoError(err)
 	genesis := consensus.MakeGenesisFunc(
-		consensus.ActorAccount(addr, types.NewAttoFILFromFIL(100)),
+		consensus.ActorAccount(ki.Address(), types.NewAttoFILFromFIL(100)),
 	)
 
 	d := requiredCommonDeps(require, genesis)
 
 	// Install the key in the wallet for use in signing.
-	err = d.wallet.Backends(wallet.DSBackendType)[0].(*wallet.DSBackend).ImportKey(&ki)
+	err := d.wallet.Backends(wallet.DSBackendType)[0].(*wallet.DSBackend).ImportKey(&ki)
 	require.NoError(err)
 	return d.wallet, d.chainStore, core.NewMessagePool()
 }

--- a/porcelain/message_test.go
+++ b/porcelain/message_test.go
@@ -3,13 +3,14 @@ package porcelain_test
 import (
 	"testing"
 
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/plumbing/cfg"
 	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/wallet"
-	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
-	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 )
 
 type fakeGetAndMaybeSetDefaultSenderAddressPlumbing struct {
@@ -39,7 +40,7 @@ func (fgamsdsap *fakeGetAndMaybeSetDefaultSenderAddressPlumbing) WalletAddresses
 	return fgamsdsap.wallet.Addresses()
 }
 
-func (fgamsdsap *fakeGetAndMaybeSetDefaultSenderAddressPlumbing) WalletNewAddress() (address.Address, error) {
+func (fgamsdsap *fakeGetAndMaybeSetDefaultSenderAddressPlumbing) WalletNewAddress() address.Address {
 	return wallet.NewAddress(fgamsdsap.wallet)
 }
 
@@ -52,8 +53,7 @@ func TestGetAndMaybeSetDefaultSenderAddress(t *testing.T) {
 
 		fp := newFakeGetAndMaybeSetDefaultSenderAddressPlumbing(require)
 
-		addrA, err := fp.WalletNewAddress()
-		require.NoError(err)
+		addrA := fp.WalletNewAddress()
 		fp.ConfigSet("wallet.defaultAddress", addrA.String())
 
 		addrB, err := porcelain.GetAndMaybeSetDefaultSenderAddress(fp)
@@ -69,9 +69,7 @@ func TestGetAndMaybeSetDefaultSenderAddress(t *testing.T) {
 
 		addresses := []address.Address{}
 		for i := 0; i < 10; i++ {
-			a, err := fp.WalletNewAddress()
-			require.NoError(err)
-			addresses = append(addresses, a)
+			addresses = append(addresses, fp.WalletNewAddress())
 		}
 
 		expected, err := porcelain.GetAndMaybeSetDefaultSenderAddress(fp)

--- a/porcelain/miner_test.go
+++ b/porcelain/miner_test.go
@@ -53,7 +53,7 @@ func (mpc *minerPreviewCreate) WalletFind(address address.Address) (wallet.Backe
 }
 
 func (mpc *minerPreviewCreate) GetAndMaybeSetDefaultSenderAddress() (address.Address, error) {
-	return wallet.NewAddress(mpc.wallet)
+	return wallet.NewAddress(mpc.wallet), nil
 }
 
 func TestMinerPreviewCreate(t *testing.T) {

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -367,8 +367,6 @@ type minerTestPorcelain struct {
 func newMinerTestPorcelain(require *require.Assertions) *minerTestPorcelain {
 	ki := types.MustGenerateKeyInfo(1, types.GenerateKeyInfoSeed())
 	mockSigner := types.NewMockSigner(ki)
-	payerAddr, err := ki[0].Address()
-	require.NoError(err, "Could not create payer address")
 
 	addressGetter := address.NewForTestGetter()
 	cidGetter := types.NewCidForTestGetter()
@@ -381,7 +379,7 @@ func newMinerTestPorcelain(require *require.Assertions) *minerTestPorcelain {
 	blockHeight := types.NewBlockHeight(773)
 	return &minerTestPorcelain{
 		config:        config,
-		payerAddress:  payerAddr,
+		payerAddress:  ki[0].Address(),
 		targetAddress: addressGetter(),
 		channelID:     types.NewChannelID(73),
 		messageCid:    &messageCid,

--- a/testhelpers/iptbtester/genesis.go
+++ b/testhelpers/iptbtester/genesis.go
@@ -62,11 +62,7 @@ func MustGenerateGenesis(t *testing.T, funds int64, dir string) *GenesisInfo {
 		t.Fatal(err)
 	}
 
-	walletAddr, err := info.Keys[0].Address()
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	walletAddr := info.Keys[0].Address()
 	minerAddr := info.Miners[0].Address
 
 	return &GenesisInfo{

--- a/types/keyinfo.go
+++ b/types/keyinfo.go
@@ -57,12 +57,12 @@ func (ki *KeyInfo) Equals(other *KeyInfo) bool {
 }
 
 // Address returns the address for this keyinfo
-func (ki *KeyInfo) Address() (address.Address, error) {
+func (ki *KeyInfo) Address() address.Address {
 	pub := ki.PublicKey()
 	addrHash := address.Hash(pub)
 
 	// TODO: Use the address type we are running on from the config.
-	return address.NewMainnet(addrHash), nil
+	return address.NewMainnet(addrHash)
 }
 
 // PublicKey returns the public key part as uncompressed bytes.

--- a/wallet/dsbackend.go
+++ b/wallet/dsbackend.go
@@ -95,10 +95,10 @@ func (backend *DSBackend) HasAddress(addr address.Address) bool {
 
 // NewAddress creates a new address and stores it.
 // Safe for concurrent access.
-func (backend *DSBackend) NewAddress() (address.Address, error) {
+func (backend *DSBackend) NewAddress() address.Address {
 	prv, err := crypto.GenerateKey()
 	if err != nil {
-		return address.Address{}, err
+		return address.Address{}
 	}
 
 	// TODO: maybe the above call should just return a keyinfo?
@@ -108,18 +108,14 @@ func (backend *DSBackend) NewAddress() (address.Address, error) {
 	}
 
 	if err := backend.putKeyInfo(ki); err != nil {
-		return address.Address{}, err
+		return address.Address{}
 	}
 
 	return ki.Address()
 }
 
 func (backend *DSBackend) putKeyInfo(ki *types.KeyInfo) error {
-	a, err := ki.Address()
-	if err != nil {
-		return err
-	}
-
+	a := ki.Address()
 	backend.lk.Lock()
 	defer backend.lk.Unlock()
 

--- a/wallet/dsbackend_test.go
+++ b/wallet/dsbackend_test.go
@@ -22,8 +22,7 @@ func TestDSBackendSimple(t *testing.T) {
 	assert.Len(fs.Addresses(), 0)
 
 	t.Log("can create new address")
-	addr, err := fs.NewAddress()
-	assert.NoError(err)
+	addr := fs.NewAddress()
 
 	t.Log("address is stored")
 	assert.True(fs.HasAddress(addr))
@@ -45,8 +44,7 @@ func TestDSBackendKeyPairMatchAddress(t *testing.T) {
 	assert.NoError(err)
 
 	t.Log("can create new address")
-	addr, err := fs.NewAddress()
-	assert.NoError(err)
+	addr := fs.NewAddress()
 
 	t.Log("address is stored")
 	assert.True(fs.HasAddress(addr))
@@ -55,11 +53,8 @@ func TestDSBackendKeyPairMatchAddress(t *testing.T) {
 	ki, err := fs.GetKeyInfo(addr)
 	assert.NoError(err)
 
-	dAddr, err := ki.Address()
-	assert.NoError(err)
-
 	t.Log("generated address and stored address should match")
-	assert.Equal(addr, dAddr)
+	assert.Equal(addr, ki.Address())
 }
 
 func TestDSBackendErrorsForUnknownAddress(t *testing.T) {
@@ -77,8 +72,7 @@ func TestDSBackendErrorsForUnknownAddress(t *testing.T) {
 	assert.NoError(err)
 
 	t.Log("can create new address in fs1")
-	addr, err := fs1.NewAddress()
-	assert.NoError(err)
+	addr := fs1.NewAddress()
 
 	t.Log("address is stored fs1")
 	assert.True(fs1.HasAddress(addr))
@@ -111,8 +105,7 @@ func TestDSBackendParallel(t *testing.T) {
 	wg.Add(count)
 	for i := 0; i < count; i++ {
 		go func() {
-			_, err := fs.NewAddress()
-			assert.NoError(err)
+			_ = fs.NewAddress()
 			wg.Done()
 		}()
 	}

--- a/wallet/signature_test.go
+++ b/wallet/signature_test.go
@@ -27,9 +27,7 @@ func requireSignerAddr(require *require.Assertions) (*DSBackend, address.Address
 	fs, err := NewDSBackend(ds)
 	require.NoError(err)
 
-	addr, err := fs.NewAddress()
-	require.NoError(err)
-	return fs, addr
+	return fs, fs.NewAddress()
 }
 
 // Signature is over the data being verified and was signed by the verifying
@@ -85,9 +83,7 @@ func TestInvalidAddress(t *testing.T) {
 	sig, err := fs.SignBytes(data, addr)
 	require.NoError(err)
 
-	badAddr, err := fs.NewAddress()
-	require.NoError(err)
-
+	badAddr := fs.NewAddress()
 	assert.False(types.IsValidSignature(data, badAddr, sig))
 }
 
@@ -128,8 +124,7 @@ func TestBadFrom(t *testing.T) {
 	require := require.New(t)
 
 	fs, addr := requireSignerAddr(require)
-	addr2, err := fs.NewAddress()
-	require.NoError(err)
+	addr2 := fs.NewAddress()
 
 	msg := types.NewMessage(addr, addr, 1, nil, "", nil)
 	meteredMsg := types.NewMeteredMessage(*msg, types.NewGasPrice(0), types.NewGasUnits(0))

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1,7 +1,6 @@
 package wallet
 
 import (
-	"fmt"
 	"reflect"
 	"sync"
 
@@ -121,10 +120,10 @@ func (w *Wallet) Ecrecover(data []byte, sig types.Signature) ([]byte, error) {
 }
 
 // NewAddress creates a new account address on the default wallet backend.
-func NewAddress(w *Wallet) (address.Address, error) {
+func NewAddress(w *Wallet) address.Address {
 	backends := w.Backends(DSBackendType)
 	if len(backends) == 0 {
-		return address.Address{}, fmt.Errorf("missing default ds backend")
+		return address.Address{}
 	}
 
 	backend := (backends[0]).(*DSBackend)
@@ -144,12 +143,7 @@ func (w *Wallet) GetPubKeyForAddress(addr address.Address) ([]byte, error) {
 
 // NewKeyInfo creates a new KeyInfo struct in the wallet backend and returns it
 func (w *Wallet) NewKeyInfo() (*types.KeyInfo, error) {
-	newAddr, err := NewAddress(w)
-	if err != nil {
-		return &types.KeyInfo{}, err
-	}
-
-	return w.keyInfoForAddr(newAddr)
+	return w.keyInfoForAddr(NewAddress(w))
 }
 
 func (w *Wallet) keyInfoForAddr(addr address.Address) (*types.KeyInfo, error) {

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -25,8 +25,7 @@ func TestWalletSimple(t *testing.T) {
 	assert.Len(w.Backends(DSBackendType), 1)
 
 	t.Log("create a new address in the backend")
-	addr, err := fs.NewAddress()
-	assert.NoError(err)
+	addr := fs.NewAddress()
 
 	t.Log("test HasAddress")
 	assert.True(w.HasAddress(addr))
@@ -61,8 +60,7 @@ func TestSimpleSignAndVerify(t *testing.T) {
 	assert.Len(w.Backends(DSBackendType), 1)
 
 	t.Log("create a new address in the backend")
-	addr, err := fs.NewAddress()
-	assert.NoError(err)
+	addr := fs.NewAddress()
 
 	t.Log("test HasAddress")
 	assert.True(w.HasAddress(addr))
@@ -129,10 +127,8 @@ func TestSignErrorCases(t *testing.T) {
 	assert.Len(w2.Backends(DSBackendType), 1)
 
 	t.Log("create a new address each backend")
-	addr1, err := fs1.NewAddress()
-	assert.NoError(err)
-	addr2, err := fs2.NewAddress()
-	assert.NoError(err)
+	addr1 := fs1.NewAddress()
+	addr2 := fs2.NewAddress()
 
 	t.Log("test HasAddress")
 	assert.True(w1.HasAddress(addr1))


### PR DESCRIPTION
The error value was removed in 619b0eb1f946a18f87b232834c8c6df1f6fc9b32.

This change is mechanical, I did nothing except pull the thread.