### PR TITLE
Timeout messages from message pool

### DIFF
--- a/chain/default_store.go
+++ b/chain/default_store.go
@@ -373,6 +373,13 @@ func (store *DefaultStore) Head() types.TipSet {
 	return store.head
 }
 
+// BlockHeight returns the chain height of the head tipset.
+// Strictly speaking, the block height is the number of tip sets that appear on chain plus
+// the number of "null blocks" that occur when a mining round fails to produce a block.
+func (store *DefaultStore) BlockHeight() (uint64, error) {
+	return store.Head().Height()
+}
+
 // LatestState returns the state associated with the latest chain head.
 func (store *DefaultStore) LatestState(ctx context.Context) (state.Tree, error) {
 	h := store.Head()

--- a/core/message_pool_test.go
+++ b/core/message_pool_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"github.com/filecoin-project/go-filecoin/testhelpers"
 	"sync"
 	"testing"
 
@@ -20,7 +21,7 @@ var newSignedMessage = types.NewSignedMessageForTestGetter(mockSigner)
 func TestMessagePoolAddRemove(t *testing.T) {
 	assert := assert.New(t)
 
-	pool := NewMessagePool()
+	pool := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 	msg1 := newSignedMessage()
 	msg2 := newSignedMessage()
 
@@ -57,7 +58,7 @@ func TestMessagePoolAddRemove(t *testing.T) {
 func TestMessagePoolAddBadSignature(t *testing.T) {
 	assert := assert.New(t)
 
-	pool := NewMessagePool()
+	pool := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 	smsg := newSignedMessage()
 	smsg.Message.Nonce = types.Uint64(uint64(smsg.Message.Nonce) + uint64(1)) // invalidate message
 
@@ -74,7 +75,7 @@ func TestMessagePoolAddBadSignature(t *testing.T) {
 func TestMessagePoolDedup(t *testing.T) {
 	assert := assert.New(t)
 
-	pool := NewMessagePool()
+	pool := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 	msg1 := newSignedMessage()
 
 	assert.Len(pool.Pending(), 0)
@@ -93,7 +94,7 @@ func TestMessagePoolAsync(t *testing.T) {
 	count := 400
 	msgs := types.NewSignedMsgs(count, mockSigner)
 
-	pool := NewMessagePool()
+	pool := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 	var wg sync.WaitGroup
 
 	for i := 0; i < 4; i++ {
@@ -163,18 +164,22 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m0],     Chain: b[m1]
 		store := hamt.NewCborStore()
-		p := NewMessagePool()
+		p := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 
 		m := types.NewSignedMsgs(2, mockSigner)
 		MustAdd(p, m[0], m[1])
 
-		oldChain := NewChainWithMessages(store, types.TipSet{}, msgsSet{})
+		parent := types.TipSet{}
+		blk := types.Block{Height: 0}
+		parent[blk.Cid()] = &blk
+
+		oldChain := NewChainWithMessages(store, parent, msgsSet{})
 		oldTipSet := headOf(oldChain)
 
-		newChain := NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{m[1]}})
+		newChain := NewChainWithMessages(store, parent, msgsSet{msgs{m[1]}})
 		newTipSet := headOf(newChain)
 
-		assert.NoError(UpdateMessagePool(ctx, p, store, oldTipSet, newTipSet))
+		assert.NoError(p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet))
 		assertPoolEquals(assert, p, m[0])
 	})
 
@@ -183,7 +188,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m0, m1], Chain: b[m2]
 		store := hamt.NewCborStore()
-		p := NewMessagePool()
+		p := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 
 		m := types.NewSignedMsgs(3, mockSigner)
 		MustAdd(p, m[0], m[1])
@@ -191,7 +196,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		oldChain := NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{m[2]}})
 		oldTipSet := headOf(oldChain)
 
-		UpdateMessagePool(ctx, p, store, oldTipSet, oldTipSet) // sic
+		p.UpdateMessagePool(ctx, store, oldTipSet, oldTipSet) // sic
 		assertPoolEquals(assert, p, m[0], m[1])
 	})
 
@@ -200,7 +205,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m1],         Chain: b[m2, m3] -> b[m4] -> b[m0] -> b[] -> b[m5, m6]
 		store := hamt.NewCborStore()
-		p := NewMessagePool()
+		p := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 
 		m := types.NewSignedMsgs(7, mockSigner)
 		MustAdd(p, m[2], m[5])
@@ -217,7 +222,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		newTipSet := headOf(newChain)
 
-		UpdateMessagePool(ctx, p, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p, m[1])
 	})
 
@@ -226,7 +231,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m1],         Chain: b[m2, m3] -> {b[m4], b[m0], b[], b[]} -> {b[], b[m6,m5]}
 		store := hamt.NewCborStore()
