### PR TITLE
Bug/message pool timeouts from wrong head

### DIFF
--- a/core/message_pool.go
+++ b/core/message_pool.go
@@ -160,7 +160,8 @@ func collectChainsMessagesToHeight(ctx context.Context, store chain.BlockProvide
 //      etc.
 func (pool *MessagePool) UpdateMessagePool(ctx context.Context, store chain.BlockProvider, old, new types.TipSet) error {
 	// Strategy: walk head-of-chain pointers old and new back until they are at the same
-	// height, then walk back in lockstep to find the common ancesetor.
+	// height, then walk back in lockstep to find the common ancestor.
+	newHead := new
 
 	// If old is higher/longer than new, collect all the messages
 	// from old's chain down to the height of new.
@@ -244,7 +245,7 @@ func (pool *MessagePool) UpdateMessagePool(ctx context.Context, store chain.Bloc
 	}
 
 	// prune all messages that have been in the pool too long
-	return pool.timeoutMessages(ctx, store, new)
+	return pool.timeoutMessages(ctx, store, newHead)
 }
 
 // timeoutMessages removes all messages from the pool that arrived more than MessageTimeout tip sets ago.

--- a/core/message_pool_test.go
+++ b/core/message_pool_test.go
@@ -433,6 +433,9 @@ func TestUpdateMessagePool(t *testing.T) {
 
 		// Add a message at each block height until MessageTimeOut is reached
 		for i := 0; i < MessageTimeOut; i++ {
+			// blockTimer.Height determines block time at which message is added
+			blockTimer.Height, err = head.Height()
+			require.NoError(err)
 
 			MustAdd(p, m[i])
 
@@ -442,10 +445,6 @@ func TestUpdateMessagePool(t *testing.T) {
 
 			// assert all added messages still in pool
 			assertPoolEquals(assert, p, m[:i+1]...)
-
-			// blockTimer.Height determines block time at which message is added
-			blockTimer.Height, err = next.Height()
-			require.NoError(err)
 
 			head = next
 		}
@@ -470,6 +469,8 @@ func TestUpdateMessagePool(t *testing.T) {
 
 		// Add a message at each block height until MessageTimeOut is reached
 		for i := 0; i < MessageTimeOut; i++ {
+			// blockTimer.Height determines block time at which message is added
+			blockTimer.Height, err = head.Height()
 			require.NoError(err)
 
 			MustAdd(p, m[i])
@@ -492,9 +493,6 @@ func TestUpdateMessagePool(t *testing.T) {
 
 			// assert all added messages still in pool
 			assertPoolEquals(assert, p, m[:i+1]...)
-
-			// blockTimer.Height determines block time at which next message is added
-			blockTimer.Height = uint64(nextHeight)
 
 			head = next
 		}

--- a/core/message_pool_test.go
+++ b/core/message_pool_test.go
@@ -453,6 +453,13 @@ func TestUpdateMessagePool(t *testing.T) {
 		next := headOf(NewChainWithMessages(store, head, msgsSet{msgs{}}))
 		p.UpdateMessagePool(ctx, &storeBlockProvider{store}, head, next)
 		assertPoolEquals(assert, p, m[1:]...)
+
+		// adding a chain of multiple tipsets times out based on final state
+		for i := 0; i < 4; i++ {
+			next = headOf(NewChainWithMessages(store, next, msgsSet{msgs{}}))
+		}
+		p.UpdateMessagePool(ctx, &storeBlockProvider{store}, head, next)
+		assertPoolEquals(assert, p, m[5:]...)
 	})
 
 	t.Run("Message timeout is unaffected by null tipsets", func(t *testing.T) {


### PR DESCRIPTION
### Problem

We now timeout message after a constant number of tipsets from the head. This calculation was being made off the `new` head after an algorithm that mutated that value down. A +/- issue mask the bug in the tests.

### Solution

Keep a reference to the head from before it mutates. Fix the tests and test the consequences of adding a chain with multiple tip sets.