### PR TITLE
include paramfetch and parameters.json in GH release bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,14 +179,14 @@ jobs:
           name: Create macos bundle
           command: ./scripts/build-bundle.sh
       - store_artifacts:
-          path: "~/go/src/github.com/filecoin-project/go-filecoin/filecoin-Darwin.tar.gz"
-          destination: filecoin-Darwin.tar.gz
+          path: "~/go/src/github.com/filecoin-project/go-filecoin/bundle/"
+          destination: bundle
       - store_test_results:
           path: test-results
       - persist_to_workspace:
           root: "."
           paths:
-            - "filecoin-Darwin.tar.gz"
+            - "bundle/"
 
   build_linux:
     docker:
@@ -294,8 +294,8 @@ jobs:
           command: ./scripts/build-bundle.sh
 
       - store_artifacts:
-          path: "/go/src/github.com/filecoin-project/go-filecoin/filecoin-Linux.tar.gz"
-          destination: filecoin-Linux.tar.gz
+          path: "/go/src/github.com/filecoin-project/go-filecoin/bundle/"
+          destination: bundle
 
       - store_test_results:
           path: test-results
@@ -308,7 +308,7 @@ jobs:
       - persist_to_workspace:
           root: "."
           paths:
-            - "filecoin-Linux.tar.gz"
+            - "bundle/"
             - "gengen/gengen"
             - "fixtures"
 
@@ -466,11 +466,6 @@ jobs:
           command: |
             git config user.email dev-helper@filecoin.io
             git config user.name filecoin-helper
-            git tag -f -a ${FILECOIN_BINARY_VERSION} -m "$(date -uIseconds)"
-            git push -f https://${GITHUB_TOKEN}@github.com/filecoin-project/go-filecoin.git ${FILECOIN_BINARY_VERSION}
-      - trigger_infra_build:
-          job: deploy_nightly_devnet
-          branch: filecoin-nightly
   trigger_user_devnet_deploy:
     docker:
       - image: circleci/golang:latest
@@ -515,6 +510,7 @@ jobs:
           command: |
             sudo apt-get install -y curl jq
             curl -X POST --header "Content-Type: application/json" -d '{"branch":"filecoin-usernet"}' https://circleci.com/api/v1.1/project/github/filecoin-project/go-filecoin-infra/build?circle-token=$CIRCLE_API_TOKEN
+
 workflows:
   version: 2
   test_all:

--- a/scripts/build-bundle.sh
+++ b/scripts/build-bundle.sh
@@ -1,16 +1,23 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
+SHORT_GIT_SHA=${CIRCLE_SHA1:0:6}
+RELEASE_TAG="${CIRCLE_TAG:-$SHORT_GIT_SHA}"
+
+mkdir bundle
+pushd bundle
 mkdir -p filecoin
 
 # binary
-cp go-filecoin filecoin/
+cp ../go-filecoin filecoin/
 chmod +x filecoin/go-filecoin
 
-# fixture data
-mkdir filecoin/fixtures
-cp fixtures/*.key filecoin/fixtures/
-cp fixtures/*.car filecoin/fixtures/
-cp fixtures/*.json filecoin/fixtures/
+# proof params data
+cp ../proofs/bin/paramfetch filecoin/
+chmod +x filecoin/paramfetch
+cp ../proofs/rust-fil-proofs/parameters.json filecoin/
 
 
-tar -zcvf "filecoin-`uname`.tar.gz" filecoin
+tar -zcvf "filecoin-$RELEASE_TAG-`uname`.tar.gz" filecoin
+rm -rf filecoin
+
+popd

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+pushd bundle
+
 RELEASE_TAG="${CIRCLE_TAG}"
 
 # make sure we have a token set, api requests won't work otherwise
@@ -41,7 +43,7 @@ fi
 
 RELEASE_UPLOAD_URL=`echo $RELEASE_RESPONSE | jq -r '.upload_url' | cut -d'{' -f1`
 
-bundles=('filecoin-Linux.tar.gz' 'filecoin-Darwin.tar.gz')
+bundles=("filecoin-$RELEASE_TAG-Linux.tar.gz" "filecoin-$RELEASE_TAG-Darwin.tar.gz")
 for RELEASE_FILE in "${bundles[@]}"
 do
   echo "Uploading release bundle: $RELEASE_FILE"


### PR DESCRIPTION
Implements https://github.com/filecoin-project/go-filecoin/issues/2171

- Include `paramfetch` binary and `parameters.json` in the GH bundle
- Update WIKI to reflect changes: https://github.com/filecoin-project/go-filecoin/wiki/Getting-Started#installing-from-binary
