### PR TITLE
Hook up expiry of messages from the outbound queue (outbox)

### DIFF
--- a/core/chains.go
+++ b/core/chains.go
@@ -9,6 +9,8 @@ import (
 
 // CollectBlocksToCommonAncestor traverses chains from two tipsets (called old and new) until their common
 // ancestor, collecting all blocks that are in one chain but not the other.
+// The resulting lists of blocks are ordered by decreasing height; the ordering of blocks with the same
+// height is undefined until https://github.com/filecoin-project/go-filecoin/issues/2310 is resolved.
 func CollectBlocksToCommonAncestor(ctx context.Context, store chain.BlockProvider, oldHead, newHead types.TipSet) (oldBlocks, newBlocks []*types.Block, err error) {
 	// Strategy: walk head-of-chain pointers old and new back until they are at the same height,
 	// then walk back in lockstep to find the common ancestor.

--- a/core/policy.go
+++ b/core/policy.go
@@ -1,0 +1,93 @@
+package core
+
+import (
+	"context"
+
+	logging "gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// OutboxMaxAgeRounds is the maximum age (in consensus rounds) to permit messages to stay in the outbound message queue.
+// This should be a little longer than the message pool's timeout so that messages expire from mining
+// pools a little before the sending node gives up on them.
+const OutboxMaxAgeRounds = 10
+
+var log = logging.Logger("mqueue")
+
+// The outbound queue object on which the policy acts.
+type policyTarget interface {
+	RemoveNext(sender address.Address, expectedNonce uint64) (msg *types.SignedMessage, found bool, err error)
+	ExpireBefore(stamp uint64) map[address.Address][]*types.SignedMessage
+}
+
+// MessageQueuePolicy manages a target message queue state in response to changes on the blockchain.
+// Messages are removed from the queue as soon as they appear in a block that's part of a heaviest chain.
+// At this point, messages are highly likely to be valid and known to a large number of nodes,
+// even if the block ends up as an abandoned fork.
+// There is no special handling for re-orgs and messages do not revert to the queue if the block
+// ends up childless (in contrast to the message pool).
+type MessageQueuePolicy struct {
+	// The queue on which this policy acts
+	queue policyTarget
+	store chain.BlockProvider
+	// Maximum difference in message stamp from current block height before expiring an address's queue
+	maxAgeRounds uint64
+}
+
+// NewMessageQueuePolicy returns a new policy which removes mined messages from the queue and expires
+// messages older than `maxAgeRounds` rounds.
+func NewMessageQueuePolicy(queue *MessageQueue, store chain.BlockProvider, maxAge uint64) *MessageQueuePolicy {
+	return &MessageQueuePolicy{queue, store, maxAge}
+}
+
+// OnNewHeadTipset updates the policy target in response to a new head tipset.
+func (p *MessageQueuePolicy) OnNewHeadTipset(ctx context.Context, oldHead, newHead types.TipSet) error {
+	_, newBlocks, err := CollectBlocksToCommonAncestor(ctx, p.store, oldHead, newHead)
+	if err != nil {
+		return err
+	}
+
+	// Remove from the queue all messages that have now been mined in new blocks.
+
+	// Rearrange the blocks in increasing height order so messages are discovered in order.
+	// Note: this is imperfect until CollectBlocksToCommonAncestor is updated to return blocks
+	// at the same height in canonical (ticket) order.
+	reverse(newBlocks)
+	for _, block := range newBlocks {
+		for _, minedMsg := range block.Messages {
+			removed, found, err := p.queue.RemoveNext(minedMsg.From, uint64(minedMsg.Nonce))
+			if err != nil {
+				return err
+			}
+			if found && minedMsg != removed {
+				log.Errorf("Queued message %v differs from mined message %v with same sender & nonce", removed, minedMsg)
+			}
+			// Else if not found, the message was not sent by this node, or has already been removed
+			// from the queue (e.g. a blockchain re-org).
+		}
+	}
+
+	// Expire messages that have been in the queue for too long; they will probably never be mined.
+	height, err := newHead.Height()
+	if err != nil {
+		return err
+	}
+	if height >= p.maxAgeRounds { // avoid uint subtraction overflow
+		expired := p.queue.ExpireBefore(height - p.maxAgeRounds)
+		for _, msg := range expired {
+			log.Errorf("Outbound message %v expired un-mined after %d rounds", msg, p.maxAgeRounds)
+		}
+	}
+	return nil
+}
+
+func reverse(list []*types.Block) {
+	// https://github.com/golang/go/wiki/SliceTricks#reversing
+	for i := len(list)/2 - 1; i >= 0; i-- {
+		opp := len(list) - 1 - i
+		list[i], list[opp] = list[opp], list[i]
+	}
+}

--- a/core/policy_test.go
+++ b/core/policy_test.go
@@ -1,0 +1,162 @@
+package core_test
+
+import (
+	"context"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+	"testing"
+
+	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/core"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// Tests for the outbound message queue policy.
+// These tests could use a fake/mock policy target, but it would require some sophistication to
+// validate the order of removals, so using a real queue is a bit easier.
+func TestMessageQueuePolicy(t *testing.T) {
+	t.Parallel() // Individual tests share a MessageMaker so not parallel (but quick)
+	ctx := context.Background()
+	assert := assert.New(t)
+	require := require.New(t)
+
+	keys := types.MustGenerateKeyInfo(2, types.GenerateKeyInfoSeed())
+	mm := types.NewMessageMaker(t, keys)
+
+	alice := mm.Addresses()[0]
+	bob := mm.Addresses()[1]
+
+	requireEnqueue := func(q *core.MessageQueue, msg *types.SignedMessage, stamp uint64) *types.SignedMessage {
+		err := q.Enqueue(msg, stamp)
+		require.NoError(err)
+		return msg
+	}
+
+	t.Run("old block does nothing", func(t *testing.T) {
+		blocks := chain.NewFakeBlockProvider()
+		q := core.NewMessageQueue()
+		policy := core.NewMessageQueuePolicy(q, blocks, 10)
+
+		fromAlice := mm.NewSignedMessage(alice, 1)
+		fromBob := mm.NewSignedMessage(bob, 1)
+		requireEnqueue(q, fromAlice, 100)
+		requireEnqueue(q, fromBob, 200)
+
+		root := blocks.NewBlock(0) // Height = 0
+		b1 := blocks.NewBlockWithMessages(1, []*types.SignedMessage{}, root)
+
+		err := policy.OnNewHeadTipset(ctx, requireTipset(t, root), requireTipset(t, b1))
+		assert.NoError(err)
+		assert.Equal(qm(fromAlice, 100), q.List(alice)[0])
+		assert.Equal(qm(fromBob, 200), q.List(bob)[0])
+	})
+
+	t.Run("removes mined messages", func(t *testing.T) {
+		blocks := chain.NewFakeBlockProvider()
+		q := core.NewMessageQueue()
+		policy := core.NewMessageQueuePolicy(q, blocks, 10)
+
+		msgs := []*types.SignedMessage{
+			requireEnqueue(q, mm.NewSignedMessage(alice, 1), 100),
+			requireEnqueue(q, mm.NewSignedMessage(alice, 2), 101),
+			requireEnqueue(q, mm.NewSignedMessage(alice, 3), 102),
+			requireEnqueue(q, mm.NewSignedMessage(bob, 1), 100),
+		}
+
+		assert.Equal(qm(msgs[0], 100), q.List(alice)[0])
+		assert.Equal(qm(msgs[3], 100), q.List(bob)[0])
+
+		root := blocks.NewBlock(0)
+		root.Height = 103
+		b1 := blocks.NewBlockWithMessages(1, []*types.SignedMessage{msgs[0]}, root)
+
+		err := policy.OnNewHeadTipset(ctx, requireTipset(t, root), requireTipset(t, b1))
+		require.NoError(err)
+		assert.Equal(qm(msgs[1], 101), q.List(alice)[0]) // First message removed successfully
+		assert.Equal(qm(msgs[3], 100), q.List(bob)[0])   // No change
+
+		// A block with no messages does nothing
+		b2 := blocks.NewBlockWithMessages(2, []*types.SignedMessage{}, b1)
+		err = policy.OnNewHeadTipset(ctx, requireTipset(t, b1), requireTipset(t, b2))
+		require.NoError(err)
+		assert.Equal(qm(msgs[1], 101), q.List(alice)[0])
+		assert.Equal(qm(msgs[3], 100), q.List(bob)[0])
+
+		// Block with both alice and bob's next message
+		b3 := blocks.NewBlockWithMessages(3, []*types.SignedMessage{msgs[1], msgs[3]}, b2)
+		err = policy.OnNewHeadTipset(ctx, requireTipset(t, b2), requireTipset(t, b3))
+		require.NoError(err)
+		assert.Equal(qm(msgs[2], 102), q.List(alice)[0])
+		assert.Empty(q.List(bob)) // None left
+
+		// Block with alice's last message
+		b4 := blocks.NewBlockWithMessages(4, []*types.SignedMessage{msgs[2]}, b3)
+		err = policy.OnNewHeadTipset(ctx, requireTipset(t, b3), requireTipset(t, b4))
+		require.NoError(err)
+		assert.Empty(q.List(alice))
+	})
+
+	t.Run("expires old messages", func(t *testing.T) {
+		blocks := chain.NewFakeBlockProvider()
+		q := core.NewMessageQueue()
+		policy := core.NewMessageQueuePolicy(q, blocks, 10)
+
+		msgs := []*types.SignedMessage{
+			requireEnqueue(q, mm.NewSignedMessage(alice, 1), 100),
+			requireEnqueue(q, mm.NewSignedMessage(alice, 2), 101),
+			requireEnqueue(q, mm.NewSignedMessage(alice, 3), 102),
+			requireEnqueue(q, mm.NewSignedMessage(bob, 1), 200),
+		}
+
+		assert.Equal(qm(msgs[0], 100), q.List(alice)[0])
+		assert.Equal(qm(msgs[3], 200), q.List(bob)[0])
+
+		root := blocks.NewBlock(0)
+		root.Height = 100
+
+		// Skip exactly 10 rounds since alice's first message enqueued
+		b1 := blocks.NewBlock(1, root)
+		b1.Height = 110
+		err := policy.OnNewHeadTipset(ctx, requireTipset(t, root), requireTipset(t, b1))
+		require.NoError(err)
+
+		assert.Equal(qm(msgs[0], 100), q.List(alice)[0]) // No change
+		assert.Equal(qm(msgs[3], 200), q.List(bob)[0])
+
+		b2 := blocks.NewBlock(2, b1) // Height 111
+		err = policy.OnNewHeadTipset(ctx, requireTipset(t, b1), requireTipset(t, b2))
+		require.NoError(err)
+		assert.Empty(q.List(alice))                    // Alice's messages all expired
+		assert.Equal(qm(msgs[3], 200), q.List(bob)[0]) // Bob's remain
+	})
+
+	t.Run("fails when messages out of nonce order", func(t *testing.T) {
+		blocks := chain.NewFakeBlockProvider()
+		q := core.NewMessageQueue()
+		policy := core.NewMessageQueuePolicy(q, blocks, 10)
+
+		msgs := []*types.SignedMessage{
+			requireEnqueue(q, mm.NewSignedMessage(alice, 1), 100),
+			requireEnqueue(q, mm.NewSignedMessage(alice, 2), 101),
+			requireEnqueue(q, mm.NewSignedMessage(alice, 3), 102),
+		}
+
+		root := blocks.NewBlock(0)
+		root.Height = 100
+
+		b1 := blocks.NewBlockWithMessages(1, []*types.SignedMessage{msgs[1]}, root)
+		err := policy.OnNewHeadTipset(ctx, requireTipset(t, root), requireTipset(t, b1))
+		require.Error(err)
+		assert.Contains(err.Error(), "nonce 1, expected 2")
+	})
+}
+
+func requireTipset(t *testing.T, blocks ...*types.Block) types.TipSet {
+	set, err := types.NewTipSet(blocks...)
+	require.NoError(t, err)
+	return set
+}
+
+func qm(msg *types.SignedMessage, stamp uint64) *core.QueuedMessage {
+	return &core.QueuedMessage{Msg: msg, Stamp: stamp}
+}

--- a/types/testing_messages.go
+++ b/types/testing_messages.go
@@ -1,0 +1,60 @@
+package types
+
+import (
+	"fmt"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+	"testing"
+
+	"github.com/filecoin-project/go-filecoin/address"
+)
+
+// MessageMaker creates unique, signed messages for use in tests.
+type MessageMaker struct {
+	DefaultGasPrice AttoFIL
+	DefaultGasUnits GasUnits
+
+	signer *MockSigner
+	seq    uint
+	t      *testing.T
+}
+
+// NewMessageMaker creates a new message maker with a set of signing keys.
+func NewMessageMaker(t *testing.T, keys []KeyInfo) *MessageMaker {
+	addresses := make([]address.Address, len(keys))
+	signer := NewMockSigner(keys)
+
+	for i, key := range keys {
+		addr, _ := key.Address()
+		addresses[i] = addr
+	}
+
+	return &MessageMaker{*ZeroAttoFIL, NewGasUnits(0), &signer, 0, t}
+}
+
+// Addresses returns the addresses for which this maker can sign messages.
+func (mm *MessageMaker) Addresses() []address.Address {
+	return mm.signer.Addresses
+}
+
+// Signer returns the signer with which this maker signs messages.
+func (mm *MessageMaker) Signer() *MockSigner {
+	return mm.signer
+}
+
+// NewSignedMessage creates a new message.
+func (mm *MessageMaker) NewSignedMessage(from address.Address, nonce uint64) *SignedMessage {
+	seq := mm.seq
+	mm.seq++
+	to, err := address.NewActorAddress([]byte("destination"))
+	require.NoError(mm.t, err)
+	msg := NewMessage(
+		from,
+		to,
+		nonce,
+		NewAttoFILFromFIL(0),
+		"method"+fmt.Sprintf("%d", seq),
+		[]byte("params"))
+	signed, err := NewSignedMessage(*msg, mm.signer, mm.DefaultGasPrice, mm.DefaultGasUnits)
+	require.NoError(mm.t, err)
+	return signed
+}


### PR DESCRIPTION
Note that the sender does not yet put messages in the outbox, so the queue is always empty at the moment.

I think we can do better than "policy" for that object, but want the name to stay somewhat meaningful (not "manager"). Suggestions welcome.

Closes #2209.