### PR TITLE
build: switch to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+linters:
+  disable-all: true
+  enable:
+    - vet
+    - gofmt
+    - misspell
+    - goconst
+    - golint
+    - errcheck
+    - unconvert
+    - staticcheck
+    - varcheck
+    - structcheck
+    - deadcode
+
+linters-settings:
+  goconst:
+    min-occurrences: 6

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Due to our use of `cgo`, you'll need a C compiler to build go-filecoin whether y
 `go-filecoin` depends on some proofs code written in Rust, housed in the
 [rust-fil-proofs](https://github.com/filecoin-project/rust-fil-proofs) repo and consumed as a submodule. You will need to have `cargo` and `jq` installed.
 
-go-filecoin's dependencies are managed by [gx][2]; this project is not "go gettable." To install gx, gometalinter, and
+go-filecoin's dependencies are managed by [gx][2]; this project is not "go gettable." To install gx, golangci-lint, and
 other build and test dependencies (with precompiled proofs, recommended), run:
 
 ```sh

--- a/build/main.go
+++ b/build/main.go
@@ -212,36 +212,7 @@ func lint(packages ...string) {
 
 	log.Printf("Linting %s ...\n", strings.Join(packages, " "))
 
-	// Run fast linters batched together
-	configs := []string{
-		"golangci-lint",
-		"run",
-		"--skip-dirs=sharness,vendor",
-		"--disable-all",
-	}
-
-	fastLinters := []string{
-		"--enable=vet",
-		"--enable=gofmt",
-		"--enable=misspell",
-		"--enable=goconst",
-		"--enable=golint",
-		"--enable=errcheck",
-		"--goconst.min-occurrences=6",
-	}
-
-	runCmd(cmd(append(append(configs, fastLinters...), packages...)...))
-
-	slowLinters := []string{
-		"--deadline=10m",
-		"--enable=unconvert",
-		"--enable=staticcheck",
-		"--enable=varcheck",
-		"--enable=structcheck",
-		"--enable=deadcode",
-	}
-
-	runCmd(cmd(append(append(configs, slowLinters...), packages...)...))
+	runCmd(cmd("golangci-lint", "run"))
 }
 
 func build() {

--- a/build/main.go
+++ b/build/main.go
@@ -113,8 +113,7 @@ func deps() {
 		cmd("go get -u github.com/whyrusleeping/gx-go"),
 		cmd("gx install"),
 		cmd("gx-go rewrite"),
-		cmd("go get -u github.com/alecthomas/gometalinter"),
-		cmd("gometalinter --install"),
+		cmd("go get -u github.com/golangci/golangci-lint/cmd/golangci-lint"),
 		cmd("go get -u github.com/stretchr/testify"),
 		cmd("go get -u github.com/xeipuuv/gojsonschema"),
 		cmd("go get -u github.com/ipfs/iptb"),
@@ -146,7 +145,6 @@ func smartdeps() {
 	cmds := []command{
 		cmd("gx install"),
 		cmd("gx-go rewrite"),
-		cmd("gometalinter --install"),
 		cmd("./scripts/install-rust-fil-proofs.sh"),
 		cmd("./scripts/install-bls-signatures.sh"),
 		cmd("./scripts/install-filecoin-parameters.sh"),
@@ -154,7 +152,7 @@ func smartdeps() {
 
 	// packages we need to install
 	pkgs := []string{
-		"github.com/alecthomas/gometalinter",
+		"github.com/golangci/golangci-lint/cmd/golangci-lint",
 		"github.com/docker/docker/api/types",
 		"github.com/docker/docker/api/types/container",
 		"github.com/docker/docker/client",
@@ -206,7 +204,7 @@ func smartdeps() {
 	}
 }
 
-// lint runs linting using gometalinter
+// lint runs linting using golangci-lint
 func lint(packages ...string) {
 	if len(packages) == 0 {
 		packages = []string{"./..."}
@@ -216,9 +214,9 @@ func lint(packages ...string) {
 
 	// Run fast linters batched together
 	configs := []string{
-		"gometalinter",
-		"--skip=sharness",
-		"--skip=vendor",
+		"golangci-lint",
+		"run",
+		"--skip-dirs=sharness,vendor",
 		"--disable-all",
 	}
 
@@ -229,7 +227,7 @@ func lint(packages ...string) {
 		"--enable=goconst",
 		"--enable=golint",
 		"--enable=errcheck",
-		"--min-occurrences=6", // for goconst
+		"--goconst.min-occurrences=6",
 	}
 
 	runCmd(cmd(append(append(configs, fastLinters...), packages...)...))

--- a/consensus/expected_test.go
+++ b/consensus/expected_test.go
@@ -342,7 +342,7 @@ func (tv *FailingTestPowerTableView) Total(ctx context.Context, st state.Tree, b
 }
 
 func (tv *FailingTestPowerTableView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (uint64, error) {
-	return uint64(tv.minerPower), nil
+	return tv.minerPower, nil
 }
 
 func (tv *FailingTestPowerTableView) HasPower(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) bool {

--- a/metrics/heartbeat_test.go
+++ b/metrics/heartbeat_test.go
@@ -183,7 +183,7 @@ func mustMakeTipset(t *testing.T, height types.Uint64) types.TipSet {
 		Ticket:          nil,
 		Parents:         types.SortedCidSet{},
 		ParentWeight:    0,
-		Height:          types.Uint64(height),
+		Height:          height,
 		Nonce:           0,
 		Messages:        nil,
 		MessageReceipts: nil,

--- a/porcelain/miner_test.go
+++ b/porcelain/miner_test.go
@@ -68,8 +68,7 @@ func (mpc *minerCreate) MessageWait(ctx context.Context, msgCid cid.Cid, cb func
 		Return:   [][]byte{mpc.address.Bytes()},
 		ExitCode: uint8(0),
 	}
-	cb(nil, nil, receipt)
-	return nil
+	return cb(nil, nil, receipt)
 }
 
 func (mpc *minerCreate) WalletDefaultAddress() (address.Address, error) {

--- a/porcelain/mpool_test.go
+++ b/porcelain/mpool_test.go
@@ -85,7 +85,7 @@ func TestMessagePoolWait(t *testing.T) {
 				plumbing.pending = types.NewSignedMsgs(1, signer)
 				plumbing.subscription.Post(nil)
 			}
-			callCount += 1
+			callCount++
 		}
 
 		plumbing = newFakeMpoolWaitPlumbing(handlePendingCalled)

--- a/porcelain/wallet_test.go
+++ b/porcelain/wallet_test.go
@@ -84,7 +84,8 @@ func TestWalletDefaultAddress(t *testing.T) {
 
 		addr, err := wdatp.WalletNewAddress()
 		require.NoError(err)
-		wdatp.ConfigSet("wallet.defaultAddress", addr.String())
+		err = wdatp.ConfigSet("wallet.defaultAddress", addr.String())
+		require.NoError(err)
 
 		_, err = porcelain.WalletDefaultAddress(wdatp)
 		require.NoError(err)

--- a/proofs/sectorbuilder/testing/interface_test.go
+++ b/proofs/sectorbuilder/testing/interface_test.go
@@ -262,9 +262,7 @@ func TestSectorBuilder(t *testing.T) {
 
 		// seal everything
 		err = hB.SectorBuilder.SealAllStagedSectors(context.Background())
-		if err != nil {
-			require.NoError(t, err)
-		}
+		require.NoError(t, err)
 
 		timeout := time.After(MaxTimeToSealASector * 2)
 	Loop:

--- a/proofs/sectorbuilder/testing/interface_test.go
+++ b/proofs/sectorbuilder/testing/interface_test.go
@@ -58,7 +58,10 @@ func TestSectorBuilder(t *testing.T) {
 		for i := 0; i < autoSealsToSchedule; i++ {
 			go func(n int) {
 				time.Sleep(time.Second * time.Duration(n))
-				h.SectorBuilder.SealAllStagedSectors(context.Background())
+				err := h.SectorBuilder.SealAllStagedSectors(context.Background())
+				if err != nil {
+					errs <- err
+				}
 			}(i)
 		}
 
@@ -258,7 +261,10 @@ func TestSectorBuilder(t *testing.T) {
 		sectorIDSet.Store(sectorIDB, true)
 
 		// seal everything
-		hB.SectorBuilder.SealAllStagedSectors(context.Background())
+		err = hB.SectorBuilder.SealAllStagedSectors(context.Background())
+		if err != nil {
+			require.NoError(t, err)
+		}
 
 		timeout := time.After(MaxTimeToSealASector * 2)
 	Loop:

--- a/repo/fsrepo_test.go
+++ b/repo/fsrepo_test.go
@@ -408,7 +408,8 @@ func TestCreateRepo(t *testing.T) {
 		assert.NoError(err)
 		defer os.RemoveAll(dir)
 
-		ioutil.WriteFile(filepath.Join(dir, "config.json"), []byte("hello"), 0644)
+		err = ioutil.WriteFile(filepath.Join(dir, "config.json"), []byte("hello"), 0644)
+		assert.NoError(err)
 
 		_, err = CreateRepo(dir, cfg)
 		assert.Contains(err.Error(), "repo already initialized")

--- a/tools/fast/series/connect.go
+++ b/tools/fast/series/connect.go
@@ -3,8 +3,6 @@ package series
 import (
 	"context"
 
-	"gx/ipfs/QmNTCey11oxhb1AxDnQBRHtdhap6Ctud872NjAYPYYXPuc/go-multiaddr"
-
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 )
 
@@ -15,16 +13,7 @@ func Connect(ctx context.Context, from, to *fast.Filecoin) error {
 		return err
 	}
 
-	var addrs []multiaddr.Multiaddr
-	for _, addr := range details.Addresses {
-		if err != nil {
-			return err
-		}
-
-		addrs = append(addrs, addr)
-	}
-
-	if _, err := from.SwarmConnect(ctx, addrs...); err != nil {
+	if _, err := from.SwarmConnect(ctx, details.Addresses...); err != nil {
 		return err
 	}
 

--- a/tools/iptb-plugins/filecoin/docker/iptb_metrics.go
+++ b/tools/iptb-plugins/filecoin/docker/iptb_metrics.go
@@ -14,8 +14,10 @@ func (l *Dockerfilecoin) Events() (io.ReadCloser, error) {
 
 // StderrReader provides an io.ReadCloser to the running daemons stderr
 func (l *Dockerfilecoin) StderrReader() (io.ReadCloser, error) {
-	cli, _ := l.GetClient()
-	ctx, _ := context.WithCancel(context.Background()) // nolint: vet
+	cli, err := l.GetClient()
+	if err != nil {
+		return nil, err
+	}
 
 	options := types.ContainerLogsOptions{
 		ShowStdout: false,
@@ -23,13 +25,15 @@ func (l *Dockerfilecoin) StderrReader() (io.ReadCloser, error) {
 		Follow:     true,
 	}
 
-	return cli.ContainerLogs(ctx, l.ID, options)
+	return cli.ContainerLogs(context.Background(), l.ID, options)
 }
 
 // StdoutReader provides an io.ReadCloser to the running daemons stdout
 func (l *Dockerfilecoin) StdoutReader() (io.ReadCloser, error) {
-	cli, _ := l.GetClient()
-	ctx, _ := context.WithCancel(context.Background()) // nolint: vet
+	cli, err := l.GetClient()
+	if err != nil {
+		return nil, err
+	}
 
 	options := types.ContainerLogsOptions{
 		ShowStdout: true,
@@ -37,7 +41,7 @@ func (l *Dockerfilecoin) StdoutReader() (io.ReadCloser, error) {
 		Follow:     true,
 	}
 
-	return cli.ContainerLogs(ctx, l.ID, options)
+	return cli.ContainerLogs(context.Background(), l.ID, options)
 }
 
 // Heartbeat not implemented

--- a/tools/iptb-plugins/filecoin/util.go
+++ b/tools/iptb-plugins/filecoin/util.go
@@ -24,9 +24,7 @@ func WaitOnAPI(l testbedi.Libp2p) error {
 		if err == nil {
 			return nil
 		}
-		if err != nil {
-			log.Warning(err.Error())
-		}
+		log.Warning(err.Error())
 		time.Sleep(time.Millisecond * 400)
 	}
 


### PR DESCRIPTION
This also switches to a single lint stage because the linters run in ~10s (on my machine, at least).

fixes #2207 

(currently based off #2305)