### PR TITLE
Feat/process block metric

### DIFF
--- a/build/main.go
+++ b/build/main.go
@@ -124,8 +124,6 @@ func deps() {
 		cmd("go get -u github.com/docker/docker/pkg/stdcopy"),
 		cmd("go get -u github.com/ipsn/go-secp256k1"),
 		cmd("go get -u github.com/json-iterator/go"),
-		cmd("go get -u github.com/prometheus/client_golang/prometheus"),
-		cmd("go get -u github.com/prometheus/client_golang/prometheus/promhttp"),
 		cmd("go get -u github.com/jstemmer/go-junit-report"),
 		cmd("go get -u github.com/pmezard/go-difflib/difflib"),
 		cmd("./scripts/install-rust-fil-proofs.sh"),

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	Wallet    *WalletConfig    `json:"wallet"`
 	Heartbeat *HeartbeatConfig `json:"heartbeat"`
 	Net       string           `json:"net"`
+	Metrics   *MetricsConfig   `json:"metrics"`
 }
 
 // APIConfig holds all configuration options related to the api.
@@ -148,6 +149,24 @@ func newDefaultHeartbeatConfig() *HeartbeatConfig {
 	}
 }
 
+// MetricsConfig holds all configuration options related to node metrics.
+type MetricsConfig struct {
+	// Enabled will enable prometheus metrics when true.
+	PrometheusEnabled bool `json:"prometheusEnabled"`
+	// ReportInterval represents how frequently filecoin will update its prometheus metrics.
+	ReportInterval string `json:"reportInterval"`
+	// PrometheusEndpoint represents the address filecoin will expose prometheus metrics at.
+	PrometheusEndpoint string `json:"prometheusEndpoint"`
+}
+
+func newDefaultMetricsConfig() *MetricsConfig {
+	return &MetricsConfig{
+		PrometheusEnabled:  false,
+		ReportInterval:     "5s",
+		PrometheusEndpoint: "/ip4/0.0.0.0/tcp/9400",
+	}
+}
+
 // NewDefaultConfig returns a config object with all the fields filled out to
 // their default values
 func NewDefaultConfig() *Config {
@@ -160,6 +179,7 @@ func NewDefaultConfig() *Config {
 		Wallet:    newDefaultWalletConfig(),
 		Heartbeat: newDefaultHeartbeatConfig(),
 		Net:       "",
+		Metrics:   newDefaultMetricsConfig(),
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -79,7 +79,12 @@ func TestWriteFile(t *testing.T) {
 		"reconnectPeriod": "10s",
 		"nickname": ""
 	},
-	"net": ""
+	"net": "",
+	"metrics": {
+		"prometheusEnabled": false,
+		"reportInterval": "5s",
+		"prometheusEndpoint": "/ip4/0.0.0.0/tcp/9400"
+	}
 }`,
 		string(content),
 	)

--- a/metrics/export.go
+++ b/metrics/export.go
@@ -1,0 +1,61 @@
+package metrics
+
+import (
+	"net/http"
+	"time"
+
+	ma "gx/ipfs/QmNTCey11oxhb1AxDnQBRHtdhap6Ctud872NjAYPYYXPuc/go-multiaddr"
+	"gx/ipfs/QmNVpHFt7QmabuVQyguf8AbkLDZoFh7ifBYztqijYT1Sd2/go.opencensus.io/exporter/prometheus"
+	"gx/ipfs/QmNVpHFt7QmabuVQyguf8AbkLDZoFh7ifBYztqijYT1Sd2/go.opencensus.io/stats/view"
+	manet "gx/ipfs/QmZcLBXKaFe8ND5YHPkJRAwmhJGrVsi1JqDZNyJ4nRK5Mj/go-multiaddr-net"
+	prom "gx/ipfs/QmaQtvgBNGwD4os5VLWtBLR6HM6TY6ApX6xFqSnfjDF2aW/client_golang/prometheus"
+
+	"github.com/filecoin-project/go-filecoin/config"
+)
+
+// RegisterPrometheusEndpoint registers and serves prometheus metrics
+func RegisterPrometheusEndpoint(cfg *config.MetricsConfig) error {
+	if !cfg.PrometheusEnabled {
+		return nil
+	}
+
+	// validate config values and marshal to types
+	interval, err := time.ParseDuration(cfg.ReportInterval)
+	if err != nil {
+		log.Errorf("invalid metrics interval: %s", err)
+		return err
+	}
+
+	promma, err := ma.NewMultiaddr(cfg.PrometheusEndpoint)
+	if err != nil {
+		return err
+	}
+
+	_, promAddr, err := manet.DialArgs(promma)
+	if err != nil {
+		return err
+	}
+
+	// setup prometheus
+	registry := prom.NewRegistry()
+	pe, err := prometheus.NewExporter(prometheus.Options{
+		Namespace: "filecoin",
+		Registry:  registry,
+	})
+	if err != nil {
+		return err
+	}
+
+	view.RegisterExporter(pe)
+	view.SetReportingPeriod(interval)
+
+	go func() {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", pe)
+		if err := http.ListenAndServe(promAddr, mux); err != nil {
+			log.Errorf("failed to serve /metrics endpoint on %v", err)
+		}
+	}()
+
+	return nil
+}

--- a/metrics/heartbeat_test.go
+++ b/metrics/heartbeat_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/config"
-	"github.com/filecoin-project/go-filecoin/fixtures"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -137,7 +136,7 @@ func TestHeartbeatRunSuccess(t *testing.T) {
 	expHeight := types.Uint64(444)
 	expTs := mustMakeTipset(t, expHeight)
 
-	addr, err := address.NewFromString(fixtures.TestAddresses[0])
+	addr, err := address.NewActorAddress([]byte("miner address"))
 	require.NoError(err)
 
 	// The handle method will run the assertions for the test

--- a/metrics/timers.go
+++ b/metrics/timers.go
@@ -1,0 +1,66 @@
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"gx/ipfs/QmNVpHFt7QmabuVQyguf8AbkLDZoFh7ifBYztqijYT1Sd2/go.opencensus.io/stats"
+	"gx/ipfs/QmNVpHFt7QmabuVQyguf8AbkLDZoFh7ifBYztqijYT1Sd2/go.opencensus.io/stats/view"
+)
+
+// NewTimer creates a Float64Timer that wraps an opencensus flat64 measurement.
+// The time defaults to milliseconds.
+func NewTimer(name, desc string) *Float64Timer {
+	log.Infof("registering timer: %s", name)
+	fMeasure := stats.Float64(name, desc, stats.UnitMilliseconds)
+	fView := &view.View{
+		Name:        name,
+		Measure:     fMeasure,
+		Description: desc,
+		// [>=0ms, >=25ms, >=50ms, >=75ms, >=100ms, >=200ms, >=400ms, >=600ms, >=800ms, >=1s, >=2s, >=4s, >=8s]
+		Aggregation: view.Distribution(25, 50, 75, 100, 200, 400, 600, 800, 1000, 2000, 4000, 8000),
+	}
+	if err := view.Register(fView); err != nil {
+		// a panic here indicates a developer error when creating a view.
+		// Since this method is called in init() methods, this panic when hit
+		// will cause running the program to fail immediately.
+		panic(err)
+	}
+
+	return &Float64Timer{
+		measureMs: fMeasure,
+		view:      fView,
+	}
+}
+
+// Float64Timer contains a opencensus measurement and view
+type Float64Timer struct {
+	measureMs *stats.Float64Measure
+	view      *view.View
+}
+
+// Start starts a timer and returns a Stopwatch.
+func (t *Float64Timer) Start(ctx context.Context) *Stopwatch {
+	return &Stopwatch{
+		ctx:      ctx,
+		start:    time.Now(),
+		recorder: t.measureMs.M,
+	}
+
+}
+
+// Stopwatch contains a start time and a recorder, when stopped it record the
+// duration since start time began via its recorder function.
+type Stopwatch struct {
+	ctx      context.Context
+	start    time.Time
+	recorder func(v float64) stats.Measurement
+}
+
+// Stop rounds the time since Start was called to milliseconds and records the value
+// in the corresponding opencensus view.
+func (sw *Stopwatch) Stop(ctx context.Context) time.Duration {
+	duration := time.Since(sw.start).Round(time.Millisecond)
+	stats.Record(ctx, sw.recorder(float64(duration)/1e6))
+	return duration
+}

--- a/metrics/timers_test.go
+++ b/metrics/timers_test.go
@@ -1,0 +1,69 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"gx/ipfs/QmNVpHFt7QmabuVQyguf8AbkLDZoFh7ifBYztqijYT1Sd2/go.opencensus.io/stats/view"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+)
+
+func TestTimerSimple(t *testing.T) {
+	assert := assert.New(t)
+
+	ctx := context.Background()
+
+	testTimer := NewTimer("testName", "testDesc")
+	// some view state is kept around after tests exit, doing this to clean that up.
+	// e.g. view will remain registered after a test exits.
+	defer view.Unregister(testTimer.view)
+
+	assert.Equal("testName", testTimer.view.Name)
+	assert.Equal("testDesc", testTimer.view.Description)
+
+	sw := testTimer.Start(ctx)
+	sw.Stop(ctx)
+	assert.NotEqual(0, sw.start)
+
+}
+
+func TestDuplicateTimersPanics(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("code should panic when 2 views with same name are registered")
+		}
+		// we pass
+	}()
+
+	NewTimer("testName", "testDesc")
+	testTimer := NewTimer("testName", "testDesc")
+	assert.Equal("testName", testTimer.view.Name)
+	assert.Equal("testDesc", testTimer.view.Description)
+
+	sw := testTimer.Start(ctx)
+	sw.Stop(ctx)
+	assert.NotEqual(0, sw.start)
+
+}
+
+func TestMultipleTimers(t *testing.T) {
+	assert := assert.New(t)
+
+	ctx1 := context.Background()
+	ctx2 := context.Background()
+
+	tt1 := NewTimer("tt1", "ttd1")
+	tt2 := NewTimer("tt2", "ttd2")
+
+	sw1 := tt1.Start(ctx1)
+	sw2 := tt2.Start(ctx2)
+
+	sw1.Stop(ctx1)
+	assert.NotEqual(0, sw1.start)
+	sw2.Stop(ctx2)
+	assert.NotEqual(0, sw2.start)
+
+}

--- a/node/node.go
+++ b/node/node.go
@@ -472,6 +472,10 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 
 // Start boots up the node.
 func (node *Node) Start(ctx context.Context) error {
+	if err := metrics.RegisterPrometheusEndpoint(node.Repo.Config().Metrics); err != nil {
+		return errors.Wrap(err, "failed to setup metrics")
+	}
+
 	var err error
 	if err = node.ChainReader.Load(ctx); err != nil {
 		return err

--- a/package.json
+++ b/package.json
@@ -194,6 +194,18 @@
       "hash": "QmceTjrpdhYXocRzx9hMEwztLyWUEvyDdRqrkSjLQeq6pE",
       "name": "go-libp2p-autonat-svc",
       "version": "1.0.10"
+    },
+    {
+      "author": "hsanjuan",
+      "hash": "QmNVpHFt7QmabuVQyguf8AbkLDZoFh7ifBYztqijYT1Sd2",
+      "name": "go.opencensus.io",
+      "version": "0.19.0"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmaQtvgBNGwD4os5VLWtBLR6HM6TY6ApX6xFqSnfjDF2aW",
+      "name": "client_golang",
+      "version": "0.9.2"
     }
   ],
   "gxVersion": "0.12.1",

--- a/repo/fsrepo_test.go
+++ b/repo/fsrepo_test.go
@@ -58,7 +58,12 @@ const (
 		"reconnectPeriod": "10s",
 		"nickname": ""
 	},
-	"net": ""
+	"net": "",
+	"metrics": {
+		"prometheusEnabled": false,
+		"reportInterval": "5s",
+		"prometheusEndpoint": "/ip4/0.0.0.0/tcp/9400"
+	}
 }`
 )
 


### PR DESCRIPTION
### What
This PR addresses https://github.com/filecoin-project/go-filecoin/issues/2257, to facilitate this we have:
- Added a metrics config, this is used to configure how and where the filecoin node exposes prometheus metrics
- Added a prometheus metric via opencensus to expose how long `ProcessBlock` and `ApplyMessage` take.

These metrics will give us the average duration of each methods execution, the number of times the method is called and a distribution of durations [defined here](https://github.com/filecoin-project/go-filecoin/pull/2266/files#diff-6bdbd3e56444b9285aa20f6442e879bdR24).