### PR TITLE
Revert "Serialize Uint64 to string in JSON (#2229)"

### DIFF
--- a/commands/chain_daemon_test.go
+++ b/commands/chain_daemon_test.go
@@ -110,18 +110,4 @@ func TestChainDaemon(t *testing.T) {
 		assert.Contains(chainLsResult, "1")
 		assert.Contains(chainLsResult, "0")
 	})
-
-	t.Run("chain ls --long with JSON encoding returns integer string block height and nonce", func(t *testing.T) {
-		t.Parallel()
-		assert := assert.New(t)
-
-		daemon := th.NewDaemon(t, th.WithMiner(fixtures.TestMiners[0])).Start()
-		defer daemon.ShutdownSuccess()
-
-		daemon.RunSuccess("mining", "once", "--enc", "text")
-		chainLsResult := daemon.RunSuccess("chain", "ls", "--long", "--enc", "json").ReadStdoutTrimNewlines()
-		assert.Contains(chainLsResult, `"height":"0"`)
-		assert.Contains(chainLsResult, `"height":"1"`)
-		assert.Contains(chainLsResult, `"nonce":"0"`)
-	})
 }

--- a/types/uint64.go
+++ b/types/uint64.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"strconv"
+	"encoding/base64"
 	"strings"
 
 	"gx/ipfs/QmSKyB5faguXT4NqbrXpnRXqaVj5DhSm7x9BtzFydBY1UK/go-leb128"
@@ -29,16 +29,17 @@ type Uint64 uint64
 
 // MarshalJSON converts a Uint64 to a json string and returns it.
 func (u Uint64) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + strconv.FormatUint(uint64(u), 10) + `"`), nil
+	encoded := base64.StdEncoding.EncodeToString(leb128.FromUInt64(uint64(u)))
+	return []byte(`"` + encoded + `"`), nil
 }
 
 // UnmarshalJSON converts a json string to a Uint64.
 func (u *Uint64) UnmarshalJSON(b []byte) error {
-	val, err := strconv.ParseUint(strings.Trim(string(b), `"`), 10, 64)
+	jd, err := base64.StdEncoding.DecodeString(strings.Trim(string(b), `"`))
 	if err != nil {
 		return err
 	}
 
-	*u = Uint64(val)
+	*u = Uint64(leb128.ToUInt64(jd))
 	return nil
 }

--- a/types/uint64_test.go
+++ b/types/uint64_test.go
@@ -27,7 +27,6 @@ func TestUint64Json(t *testing.T) {
 	v := Uint64(64)
 	m, err := json.Marshal(v)
 	assert.NoError(err)
-	assert.Equal(`"64"`, string(m))
 	var got Uint64
 	err = json.Unmarshal(m, &got)
 	assert.NoError(err)


### PR DESCRIPTION
This reverts commit 4940e56f5124b51d87c2662ff3fcffbca6dc9129.

This fixes failure of `TestChainDaemon/chain_ls_--long_with_JSON_encoding_returns_integer_string_block_height_and_nonce`, added in this commit, that's currently failing on master.

cc @mslipper @travisperson I'm not sure what happened here