### PR TITLE
Implemented chain tipset and block iterators.

### DIFF
--- a/chain/traversal.go
+++ b/chain/traversal.go
@@ -1,0 +1,64 @@
+package chain
+
+import (
+	"context"
+
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// BlockProvider provides blocks. This is a subset of the ReadStore interface.
+type BlockProvider interface {
+	GetBlock(ctx context.Context, cid cid.Cid) (*types.Block, error)
+}
+
+// GetParentTipSet returns the parent tipset of a tipset.
+// The result is empty if the tipset has no parents (including if it is empty itself)
+func GetParentTipSet(ctx context.Context, store BlockProvider, ts types.TipSet) (types.TipSet, error) {
+	newTipSet := types.TipSet{}
+	parents, err := ts.Parents()
+	if err != nil {
+		return nil, err
+	}
+	for it := parents.Iter(); !it.Complete() && ctx.Err() == nil; it.Next() {
+		newBlk, err := store.GetBlock(ctx, it.Value())
+		if err != nil {
+			return nil, err
+		}
+		if err := newTipSet.AddBlock(newBlk); err != nil {
+			return nil, err
+		}
+	}
+	return newTipSet, nil
+}
+
+// IterAncestors returns an iterator over tipset ancestors, yielding first the start tipset and
+// then its parent tipsets until (and including) the genesis tipset.
+func IterAncestors(ctx context.Context, store BlockProvider, start types.TipSet) *TipsetIterator {
+	return &TipsetIterator{ctx, store, start, nil}
+}
+
+// TipsetIterator is an iterator over tipsets.
+type TipsetIterator struct {
+	ctx   context.Context
+	store BlockProvider
+	value types.TipSet
+	err   error
+}
+
+// Value returns the iterator's current value, if not Complete().
+func (it *TipsetIterator) Value() types.TipSet {
+	return it.value
+}
+
+// Complete tests whether the iterator is exhausted.
+func (it *TipsetIterator) Complete() bool {
+	return len(it.value) == 0
+}
+
+// Next advances the iterator to the next value.
+func (it *TipsetIterator) Next() error {
+	it.value, it.err = GetParentTipSet(it.ctx, it.store, it.value)
+	return it.err
+}

--- a/chain/traversal_test.go
+++ b/chain/traversal_test.go
@@ -1,0 +1,120 @@
+package chain_test
+
+import (
+	"context"
+	"testing"
+
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
+
+	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+func TestGetParentTipSet(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := context.Background()
+	store := newBlockStore()
+
+	root := store.NewBlock(0)
+	b11 := store.NewBlock(1, root)
+	b12 := store.NewBlock(2, root)
+	b21 := store.NewBlock(3, b11, b12)
+
+	t.Run("root has empty parent", func(t *testing.T) {
+		ts := requireTipset(t, root)
+		parent, e := chain.GetParentTipSet(ctx, store, ts)
+		require.NoError(e)
+		assert.Empty(parent)
+	})
+	t.Run("plural tipset", func(t *testing.T) {
+		ts := requireTipset(t, b11, b12)
+		parent, e := chain.GetParentTipSet(ctx, store, ts)
+		require.NoError(e)
+		assert.True(requireTipset(t, root).Equals(parent))
+	})
+	t.Run("plural parent", func(t *testing.T) {
+		ts := requireTipset(t, b21)
+		parent, e := chain.GetParentTipSet(ctx, store, ts)
+		require.NoError(e)
+		assert.True(requireTipset(t, b11, b12).Equals(parent))
+	})
+}
+
+func TestIterAncestors(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	ctx := context.Background()
+	store := newBlockStore()
+
+	root := store.NewBlock(0)
+	b11 := store.NewBlock(1, root)
+	b12 := store.NewBlock(2, root)
+	b21 := store.NewBlock(3, b11, b12)
+
+	t0 := requireTipset(t, root)
+	t1 := requireTipset(t, b11, b12)
+	t2 := requireTipset(t, b21)
+
+	it := chain.IterAncestors(ctx, store, t2)
+	assert.False(it.Complete())
+	assert.True(t2.Equals(it.Value()))
+
+	assert.NoError(it.Next())
+	assert.False(it.Complete())
+	assert.True(t1.Equals(it.Value()))
+
+	assert.NoError(it.Next())
+	assert.False(it.Complete())
+	assert.True(t0.Equals(it.Value()))
+
+	assert.NoError(it.Next())
+	assert.True(it.Complete())
+}
+
+type fakeBlockStore struct {
+	blocks map[cid.Cid]*types.Block
+	seq    int
+}
+
+func newBlockStore() *fakeBlockStore {
+	return &fakeBlockStore{
+		make(map[cid.Cid]*types.Block),
+		0,
+	}
+}
+
+func (bs *fakeBlockStore) GetBlock(ctx context.Context, cid cid.Cid) (*types.Block, error) {
+	block, ok := bs.blocks[cid]
+	if ok {
+		return block, nil
+	}
+	return nil, errors.New("No such block")
+}
+
+func (bs *fakeBlockStore) NewBlock(nonce uint64, parents ...*types.Block) *types.Block {
+	b := &types.Block{
+		Nonce: types.Uint64(nonce),
+	}
+
+	if len(parents) > 0 {
+		b.Height = parents[0].Height + 1
+		b.StateRoot = parents[0].StateRoot
+		for _, p := range parents {
+			b.Parents.Add(p.Cid())
+		}
+	}
+
+	bs.blocks[b.Cid()] = b
+	return b
+}
+
+func requireTipset(t *testing.T, blocks ...*types.Block) types.TipSet {
+	set, err := types.NewTipSet(blocks...)
+	require.NoError(t, err)
+	return set
+}

--- a/core/message_pool_test.go
+++ b/core/message_pool_test.go
@@ -3,15 +3,17 @@ package core
 import (
 	"context"
 	"fmt"
-	"github.com/filecoin-project/go-filecoin/testhelpers"
 	"sync"
 	"testing"
 
 	"gx/ipfs/QmNf3wujpV2Y7Lnj2hy2UrmuX8bhMDStRHbnSLh7Ypf36h/go-hamt-ipld"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
 
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -179,7 +181,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		newChain := NewChainWithMessages(store, parent, msgsSet{msgs{m[1]}})
 		newTipSet := headOf(newChain)
 
-		assert.NoError(p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet))
+		assert.NoError(p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet))
 		assertPoolEquals(assert, p, m[0])
 	})
 
