### PR TITLE
chainReader should be chainStore

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -444,7 +444,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 		bs,
 		&cstOffline,
 		&cstOnline,
-		chainReader,
+		chainStore,
 		nodeConsensus,
 		blockTime,
 		mineDelay,


### PR DESCRIPTION
https://github.com/filecoin-project/go-filecoin/commit/11c3025255f75defe5950262e48948ce112b78ae removes chainReader and uses chainStore instead.

replaces deprecated chainReader reference with chainStore

likely caused by master merge contention