### PR TITLE
Hook up message sender to put messages in outbound queue

### DIFF
--- a/core/policy.go
+++ b/core/policy.go
@@ -62,7 +62,7 @@ func (p *MessageQueuePolicy) OnNewHeadTipset(ctx context.Context, oldHead, newHe
 			if err != nil {
 				return err
 			}
-			if found && minedMsg != removed {
+			if found && !minedMsg.Equals(removed) {
 				log.Errorf("Queued message %v differs from mined message %v with same sender & nonce", removed, minedMsg)
 			}
 			// Else if not found, the message was not sent by this node, or has already been removed

--- a/core/testing.go
+++ b/core/testing.go
@@ -37,11 +37,19 @@ func MustGetNonce(st state.Tree, a address.Address) uint64 {
 	return nonce
 }
 
-// MustAdd adds the given messages to the messagepool or panics if it
-// cannot.
+// MustAdd adds the given messages to the messagepool or panics if it cannot.
 func MustAdd(p *MessagePool, msgs ...*types.SignedMessage) {
 	for _, m := range msgs {
 		if _, err := p.Add(m); err != nil {
+			panic(err)
+		}
+	}
+}
+
+// MustEnqueue adds the given messages to the messagepool or panics if it cannot.
+func MustEnqueue(q *MessageQueue, stamp uint64, msgs ...*types.SignedMessage) {
+	for _, m := range msgs {
+		if err := q.Enqueue(m, stamp); err != nil {
 			panic(err)
 		}
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -421,7 +421,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 		MsgPool:      msgPool,
 		MsgPreviewer: msg.NewPreviewer(fcWallet, chainStore, &cstOffline, bs),
 		MsgQueryer:   msg.NewQueryer(nc.Repo, fcWallet, chainStore, &cstOffline, bs),
-		MsgSender:    msg.NewSender(fcWallet, chainStore, msgPool, consensus.NewOutboundMessageValidator(), fsub.Publish),
+		MsgSender:    msg.NewSender(fcWallet, chainStore, chainStore, outbox, msgPool, consensus.NewOutboundMessageValidator(), fsub.Publish),
 		MsgWaiter:    msg.NewWaiter(chainStore, bs, &cstOffline),
 		Network:      net.New(peerHost, pubsub.NewPublisher(fsub), pubsub.NewSubscriber(fsub), net.NewRouter(router), bandwidthTracker, pinger),
 		SigGetter:    mthdsig.NewGetter(chainStore),

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -164,7 +164,7 @@ func TestNodeStartMining(t *testing.T) {
 		MsgPool:      nil,
 		MsgPreviewer: msg.NewPreviewer(minerNode.Wallet, minerNode.ChainReader, minerNode.CborStore(), minerNode.Blockstore),
 		MsgQueryer:   msg.NewQueryer(minerNode.Repo, minerNode.Wallet, minerNode.ChainReader, minerNode.CborStore(), minerNode.Blockstore),
-		MsgSender:    msg.NewSender(minerNode.Wallet, minerNode.ChainReader, minerNode.MsgPool, validator, minerNode.PorcelainAPI.PubSubPublish),
+		MsgSender:    msg.NewSender(minerNode.Wallet, nil, nil, minerNode.Outbox, minerNode.MsgPool, validator, minerNode.PorcelainAPI.PubSubPublish),
 		MsgWaiter:    msg.NewWaiter(minerNode.ChainReader, minerNode.Blockstore, minerNode.CborStore()),
 		Network:      net.New(minerNode.Host(), nil, nil, nil, nil, nil),
 		SigGetter:    mthdsig.NewGetter(minerNode.ChainReader),

--- a/plumbing/msg/sender.go
+++ b/plumbing/msg/sender.go
@@ -10,7 +10,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/core"
-	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
@@ -66,7 +65,7 @@ func (s *Sender) Send(ctx context.Context, from, to address.Address, value *type
 		return cid.Undef, errors.Wrapf(err, "no actor at address %s", from)
 	}
 
-	nonce, err := nextNonce(ctx, st, s.msgPool, from)
+	nonce, err := nextNonce(fromActor, s.msgPool, from)
 	if err != nil {
 		return cid.Undef, errors.Wrapf(err, "failed calculating nonce for actor %s", from)
 	}
@@ -102,12 +101,7 @@ func (s *Sender) Send(ctx context.Context, from, to address.Address, value *type
 
 // nextNonce returns the next expected nonce value for an account actor. This is the larger
 // of the actor's nonce value, or one greater than the largest nonce from the actor found in the message pool.
-// The address must be the address of an account actor, or be not contained in, in the provided state tree.
-func nextNonce(ctx context.Context, st state.Tree, pool *core.MessagePool, address address.Address) (uint64, error) {
-	act, err := st.GetActor(ctx, address)
-	if err != nil && !state.IsActorNotFoundError(err) {
-		return 0, err
-	}
+func nextNonce(act *actor.Actor, pool *core.MessagePool, address address.Address) (uint64, error) {
 	actorNonce, err := actor.NextNonce(act)
 	if err != nil {
 		return 0, err

--- a/plumbing/msg/sender.go
+++ b/plumbing/msg/sender.go
@@ -10,6 +10,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/core"
+	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
@@ -19,6 +20,12 @@ import (
 // Topic is the network pubsub topic identifier on which new messages are announced.
 const Topic = "/fil/msgs"
 
+// Abstracts over a store of blockchain state.
+type chainState interface {
+	// LatestState returns the latest chain state.
+	LatestState(ctx context.Context) (state.Tree, error)
+}
+
 // PublishFunc is a function the Sender calls to publish a message to the network.
 type PublishFunc func(topic string, data []byte) error
 
@@ -26,10 +33,14 @@ type PublishFunc func(topic string, data []byte) error
 type Sender struct {
 	// Signs messages.
 	signer types.Signer
-	// Provides actor state (we could reduce this dependency to only LatestState()).
-	chainReader chain.ReadStore
-	// Pool of existing message, and receiver of the sent message.
-	msgPool *core.MessagePool
+	// Provides actor state
+	chainState chainState
+	// Provides the current block height
+	blockTimer core.BlockTimer
+	// Tracks inbound messages for mining
+	inbox *core.MessagePool
+	// Tracks outbound messages
+	outbox *core.MessageQueue
 	// Validates messages before sending them.
 	validator consensus.SignedMessageValidator
 	// Invoked to publish the new message to the network.
@@ -40,8 +51,18 @@ type Sender struct {
 
 // NewSender returns a new Sender. There should be exactly one of these per node because
 // sending locks to reduce nonce collisions.
-func NewSender(signer types.Signer, chainReader chain.ReadStore, msgPool *core.MessagePool, validator consensus.SignedMessageValidator, publish PublishFunc) *Sender {
-	return &Sender{signer: signer, chainReader: chainReader, msgPool: msgPool, validator: validator, publish: publish}
+func NewSender(signer types.Signer, chainReader chain.ReadStore, blockTimer core.BlockTimer,
+	msgQueue *core.MessageQueue, msgPool *core.MessagePool,
+	validator consensus.SignedMessageValidator, publish PublishFunc) *Sender {
+	return &Sender{
+		signer:     signer,
+		chainState: chainReader,
+		blockTimer: blockTimer,
+		inbox:      msgPool,
+		outbox:     msgQueue,
+		validator:  validator,
+		publish:    publish,
+	}
 }
 
 // Send sends a message. See api description.
@@ -55,7 +76,7 @@ func (s *Sender) Send(ctx context.Context, from, to address.Address, value *type
 	s.l.Lock()
 	defer s.l.Unlock()
 
-	st, err := s.chainReader.LatestState(ctx)
+	st, err := s.chainState.LatestState(ctx)
 	if err != nil {
 		return cid.Undef, errors.Wrap(err, "failed to load state from chain")
 	}
@@ -65,7 +86,7 @@ func (s *Sender) Send(ctx context.Context, from, to address.Address, value *type
 		return cid.Undef, errors.Wrapf(err, "no actor at address %s", from)
 	}
 
-	nonce, err := nextNonce(fromActor, s.msgPool, from)
+	nonce, err := nextNonce(fromActor, s.outbox, from)
 	if err != nil {
 		return cid.Undef, errors.Wrapf(err, "failed calculating nonce for actor %s", from)
 	}
@@ -86,9 +107,17 @@ func (s *Sender) Send(ctx context.Context, from, to address.Address, value *type
 		return cid.Undef, errors.Wrap(err, "failed to marshal message")
 	}
 
-	// Add to the local message pool at the last possible moment before broadcasting to network.
-	if _, err := s.msgPool.Add(smsg); err != nil {
-		return cid.Undef, errors.Wrap(err, "failed to add message to the message pool")
+	height, err := s.blockTimer.BlockHeight()
+	if err != nil {
+		return cid.Undef, errors.Wrap(err, "failed to get block height")
+	}
+
+	// Add to the local message queue/pool at the last possible moment before broadcasting to network.
+	if err := s.outbox.Enqueue(smsg, height); err != nil {
+		return cid.Undef, errors.Wrap(err, "failed to add message to outbound queue")
+	}
+	if _, err := s.inbox.Add(smsg); err != nil {
+		return cid.Undef, errors.Wrap(err, "failed to add message to message pool")
 	}
 
 	if err = s.publish(Topic, smsgdata); err != nil {
@@ -101,13 +130,13 @@ func (s *Sender) Send(ctx context.Context, from, to address.Address, value *type
 
 // nextNonce returns the next expected nonce value for an account actor. This is the larger
 // of the actor's nonce value, or one greater than the largest nonce from the actor found in the message pool.
-func nextNonce(act *actor.Actor, pool *core.MessagePool, address address.Address) (uint64, error) {
+func nextNonce(act *actor.Actor, outbox *core.MessageQueue, address address.Address) (uint64, error) {
 	actorNonce, err := actor.NextNonce(act)
 	if err != nil {
 		return 0, err
 	}
 
-	poolNonce, found := pool.LargestNonce(address)
+	poolNonce, found := outbox.LargestNonce(address)
 	if found && poolNonce >= actorNonce {
 		return poolNonce + 1, nil
 	}


### PR DESCRIPTION
The sender now uses the outbound queue for nonce calculation. Inbox/outbox terminology suggested by @rosalinekarr, and I think we could push it further. Closes #2146.

- [x] Based on #2272
- [x] Merge #2311 first (which expires old messages from the queue)

@acruikshank this about finishes the hookup of the outbound queue (still to add a status command and msgwait equivalent). Not for this PR, but we can discuss more cohesion with the message pool.
- I think the `Sender` is doing too much work for a bit of plumbing and could be factored out next to the message pool/queue implementations
- I would also extract UpdateMessagePool next to the the outbound queue expiry policy thingy