@@ -196,7 +198,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		oldChain := NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{m[2]}})
 		oldTipSet := headOf(oldChain)
 
-		p.UpdateMessagePool(ctx, store, oldTipSet, oldTipSet) // sic
+		p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, oldTipSet) // sic
 		assertPoolEquals(assert, p, m[0], m[1])
 	})
 
@@ -222,7 +224,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		newTipSet := headOf(newChain)
 
-		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p, m[1])
 	})
 
@@ -246,7 +248,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		newTipSet := headOf(newChain)
 
-		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p, m[1])
 	})
 
@@ -266,7 +268,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		newChain := NewChainWithMessages(store, oldChain[0], msgsSet{msgs{m[3]}}, msgsSet{msgs{m[4], m[5]}})
 		newTipSet := headOf(newChain)
 
-		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p, m[1], m[2])
 	})
 
@@ -295,7 +297,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		newTipSet := headOf(newChain)
 
-		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p, m[6])
 	})
 
@@ -322,7 +324,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		newTipSet := headOf(newChain)
 
-		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p, m[6])
 	})
 
@@ -348,7 +350,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		newTipSet := headOf(newChain)
 
-		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p, m[3], m[5])
 	})
 
@@ -369,7 +371,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		oldTipSet := headOf(oldChain)
 
 		oldTipSetPrev := oldChain[1]
-		p.UpdateMessagePool(ctx, store, oldTipSet, oldTipSetPrev)
+		p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, oldTipSetPrev)
 		assertPoolEquals(assert, p, m[2], m[3])
 	})
 
@@ -389,7 +391,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		newChain := NewChainWithMessages(store, oldChain[len(oldChain)-1], msgsSet{msgs{m[1], m[2]}})
 		newTipSet := headOf(newChain)
 
-		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p, m[0])
 	})
 
@@ -413,7 +415,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		newTipSet := headOf(newChain)
 
-		p.UpdateMessagePool(ctx, store, oldTipSet, newTipSet)
+		p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet)
 		assertPoolEquals(assert, p)
 	})
 
@@ -436,7 +438,7 @@ func TestUpdateMessagePool(t *testing.T) {
 
 			// update pool with tipset that has no messages
 			next := headOf(NewChainWithMessages(store, head, msgsSet{msgs{}}))
-			p.UpdateMessagePool(ctx, store, head, next)
+			p.UpdateMessagePool(ctx, &storeBlockProvider{store}, head, next)
 
 			// assert all added messages still in pool
 			assertPoolEquals(assert, p, m[:i+1]...)
@@ -450,7 +452,7 @@ func TestUpdateMessagePool(t *testing.T) {
 
 		// next tipset times out first message only
 		next := headOf(NewChainWithMessages(store, head, msgsSet{msgs{}}))
-		p.UpdateMessagePool(ctx, store, head, next)
+		p.UpdateMessagePool(ctx, &storeBlockProvider{store}, head, next)
 		assertPoolEquals(assert, p, m[1:]...)
 	})
 
