### PR TITLE
Moved Client ListAsks from node api to porcelain

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -11,18 +11,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
-	"github.com/filecoin-project/go-filecoin/types"
 )
-
-// Ask is a result of querying for an ask, it may contain an error
-type Ask struct {
-	Miner  address.Address
-	Price  *types.AttoFIL
-	Expiry *types.BlockHeight
-	ID     uint64
-
-	Error error
-}
 
 // Client is the interface that defines methods to manage client operations.
 type Client interface {
@@ -30,6 +19,5 @@ type Client interface {
 	ImportData(ctx context.Context, data io.Reader) (ipld.Node, error)
 	ProposeStorageDeal(ctx context.Context, data cid.Cid, miner address.Address, ask uint64, duration uint64, allowDuplicates bool) (*storagedeal.Response, error)
 	QueryStorageDeal(ctx context.Context, prop cid.Cid) (*storagedeal.Response, error)
-	ListAsks(ctx context.Context) (<-chan Ask, error)
 	Payments(ctx context.Context, dealCid cid.Cid) ([]*paymentbroker.PaymentVoucher, error)
 }

--- a/api/impl/client.go
+++ b/api/impl/client.go
@@ -3,10 +3,8 @@ package impl
 import (
 	"context"
 	"io"
-	"math/big"
 
 	"github.com/filecoin-project/go-filecoin/api"
-	"github.com/filecoin-project/go-filecoin/plumbing/msg"
 
 	dag "gx/ipfs/QmNRAuGmvnVw8urHkUZQirhu42VTiZjVWASa2aTznEMmpP/go-merkledag"
 	cid "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
@@ -14,15 +12,10 @@ import (
 	uio "gx/ipfs/QmRDWTzVdbHXdtat7tVJ7YC7kRaW7rTZTEF79yykcLYa49/go-unixfs/io"
 	ipld "gx/ipfs/QmRL22E4paat7ky7vx9MLpR97JHHbFPrg3ytFQw6qp1y1s/go-ipld-format"
 	chunk "gx/ipfs/QmXivYDjgMqNQXbEQVC7TMuZnRADCa71ABQUQxWPZPTLbd/go-ipfs-chunker"
-	cbor "gx/ipfs/QmcZLyosDwMKdB6NLRsiss9HXzDPhVhhRtPy67JFKTDQDX/go-ipld-cbor"
 
-	"github.com/filecoin-project/go-filecoin/actor"
-	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
-	mapi "github.com/filecoin-project/go-filecoin/api"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
-	"github.com/filecoin-project/go-filecoin/types"
 )
 
 type nodeClient struct {
@@ -69,67 +62,6 @@ func (api *nodeClient) ProposeStorageDeal(ctx context.Context, data cid.Cid, min
 
 func (api *nodeClient) QueryStorageDeal(ctx context.Context, prop cid.Cid) (*storagedeal.Response, error) {
 	return api.api.node.StorageMinerClient.QueryDeal(ctx, prop)
-}
-
-func (api *nodeClient) ListAsks(ctx context.Context) (<-chan mapi.Ask, error) {
-	nd := api.api.node
-
-	st, err := nd.ChainReader.LatestState(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	out := make(chan mapi.Ask)
-
-	go func() {
-		defer close(out)
-		err = st.ForEachActor(ctx, func(addr address.Address, act *actor.Actor) error {
-			if !types.MinerActorCodeCid.Equals(act.Code) && !types.BootstrapMinerActorCodeCid.Equals(act.Code) {
-				return nil
-			}
-
-			// TODO: at some point, we will need to check that the miners are actually part of the storage market
-			// for now, its impossible for them not to be.
-			queryer := msg.NewQueryer(nd.Repo, nd.Wallet, nd.ChainReader, nd.CborStore(), nd.Blockstore)
-			ret, _, err := queryer.Query(ctx, address.Undef, addr, "getAsks")
-			if err != nil {
-				return err
-			}
-
-			var asksIds []uint64
-			if err := cbor.DecodeInto(ret[0], &asksIds); err != nil {
-				return err
-			}
-
-			for _, id := range asksIds {
-				ret, _, err := queryer.Query(ctx, address.Undef, addr, "getAsk", big.NewInt(int64(id)))
-				if err != nil {
-					return err
-				}
-
-				var ask miner.Ask
-				if err := cbor.DecodeInto(ret[0], &ask); err != nil {
-					return err
-				}
-
-				out <- mapi.Ask{
-					Expiry: ask.Expiry,
-					ID:     ask.ID.Uint64(),
-					Price:  ask.Price,
-					Miner:  addr,
-				}
-			}
-
-			return nil
-		})
-		if err != nil {
-			out <- mapi.Ask{
-				Error: err,
-			}
-		}
-	}()
-
-	return out, nil
 }
 
 func (api *nodeClient) Payments(ctx context.Context, dealCid cid.Cid) ([]*paymentbroker.PaymentVoucher, error) {

--- a/commands/client.go
+++ b/commands/client.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/api"
+	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 )
 
@@ -208,14 +208,11 @@ respectively.
 `,
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
-		asksCh, err := GetAPI(env).Client().ListAsks(req.Context)
-		if err != nil {
-			return err
-		}
+		asksCh := GetPorcelainAPI(env).ClientListAsks(req.Context)
 
 		for a := range asksCh {
 			if a.Error != nil {
-				return err
+				return a.Error
 			}
 			if err := re.Emit(a); err != nil {
 				return err
@@ -223,9 +220,9 @@ respectively.
 		}
 		return nil
 	},
-	Type: api.Ask{},
+	Type: porcelain.Ask{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, ask *api.Ask) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, ask *porcelain.Ask) error {
 			fmt.Fprintf(w, "%s %.3d %s %s\n", ask.Miner, ask.ID, ask.Price, ask.Expiry) // nolint: errcheck
 			return nil
 		}),

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -188,3 +188,8 @@ func (a *API) PaymentChannelVoucher(
 ) (voucher *paymentbroker.PaymentVoucher, err error) {
 	return PaymentChannelVoucher(ctx, a, fromAddr, channel, amount, validAt)
 }
+
+// ClientListAsks returns a channel with asks from the latest chain state
+func (a *API) ClientListAsks(ctx context.Context) <-chan Ask {
+	return ClientListAsks(ctx, a)
+}

--- a/porcelain/client.go
+++ b/porcelain/client.go
@@ -1,0 +1,117 @@
+package porcelain
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/exec"
+	"github.com/filecoin-project/go-filecoin/state"
+	"github.com/filecoin-project/go-filecoin/types"
+
+	cbor "gx/ipfs/QmcZLyosDwMKdB6NLRsiss9HXzDPhVhhRtPy67JFKTDQDX/go-ipld-cbor"
+)
+
+// Ask is a result of querying for an ask, it may contain an error
+type Ask struct {
+	Miner  address.Address
+	Price  *types.AttoFIL
+	Expiry *types.BlockHeight
+	ID     uint64
+
+	Error error
+}
+
+type claPlubming interface {
+	ActorLs(ctx context.Context) (<-chan state.GetAllActorsResult, error)
+	MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, *exec.FunctionSignature, error)
+}
+
+// ClientListAsks returns a channel with asks from the latest chain state
+func ClientListAsks(ctx context.Context, plumbing claPlubming) <-chan Ask {
+	out := make(chan Ask)
+
+	go func() {
+		defer close(out)
+		actorCh, err := plumbing.ActorLs(ctx)
+		if err != nil {
+			out <- Ask{
+				Error: err,
+			}
+			return
+		}
+
+		for actorResult := range actorCh {
+			err := listAsksFromActorResult(ctx, plumbing, actorResult, out)
+			if err != nil {
+				out <- Ask{
+					Error: err,
+				}
+				return
+			}
+		}
+	}()
+
+	return out
+}
+
+func listAsksFromActorResult(ctx context.Context, plumbing claPlubming, actorResult state.GetAllActorsResult, out chan Ask) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		if actorResult.Error != nil {
+			return actorResult.Error
+		}
+
+		addr, _ := address.NewFromString(actorResult.Address)
+		actor := actorResult.Actor
+
+		if !types.MinerActorCodeCid.Equals(actor.Code) && !types.BootstrapMinerActorCodeCid.Equals(actor.Code) {
+			return nil
+		}
+
+		// TODO: at some point, we will need to check that the miners are actually part of the storage market
+		// for now, its impossible for them not to be.
+		ret, _, err := plumbing.MessageQuery(ctx, address.Undef, addr, "getAsks")
+		if err != nil {
+			return err
+		}
+
+		var asksIds []uint64
+		if err := cbor.DecodeInto(ret[0], &asksIds); err != nil {
+			return err
+		}
+
+		for _, id := range asksIds {
+			ask, err := getAskByID(ctx, plumbing, addr, id)
+			if err != nil {
+				return err
+			}
+
+			out <- ask
+		}
+	}
+
+	return nil
+}
+
+func getAskByID(ctx context.Context, plumbing claPlubming, addr address.Address, id uint64) (Ask, error) {
+	ret, _, err := plumbing.MessageQuery(ctx, address.Undef, addr, "getAsk", big.NewInt(int64(id)))
+	if err != nil {
+		return Ask{}, err
+	}
+
+	var ask miner.Ask
+	if err := cbor.DecodeInto(ret[0], &ask); err != nil {
+		return Ask{}, err
+	}
+
+	return Ask{
+		Expiry: ask.Expiry,
+		ID:     ask.ID.Uint64(),
+		Price:  ask.Price,
+		Miner:  addr,
+	}, nil
+}

--- a/porcelain/client_test.go
+++ b/porcelain/client_test.go
@@ -1,0 +1,139 @@
+package porcelain_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/filecoin-project/go-filecoin/actor"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/exec"
+	"github.com/filecoin-project/go-filecoin/porcelain"
+	"github.com/filecoin-project/go-filecoin/state"
+	"github.com/filecoin-project/go-filecoin/types"
+
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
+	cbor "gx/ipfs/QmcZLyosDwMKdB6NLRsiss9HXzDPhVhhRtPy67JFKTDQDX/go-ipld-cbor"
+)
+
+type claPlumbing struct {
+	actorFail   bool
+	actorChFail bool
+	messageFail bool
+
+	MinerAddress address.Address
+}
+
+func (cla *claPlumbing) ActorLs(ctx context.Context) (<-chan state.GetAllActorsResult, error) {
+	out := make(chan state.GetAllActorsResult)
+
+	if cla.actorFail {
+		return nil, errors.New("ACTOR FAILURE")
+	}
+
+	go func() {
+		defer close(out)
+		for i := 0; i < 42; i++ {
+			if cla.actorChFail {
+				out <- state.GetAllActorsResult{
+					Error: errors.New("ACTOR CHANNEL FAILURE"),
+				}
+			} else {
+				cla.MinerAddress = address.NewForTestGetter()()
+				actor := actor.Actor{Code: types.MinerActorCodeCid}
+				out <- state.GetAllActorsResult{
+					Address: cla.MinerAddress.String(),
+					Actor:   &actor,
+				}
+			}
+		}
+	}()
+
+	return out, nil
+}
+
+func (cla *claPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, *exec.FunctionSignature, error) {
+	if cla.messageFail {
+		return nil, nil, errors.New("MESSAGE FAILURE")
+	}
+
+	if method == "getAsks" {
+		askIDs, _ := cbor.DumpObject([]uint64{0})
+		return [][]byte{askIDs}, nil, nil
+	}
+
+	ask := miner.Ask{
+		Expiry: types.NewBlockHeight(1),
+		ID:     big.NewInt(2),
+		Price:  types.NewAttoFILFromFIL(3),
+	}
+	askBytes, _ := cbor.DumpObject(ask)
+	return [][]byte{askBytes}, nil, nil
+}
+
+func TestClientListAsks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		assert := assert.New(t)
+
+		ctx := context.Background()
+		plumbing := &claPlumbing{}
+
+		results := porcelain.ClientListAsks(ctx, plumbing)
+		result := <-results
+
+		expectedResult := porcelain.Ask{
+			Expiry: types.NewBlockHeight(1),
+			ID:     uint64(2),
+			Miner:  plumbing.MinerAddress,
+			Price:  types.NewAttoFILFromFIL(3),
+		}
+
+		assert.Equal(expectedResult, result)
+	})
+
+	t.Run("failed actor ls", func(t *testing.T) {
+		assert := assert.New(t)
+
+		ctx := context.Background()
+		plumbing := &claPlumbing{
+			actorFail: true,
+		}
+
+		results := porcelain.ClientListAsks(ctx, plumbing)
+		result := <-results
+
+		assert.Error(result.Error, "ACTOR FAILURE")
+	})
+
+	t.Run("failed actor ls via channel", func(t *testing.T) {
+		assert := assert.New(t)
+
+		ctx := context.Background()
+		plumbing := &claPlumbing{
+			actorChFail: true,
+		}
+
+		results := porcelain.ClientListAsks(ctx, plumbing)
+		result := <-results
+
+		assert.Error(result.Error, "ACTOR CHANNEL FAILURE")
+	})
+
+	t.Run("failed message query", func(t *testing.T) {
+		assert := assert.New(t)
+
+		ctx := context.Background()
+		plumbing := &claPlumbing{
+			messageFail: true,
+		}
+
+		results := porcelain.ClientListAsks(ctx, plumbing)
+		result := <-results
+
+		assert.Error(result.Error, "MESSAGE FAILURE")
+	})
+}

--- a/state/tree.go
+++ b/state/tree.go
@@ -256,8 +256,8 @@ func GetAllActors(ctx context.Context, t Tree) <-chan GetAllActorsResult {
 	st := t.(*tree)
 	out := make(chan GetAllActorsResult)
 	go func() {
+		defer close(out)
 		st.getActorsFromPointers(ctx, out, st.root.Pointers)
-		close(out)
 	}()
 	return out
 }

--- a/tools/fast/series/create_miner_with_ask.go
+++ b/tools/fast/series/create_miner_with_ask.go
@@ -4,22 +4,22 @@ import (
 	"context"
 	"math/big"
 
-	"github.com/filecoin-project/go-filecoin/api"
+	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 )
 
 // CreateMinerWithAsk setups a miner and sets an ask price. The created ask is
 // returned. The node will be mining as well.
-func CreateMinerWithAsk(ctx context.Context, miner *fast.Filecoin, pledge uint64, collateral *big.Int, price *big.Float, expiry *big.Int) (api.Ask, error) {
+func CreateMinerWithAsk(ctx context.Context, miner *fast.Filecoin, pledge uint64, collateral *big.Int, price *big.Float, expiry *big.Int) (porcelain.Ask, error) {
 
 	// Create miner
 	_, err := miner.MinerCreate(ctx, pledge, collateral, fast.AOPrice(big.NewFloat(1.0)), fast.AOLimit(300))
 	if err != nil {
-		return api.Ask{}, err
+		return porcelain.Ask{}, err
 	}
 
 	if err := miner.MiningStart(ctx); err != nil {
-		return api.Ask{}, err
+		return porcelain.Ask{}, err
 	}
 
 	return SetPriceGetAsk(ctx, miner, price, expiry)

--- a/tools/fast/series/import_and_store.go
+++ b/tools/fast/series/import_and_store.go
@@ -7,14 +7,14 @@ import (
 	"gx/ipfs/QmQmhotPUzVrMEWNK3x1R5jQ5ZHWyL7tVUrmRPjrBrvyCb/go-ipfs-files"
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 
-	"github.com/filecoin-project/go-filecoin/api"
+	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 )
 
 // ImportAndStore imports the `data` to the `client`, and proposes a storage
 // deal using the provided `ask`, returning the cid of the import and the
 // created deal.
-func ImportAndStore(ctx context.Context, client *fast.Filecoin, ask api.Ask, data files.File) (cid.Cid, *storagedeal.Response, error) {
+func ImportAndStore(ctx context.Context, client *fast.Filecoin, ask porcelain.Ask, data files.File) (cid.Cid, *storagedeal.Response, error) {
 	// Client neeeds to import the data
 	dcid, err := client.ClientImport(ctx, data)
 	if err != nil {

--- a/tools/fast/series/set_price_ask.go
+++ b/tools/fast/series/set_price_ask.go
@@ -7,46 +7,46 @@ import (
 	"math/big"
 
 	"github.com/filecoin-project/go-filecoin/abi"
-	"github.com/filecoin-project/go-filecoin/api"
+	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 )
 
 // SetPriceGetAsk issues a `set-price` and tries, to the best it can, return the
 // created ask. This series will run until it finds an ask, or the context is
 // canceled.
-func SetPriceGetAsk(ctx context.Context, miner *fast.Filecoin, price *big.Float, expiry *big.Int) (api.Ask, error) {
+func SetPriceGetAsk(ctx context.Context, miner *fast.Filecoin, price *big.Float, expiry *big.Int) (porcelain.Ask, error) {
 	// Set a price
 	pinfo, err := miner.MinerSetPrice(ctx, price, expiry, fast.AOPrice(big.NewFloat(1.0)), fast.AOLimit(300))
 	if err != nil {
-		return api.Ask{}, err
+		return porcelain.Ask{}, err
 	}
 
 	response, err := miner.MessageWait(ctx, pinfo.AddAskCid)
 	if err != nil {
-		return api.Ask{}, err
+		return porcelain.Ask{}, err
 	}
 
 	bbs := response.Receipt.Return[0]
 	value, err := abi.Deserialize(bbs, abi.Integer)
 	if err != nil {
-		return api.Ask{}, err
+		return porcelain.Ask{}, err
 	}
 
 	val, ok := value.Val.(*big.Int)
 	if !ok {
-		return api.Ask{}, fmt.Errorf("could not cast askid")
+		return porcelain.Ask{}, fmt.Errorf("could not cast askid")
 	}
 
-	var ask api.Ask
+	var ask porcelain.Ask
 	dec, err := miner.ClientListAsks(ctx)
 	if err != nil {
-		return api.Ask{}, err
+		return porcelain.Ask{}, err
 	}
 
 	for {
 		err := dec.Decode(&ask)
 		if err != nil && err != io.EOF {
-			return api.Ask{}, err
+			return porcelain.Ask{}, err
 		}
 
 		if val.Uint64() == ask.ID && ask.Miner == pinfo.MinerAddr {
@@ -58,5 +58,5 @@ func SetPriceGetAsk(ctx context.Context, miner *fast.Filecoin, price *big.Float,
 		}
 	}
 
-	return api.Ask{}, fmt.Errorf("could not find ask")
+	return porcelain.Ask{}, fmt.Errorf("could not find ask")
 }


### PR DESCRIPTION
# Problem

We want to remove the `api` directory, but Client ListAsks is part of it

# Solution

Moved Client ListAsks to porcelain

Resolves #1802 