### PR TITLE
change parameters yaml key to params

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 
-parameters:
+params:
   sector_builder_tests_param: &sector_builder_tests_param
     sector_builder_tests:
       description: "Run the sector builder integration tests"


### PR DESCRIPTION
config validator started complaining and build error appearing seemingly randomly

$ circleci config validate
Error: ERROR IN CONFIG FILE:
[#/parameters/sector_builder_tests_param] 3 schema violations found
1. [#/parameters/sector_builder_tests_param] required key [default] not found
2. [#/parameters/sector_builder_tests_param] required key [type] not found
3. [#/parameters/sector_builder_tests_param] extraneous key [sector_builder_tests] is not permitted

s/parameters/params/ fixes error so assuming parameters has become a reserved top level key

relates to https://github.com/filecoin-project/go-filecoin/issues/2275