-		p := NewMessagePool()
+		p := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 
 		m := types.NewSignedMsgs(7, mockSigner)
 		MustAdd(p, m[2], m[5])
@@ -241,7 +246,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		newTipSet := headOf(newChain)
 
-		UpdateMessagePool(ctx, p, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p, m[1])
 	})
 
@@ -250,7 +255,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m1, m2],     Chain: b[m0] -> b[m3] -> b[m4, m5]
 		store := hamt.NewCborStore()
-		p := NewMessagePool()
+		p := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 
 		m := types.NewSignedMsgs(6, mockSigner)
 		MustAdd(p, m[3], m[5])
@@ -261,7 +266,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		newChain := NewChainWithMessages(store, oldChain[0], msgsSet{msgs{m[3]}}, msgsSet{msgs{m[4], m[5]}})
 		newTipSet := headOf(newChain)
 
-		UpdateMessagePool(ctx, p, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p, m[1], m[2])
 	})
 
@@ -270,7 +275,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m6],         Chain: b[m0] -> b[m3] -> b[m4] -> b[m5] -> b[m1, m2]
 		store := hamt.NewCborStore()
-		p := NewMessagePool()
+		p := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 
 		m := types.NewSignedMsgs(7, mockSigner)
 		MustAdd(p, m[6])
@@ -290,7 +295,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		newTipSet := headOf(newChain)
 
-		UpdateMessagePool(ctx, p, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p, m[6])
 	})
 
@@ -299,7 +304,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m6],         Chain: {b[m0], b[m1]} -> b[m3] -> b[m4] -> {b[m5], b[m1, m2]}
 		store := hamt.NewCborStore()
-		p := NewMessagePool()
+		p := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 
 		m := types.NewSignedMsgs(7, mockSigner)
 		MustAdd(p, m[6])
@@ -317,7 +322,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		newTipSet := headOf(newChain)
 
-		UpdateMessagePool(ctx, p, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p, m[6])
 	})
 
@@ -326,7 +331,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m3, m5],     Chain: {b[m0], b[m1], b[m2]}
 		store := hamt.NewCborStore()
-		p := NewMessagePool()
+		p := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 
 		m := types.NewSignedMsgs(6, mockSigner)
 		MustAdd(p, m[3], m[5])
@@ -343,7 +348,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		newTipSet := headOf(newChain)
 
-		UpdateMessagePool(ctx, p, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p, m[3], m[5])
 	})
 
@@ -352,7 +357,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m2, m3],         Chain: b[m0] -> b[m1]
 		store := hamt.NewCborStore()
-		p := NewMessagePool()
+		p := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 		m := types.NewSignedMsgs(4, mockSigner)
 
 		oldChain := NewChainWithMessages(store, types.TipSet{},
@@ -364,7 +369,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		oldTipSet := headOf(oldChain)
 
 		oldTipSetPrev := oldChain[1]
-		UpdateMessagePool(ctx, p, store, oldTipSet, oldTipSetPrev)
+		p.UpdateMessagePool(ctx, store, oldTipSet, oldTipSetPrev)
 		assertPoolEquals(assert, p, m[2], m[3])
 	})
 
@@ -373,7 +378,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m0],     Chain: b[] -> b[m1, m2]
 		store := hamt.NewCborStore()
-		p := NewMessagePool()
+		p := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 
 		m := types.NewSignedMsgs(3, mockSigner)
 		MustAdd(p, m[0], m[1])
@@ -384,7 +389,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		newChain := NewChainWithMessages(store, oldChain[len(oldChain)-1], msgsSet{msgs{m[1], m[2]}})
 		newTipSet := headOf(newChain)
 
-		UpdateMessagePool(ctx, p, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p, m[0])
 	})
 
@@ -393,7 +398,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [],           Chain: b[m0] -> b[m1] -> b[m2, m3] -> b[m4] -> b[m5, m6]
 		store := hamt.NewCborStore()
-		p := NewMessagePool()
+		p := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 
 		m := types.NewSignedMsgs(7, mockSigner)
 		MustAdd(p, m[2], m[5])
@@ -408,8 +413,94 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		newTipSet := headOf(newChain)
 
