### PR TITLE
test: add a "genesis" block

### DIFF
--- a/core/message_pool_test.go
+++ b/core/message_pool_test.go
@@ -265,7 +265,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		oldChain := NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{m[0]}}, msgsSet{msgs{m[1]}}, msgsSet{msgs{m[2]}})
 		oldTipSet := headOf(oldChain)
 
-		newChain := NewChainWithMessages(store, oldChain[0], msgsSet{msgs{m[3]}}, msgsSet{msgs{m[4], m[5]}})
+		newChain := NewChainWithMessages(store, oldChain[1], msgsSet{msgs{m[3]}}, msgsSet{msgs{m[4], m[5]}})
 		newTipSet := headOf(newChain)
 
 		assert.NoError(p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet))
@@ -289,7 +289,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		oldTipSet := headOf(oldChain)
 
-		newChain := NewChainWithMessages(store, oldChain[0],
+		newChain := NewChainWithMessages(store, oldChain[1],
 			msgsSet{msgs{m[3]}},
 			msgsSet{msgs{m[4]}},
 			msgsSet{msgs{m[5]}},
@@ -317,7 +317,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		oldTipSet := headOf(oldChain)
 
-		newChain := NewChainWithMessages(store, oldChain[0],
+		newChain := NewChainWithMessages(store, oldChain[1],
 			msgsSet{msgs{m[3]}},
 			msgsSet{msgs{m[4]}},
 			msgsSet{msgs{m[5]}, msgs{m[1], m[2]}},
@@ -370,7 +370,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		)
 		oldTipSet := headOf(oldChain)
 
-		oldTipSetPrev := oldChain[1]
+		oldTipSetPrev := oldChain[2]
 		assert.NoError(p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, oldTipSetPrev))
 		assertPoolEquals(assert, p, m[2], m[3])
 	})
@@ -408,7 +408,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		oldChain := NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{m[0]}}, msgsSet{msgs{m[1]}})
 		oldTipSet := headOf(oldChain)
 
-		newChain := NewChainWithMessages(store, oldChain[1],
+		newChain := NewChainWithMessages(store, oldChain[2],
 			msgsSet{msgs{m[2], m[3]}},
 			msgsSet{msgs{m[4]}},
 			msgsSet{msgs{m[5], m[6]}},

--- a/core/testing.go
+++ b/core/testing.go
@@ -69,16 +69,26 @@ func NewChainWithMessages(store *hamt.CborIpldStore, root types.TipSet, msgSets 
 	tipSets := []types.TipSet{}
 	parents := root
 
-	// only add root to the chain if it is not the zero-valued-tipset
-	if len(parents) != 0 {
-		for _, blk := range parents {
-			MustPut(store, blk)
+	// make a genesis block if we're starting a new chain.
+	if len(parents) == 0 {
+		genesis := &types.Block{
+			Height: types.Uint64(0),
 		}
-		tipSets = append(tipSets, parents)
+		parents = types.TipSet{
+			genesis.Cid(): genesis,
+		}
 	}
 
+	for _, blk := range parents {
+		MustPut(store, blk)
+	}
+
+	tipSets = append(tipSets, parents)
+
 	for _, tsMsgs := range msgSets {
+		// TODO: We shouldn't be ignoring this error...
 		height, _ := parents.Height()
+
 		ts := types.TipSet{}
 		// If a message set does not contain a slice of messages then
 		// add a tipset with no messages and a single block to the chain


### PR DESCRIPTION
Otherwise, if the initial tipset is empty, the first block has a height of 1.

Note: As far as I can tell, the genesis block _has_ to be empty because `UpdateMessagePool` skips the 0th (genesis) block.

(not sure if this is the right fix but the chain needs to start at 0)