### PR TITLE
refactor: remove wallet addrs command

### DIFF
--- a/commands/address.go
+++ b/commands/address.go
@@ -20,7 +20,6 @@ var walletCmd = &cmds.Command{
 		Tagline: "Manage your filecoin wallets",
 	},
 	Subcommands: map[string]*cmds.Command{
-		"addrs":   addrsCmd,
 		"balance": balanceCmd,
 		"import":  walletImportCmd,
 		"export":  walletExportCmd,

--- a/commands/address_daemon_test.go
+++ b/commands/address_daemon_test.go
@@ -24,10 +24,10 @@ func TestAddrsNewAndList(t *testing.T) {
 
 	addrs := make([]string, 10)
 	for i := 0; i < 10; i++ {
-		addrs[i] = d.CreateWalletAddr()
+		addrs[i] = d.CreateAddress()
 	}
 
-	list := d.RunSuccess("wallet", "addrs", "ls").ReadStdout()
+	list := d.RunSuccess("address", "ls").ReadStdout()
 	for _, addr := range addrs {
 		assert.Contains(list, addr)
 	}
@@ -39,7 +39,7 @@ func TestWalletBalance(t *testing.T) {
 
 	d := th.NewDaemon(t).Start()
 	defer d.ShutdownSuccess()
-	addr := d.CreateWalletAddr()
+	addr := d.CreateAddress()
 
 	t.Log("[success] not found, zero")
 	balance := d.RunSuccess("wallet", "balance", addr)
@@ -50,7 +50,7 @@ func TestWalletBalance(t *testing.T) {
 	assert.Equal("9999900000", balance.ReadStdoutTrimNewlines())
 
 	t.Log("[success] newly generated one")
-	addrNew := d.RunSuccess("wallet addrs new")
+	addrNew := d.RunSuccess("address new")
 	balance = d.RunSuccess("wallet", "balance", addrNew.ReadStdoutTrimNewlines())
 	assert.Equal("0", balance.ReadStdoutTrimNewlines())
 }

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -237,7 +237,7 @@ func TestMinerCreate(t *testing.T) {
 		d := th.NewDaemon(t).Start()
 		defer d.ShutdownSuccess()
 
-		d.CreateWalletAddr()
+		d.CreateAddress()
 
 		d.RunFail("invalid peer id",
 			"miner", "create",

--- a/functional-tests/faucet_test.go
+++ b/functional-tests/faucet_test.go
@@ -80,7 +80,7 @@ func TestFaucetSendFunds(t *testing.T) {
 
 	// Get address for target node
 	var targetAddr commands.AddressLsResult
-	node1.MustRunCmdJSON(ctx, &targetAddr, "go-filecoin", "wallet", "addrs", "ls")
+	node1.MustRunCmdJSON(ctx, &targetAddr, "go-filecoin", "address", "ls")
 
 	// Start Tests
 

--- a/testhelpers/commands.go
+++ b/testhelpers/commands.go
@@ -520,13 +520,13 @@ func (td *TestDaemon) WaitForMessageRequireSuccess(msgCid cid.Cid) *types.Messag
 	return rcpt
 }
 
-// CreateWalletAddr adds a new address to the daemons wallet and
+// CreateAddress adds a new address to the daemons wallet and
 // returns it.
 // equivalent to:
-//     `go-filecoin wallet addrs new`
-func (td *TestDaemon) CreateWalletAddr() string {
+//     `go-filecoin address new`
+func (td *TestDaemon) CreateAddress() string {
 	td.test.Helper()
-	outNew := td.RunSuccess("wallet", "addrs", "new")
+	outNew := td.RunSuccess("address", "new")
 	addr := strings.Trim(outNew.ReadStdout(), "\n")
 	require.NotEmpty(td.test, addr)
 	return addr
@@ -627,7 +627,7 @@ func (td *TestDaemon) MakeMoney(rewards int, peers ...*TestDaemon) {
 
 // GetDefaultAddress returns the default sender address for this daemon.
 func (td *TestDaemon) GetDefaultAddress() string {
-	addrs := td.RunSuccess("wallet", "addrs", "ls")
+	addrs := td.RunSuccess("address", "ls")
 	return strings.Split(addrs.ReadStdout(), "\n")[0]
 }
 


### PR DESCRIPTION
Gone!:

```console
$ ./go-filecoin wallet --help
USAGE
  ./go-filecoin wallet - Manage your filecoin wallets

SYNOPSIS
  ./go-filecoin wallet

SUBCOMMANDS
  ./go-filecoin wallet balance <address>     - 
  ./go-filecoin wallet export <addresses>... - 
  ./go-filecoin wallet import <walletFile>   - 

  Use './go-filecoin wallet <subcmd> --help' for more information about each command.
```

resolves #1693