### PR TITLE
Add feat/add-porcelain-default-wallet-address

### DIFF
--- a/commands/address.go
+++ b/commands/address.go
@@ -31,9 +31,10 @@ var addrsCmd = &cmds.Command{
 		Tagline: "Interact with addresses",
 	},
 	Subcommands: map[string]*cmds.Command{
-		"ls":     addrsLsCmd,
-		"new":    addrsNewCmd,
-		"lookup": addrsLookupCmd,
+		"ls":      addrsLsCmd,
+		"new":     addrsNewCmd,
+		"lookup":  addrsLookupCmd,
+		"default": defaultWalletAddress,
 	},
 }
 
@@ -111,6 +112,24 @@ var addrsLookupCmd = &cmds.Command{
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, pid string) error {
 			_, err := fmt.Fprintln(w, pid)
+			return err
+		}),
+	},
+}
+
+var defaultWalletAddress = &cmds.Command{
+	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+		addr, err := GetPorcelainAPI(env).DefaultWalletAddress()
+		if err != nil {
+			return err
+		}
+
+		return re.Emit(&addressResult{addr.String()})
+	},
+	Type: &addressResult{},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, a *addressResult) error {
+			_, err := fmt.Fprintln(w, a.Address)
 			return err
 		}),
 	},

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -144,6 +144,11 @@ func (a *API) WalletBalance(ctx context.Context, address address.Address) (*type
 	return WalletBalance(ctx, a, address)
 }
 
+// DefaultWalletAddress returns a default wallet address from the config.
+func (a *API) DefaultWalletAddress() (address.Address, error) {
+	return DefaultWalletAddress(a)
+}
+
 // PaymentChannelLs lists payment channels for a given payer
 func (a *API) PaymentChannelLs(
 	ctx context.Context,

--- a/porcelain/wallet_test.go
+++ b/porcelain/wallet_test.go
@@ -16,11 +16,18 @@ import (
 
 type walletTestPlumbing struct {
 	balance *types.AttoFIL
+	addr    address.Address
 }
 
 func (wtp *walletTestPlumbing) ActorGet(ctx context.Context, addr address.Address) (*actor.Actor, error) {
 	testActor := actor.NewActor(cid.Undef, wtp.balance)
 	return testActor, nil
+}
+
+func (wtp *walletTestPlumbing) ConfigGet(dottedPath string) (interface{}, error) {
+	testHash := address.Hash([]byte("test"))
+	return address.NewMainnet(testHash), nil
+
 }
 
 func TestWalletBalance(t *testing.T) {
@@ -37,5 +44,22 @@ func TestWalletBalance(t *testing.T) {
 		require.NoError(err)
 
 		assert.Equal(expectedBalance, balance)
+	})
+}
+
+func TestDefaultWalletAddress(t *testing.T) {
+	t.Run("Returns the correct value for default wallet address", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		testHash := address.Hash([]byte("test"))
+		expectedAddress := address.NewMainnet(testHash)
+		plumbing := &walletTestPlumbing{
+			addr: expectedAddress,
+		}
+		address, err := porcelain.DefaultWalletAddress(plumbing)
+		require.NoError(err)
+
+		assert.Equal(expectedAddress, address)
 	})
 }

--- a/tools/fast/series/series_sendfilecoindefaults.go
+++ b/tools/fast/series/series_sendfilecoindefaults.go
@@ -3,15 +3,17 @@ package series
 import (
 	"context"
 
-	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 )
 
 // SendFilecoinDefaults sends the `value` amount of fil from the default wallet
 // address of the `from` node to the `to` node's default wallet.
 func SendFilecoinDefaults(ctx context.Context, from, to *fast.Filecoin, value int) error {
-	var toAddr address.Address
-	if err := to.ConfigGet(ctx, "wallet.defaultAddress", &toAddr); err != nil {
+	var porcelainAPI *porcelain.API
+
+	toAddr, err := porcelainAPI.DefaultWalletAddress()
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Provide porcelain and cli command to retrieve default wallet address
1 Add the method  DefaultWalletAddress 
2 Add the CLI command "go-filecoin address  default"

referenced #2049 

thanks