-		UpdateMessagePool(ctx, p, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p)
+	})
+
+	t.Run("Times out old messages", func(t *testing.T) {
+		require := require.New(t)
+
+		var err error
+		store := hamt.NewCborStore()
+		blockTimer := testhelpers.NewTestBlockTimer(0)
+		p := NewMessagePool(blockTimer)
+
+		m := types.NewSignedMsgs(MessageTimeOut, mockSigner)
+
+		head := headOf(NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{}}))
+
+		// Add a message at each block height until MessageTimeOut is reached
+		for i := 0; i < MessageTimeOut; i++ {
+
+			MustAdd(p, m[i])
+
+			// update pool with tipset that has no messages
+			next := headOf(NewChainWithMessages(store, head, msgsSet{msgs{}}))
+			p.UpdateMessagePool(ctx, store, head, next)
+
+			// assert all added messages still in pool
+			assertPoolEquals(assert, p, m[:i+1]...)
+
+			// blockTimer.Height determines block time at which message is added
+			blockTimer.Height, err = next.Height()
+			require.NoError(err)
+
+			head = next
+		}
+
+		// next tipset times out first message only
+		next := headOf(NewChainWithMessages(store, head, msgsSet{msgs{}}))
+		p.UpdateMessagePool(ctx, store, head, next)
+		assertPoolEquals(assert, p, m[1:]...)
+	})
+
+	t.Run("Message timeout is unaffected by null tipsets", func(t *testing.T) {
+		require := require.New(t)
+
+		var err error
+		store := hamt.NewCborStore()
+		blockTimer := testhelpers.NewTestBlockTimer(0)
+		p := NewMessagePool(blockTimer)
+
+		m := types.NewSignedMsgs(MessageTimeOut, mockSigner)
+
+		head := headOf(NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{}}))
+
+		// Add a message at each block height until MessageTimeOut is reached
+		for i := 0; i < MessageTimeOut; i++ {
+			require.NoError(err)
+
+			MustAdd(p, m[i])
+
+			// update pool with tipset that has no messages
+			height, err := head.Height()
+			require.NoError(err)
+
+			// create a tipset at given height with one block containing no messages
+			next := types.TipSet{}
+			nextHeight := types.Uint64(height + 5) // simulate 4 null blocks
+			blk := &types.Block{
+				Height:  nextHeight,
+				Parents: head.ToSortedCidSet(),
+			}
+			MustPut(store, blk)
+			next[blk.Cid()] = blk
+
+			p.UpdateMessagePool(ctx, store, head, next)
+
+			// assert all added messages still in pool
+			assertPoolEquals(assert, p, m[:i+1]...)
+
+			// blockTimer.Height determines block time at which next message is added
+			blockTimer.Height = uint64(nextHeight)
+
+			head = next
+		}
+
+		// next tipset times out first message only
+		next := headOf(NewChainWithMessages(store, head, msgsSet{msgs{}}))
+		p.UpdateMessagePool(ctx, store, head, next)
+		assertPoolEquals(assert, p, m[1:]...)
 	})
 }
 
