### PR TITLE
Simple way to guard user devnet

### DIFF
--- a/build/main.go
+++ b/build/main.go
@@ -272,6 +272,9 @@ func forceBuildFC() {
 	log.Println("Force building go-filecoin...")
 
 	commit := runCapture("git log -n 1 --format=%H")
+	if os.Getenv("FILECOIN_OVERRIDE_BUILD_SHA") != "" {
+		commit = os.Getenv("FILECOIN_OVERRIDE_BUILD_SHA")
+	}
 
 	runCmd(cmd([]string{
 		"go", "build",
@@ -295,6 +298,9 @@ func buildFilecoin() {
 	log.Println("Building go-filecoin...")
 
 	commit := runCapture("git log -n 1 --format=%H")
+	if os.Getenv("FILECOIN_OVERRIDE_BUILD_SHA") != "" {
+		commit = os.Getenv("FILECOIN_OVERRIDE_BUILD_SHA")
+	}
 
 	runCmd(cmd([]string{
 		"go", "build",

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Mining    *MiningConfig    `json:"mining"`
 	Wallet    *WalletConfig    `json:"wallet"`
 	Heartbeat *HeartbeatConfig `json:"heartbeat"`
+	Net       string           `json:"net"`
 }
 
 // APIConfig holds all configuration options related to the api.
@@ -158,6 +159,7 @@ func NewDefaultConfig() *Config {
 		Mining:    newDefaultMiningConfig(),
 		Wallet:    newDefaultWalletConfig(),
 		Heartbeat: newDefaultHeartbeatConfig(),
+		Net:       "",
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -76,7 +76,8 @@ func TestWriteFile(t *testing.T) {
 		"beatPeriod": "3s",
 		"reconnectPeriod": "10s",
 		"nickname": ""
-	}
+	},
+	"net": ""
 }`,
 		string(content),
 	)

--- a/node/node.go
+++ b/node/node.go
@@ -45,6 +45,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/config"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/core"
+	"github.com/filecoin-project/go-filecoin/flags"
 	"github.com/filecoin-project/go-filecoin/metrics"
 	"github.com/filecoin-project/go-filecoin/mining"
 	"github.com/filecoin-project/go-filecoin/net"
@@ -478,7 +479,7 @@ func (node *Node) Start(ctx context.Context) error {
 			log.Infof("error handling blocks: %s", types.NewSortedCidSet(cids...).String())
 		}
 	}
-	node.HelloSvc = hello.New(node.Host(), node.ChainReader.GenesisCid(), syncCallBack, node.ChainReader.Head)
+	node.HelloSvc = hello.New(node.Host(), node.ChainReader.GenesisCid(), syncCallBack, node.ChainReader.Head, node.Repo.Config().Net, flags.Commit)
 
 	cni := storage.NewClientNodeImpl(dag.NewDAGService(node.BlockService()), node.Host(), node.Ping, node.GetBlockTime())
 	var err error

--- a/protocol/hello/hello_test.go
+++ b/protocol/hello/hello_test.go
@@ -54,8 +54,8 @@ func TestHelloHandshake(t *testing.T) {
 	msc1, msc2 := new(mockSyncCallback), new(mockSyncCallback)
 	hg1, hg2 := &mockHeaviestGetter{heavy1}, &mockHeaviestGetter{heavy2}
 
-	New(a, genesisA.Cid(), msc1.SyncCallback, hg1.getHeaviestTipSet)
-	New(b, genesisA.Cid(), msc2.SyncCallback, hg2.getHeaviestTipSet)
+	New(a, genesisA.Cid(), msc1.SyncCallback, hg1.getHeaviestTipSet, "", "")
+	New(b, genesisA.Cid(), msc2.SyncCallback, hg2.getHeaviestTipSet, "", "")
 
 	msc1.On("SyncCallback", b.ID(), heavy2.ToSortedCidSet().ToSlice(), uint64(3)).Return()
 	msc2.On("SyncCallback", a.ID(), heavy1.ToSortedCidSet().ToSlice(), uint64(2)).Return()
@@ -109,10 +109,44 @@ func TestHelloBadGenesis(t *testing.T) {
 	msc1, msc2 := new(mockSyncCallback), new(mockSyncCallback)
 	hg1, hg2 := &mockHeaviestGetter{heavy1}, &mockHeaviestGetter{heavy2}
 
-	New(a, genesisA.Cid(), msc1.SyncCallback, hg1.getHeaviestTipSet)
-	New(b, genesisB.Cid(), msc2.SyncCallback, hg2.getHeaviestTipSet)
+	New(a, genesisA.Cid(), msc1.SyncCallback, hg1.getHeaviestTipSet, "", "")
+	New(b, genesisB.Cid(), msc2.SyncCallback, hg2.getHeaviestTipSet, "", "")
 
 	msc1.On("SyncCallback", mock.Anything, mock.Anything, mock.Anything).Return()
+	msc2.On("SyncCallback", mock.Anything, mock.Anything, mock.Anything).Return()
+
+	require.NoError(mn.LinkAll())
+	require.NoError(mn.ConnectAllButSelf())
+
+	time.Sleep(time.Millisecond * 50)
+
+	msc1.AssertNumberOfCalls(t, "SyncCallback", 0)
+	msc2.AssertNumberOfCalls(t, "SyncCallback", 0)
+}
+
+func TestHelloWrongVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require := require.New(t)
+
+	mn, err := mocknet.WithNPeers(ctx, 2)
+	assert.NoError(t, err)
+
+	a, b := mn.Hosts()[0], mn.Hosts()[1]
+
+	genesisA := &types.Block{Nonce: 451}
+
+	heavy := th.RequireNewTipSet(require, &types.Block{Nonce: 1000, Height: 2})
+
+	msc1, msc2 := new(mockSyncCallback), new(mockSyncCallback)
+	hg := &mockHeaviestGetter{heavy}
+
+	New(a, genesisA.Cid(), msc1.SyncCallback, hg.getHeaviestTipSet, "devnet-user", "sha1")
+	msc1.On("SyncCallback", mock.Anything, mock.Anything, mock.Anything).Return()
+
+	New(b, genesisA.Cid(), msc2.SyncCallback, hg.getHeaviestTipSet, "devnet-user", "sha2")
 	msc2.On("SyncCallback", mock.Anything, mock.Anything, mock.Anything).Return()
 
 	require.NoError(mn.LinkAll())
@@ -153,8 +187,8 @@ func TestHelloMultiBlock(t *testing.T) {
 	msc1, msc2 := new(mockSyncCallback), new(mockSyncCallback)
 	hg1, hg2 := &mockHeaviestGetter{heavy1}, &mockHeaviestGetter{heavy2}
 
-	New(a, genesisA.Cid(), msc1.SyncCallback, hg1.getHeaviestTipSet)
-	New(b, genesisA.Cid(), msc2.SyncCallback, hg2.getHeaviestTipSet)
+	New(a, genesisA.Cid(), msc1.SyncCallback, hg1.getHeaviestTipSet, "", "")
+	New(b, genesisA.Cid(), msc2.SyncCallback, hg2.getHeaviestTipSet, "", "")
 
 	msc1.On("SyncCallback", b.ID(), heavy2.ToSortedCidSet().ToSlice(), uint64(3)).Return()
 	msc2.On("SyncCallback", a.ID(), heavy1.ToSortedCidSet().ToSlice(), uint64(2)).Return()

--- a/repo/fsrepo_test.go
+++ b/repo/fsrepo_test.go
@@ -57,7 +57,8 @@ const (
 		"beatPeriod": "3s",
 		"reconnectPeriod": "10s",
 		"nickname": ""
-	}
+	},
+	"net": ""
 }`
 )
 


### PR DESCRIPTION
A way less crazy way to resolve #2182 

## Problem

Users can easily join the user devnet with the wrong version of the filecoin codebase

## Solution

Require a specific code version for user devnet in the hello protocol. This version specifier is capable of being overwritten during build time if a developer needs to test something with a different code version.
    
    
Additionally:
    - Clean up some redundant or repetitive code in daemon.Init
    - Bolster checks for using multiple `devnet` flags at once