### PR TITLE
integrate go-filecoin with real PoSt generation and verification routines

### DIFF
--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -451,6 +451,10 @@ func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR,
 		return 1, errors.NewRevertError("invalid sized commRStar")
 	}
 
+	// As with submitPoSt messages, bootstrap miner actors don't verify
+	// the commitSector messages that they are sent.
+	//
+	// This switching will be removed when issue #2270 is completed.
 	if !ma.Bootstrap {
 		// This unfortunate environment variable-checking needs to happen because
 		// the PoRep verification operation needs to know some things (e.g. size)
@@ -661,41 +665,46 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, postProofs []proofs.PoStProof) (
 			return nil, errors.NewRevertErrorf("submitted PoSt late, need to pay a fee")
 		}
 
-		// reach in to actor storage to grab comm-r for each committed sector
-		var commRs []proofs.CommR
-		for _, v := range state.SectorCommitments {
-			commRs = append(commRs, v.CommR)
-		}
-
-		// See comment above, in CommitSector.
+		// As with commitSector messages, bootstrap miner actors don't verify
+		// the submitPoSt messages that they are sent.
 		//
-		// It is undefined behavior for a miner in "Live" mode to verify a proof
-		// created by a miner in "ProofsTest" mode (and vice-versa).
-		//
-		sectorStoreType := proofs.Live
-		if os.Getenv("FIL_USE_SMALL_SECTORS") == "true" {
-			sectorStoreType = proofs.Test
-		}
+		// This switching will be removed when issue #2270 is completed.
+		if !ma.Bootstrap {
+			// See comment above, in CommitSector.
+			//
+			// It is undefined behavior for a miner in "Live" mode to verify a proof
+			// created by a miner in "ProofsTest" mode (and vice-versa).
+			//
+			sectorStoreType := proofs.Live
+			if os.Getenv("FIL_USE_SMALL_SECTORS") == "true" {
+				sectorStoreType = proofs.Test
+			}
 
-		seed, err := currentProvingPeriodPoStChallengeSeed(ctx, state)
-		if err != nil {
-			return nil, errors.FaultErrorWrap(err, "failed to sample chain for challenge seed")
-		}
+			seed, err := currentProvingPeriodPoStChallengeSeed(ctx, state)
+			if err != nil {
+				return nil, errors.FaultErrorWrap(err, "failed to sample chain for challenge seed")
+			}
 
-		req := proofs.VerifyPoSTRequest{
-			ChallengeSeed: seed,
-			CommRs:        commRs,
-			Faults:        []uint64{},
-			Proofs:        postProofs,
-			StoreType:     sectorStoreType,
-		}
+			var commRs []proofs.CommR
+			for _, v := range state.SectorCommitments {
+				commRs = append(commRs, v.CommR)
+			}
 
-		res, err := (&proofs.RustVerifier{}).VerifyPoST(req)
-		if err != nil {
-			return nil, errors.RevertErrorWrap(err, "failed to verify PoSt")
-		}
-		if !res.IsValid {
-			return nil, Errors[ErrInvalidPoSt]
+			req := proofs.VerifyPoSTRequest{
+				ChallengeSeed: seed,
+				CommRs:        commRs,
+				Faults:        []uint64{},
+				Proofs:        postProofs,
+				StoreType:     sectorStoreType,
+			}
+
+			res, err := (&proofs.RustVerifier{}).VerifyPoST(req)
+			if err != nil {
+				return nil, errors.RevertErrorWrap(err, "failed to verify PoSt")
+			}
+			if !res.IsValid {
+				return nil, Errors[ErrInvalidPoSt]
+			}
 		}
 
 		// transition to the next proving period

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -234,6 +234,10 @@ var minerExports = exec.Exports{
 		Params: nil,
 		Return: []abi.Type{abi.CommitmentsMap},
 	},
+	"isBootstrapMiner": &exec.FunctionSignature{
+		Params: nil,
+		Return: []abi.Type{abi.Boolean},
+	},
 }
 
 // Exports returns the miner actors exported functions.
@@ -401,6 +405,12 @@ func (ma *Actor) GetLastUsedSectorID(ctx exec.VMContext) (uint64, uint8, error) 
 	}
 
 	return a, 0, nil