@@ -486,7 +488,7 @@ func TestUpdateMessagePool(t *testing.T) {
 			MustPut(store, blk)
 			next[blk.Cid()] = blk
 
-			p.UpdateMessagePool(ctx, store, head, next)
+			p.UpdateMessagePool(ctx, &storeBlockProvider{store}, head, next)
 
 			// assert all added messages still in pool
 			assertPoolEquals(assert, p, m[:i+1]...)
@@ -499,7 +501,7 @@ func TestUpdateMessagePool(t *testing.T) {
 
 		// next tipset times out first message only
 		next := headOf(NewChainWithMessages(store, head, msgsSet{msgs{}}))
-		p.UpdateMessagePool(ctx, store, head, next)
+		p.UpdateMessagePool(ctx, &storeBlockProvider{store}, head, next)
 		assertPoolEquals(assert, p, m[1:]...)
 	})
 }
@@ -551,4 +553,16 @@ func TestLargestNonce(t *testing.T) {
 		assert.True(found)
 		assert.Equal(uint64(2), largest)
 	})
+}
+
+type storeBlockProvider struct {
+	store *hamt.CborIpldStore
+}
+
+func (p *storeBlockProvider) GetBlock(ctx context.Context, cid cid.Cid) (*types.Block, error) {
+	var blk types.Block
+	if err := p.store.Get(ctx, cid, &blk); err != nil {
+		return nil, errors.Wrapf(err, "failed to get block %s", cid)
+	}
+	return &blk, nil
 }

--- a/core/message_queue.go
+++ b/core/message_queue.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/types"
-	"github.com/pkg/errors"
+
+	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
 )
 
 // MessageQueue stores an ordered list of messages (per actor) and enforces that their nonces form a contiguous sequence.

--- a/node/node.go
+++ b/node/node.go
@@ -656,7 +656,7 @@ func (node *Node) handleNewHeaviestTipSet(ctx context.Context, head types.TipSet
 
 			// When a new best TipSet is promoted we remove messages in it from the
 			// message pool (and add them back in if we have a re-org).
-			if err := node.MsgPool.UpdateMessagePool(ctx, node.CborStore(), head, newHead); err != nil {
+			if err := node.MsgPool.UpdateMessagePool(ctx, node.ChainReadStore(), head, newHead); err != nil {
 				log.Error("error updating message pool for new tipset:", err)
 				continue
 			}

--- a/types/sorted_cid_set.go
+++ b/types/sorted_cid_set.go
@@ -93,8 +93,8 @@ func (s *SortedCidSet) Clear() {
 }
 
 // Iter returns an iterator that allows the caller to iterate the set in its sort order.
-func (s SortedCidSet) Iter() sortedCidSetIterator { // nolint
-	return sortedCidSetIterator{
+func (s SortedCidSet) Iter() SortedCidSetIterator {
+	return SortedCidSetIterator{
 		s: s.s,
 		i: 0,
 	}
@@ -174,18 +174,19 @@ func (s SortedCidSet) search(id cid.Cid) int {
 	})
 }
 
-type sortedCidSetIterator struct {
+// SortedCidSetIterator is a iterator over a sorted collection of CIDs.
+type SortedCidSetIterator struct {
 	s []cid.Cid
 	i int
 }
 
 // Complete returns true if the iterator has reached the end of the set.
-func (si *sortedCidSetIterator) Complete() bool {
+func (si *SortedCidSetIterator) Complete() bool {
 	return si.i >= len(si.s)
 }
 
 // Next advances the iterator to the next item and returns true if there is such an item.
-func (si *sortedCidSetIterator) Next() bool {
+func (si *SortedCidSetIterator) Next() bool {
 	switch {
 	case si.i < len(si.s):
 		si.i++
@@ -198,7 +199,7 @@ func (si *sortedCidSetIterator) Next() bool {
 }
 
 // Value returns the current item for the iterator
-func (si sortedCidSetIterator) Value() cid.Cid {
+func (si SortedCidSetIterator) Value() cid.Cid {
 	switch {
 	case si.i < len(si.s):
 		return si.s[si.i]


### PR DESCRIPTION
My primary goal here is to factor chain traversal out of the MessageQueue so I can re-use
logic for collecting new/old messages in the case of a re-org and expire messages in the
outbound queue. I'm informed the iterators may be useful elsewhere too.