@@ -418,17 +509,17 @@ func TestLargestNonce(t *testing.T) {
 	require := require.New(t)
 
 	t.Run("No matches", func(t *testing.T) {
-		p := NewMessagePool()
+		p := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 
 		m := types.NewSignedMsgs(2, mockSigner)
 		MustAdd(p, m[0], m[1])
 
-		_, found := LargestNonce(p, address.NewForTestGetter()())
+		_, found := p.LargestNonce(address.NewForTestGetter()())
 		assert.False(found)
 	})
 
 	t.Run("Match, largest is zero", func(t *testing.T) {
-		p := NewMessagePool()
+		p := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 
 		m := types.NewMsgsWithAddrs(1, mockSigner.Addresses)
 		m[0].Nonce = 0
@@ -438,13 +529,13 @@ func TestLargestNonce(t *testing.T) {
 
 		MustAdd(p, sm...)
 
-		largest, found := LargestNonce(p, m[0].From)
+		largest, found := p.LargestNonce(m[0].From)
 		assert.True(found)
 		assert.Equal(uint64(0), largest)
 	})
 
 	t.Run("Match", func(t *testing.T) {
-		p := NewMessagePool()
+		p := NewMessagePool(testhelpers.NewTestBlockTimer(0))
 
 		m := types.NewMsgsWithAddrs(3, mockSigner.Addresses)
 		m[1].Nonce = 1
@@ -456,7 +547,7 @@ func TestLargestNonce(t *testing.T) {
 
 		MustAdd(p, sm...)
 
-		largest, found := LargestNonce(p, m[2].From)
+		largest, found := p.LargestNonce(m[2].From)
 		assert.True(found)
 		assert.Equal(uint64(2), largest)
 	})

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -98,7 +98,7 @@ func Test_Mine(t *testing.T) {
 
 func sharedSetupInitial() (*hamt.CborIpldStore, *core.MessagePool, cid.Cid) {
 	cst := hamt.NewCborStore()
-	pool := core.NewMessagePool()
+	pool := core.NewMessagePool(th.NewTestBlockTimer(0))
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.AccountActorCodeCid
 	return cst, pool, fakeActorCodeCid

--- a/plumbing/msg/sender.go
+++ b/plumbing/msg/sender.go
@@ -113,7 +113,7 @@ func nextNonce(ctx context.Context, st state.Tree, pool *core.MessagePool, addre
 		return 0, err
 	}
 
-	poolNonce, found := core.LargestNonce(pool, address)
+	poolNonce, found := pool.LargestNonce(address)
 	if found && poolNonce >= actorNonce {
 		return poolNonce + 1, nil
 	}

--- a/plumbing/msg/sender_test.go
+++ b/plumbing/msg/sender_test.go
@@ -114,7 +114,7 @@ func TestNextNonce(t *testing.T) {
 
 		address := address.NewForTestGetter()()
 
-		n, err := nextNonce(ctx, st, core.NewMessagePool(), address)
+		n, err := nextNonce(ctx, st, core.NewMessagePool(testhelpers.NewTestBlockTimer(0)), address)
 		assert.NoError(err)
 		assert.Equal(uint64(0), n)
 	})
@@ -130,7 +130,7 @@ func TestNextNonce(t *testing.T) {
 		assert.NoError(err)
 		_ = state.MustSetActor(st, address, actor)
 
-		_, err = nextNonce(ctx, st, core.NewMessagePool(), address)
+		_, err = nextNonce(ctx, st, core.NewMessagePool(testhelpers.NewTestBlockTimer(0)), address)
 		assert.Error(err)
 		assert.Contains(err.Error(), "account or empty")
 	})
@@ -146,7 +146,7 @@ func TestNextNonce(t *testing.T) {
 		actor.Nonce = 42
 		state.MustSetActor(st, address, actor)
 
-		nonce, err := nextNonce(ctx, st, core.NewMessagePool(), address)
+		nonce, err := nextNonce(ctx, st, core.NewMessagePool(testhelpers.NewTestBlockTimer(0)), address)
 		assert.NoError(err)
 		assert.Equal(uint64(42), nonce)
 	})
@@ -156,7 +156,7 @@ func TestNextNonce(t *testing.T) {
 		assert := assert.New(t)
 		store := hamt.NewCborStore()
 		st := state.NewEmptyStateTree(store)
-		mp := core.NewMessagePool()
+		mp := core.NewMessagePool(testhelpers.NewTestBlockTimer(0))
 		addr := mockSigner.Addresses[0]
 		actor, err := account.NewActor(types.NewAttoFILFromFIL(0))
 		assert.NoError(err)
@@ -210,5 +210,5 @@ func setupSendTest(require *require.Assertions) (*wallet.Wallet, *chain.DefaultS
 	// Install the key in the wallet for use in signing.
 	err = d.wallet.Backends(wallet.DSBackendType)[0].(*wallet.DSBackend).ImportKey(&ki)
 	require.NoError(err)
-	return d.wallet, d.chainStore, core.NewMessagePool()
+	return d.wallet, d.chainStore, core.NewMessagePool(testhelpers.NewTestBlockTimer(0))
 }

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -92,6 +92,21 @@ func RequireRandomPeerID() peer.ID {
 	return pid
 }
 
+// TestBlockTimer provides a simple BlockTimer interface implementation.
+type TestBlockTimer struct {
+	Height uint64
+}
+
+// NewTestBlockTimer creates a new TestBlockTimer.
+func NewTestBlockTimer(h uint64) *TestBlockTimer {
+	return &TestBlockTimer{Height: h}
+}
+
+// BlockHeight represents the height of the highest tipset.
+func (tbt *TestBlockTimer) BlockHeight() (uint64, error) {
+	return tbt.Height, nil
+}
+
 // VMStorage creates a new storage object backed by an in memory datastore
 func VMStorage() vm.StorageMap {
 	return vm.NewStorageMap(blockstore.NewBlockstore(datastore.NewMapDatastore()))


### PR DESCRIPTION
closes #2133

### Problem

The message pool currently has no invalidation mechanism. Temporary failures and other issues can cause a message to remain in the message pool indefinitely. This also means there's no clean recovery mechanism when several messages are sent and the first message fails.

### Solution

Add  a timeout mechanism to the message pool. The mechanism involves the following steps:

1. Store `timedMessages` instead of just messages. `timedMessages` are a message plus a block height.
2. On `UpdateMessagePool`, search `MessageTimeOut` tipsets back in the chain to get the timeout block height.
3. Remove every message in the `pending` map that has a block height below the timeout.

It's important that the timeout block height be based on the number of tipsets seen, rather than a specific block height. It's possible for the chain to have upwards of 10 null tipsets, so the block time when a message is added might be lower than expected. 

For example: If a message is added to the pool ~5 minutes after the node received tip set 100, and then 10 null tip sets occur, when tip set 110 arrives the message appears to be 10 blocks old, even though it hasn't really had a chance to have been mined in a block. Walking back tip sets bases the timeout on the number of opportunities the block should have had to have been mined.