+}
+
+// IsBootstrapMiner indicates whether the receiving miner was created in the
+// genesis block, i.e. used to bootstrap the network
+func (ma *Actor) IsBootstrapMiner(ctx exec.VMContext) (bool, uint8, error) {
+	return ma.Bootstrap, 0, nil
 }
 
 // GetSectorCommitments returns all sector commitments posted by this miner.

--- a/functional-tests/lib/helpers.bash
+++ b/functional-tests/lib/helpers.bash
@@ -8,7 +8,7 @@ function finish {
   echo ""
   echo "cleaning up..."
   kill "$BOOTSTRAP_MN_PID" || true
-  kill "$MN_PID" || true
+  kill "$STORAGE_MN_PID" || true
   kill "$CL_PID" || true
 
   # Force KILL after MAX_WAIT seconds if the daemons don't exit
@@ -19,7 +19,7 @@ function finish {
 
   # Force KILL after MAX_WAIT seconds if the daemons don't exit
   (
-    sleep $MAX_WAIT && kill -9 "$MN_PID";
+    sleep $MAX_WAIT && kill -9 "$STORAGE_MN_PID";
     echo "Sent SIGKILL to MN, daemon failed to stop within $MAX_WAIT second at end of test";
   ) & WAITER_MN=$!
 
@@ -30,7 +30,7 @@ function finish {
 
   # Wait for daemons to exit
   wait "$BOOTSTRAP_MN_PID"
-  wait "$MN_PID"
+  wait "$STORAGE_MN_PID"
   wait "$CL_PID"
 
   # Kill watchers

--- a/functional-tests/lib/helpers.bash
+++ b/functional-tests/lib/helpers.bash
@@ -7,8 +7,15 @@ function finish {
 
   echo ""
   echo "cleaning up..."
+  kill "$BOOTSTRAP_MN_PID" || true
   kill "$MN_PID" || true
   kill "$CL_PID" || true
+
+  # Force KILL after MAX_WAIT seconds if the daemons don't exit
+  (
+    sleep $MAX_WAIT && kill -9 "$BOOTSTRAP_MN_PID";
+    echo "Sent SIGKILL to BOOTSTRAP_MN, daemon failed to stop within $MAX_WAIT second at end of test";
+  ) & WAITER_BOOTSTRAP_MN=$!
 
   # Force KILL after MAX_WAIT seconds if the daemons don't exit
   (
@@ -22,10 +29,12 @@ function finish {
   ) & WAITER_CL=$!
 
   # Wait for daemons to exit
+  wait "$BOOTSTRAP_MN_PID"
   wait "$MN_PID"
   wait "$CL_PID"
 
   # Kill watchers
+  kill $WAITER_BOOTSTRAP_MN
   kill $WAITER_MN
   kill $WAITER_CL
 
@@ -33,6 +42,7 @@ function finish {
   rm -f "${PIECE_2_PATH}"
   rm -f "${UNSEAL_PATH}"
   rm -rf "${CL_REPO_DIR}"
+  rm -rf "${BOOTSTRAP_MN_REPO_DIR}"
   rm -rf "${MN_REPO_DIR}"
 }
 
@@ -149,6 +159,23 @@ function wait_for_message_in_chain_by_method_and_sender {
   unset IFS
 }
 
+function create_miner {
+  ./go-filecoin miner create 10 100 \
+    --gas-limit=10000 \
+    --gas-price=0 \
+    --repodir="$1"
+}
+
+function send_fil {
+  ./go-filecoin message send \
+    --from "$1" \
+    --value $2 \
+    --gas-limit=10000 \
+    --gas-price=0 \
+    "$3" \
+    --repodir="$4"
+}
+
 function set_wallet_default_address_in_config {
   ./go-filecoin config wallet.defaultAddress \""$1"\" \
     --repodir="$2"
@@ -173,4 +200,16 @@ function miner_update_pid {
   ./go-filecoin miner update-peerid "$1" "$2" \
     --gas-price=0 --gas-limit=300 \
     --repodir="$3"
+}
+
+function message_wait {
+    ./go-filecoin message wait $1 --repodir=$2
+}
+
+function fork_message_wait {
+  eval "exec $1< <(./go-filecoin message wait $2 --repodir=$3)"
+}
+
+function join {
+  cat <&"$1"
 }

--- a/functional-tests/retrieval
+++ b/functional-tests/retrieval
@@ -127,8 +127,6 @@ echo "bootstrap miner node starts mining (so that messages can be processed)..."
 ./go-filecoin mining start \
   --repodir="$BOOTSTRAP_MN_REPO_DIR" \
 
-MINER_ADD_ASK_MSG_CID=$(set_price 10 10000 "${MN_REPO_DIR}")
-
 echo ""
 echo "bootstrap miner shares some funds with the storage miner..."
 SEND_FIL_MSG_CID=$(send_fil "$BOOTSTRAP_MN_MINER_OWNER_FIL_ADDR" 100 "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${BOOTSTRAP_MN_REPO_DIR}")
@@ -154,16 +152,16 @@ STORAGE_MN_MINER_UPDATE_PID_MSG_CID=$(miner_update_pid "${STORAGE_MN_MINER_FIL_A
 
 echo ""
 echo "storage miner adds its ask to the market..."
-STORAGE_MN_MINER_ADD_ASK_MSG_CID=$(add_ask "${STORAGE_MN_MINER_FIL_ADDR}" 10 10000 "${STORAGE_MN_REPO_DIR}")
+STORAGE_MN_MINER_SET_PRICE_MSG_CID=$(set_price 10 10000 "${STORAGE_MN_REPO_DIR}")
 
 echo ""
-echo "block until miner peer id-update message appears in chains..."
+echo "block until miner peer id-update and set price-messages appear in chains..."
 message_wait "${STORAGE_MN_MINER_UPDATE_PID_MSG_CID}" "${BOOTSTRAP_MN_REPO_DIR}"
 message_wait "${STORAGE_MN_MINER_UPDATE_PID_MSG_CID}" "${CL_REPO_DIR}"
 message_wait "${STORAGE_MN_MINER_UPDATE_PID_MSG_CID}" "${STORAGE_MN_REPO_DIR}"
-message_wait "${STORAGE_MN_MINER_ADD_ASK_MSG_CID}" "${BOOTSTRAP_MN_REPO_DIR}"
-message_wait "${STORAGE_MN_MINER_ADD_ASK_MSG_CID}" "${CL_REPO_DIR}"
-message_wait "${STORAGE_MN_MINER_ADD_ASK_MSG_CID}" "${STORAGE_MN_REPO_DIR}"
+message_wait "${STORAGE_MN_MINER_SET_PRICE_MSG_CID}" "${BOOTSTRAP_MN_REPO_DIR}"
+message_wait "${STORAGE_MN_MINER_SET_PRICE_MSG_CID}" "${CL_REPO_DIR}"
+message_wait "${STORAGE_MN_MINER_SET_PRICE_MSG_CID}" "${STORAGE_MN_REPO_DIR}"
 
 echo ""
 echo "client proposes a storage deal, which transfers file 1..."

--- a/functional-tests/retrieval
+++ b/functional-tests/retrieval
@@ -180,7 +180,7 @@ wait_for_message_in_chain_by_method_and_sender commitSector "${STORAGE_MN_MINER_
 wait_for_message_in_chain_by_method_and_sender commitSector "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${STORAGE_MN_REPO_DIR}"
 
 echo ""
-echo "wait for for submitPoSt, too..."
+echo "wait for submitPoSt, too..."
 wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${CL_REPO_DIR}"
 wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${BOOTSTRAP_MN_REPO_DIR}"
 wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${STORAGE_MN_REPO_DIR}"

--- a/functional-tests/retrieval
+++ b/functional-tests/retrieval
@@ -26,9 +26,11 @@ else
 fi
 
 # forward-declare stuff that we need to clean up
-MN_PID=""
+STORAGE_MN_PID=""
+BOOTSTRAP_MN_PID=""
 CL_PID=""
-MN_REPO_DIR=""
+STORAGE_MN_REPO_DIR=""
+BOOTSTRAP_MN_REPO_DIR=""
 CL_REPO_DIR=""
 PIECE_1_PATH=$(mktemp)
 PIECE_2_PATH=$(mktemp)
@@ -49,9 +51,13 @@ fi
 
 trap finish EXIT
 
-MN_REPO_DIR=$(mktemp -d)
-MN_CMDAPI_PORT=$(free_port)
-MN_SWARM_PORT=$(free_port)
+STORAGE_MN_REPO_DIR=$(mktemp -d)
+STORAGE_MN_CMDAPI_PORT=$(free_port)
+STORAGE_MN_SWARM_PORT=$(free_port)
+
+BOOTSTRAP_MN_REPO_DIR=$(mktemp -d)
+BOOTSTRAP_MN_CMDAPI_PORT=$(free_port)
+BOOTSTRAP_MN_SWARM_PORT=$(free_port)
 
 CL_REPO_DIR=$(mktemp -d)
 CL_CMDAPI_PORT=$(free_port)
@@ -59,53 +65,54 @@ CL_SWARM_PORT=$(free_port)
 
 echo ""
 echo "generating private keys..."
-
-MN_MINER_FIL_ADDR=$(jq -r '.Miners[] | select(.Owner == 0).Address' < fixtures/gen.json)
+BOOTSTRAP_MN_MINER_FIL_ADDR=$(jq -r '.Miners[] | select(.Owner == 0).Address' < fixtures/gen.json)
 
 echo ""
 echo "initializing daemons..."
-init_local_daemon "${MN_REPO_DIR}" "${MN_CMDAPI_PORT}" ./fixtures/genesis.car
+init_local_daemon "${BOOTSTRAP_MN_REPO_DIR}" "${BOOTSTRAP_MN_CMDAPI_PORT}" ./fixtures/genesis.car
+init_local_daemon "${STORAGE_MN_REPO_DIR}" "${STORAGE_MN_CMDAPI_PORT}" ./fixtures/genesis.car
 init_local_daemon "${CL_REPO_DIR}" "${CL_CMDAPI_PORT}" ./fixtures/genesis.car
 
 echo ""
 echo "start daemons..."
-start_daemon "${MN_REPO_DIR}" "${MN_CMDAPI_PORT}" "${MN_SWARM_PORT}"
-MN_PID=$!
+start_daemon "${STORAGE_MN_REPO_DIR}" "${STORAGE_MN_CMDAPI_PORT}" "${STORAGE_MN_SWARM_PORT}"
+STORAGE_MN_PID=$!
+start_daemon "${BOOTSTRAP_MN_REPO_DIR}" "${BOOTSTRAP_MN_CMDAPI_PORT}" "${BOOTSTRAP_MN_SWARM_PORT}"
+BOOTSTRAP_MN_PID=$!
 start_daemon "${CL_REPO_DIR}" "${CL_CMDAPI_PORT}" "${CL_SWARM_PORT}"
 CL_PID=$!
 
 sleep 2
 
 echo ""
-echo "importing private keys..."
-MN_MINER_OWNER_FIL_ADDR=$(import_private_key 0 "${MN_REPO_DIR}")
-CL_FIL_ADDRESS=$(import_private_key 1 "${CL_REPO_DIR}")
+echo "client imports pieces..."
+PIECE_1_CID=$(./go-filecoin client import --repodir="${CL_REPO_DIR}" < "${PIECE_1_PATH}")
+PIECE_2_CID=$(./go-filecoin client import --repodir="${CL_REPO_DIR}" < "${PIECE_2_PATH}")
 
 echo ""
-echo "ensure that miner address is set so that the miner-node can mine..."
-set_mining_address_in_config "${MN_MINER_FIL_ADDR}" "${MN_REPO_DIR}"
+echo "importing private keys..."
+BOOTSTRAP_MN_MINER_OWNER_FIL_ADDR=$(import_private_key 0 "${BOOTSTRAP_MN_REPO_DIR}")
+CL_FIL_ADDRESS=$(import_private_key 1 "${CL_REPO_DIR}")
+STORAGE_MN_MINER_OWNER_FIL_ADDR=$(import_private_key 2 "${STORAGE_MN_REPO_DIR}")
+
+echo ""
+echo "ensure that miner address is set so that the bootstrap miner-node can mine..."
+set_mining_address_in_config "${BOOTSTRAP_MN_MINER_FIL_ADDR}" "${BOOTSTRAP_MN_REPO_DIR}"
 
 echo ""
 echo "node default address should match what's associated with imported SK..."
 set_wallet_default_address_in_config "${CL_FIL_ADDRESS}" "${CL_REPO_DIR}"
-set_wallet_default_address_in_config "${MN_MINER_OWNER_FIL_ADDR}" "${MN_REPO_DIR}"
+set_wallet_default_address_in_config "${BOOTSTRAP_MN_MINER_OWNER_FIL_ADDR}" "${BOOTSTRAP_MN_REPO_DIR}"
+set_wallet_default_address_in_config "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${STORAGE_MN_REPO_DIR}"
 
 echo ""
-echo "get mining node's libp2p identity..."
-MN_PEER_ID=$(get_peer_id "${MN_REPO_DIR}")
-
-#echo ""
-#echo "get the client's peer id..."
-#CL_PEER_ID=$(get_peer_id "${CL_REPO_DIR}")
-
-echo ""
-echo "update miner's libp2p identity to match its node's..."
-MINER_UPDATE_PID_MSG_CID=$(miner_update_pid "${MN_MINER_FIL_ADDR}" "${MN_PEER_ID}" "${MN_REPO_DIR}")
+echo "get storage mining node's libp2p identity..."
+STORAGE_MN_PEER_ID=$(get_peer_id "${STORAGE_MN_REPO_DIR}")
 
 echo ""
 echo "connecting daemons..."
-swarm_connect "$(get_first_address "${CL_REPO_DIR}")" "${MN_REPO_DIR}"
-swarm_connect "$(get_first_address "${MN_REPO_DIR}")" "${CL_REPO_DIR}"
+swarm_connect "$(get_first_address "${CL_REPO_DIR}")" "${BOOTSTRAP_MN_REPO_DIR}"
+swarm_connect "$(get_first_address "${BOOTSTRAP_MN_REPO_DIR}")" "${STORAGE_MN_REPO_DIR}"
 
 echo ""
 echo ""
@@ -116,42 +123,70 @@ echo ""
 echo ""
 
 echo ""
-echo "miner node starts mining..."
+echo "bootstrap miner node starts mining (so that messages can be processed)..."
 ./go-filecoin mining start \
-  --repodir="$MN_REPO_DIR" \
+  --repodir="$BOOTSTRAP_MN_REPO_DIR" \
 
 MINER_ADD_ASK_MSG_CID=$(set_price 10 10000 "${MN_REPO_DIR}")
 
 echo ""
-echo "waiting until messages are in blockchain..."
-./go-filecoin message wait "${MINER_UPDATE_PID_MSG_CID}" --repodir="${MN_REPO_DIR}"
-./go-filecoin message wait "${MINER_UPDATE_PID_MSG_CID}" --repodir="${CL_REPO_DIR}"
-# No need to see add ask msg on miner daemon chain, as `set-price` waits for it to appear.
-./go-filecoin message wait "${MINER_ADD_ASK_MSG_CID}" --repodir="${CL_REPO_DIR}"
+echo "bootstrap miner shares some funds with the storage miner..."
+SEND_FIL_MSG_CID=$(send_fil "$BOOTSTRAP_MN_MINER_OWNER_FIL_ADDR" 100 "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${BOOTSTRAP_MN_REPO_DIR}")
 
 echo ""
-echo "client imports piece 1..."
-PIECE_1_CID=$(./go-filecoin client import --repodir="${CL_REPO_DIR}" < "${PIECE_1_PATH}")
+echo "block until FIL-transferring messages are in blockchain..."
+message_wait "${SEND_FIL_MSG_CID}" "${BOOTSTRAP_MN_REPO_DIR}"
+message_wait "${SEND_FIL_MSG_CID}" "${CL_REPO_DIR}"
+message_wait "${SEND_FIL_MSG_CID}" "${STORAGE_MN_REPO_DIR}"
+
+echo ""
+echo "create a new miner actor (for storage miner)..."
+STORAGE_MN_MINER_FIL_ADDR=$(create_miner "${STORAGE_MN_REPO_DIR}")
+
+echo ""
+echo "storage miner node starts mining (so that it processes storage proposals)..."
+./go-filecoin mining start \
+  --repodir="$STORAGE_MN_REPO_DIR" \
+
+echo ""
+echo "update miner's libp2p identity to match its node's..."
+STORAGE_MN_MINER_UPDATE_PID_MSG_CID=$(miner_update_pid "${STORAGE_MN_MINER_FIL_ADDR}" "${STORAGE_MN_PEER_ID}" "${STORAGE_MN_REPO_DIR}")
+
+echo ""
+echo "storage miner adds its ask to the market..."
+STORAGE_MN_MINER_ADD_ASK_MSG_CID=$(add_ask "${STORAGE_MN_MINER_FIL_ADDR}" 10 10000 "${STORAGE_MN_REPO_DIR}")
+
+echo ""
+echo "block until miner peer id-update message appears in chains..."
+message_wait "${STORAGE_MN_MINER_UPDATE_PID_MSG_CID}" "${BOOTSTRAP_MN_REPO_DIR}"
+message_wait "${STORAGE_MN_MINER_UPDATE_PID_MSG_CID}" "${CL_REPO_DIR}"
+message_wait "${STORAGE_MN_MINER_UPDATE_PID_MSG_CID}" "${STORAGE_MN_REPO_DIR}"
+message_wait "${STORAGE_MN_MINER_ADD_ASK_MSG_CID}" "${BOOTSTRAP_MN_REPO_DIR}"
+message_wait "${STORAGE_MN_MINER_ADD_ASK_MSG_CID}" "${CL_REPO_DIR}"
+message_wait "${STORAGE_MN_MINER_ADD_ASK_MSG_CID}" "${STORAGE_MN_REPO_DIR}"
 
 echo ""
 echo "client proposes a storage deal, which transfers file 1..."
-./go-filecoin client propose-storage-deal "${MN_MINER_FIL_ADDR}" "${PIECE_1_CID}" 0 5 \
+./go-filecoin client propose-storage-deal "${STORAGE_MN_MINER_FIL_ADDR}" "${PIECE_1_CID}" 0 5 \
   --repodir="$CL_REPO_DIR" \
 
 echo ""
-echo "client imports piece 2..."
-PIECE_2_CID=$(./go-filecoin client import --repodir="${CL_REPO_DIR}" < "${PIECE_2_PATH}")
-
-echo ""
-echo "client proposes a storage deal, which transfers piece 2 (triggers seal)..."
-./go-filecoin client propose-storage-deal "${MN_MINER_FIL_ADDR}" "${PIECE_2_CID}" 0 5 \
+echo "client proposes a storage deal, which transfers piece 2..."
+./go-filecoin client propose-storage-deal "${STORAGE_MN_MINER_FIL_ADDR}" "${PIECE_2_CID}" 0 5 \
   --repodir="$CL_REPO_DIR" \
 
 echo ""
-echo "wait for commitSector sent by miner owner to be included in a block viewable by both nodes..."
-wait_for_message_in_chain_by_method_and_sender commitSector "${MN_MINER_OWNER_FIL_ADDR}" "${CL_REPO_DIR}"
+echo "wait for commitSector sent by miner owner to be included in a block viewable by all nodes..."
+wait_for_message_in_chain_by_method_and_sender commitSector "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${CL_REPO_DIR}"
+wait_for_message_in_chain_by_method_and_sender commitSector "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${BOOTSTRAP_MN_REPO_DIR}"
+wait_for_message_in_chain_by_method_and_sender commitSector "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${STORAGE_MN_REPO_DIR}"
 
-wait_for_message_in_chain_by_method_and_sender commitSector "${MN_MINER_OWNER_FIL_ADDR}" "${MN_REPO_DIR}"
+echo ""
+echo "wait for for submitPoSt, too..."
+wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${CL_REPO_DIR}"
+wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${BOOTSTRAP_MN_REPO_DIR}"
+wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${STORAGE_MN_REPO_DIR}"
+
 echo ""
 echo ""
 echo ""
@@ -160,7 +195,7 @@ echo ""
 echo ""
 echo ""
 
-./go-filecoin retrieval-client retrieve-piece  "${MN_MINER_FIL_ADDR}" "${PIECE_1_CID}" \
+./go-filecoin retrieval-client retrieve-piece  "${STORAGE_MN_MINER_FIL_ADDR}" "${PIECE_1_CID}" \
   --repodir="${CL_REPO_DIR}" > "${UNSEAL_PATH}"
 
 GOT=$(shasum < "${UNSEAL_PATH}")

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -622,7 +622,7 @@ func (sm *Miner) currentProvingPeriodPoStChallengeSeed(ctx context.Context) (pro
 }
 
 // isBootstrapMinerActor is a convenience method used to determine if the miner
-// actor was created when bootstrapping the network. It it was,
+// actor was created when bootstrapping the network. If it was,
 func (sm *Miner) isBootstrapMinerActor(ctx context.Context) (bool, error) {
 	returnValues, sig, err := sm.porcelainAPI.MessageQuery(
 		ctx,

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"math/big"
 	"strconv"
 	"sync"
@@ -29,6 +28,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/util/convert"
@@ -602,6 +602,8 @@ func (sm *Miner) onCommitFail(dealCid cid.Cid, message string) {
 	log.Errorf("commit failure but could not update to deal 'Failed' state: %s", err)
 }
 
+// currentProvingPeriodPoStChallengeSeed produces a PoSt challenge seed for
+// the miner actor's current proving period.
 func (sm *Miner) currentProvingPeriodPoStChallengeSeed(ctx context.Context) (proofs.PoStChallengeSeed, error) {
 	currentProvingPeriodStart, err := sm.getProvingPeriodStart()
 	if err != nil {
@@ -619,31 +621,78 @@ func (sm *Miner) currentProvingPeriodPoStChallengeSeed(ctx context.Context) (pro
 	return seed, nil
 }
 
-// OnNewHeaviestTipSet is a callback called by node, everytime the the latest head is updated.
-// It is used to check if we are in a new proving period and need to trigger PoSt submission.
-func (sm *Miner) OnNewHeaviestTipSet(ts types.TipSet) {
-	ctx := context.Background()
+// isBootstrapMinerActor is a convenience method used to determine if the miner
+// actor was created when bootstrapping the network. It it was,
+func (sm *Miner) isBootstrapMinerActor(ctx context.Context) (bool, error) {
+	returnValues, sig, err := sm.porcelainAPI.MessageQuery(
+		ctx,
+		address.Address{},
+		sm.minerAddr,
+		"isBootstrapMiner",
+	)
+	if err != nil {
+		return false, errors.Wrap(err, "query method failed")
+	}
 
-	rets, sig, err := sm.porcelainAPI.MessageQuery(
+	deserialized, err := abi.Deserialize(returnValues[0], sig.Return[0])
+	if err != nil {
+		return false, errors.Wrap(err, "deserialization failed")
+	}
+
+	isBootstrap, ok := deserialized.Val.(bool)
+	if !ok {
+		return false, errors.Wrap(err, "type assertion failed")
+	}
+
+	return isBootstrap, nil
+}
+
+// getActorSectorCommitments is a convenience method used to obtain miner actor
+// commitments.
+func (sm *Miner) getActorSectorCommitments(ctx context.Context) (map[string]types.Commitments, error) {
+	returnValues, sig, err := sm.porcelainAPI.MessageQuery(
 		ctx,
 		address.Undef,
 		sm.minerAddr,
 		"getSectorCommitments",
 	)
 	if err != nil {
-		log.Errorf("failed to call query method getSectorCommitments: %s", err)
-		return
+		return nil, errors.Wrap(err, "query method failed")
 	}
 
-	commitmentsVal, err := abi.Deserialize(rets[0], sig.Return[0])
+	commitmentsVal, err := abi.Deserialize(returnValues[0], sig.Return[0])
 	if err != nil {
-		log.Errorf("failed to convert returned ABI value: %s", err)
-		return
+		return nil, errors.Wrap(err, "deserialization failed")
 	}
 
 	commitments, ok := commitmentsVal.Val.(map[string]types.Commitments)
 	if !ok {
-		log.Errorf("failed to convert returned ABI value to miner.Commitments")
+		return nil, errors.Wrap(err, "type assertion failed")
+	}
+
+	return commitments, nil
+}
+
+// OnNewHeaviestTipSet is a callback called by node, every time the the latest
+// head is updated. It is used to check if we are in a new proving period and
+// need to trigger PoSt submission.
+func (sm *Miner) OnNewHeaviestTipSet(ts types.TipSet) {
+	ctx := context.Background()
+
+	isBootstrapMinerActor, err := sm.isBootstrapMinerActor(ctx)
+	if err != nil {
+		log.Errorf("could not determine if actor created for bootstrapping: %s", err)
+		return
+	}
+
+	if isBootstrapMinerActor {
+		log.Info("bootstrap miner actor skips PoSt-generation flow")
+		return
+	}
+
+	commitments, err := sm.getActorSectorCommitments(ctx)
+	if err != nil {
+		log.Errorf("failed to get miner actor commitments: %s", err)
 		return
 	}
 


### PR DESCRIPTION
Fixes #1586 

## What's in this PR?

1. Consume new version of rust-fil-proofs which performs real PoSts!
1. Expose bootstrap actor-boolean outside of the state machine so that bootstrap miners don't try to generate PoSts over fake commitments (created by gengen in genesis block).
1. Modify retrieval test such that it exercises seal proof verification, PoSt generation, and PoSt verification.

## Why is this PR needed?

1. We want storage miners to exercises the PoSt generation and verification code
1. We want some automated tests exercising the PoSt generation, PoSt verification, and seal proof-verification code (modifications to retrieval test)

## Changes in this rust-fil-proofs release

```

-----------------------------------------------
commit 002597027d8e720cb8010919915d704b97740e5d
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Mon Mar 18 05:32:16 2019 -0700

    Feat/gf1586 integrate real post (#557)
    
    * use real PoSt
    
    * update comment
    
    * add FFI logging for seal generation and post verification/generation
    
    * error message disambiguating CommR -> FrBytes mapping issue


-----------------------------------------------
commit 7f300f01901dc97e28e54983c7e0a3d357e54376
Author: Steven Li <steven004@gmail.com>
Date:   Fri Mar 15 19:33:00 2019 +0800

    docs: fix some links
    
    - add sectorbuilder implementation and interface links
    - fix verifier links
    - remove sectorbase interfaces since they are not needed at this moment.


-----------------------------------------------
commit b28ba82f533f10e0d0fba2d2c4b187d55cc31594
Author: Friedel Ziegelmayer <dignifiedquire@users.noreply.github.com>
Date:   Thu Mar 14 20:38:22 2019 +0100

    perf(layered-drgporep): reduce memory usage in replication
    
    Reduces max resident size (maximum memory usage) during replication with zigzag (128MB  Sector)
    - from `5,925,036 KB`
    - to`3,172,848 KB`
    
    by avoiding one round of cloning graphs.


-----------------------------------------------
commit 3fad63d0ca260780e757b1a0537e49e98d9da2af
Author: Volker Mische <volker.mische@gmail.com>
Date:   Wed Mar 13 20:56:27 2019 +0100

    refactor(ffi): add a macro to free memory in the FFI automatically
    
    Dropping memory is a large part of the reposonses FFI code. With
    this new macro `#[derive(DropStructMacro)]` the `Drop` implementation
    will be auto-generated based on the struct.
    
    Example:
    
    ```rust
    pub struct FFIStagedSectorMetadata {
        pub sector_access: *const libc::c_char,
        pub sector_id: u64,
        pub pieces_len: libc::size_t,
        pub pieces_ptr: *const FFIPieceMetadata,
    
        // must be one of: Pending, Failed, Sealing
        pub seal_status_code: FFISealStatus,
    
        // if sealing failed - here's the error
        pub seal_error_msg: *const libc::c_char,
    }
    ```
    
    Will automatically create:
    
    ```rust
    impl Drop for FFIStagedSectorMetadata {
        fn drop(&mut self) {
            unsafe {
                free_c_str(self.sector_access as *mut libc::c_char);
                drop(Vec::from_raw_parts(
                    self.pieces_ptr as *mut FFIPieceMetadata,
                    self.pieces_len,
                    self.pieces_len,
                ));
                free_c_str(self.seal_error_msg as *mut libc::c_char);
            };
        }
    }
    ```
    
    To view the generated output after the macro was applied, you can use
    [cargo-expand](https://github.com/dtolnay/cargo-expand):
    
    ```console
    $ cd filecoin-proofs
    $ cargo expand --lib api::responses
    …
    ```
    
    The diff between the original code and the generated code after running
    `cargo expand --lib api::responses` and re-arranging it a bit (just
    moving the `Drop` to the same place) the diff is:
    
    ```diff
    164c164
    <                     self.faults_ptr as *mut u8,
    ---
    >                     self.faults_ptr as *mut u64,
    417c417
    <             }
    ---
    >             };
    476c476
    <             }
    ---
    >             };
    500c500
    <             }
    ---
    >             };
    530c530
    <             }
    ---
    >             };
    566c566
    <             }
    ---
    >             };
    ```
    
    Closes #303.


-----------------------------------------------
commit bb5a96e0fe198d407775cabd8b2bda35554ecfa9
Author: Lucas Molas <schomatis@gmail.com>
Date:   Fri Feb 8 00:11:55 2019 -0300

    zigzag: cache expansion parents


-----------------------------------------------
commit d3b9d27aa7fa1d00b818061b75e20351ae19e912
Author: Lucas Molas <schomatis@gmail.com>
Date:   Wed Mar 13 12:40:14 2019 -0300

    deps: lock `merkle_light` dependency to the current `master` commit
```