### PR TITLE
FAST payment channel tests

### DIFF
--- a/commands/payment_channel.go
+++ b/commands/payment_channel.go
@@ -31,7 +31,8 @@ var paymentChannelCmd = &cmds.Command{
 	},
 }
 
-type createChannelResult struct {
+// CreateChannelResult type returned from CreateChannel
+type CreateChannelResult struct {
 	Cid     cid.Cid
 	GasUsed types.GasUnits
 	Preview bool
@@ -91,7 +92,7 @@ message to be mined to get the channelID.`,
 			if err != nil {
 				return err
 			}
-			return re.Emit(&createChannelResult{
+			return re.Emit(&CreateChannelResult{
 				Cid:     cid.Cid{},
 				GasUsed: usedGas,
 				Preview: true,
@@ -113,15 +114,15 @@ message to be mined to get the channelID.`,
 			return err
 		}
 
-		return re.Emit(&createChannelResult{
+		return re.Emit(&CreateChannelResult{
 			Cid:     c,
 			GasUsed: types.NewGasUnits(0),
 			Preview: false,
 		})
 	},
-	Type: &createChannelResult{},
+	Type: &CreateChannelResult{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *createChannelResult) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *CreateChannelResult) error {
 			if res.Preview {
 				output := strconv.FormatUint(uint64(res.GasUsed), 10)
 				_, err := w.Write([]byte(output))
@@ -233,7 +234,8 @@ var voucherCmd = &cmds.Command{
 	},
 }
 
-type redeemResult struct {
+// RedeemResult type returned from Redeem
+type RedeemResult struct {
 	Cid     cid.Cid
 	GasUsed types.GasUnits
 	Preview bool
@@ -285,7 +287,7 @@ var redeemCmd = &cmds.Command{
 			if err != nil {
 				return err
 			}
-			return re.Emit(&redeemResult{
+			return re.Emit(&RedeemResult{
 				Cid:     cid.Cid{},
 				GasUsed: usedGas,
 				Preview: true,
@@ -311,15 +313,15 @@ var redeemCmd = &cmds.Command{
 			return err
 		}
 
-		return re.Emit(&redeemResult{
+		return re.Emit(&RedeemResult{
 			Cid:     c,
 			GasUsed: types.NewGasUnits(0),
 			Preview: false,
 		})
 	},
-	Type: &redeemResult{},
+	Type: &RedeemResult{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *redeemResult) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *RedeemResult) error {
 			if res.Preview {
 				output := strconv.FormatUint(uint64(res.GasUsed), 10)
 				_, err := w.Write([]byte(output))
@@ -330,7 +332,8 @@ var redeemCmd = &cmds.Command{
 	},
 }
 
-type reclaimResult struct {
+// ReclaimResult type returned from Reclaim
+type ReclaimResult struct {
 	Cid     cid.Cid
 	GasUsed types.GasUnits
 	Preview bool
@@ -376,7 +379,7 @@ var reclaimCmd = &cmds.Command{
 			if err != nil {
 				return err
 			}
-			return re.Emit(&reclaimResult{
+			return re.Emit(&ReclaimResult{
 				Cid:     cid.Cid{},
 				GasUsed: usedGas,
 				Preview: true,
@@ -397,15 +400,15 @@ var reclaimCmd = &cmds.Command{
 			return err
 		}
 
-		return re.Emit(&reclaimResult{
+		return re.Emit(&ReclaimResult{
 			Cid:     c,
 			GasUsed: types.NewGasUnits(0),
 			Preview: false,
 		})
 	},
-	Type: &reclaimResult{},
+	Type: &ReclaimResult{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *reclaimResult) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *ReclaimResult) error {
 			if res.Preview {
 				output := strconv.FormatUint(uint64(res.GasUsed), 10)
 				_, err := w.Write([]byte(output))
@@ -416,7 +419,8 @@ var reclaimCmd = &cmds.Command{
 	},
 }
 
-type closeResult struct {
+// CloseResult type returned from Close
+type CloseResult struct {
 	Cid     cid.Cid
 	GasUsed types.GasUnits
 	Preview bool
@@ -468,7 +472,7 @@ var closeCmd = &cmds.Command{
 			if err != nil {
 				return err
 			}
-			return re.Emit(&closeResult{
+			return re.Emit(&CloseResult{
 				Cid:     cid.Cid{},
 				GasUsed: usedGas,
 				Preview: true,
@@ -494,15 +498,15 @@ var closeCmd = &cmds.Command{
 			return err
 		}
 
-		return re.Emit(&closeResult{
+		return re.Emit(&CloseResult{
 			Cid:     c,
 			GasUsed: types.NewGasUnits(0),
 			Preview: false,
 		})
 	},
-	Type: &closeResult{},
+	Type: &CloseResult{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *closeResult) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *CloseResult) error {
 			if res.Preview {
 				output := strconv.FormatUint(uint64(res.GasUsed), 10)
 				_, err := w.Write([]byte(output))
@@ -513,7 +517,8 @@ var closeCmd = &cmds.Command{
 	},
 }
 
-type extendResult struct {
+// ExtendResult type returned from Extend
+type ExtendResult struct {
 	Cid     cid.Cid
 	GasUsed types.GasUnits
 	Preview bool
@@ -571,7 +576,7 @@ var extendCmd = &cmds.Command{
 			if err != nil {
 				return err
 			}
-			return re.Emit(&extendResult{
+			return re.Emit(&ExtendResult{
 				Cid:     cid.Cid{},
 				GasUsed: usedGas,
 				Preview: true,
@@ -592,15 +597,15 @@ var extendCmd = &cmds.Command{
 			return err
 		}
 
-		return re.Emit(&extendResult{
+		return re.Emit(&ExtendResult{
 			Cid:     c,
 			GasUsed: types.NewGasUnits(0),
 			Preview: false,
 		})
 	},
-	Type: &extendResult{},
+	Type: &ExtendResult{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *extendResult) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *ExtendResult) error {
 			if res.Preview {
 				output := strconv.FormatUint(uint64(res.GasUsed), 10)
 				_, err := w.Write([]byte(output))

--- a/commands/payment_channel_daemon_test.go
+++ b/commands/payment_channel_daemon_test.go
@@ -1,121 +1,214 @@
 package commands_test
 
 import (
-	"fmt"
-	"strings"
-	"sync"
+	"context"
+	"math/big"
 	"testing"
+	"time"
 
-	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
-
+	"github.com/multiformats/go-multibase"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/multiformats/go-multibase"
-
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/fixtures"
-	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/tools/fast/fasting"
+	"github.com/filecoin-project/go-filecoin/tools/fast/series"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
+func VoucherFromString(data string) (paymentbroker.PaymentVoucher, error) {
+	_, cborVoucher, err := multibase.Decode(data)
+	if err != nil {
+		return paymentbroker.PaymentVoucher{}, err
+	}
+
+	var voucher paymentbroker.PaymentVoucher
+	if err = cbor.DecodeInto(cborVoucher, &voucher); err != nil {
+		return paymentbroker.PaymentVoucher{}, err
+	}
+
+	return voucher, nil
+}
+
 func TestPaymentChannelCreateSuccess(t *testing.T) {
 	t.Parallel()
-	assert := assert.New(t)
+	require := require.New(t)
 
-	d := makeTestDaemonWithMinerAndStart(t)
-	defer d.ShutdownSuccess()
+	// This test should run in 20 block times
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
+	defer cancel()
 
-	args := []string{"paych", "create"}
-	args = append(args, "--from", fixtures.TestAddresses[0], "--gas-price", "0", "--gas-limit", "300")
-	args = append(args, fixtures.TestAddresses[1], "10000", "20")
+	// Get basic testing environment
+	env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
 
-	paymentChannelCmd := d.RunSuccess(args...)
-	messageCid, err := cid.Parse(strings.Trim(paymentChannelCmd.ReadStdout(), "\n"))
-	require.NoError(t, err)
+	// Teardown after test ends
+	defer env.Teardown(ctx)
 
-	var wg sync.WaitGroup
+	// Start test
+	targetDaemon := NewNode()
+	payerDaemon := NewNode()
 
-	wg.Add(1)
-	go func() {
-		wait := d.RunSuccess("message", "wait",
-			"--return",
-			"--message=false",
-			"--receipt=false",
-			messageCid.String(),
-		)
-		_, ok := types.NewChannelIDFromString(strings.Trim(wait.ReadStdout(), "\n"), 10)
-		assert.True(ok)
-		wg.Done()
-	}()
+	addrs, err := targetDaemon.AddressLs(ctx)
+	require.NoError(err)
+	targetAddr := addrs[0]
 
-	d.RunSuccess("mining once")
+	addrs, err = payerDaemon.AddressLs(ctx)
+	require.NoError(err)
+	payerAddr := addrs[0]
 
-	wg.Wait()
+	channelExpiry := types.NewBlockHeight(20)
+	channelAmount := types.NewAttoFILFromFIL(1000)
+
+	WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+		require.NotNil(chanid)
+	})
+}
+
+// WithPaymentChannel takes a filecoin daemon and constructs a payment channel to the `target` for the `amt` for `eol`, and calls fn with the channel id
+func WithPaymentChannel(t *testing.T, ctx context.Context, p *fast.Filecoin, from, target address.Address, amt *types.AttoFIL, eol *types.BlockHeight, fn func(chanid *types.ChannelID)) {
+	require := require.New(t)
+
+	mcid, err := p.PaychCreate(ctx, target, amt, eol, fast.AOFromAddr(from), fast.AOPrice(big.NewFloat(0)), fast.AOLimit(300))
+	require.NoError(err)
+
+	series.MiningOnceFromCtx(ctx)
+
+	response, err := p.MessageWait(ctx, mcid)
+	require.NoError(err)
+
+	chanid := types.NewChannelIDFromBytes(response.Receipt.Return[0])
+	fn(chanid)
 }
 
 func TestPaymentChannelLs(t *testing.T) {
 	t.Parallel()
-	assert := assert.New(t)
-	require := require.New(t)
 
 	t.Run("Works with default payer", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
+		assert := assert.New(t)
 
-		payer, err := address.NewFromString(fixtures.TestAddresses[2])
+		// This test should run in 20 block times
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
+		defer cancel()
+
+		// Get basic testing environment
+		env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
+
+		// Teardown after test ends
+		defer env.Teardown(ctx)
+
+		// Start test
+		targetDaemon := NewNode()
+		payerDaemon := NewNode()
+
+		addrs, err := targetDaemon.AddressLs(ctx)
 		require.NoError(err)
-		target, err := address.NewFromString(fixtures.TestAddresses[1])
+		targetAddr := addrs[0]
+
+		addrs, err = payerDaemon.AddressLs(ctx)
 		require.NoError(err)
+		payerAddr := addrs[0]
 
-		eol := types.NewBlockHeight(20)
-		amt := types.NewAttoFILFromFIL(10000)
+		channelExpiry := types.NewBlockHeight(20)
+		channelAmount := types.NewAttoFILFromFIL(1000)
 
-		daemonTestWithPaymentChannel(t, &payer, &target, amt, eol, func(d *th.TestDaemon, channelID *types.ChannelID) {
-			ls := listChannelsAsStrs(d, &payer)[0]
+		WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+			channels, err := payerDaemon.PaychLs(ctx)
+			require.NoError(err)
 
-			assert.Equal(fmt.Sprintf("%s: target: %s, amt: 10000, amt redeemed: 0, eol: 20", channelID, target.String()), ls)
+			assert.Len(channels, 1)
+
+			channel := channels[chanid.String()]
+			assert.Equal(channelAmount, channel.Amount)
+			assert.Equal(channelExpiry, channel.Eol)
+			assert.Equal(targetAddr, channel.Target)
+			assert.Equal(types.ZeroAttoFIL, channel.AmountRedeemed)
 		})
 	})
 
 	t.Run("Works with specified payer", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
+		assert := assert.New(t)
 
-		payer, err := address.NewFromString(fixtures.TestAddresses[2])
+		// This test should run in 20 block times
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
+		defer cancel()
+
+		// Get basic testing environment
+		env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
+
+		// Teardown after test ends
+		defer env.Teardown(ctx)
+
+		// Start test
+		targetDaemon := NewNode()
+		payerDaemon := NewNode()
+
+		addrs, err := targetDaemon.AddressLs(ctx)
 		require.NoError(err)
-		target, err := address.NewFromString(fixtures.TestAddresses[1])
+		targetAddr := addrs[0]
+
+		addrs, err = payerDaemon.AddressLs(ctx)
 		require.NoError(err)
+		payerAddr := addrs[0]
 
-		eol := types.NewBlockHeight(20)
-		amt := types.NewAttoFILFromFIL(10000)
+		channelExpiry := types.NewBlockHeight(20)
+		channelAmount := types.NewAttoFILFromFIL(1000)
 
-		daemonTestWithPaymentChannel(t, &payer, &target, amt, eol, func(d *th.TestDaemon, channelID *types.ChannelID) {
-			args := []string{"paych", "ls"}
-			args = append(args, "--from", target.String())
-			args = append(args, "--payer", payer.String())
+		WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+			channels, err := payerDaemon.PaychLs(ctx, fast.AOPayer(payerAddr))
+			require.NoError(err)
 
-			ls := th.RunSuccessLines(d, args...)[0]
+			assert.Len(channels, 1)
 
-			assert.Equal(fmt.Sprintf("%s: target: %s, amt: 10000, amt redeemed: 0, eol: 20", channelID, target.String()), ls)
+			channel := channels[chanid.String()]
+			assert.Equal(channelAmount, channel.Amount)
+			assert.Equal(channelExpiry, channel.Eol)
+			assert.Equal(targetAddr, channel.Target)
+			assert.Equal(types.ZeroAttoFIL, channel.AmountRedeemed)
 		})
 	})
 
-	t.Run("Notifies when channels not found", func(t *testing.T) {
+	t.Run("No results when listing with different from address", func(t *testing.T) {
 		t.Parallel()
+		require := require.New(t)
+		assert := assert.New(t)
 
-		payer, err := address.NewFromString(fixtures.TestAddresses[2])
+		// This test should run in 20 block times
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
+		defer cancel()
+
+		// Get basic testing environment
+		env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
+
+		// Teardown after test ends
+		defer env.Teardown(ctx)
+
+		// Start test
+		targetDaemon := NewNode()
+		payerDaemon := NewNode()
+
+		addrs, err := targetDaemon.AddressLs(ctx)
 		require.NoError(err)
-		target, err := address.NewFromString(fixtures.TestAddresses[1])
+		targetAddr := addrs[0]
+
+		addrs, err = payerDaemon.AddressLs(ctx)
 		require.NoError(err)
+		payerAddr := addrs[0]
 
-		eol := types.NewBlockHeight(20)
-		amt := types.NewAttoFILFromFIL(10000)
+		channelExpiry := types.NewBlockHeight(20)
+		channelAmount := types.NewAttoFILFromFIL(1000)
 
-		daemonTestWithPaymentChannel(t, &payer, &target, amt, eol, func(d *th.TestDaemon, channelID *types.ChannelID) {
-			ls := listChannelsAsStrs(d, &target)[0]
+		WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+			channels, err := payerDaemon.PaychLs(ctx, fast.AOFromAddr(targetAddr))
+			require.NoError(err)
 
-			assert.Equal("no channels", ls)
+			assert.Len(channels, 0)
 		})
 	})
 }
@@ -123,425 +216,364 @@ func TestPaymentChannelLs(t *testing.T) {
 func TestPaymentChannelVoucherSuccess(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
+	assert := assert.New(t)
 
-	payer, err := address.NewFromString(fixtures.TestAddresses[2])
+	// This test should run in 20 block times
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
+	defer cancel()
+
+	// Get basic testing environment
+	env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
+
+	// Teardown after test ends
+	defer env.Teardown(ctx)
+
+	// Start test
+	targetDaemon := NewNode()
+	payerDaemon := NewNode()
+
+	addrs, err := targetDaemon.AddressLs(ctx)
 	require.NoError(err)
-	target, err := address.NewFromString(fixtures.TestAddresses[1])
+	targetAddr := addrs[0]
+
+	addrs, err = payerDaemon.AddressLs(ctx)
 	require.NoError(err)
+	payerAddr := addrs[0]
 
-	eol := types.NewBlockHeight(20)
-	amt := types.NewAttoFILFromFIL(10000)
+	channelExpiry := types.NewBlockHeight(20)
+	channelAmount := types.NewAttoFILFromFIL(1000)
 
-	daemonTestWithPaymentChannel(t, &payer, &target, amt, eol, func(d *th.TestDaemon, channelID *types.ChannelID) {
-		assert := assert.New(t)
+	WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+		voucherAmount := types.NewAttoFILFromFIL(10)
+		voucherValidAt := types.NewBlockHeight(0)
+		voucherStr, err := payerDaemon.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(payerAddr), fast.AOValidAt(voucherValidAt))
+		require.NoError(err)
 
-		voucher := mustCreateVoucher(t, d, channelID, types.NewAttoFILFromFIL(100), &payer)
+		voucher, err := VoucherFromString(voucherStr)
+		require.NoError(err)
 
-		assert.Equal(*types.NewAttoFILFromFIL(100), voucher.Amount)
+		assert.Equal(voucherAmount, &voucher.Amount)
 	})
 }
 
 func TestPaymentChannelRedeemSuccess(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
+	assert := assert.New(t)
 
-	payer, err := address.NewFromString(fixtures.TestAddresses[2])
+	// This test should run in 20 block times
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
+	defer cancel()
+
+	// Get basic testing environment
+	env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
+
+	// Teardown after test ends
+	defer env.Teardown(ctx)
+
+	// Start test
+	targetDaemon := NewNode()
+	payerDaemon := NewNode()
+
+	addrs, err := targetDaemon.AddressLs(ctx)
 	require.NoError(err)
-	target, err := address.NewFromString(fixtures.TestAddresses[1])
+	targetAddr := addrs[0]
+
+	addrs, err = payerDaemon.AddressLs(ctx)
 	require.NoError(err)
+	payerAddr := addrs[0]
 
-	eol := types.NewBlockHeight(20)
-	amt := types.NewAttoFILFromFIL(10000)
+	channelExpiry := types.NewBlockHeight(20)
+	channelAmount := types.NewAttoFILFromFIL(1000)
 
-	targetDaemon := th.NewDaemon(
-		t,
-		// must include 0th keyfilepath if using 0th TestMiner
-		th.WithMiner(fixtures.TestMiners[0]),
-		th.KeyFile(fixtures.KeyFilePaths()[0]),
-		th.KeyFile(fixtures.KeyFilePaths()[1]),
-	).Start()
-	defer targetDaemon.ShutdownSuccess()
+	WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+		voucherAmount := types.NewAttoFILFromFIL(10)
+		voucherValidAt := types.NewBlockHeight(0)
+		voucherStr, err := payerDaemon.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(payerAddr), fast.AOValidAt(voucherValidAt))
+		require.NoError(err)
 
-	daemonTestWithPaymentChannel(t, &payer, &target, amt, eol, func(d *th.TestDaemon, channelID *types.ChannelID) {
-		assert := assert.New(t)
+		// TODO(tperson) allow setting Price / Limit on process?
+		mcid, err := targetDaemon.PaychRedeem(ctx, voucherStr, fast.AOFromAddr(targetAddr), fast.AOPrice(big.NewFloat(0)), fast.AOLimit(300))
+		require.NoError(err)
 
-		d.ConnectSuccess(targetDaemon)
+		series.MiningOnceFromCtx(ctx)
 
-		voucher := createVoucherStr(t, d, channelID, types.NewAttoFILFromFIL(111), &payer, uint64(0))
+		_, err = targetDaemon.MessageWait(ctx, mcid)
+		require.NoError(err)
 
-		mustRedeemVoucher(t, targetDaemon, voucher, &target)
+		channels, err := targetDaemon.PaychLs(ctx, fast.AOFromAddr(payerAddr))
+		require.NoError(err)
 
-		ls := listChannelsAsStrs(targetDaemon, &payer)[0]
-		assert.Equal(fmt.Sprintf("%v: target: %s, amt: 10000, amt redeemed: 111, eol: 20", channelID.String(), target.String()), ls)
+		channel := channels[chanid.String()]
+		assert.Equal(channelAmount, channel.Amount)
+		assert.Equal(voucherAmount, channel.AmountRedeemed)
 	})
 }
 
 func TestPaymentChannelRedeemTooEarlyFails(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
+	assert := assert.New(t)
 
-	payer, err := address.NewFromString(fixtures.TestAddresses[2])
+	// This test should run in 20 block times
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
+	defer cancel()
+
+	// Get basic testing environment
+	env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
+
+	// Teardown after test ends
+	defer env.Teardown(ctx)
+
+	// Start test
+	targetDaemon := NewNode()
+	payerDaemon := NewNode()
+
+	addrs, err := targetDaemon.AddressLs(ctx)
 	require.NoError(err)
-	target, err := address.NewFromString(fixtures.TestAddresses[1])
+	targetAddr := addrs[0]
+
+	addrs, err = payerDaemon.AddressLs(ctx)
 	require.NoError(err)
+	payerAddr := addrs[0]
 
-	eol := types.NewBlockHeight(20)
-	amt := types.NewAttoFILFromFIL(10000)
+	channelExpiry := types.NewBlockHeight(20)
+	channelAmount := types.NewAttoFILFromFIL(1000)
 
-	targetDaemon := th.NewDaemon(
-		t,
-		// must include 0th keyfilepath if using 0th TestMiner
-		th.WithMiner(fixtures.TestMiners[0]),
-		th.KeyFile(fixtures.KeyFilePaths()[0]),
-		th.KeyFile(fixtures.KeyFilePaths()[1]),
-	).Start()
-	defer targetDaemon.ShutdownSuccess()
+	WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+		voucherAmount := types.NewAttoFILFromFIL(10)
+		voucherValidAt := types.NewBlockHeight(10)
+		voucherStr, err := payerDaemon.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(payerAddr), fast.AOValidAt(voucherValidAt))
+		require.NoError(err)
 
-	daemonTestWithPaymentChannel(t, &payer, &target, amt, eol, func(d *th.TestDaemon, channelID *types.ChannelID) {
-		assert := assert.New(t)
+		// TODO(tperson) allow setting Price / Limit on process?
+		mcid, err := targetDaemon.PaychRedeem(ctx, voucherStr, fast.AOFromAddr(targetAddr), fast.AOPrice(big.NewFloat(0)), fast.AOLimit(300))
+		require.NoError(err)
 
-		d.ConnectSuccess(targetDaemon)
+		series.MiningOnceFromCtx(ctx)
 
-		voucher := createVoucherStr(t, d, channelID, types.NewAttoFILFromFIL(111), &payer, uint64(8))
+		_, err = targetDaemon.MessageWait(ctx, mcid)
+		require.NoError(err)
 
-		// Wait for the voucher message to be processed.
-		mustRedeemVoucher(t, targetDaemon, voucher, &target)
+		channels, err := targetDaemon.PaychLs(ctx, fast.AOFromAddr(payerAddr))
+		require.NoError(err)
 
-		ls := listChannelsAsStrs(targetDaemon, &payer)[0]
-		assert.Equal(fmt.Sprintf("%v: target: %s, amt: 10000, amt redeemed: 0, eol: 20", channelID.String(), target.String()), ls)
+		channel := channels[chanid.String()]
+		assert.Equal(channelAmount, channel.Amount)
+		assert.Equal(types.ZeroAttoFIL, channel.AmountRedeemed)
 	})
 }
 
 func TestPaymentChannelReclaimSuccess(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
+	assert := assert.New(t)
 
-	// Initial Balance 10,000
-	payer, err := address.NewFromString(fixtures.TestAddresses[2])
+	// This test should run in 20 block times
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
+	defer cancel()
+
+	// Get basic testing environment
+	env, p, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
+
+	// Teardown after test ends
+	defer env.Teardown(ctx)
+
+	// Start test
+	targetDaemon := NewNode()
+	payerDaemon := NewNode()
+
+	addrs, err := targetDaemon.AddressLs(ctx)
 	require.NoError(err)
-	// Initial Balance 50,000
-	target, err := address.NewFromString(fixtures.TestAddresses[1])
+	targetAddr := addrs[0]
+
+	addrs, err = payerDaemon.AddressLs(ctx)
+	require.NoError(err)
+	payerAddr := addrs[0]
+
+	bh, err := series.GetHeadBlockHeight(ctx, p)
 	require.NoError(err)
 
-	// Not used in logic
-	eol := types.NewBlockHeight(5)
-	amt := types.NewAttoFILFromFIL(1000)
+	// Expiry is current height, plus 3
+	// - Setting up the payment channel
+	// - Redeeming one voucher
+	// - Expires on third block
+	channelExpiry := types.NewBlockHeight(3).Add(bh)
+	channelAmount := types.NewAttoFILFromFIL(1000)
 
-	targetDaemon := th.NewDaemon(t,
-		th.KeyFile(fixtures.KeyFilePaths()[1]),
-		// must include 0th keyfilepath if using 0th TestMiner
-		th.KeyFile(fixtures.KeyFilePaths()[0]),
-		th.WithMiner(fixtures.TestMiners[0])).Start()
-	defer targetDaemon.ShutdownSuccess()
+	balanceBefore, err := payerDaemon.WalletBalance(ctx, payerAddr)
+	require.NoError(err)
 
-	daemonTestWithPaymentChannel(t, &payer, &target, amt, eol, func(d *th.TestDaemon, channelID *types.ChannelID) {
-		assert := assert.New(t)
+	WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+		voucherAmount := types.NewAttoFILFromFIL(10)
+		voucherValidAt := types.NewBlockHeight(0)
+		voucherStr, err := payerDaemon.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(payerAddr), fast.AOValidAt(voucherValidAt))
+		require.NoError(err)
 
-		d.ConnectSuccess(targetDaemon)
+		// TODO(tperson) allow setting Price / Limit on process?
+		mcid, err := targetDaemon.PaychRedeem(ctx, voucherStr, fast.AOFromAddr(targetAddr), fast.AOPrice(big.NewFloat(0)), fast.AOLimit(300))
+		require.NoError(err)
 
-		// payer creates a voucher to be redeemed by target (off-chain)
-		voucher := createVoucherStr(t, d, channelID, types.NewAttoFILFromFIL(10), &payer, uint64(0))
+		series.MiningOnceFromCtx(ctx)
 
-		// target redeems the voucher (on-chain)
-		mustRedeemVoucher(t, targetDaemon, voucher, &target)
+		_, err = targetDaemon.MessageWait(ctx, mcid)
+		require.NoError(err)
 
-		lsStr := listChannelsAsStrs(targetDaemon, &payer)[0]
-		assert.Equal(fmt.Sprintf("%v: target: %s, amt: 1000, amt redeemed: 10, eol: %s", channelID, target.String(), eol.String()), lsStr)
+		channels, err := targetDaemon.PaychLs(ctx, fast.AOFromAddr(payerAddr))
+		require.NoError(err)
 
-		d.RunSuccess("mining once")
-		d.RunSuccess("mining once")
+		channel := channels[chanid.String()]
+		assert.Equal(channelAmount, channel.Amount)
+		assert.Equal(voucherAmount, channel.AmountRedeemed)
 
-		// payer reclaims channel funds (on-chain)
-		mustReclaimChannel(t, d, channelID, &payer)
+		series.MiningOnceFromCtx(ctx)
 
-		lsStr = listChannelsAsStrs(d, &payer)[0]
-		assert.Contains(lsStr, "no channels")
+		mcid, err = payerDaemon.PaychReclaim(ctx, chanid, fast.AOFromAddr(payerAddr), fast.AOPrice(big.NewFloat(0)), fast.AOLimit(300))
+		require.NoError(err)
 
-		args := []string{"wallet", "balance", payer.String()}
-		balStr := th.RunSuccessFirstLine(d, args...)
+		series.MiningOnceFromCtx(ctx)
 
-		// channel's original locked funds minus the redeemed voucher amount
-		// are returned to the payer
-		assert.Equal("999999999990", balStr)
+		_, err = payerDaemon.MessageWait(ctx, mcid)
+		require.NoError(err)
+
+		channels, err = payerDaemon.PaychLs(ctx, fast.AOFromAddr(payerAddr))
+		require.NoError(err)
+		require.Len(channels, 0)
+
+		balanceAfter, err := payerDaemon.WalletBalance(ctx, payerAddr)
+		require.NoError(err)
+
+		assert.Equal(balanceBefore, balanceAfter.Add(voucherAmount))
 	})
 }
 
 func TestPaymentChannelCloseSuccess(t *testing.T) {
+	t.Parallel()
 	require := require.New(t)
+	assert := assert.New(t)
 
-	// Initial Balance 10,000,000
-	payerA, err := address.NewFromString(fixtures.TestAddresses[2])
+	// This test should run in 20 block times
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
+	defer cancel()
+
+	// Get basic testing environment
+	env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
+
+	// Teardown after test ends
+	defer env.Teardown(ctx)
+
+	// Start test
+	targetDaemon := NewNode()
+	payerDaemon := NewNode()
+
+	addrs, err := targetDaemon.AddressLs(ctx)
+	require.NoError(err)
+	targetAddr := addrs[0]
+
+	channelExpiry := types.NewBlockHeight(5)
+	channelAmount := types.NewAttoFILFromFIL(1000)
+
+	addrs, err = payerDaemon.AddressLs(ctx)
+	require.NoError(err)
+	payerAddr := addrs[0]
+
+	payerBalanceBefore, err := payerDaemon.WalletBalance(ctx, payerAddr)
 	require.NoError(err)
 
-	// Initial Balance 10,000,000
-	targetA, err := address.NewFromString(fixtures.TestAddresses[1])
+	targetBalanceBefore, err := targetDaemon.WalletBalance(ctx, targetAddr)
 	require.NoError(err)
-	payer := &payerA
-	target := &targetA
-	eol := types.NewBlockHeight(100)
-	amt := types.NewAttoFILFromFIL(10000)
 
-	targetDaemon := th.NewDaemon(t,
-		th.KeyFile(fixtures.KeyFilePaths()[1]),
-		// must include 0th keyfilepath if using 0th TestMiner
-		th.KeyFile(fixtures.KeyFilePaths()[0]),
-		th.WithMiner(fixtures.TestMiners[0])).Start()
-	defer targetDaemon.ShutdownSuccess()
+	WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+		voucherAmount := types.NewAttoFILFromFIL(10)
+		voucherValidAt := types.NewBlockHeight(0)
+		voucherStr, err := payerDaemon.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(payerAddr), fast.AOValidAt(voucherValidAt))
+		require.NoError(err)
 
-	daemonTestWithPaymentChannel(t, payer, target, amt, eol, func(d *th.TestDaemon, channelID *types.ChannelID) {
-		assert := assert.New(t)
+		// TODO(tperson) allow setting Price / Limit on process?
+		mcid, err := targetDaemon.PaychClose(ctx, voucherStr, fast.AOFromAddr(targetAddr), fast.AOPrice(big.NewFloat(0)), fast.AOLimit(300))
+		require.NoError(err)
 
-		d.ConnectSuccess(targetDaemon)
+		series.MiningOnceFromCtx(ctx)
 
-		// payer creates a voucher to be redeemed by target (off-chain)
-		voucher := mustCreateVoucher(t, d, channelID, types.NewAttoFILFromFIL(10), payer)
+		_, err = targetDaemon.MessageWait(ctx, mcid)
+		require.NoError(err)
 
-		// target redeems the voucher (on-chain) and simultaneously closes the channel
-		mustCloseChannel(t, targetDaemon, voucher, target)
+		channels, err := targetDaemon.PaychLs(ctx, fast.AOFromAddr(payerAddr))
+		require.NoError(err)
+		require.Len(channels, 0)
 
-		// channel has been closed
-		lsStr := listChannelsAsStrs(targetDaemon, payer)[0]
-		assert.Contains(lsStr, "no channels")
+		payerBalanceAfter, err := payerDaemon.WalletBalance(ctx, payerAddr)
+		require.NoError(err)
+		assert.Equal(payerBalanceBefore.Sub(voucherAmount), payerBalanceAfter)
 
-		// channel's original locked funds minus the redeemed voucher amount
-		// are returned to the payer
-		args := []string{"wallet", "balance", payer.String()}
-		balStr := th.RunSuccessFirstLine(targetDaemon, args...)
-		assert.Equal("999999999990", balStr)
-
-		// target's balance reflects redeemed voucher
-		args = []string{"wallet", "balance", target.String()}
-		balStr = th.RunSuccessFirstLine(targetDaemon, args...)
-		assert.Equal("1000000000010", balStr)
+		targetBalanceAfter, err := targetDaemon.WalletBalance(ctx, targetAddr)
+		require.NoError(err)
+		assert.Equal(targetBalanceBefore.Add(voucherAmount), targetBalanceAfter)
 	})
 }
 
 func TestPaymentChannelExtendSuccess(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-
-	payer, err := address.NewFromString(fixtures.TestAddresses[2])
-	require.NoError(err)
-	target, err := address.NewFromString(fixtures.TestAddresses[1])
-	require.NoError(err)
-
-	eol := types.NewBlockHeight(5)
-	amt := types.NewAttoFILFromFIL(2000)
-
-	daemonTestWithPaymentChannel(t, &payer, &target, amt, eol, func(d *th.TestDaemon, channelID *types.ChannelID) {
-		assert := assert.New(t)
-
-		extendedEOL := types.NewBlockHeight(6)
-		extendedAmt := types.NewAttoFILFromFIL(3001)
-
-		lsStr := listChannelsAsStrs(d, &payer)[0]
-		assert.Equal(fmt.Sprintf("%v: target: %s, amt: 2000, amt redeemed: 0, eol: %s", channelID.String(), target.String(), eol.String()), lsStr)
-
-		mustExtendChannel(t, d, channelID, extendedAmt, extendedEOL, &payer)
-
-		lsStr = listChannelsAsStrs(d, &payer)[0]
-		assert.Equal(fmt.Sprintf("%v: target: %s, amt: %s, amt redeemed: 0, eol: %s", channelID.String(), target.String(), extendedAmt.Add(amt), extendedEOL), lsStr)
-	})
-}
-
-func daemonTestWithPaymentChannel(t *testing.T, payerAddress *address.Address, targetAddress *address.Address,
-	fundsToLock *types.AttoFIL, eol *types.BlockHeight, f func(*th.TestDaemon, *types.ChannelID)) {
 	assert := assert.New(t)
-	require := require.New(t)
 
-	d := th.NewDaemon(
-		t,
-		// must include 0th keyfilepath with TestMiner 0
-		th.WithMiner(fixtures.TestMiners[0]),
-		th.KeyFile(fixtures.KeyFilePaths()[0]),
-		th.KeyFile(fixtures.KeyFilePaths()[2]),
-	).Start()
-	defer d.ShutdownSuccess()
+	// This test should run in 20 block times
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
+	defer cancel()
 
-	args := []string{"paych", "create"}
-	args = append(args, "--from", payerAddress.String(), "--gas-price", "0", "--gas-limit", "300")
-	args = append(args, targetAddress.String(), fundsToLock.String(), eol.String())
+	// Get basic testing environment
+	env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
 
-	paymentChannelCmd := d.RunSuccess(args...)
-	messageCid, err := cid.Parse(strings.Trim(paymentChannelCmd.ReadStdout(), "\n"))
+	// Teardown after test ends
+	defer env.Teardown(ctx)
+
+	// Start test
+	targetDaemon := NewNode()
+	payerDaemon := NewNode()
+
+	addrs, err := targetDaemon.AddressLs(ctx)
 	require.NoError(err)
+	targetAddr := addrs[0]
 
-	var wg sync.WaitGroup
+	channelExpiry := types.NewBlockHeight(5)
+	channelAmount := types.NewAttoFILFromFIL(1000)
 
-	wg.Add(1)
-	go func() {
-		wait := d.RunSuccess("message", "wait",
-			"--return",
-			"--message=false",
-			"--receipt=false",
-			messageCid.String(),
-		)
-		stdout := strings.Trim(wait.ReadStdout(), "\n")
-		channelID, ok := types.NewChannelIDFromString(stdout, 10)
-		assert.True(ok)
-
-		f(d, channelID)
-
-		wg.Done()
-	}()
-
-	d.RunSuccess("mining once")
-	wg.Wait()
-}
-
-func mustCreateVoucher(t *testing.T, d *th.TestDaemon, channelID *types.ChannelID, amount *types.AttoFIL, fromAddress *address.Address) paymentbroker.PaymentVoucher {
-	require := require.New(t)
-
-	voucherString := createVoucherStr(t, d, channelID, amount, fromAddress, uint64(0))
-
-	_, cborVoucher, err := multibase.Decode(voucherString)
+	addrs, err = payerDaemon.AddressLs(ctx)
 	require.NoError(err)
+	payerAddr := addrs[0]
 
-	var voucher paymentbroker.PaymentVoucher
-	err = cbor.DecodeInto(cborVoucher, &voucher)
-	require.NoError(err)
+	WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+		channels, err := payerDaemon.PaychLs(ctx)
+		require.NoError(err)
 
-	return voucher
-}
+		assert.Len(channels, 1)
 
-func createVoucherStr(t *testing.T, d *th.TestDaemon, channelID *types.ChannelID, amount *types.AttoFIL, payerAddress *address.Address, validAt uint64) string {
-	args := []string{"paych", "voucher", channelID.String(), amount.String()}
-	args = append(args, "--from", payerAddress.String(), "--validat", fmt.Sprintf("%d", validAt))
+		channel := channels[chanid.String()]
+		assert.Equal(channelAmount, channel.Amount)
+		assert.Equal(channelExpiry, channel.Eol)
+		assert.Equal(targetAddr, channel.Target)
+		assert.Equal(types.ZeroAttoFIL, channel.AmountRedeemed)
 
-	return th.RunSuccessFirstLine(d, args...)
-}
+		extendAmount := types.NewAttoFILFromFIL(100)
+		extendExpiry := types.NewBlockHeight(100)
 
-func listChannelsAsStrs(d *th.TestDaemon, fromAddress *address.Address) []string {
-	args := []string{"paych", "ls"}
-	args = append(args, "--from", fromAddress.String())
+		mcid, err := payerDaemon.PaychExtend(ctx, chanid, extendAmount, extendExpiry, fast.AOFromAddr(payerAddr), fast.AOPrice(big.NewFloat(0)), fast.AOLimit(300))
+		require.NoError(err)
 
-	return th.RunSuccessLines(d, args...)
-}
+		series.MiningOnceFromCtx(ctx)
 
-func mustExtendChannel(t *testing.T, d *th.TestDaemon, channelID *types.ChannelID, amount *types.AttoFIL, eol *types.BlockHeight, payerAddress *address.Address) {
-	require := require.New(t)
+		_, err = payerDaemon.MessageWait(ctx, mcid)
+		require.NoError(err)
 
-	args := []string{"paych", "extend"}
-	args = append(args, "--from", payerAddress.String(), "--gas-price", "0", "--gas-limit", "300")
-	args = append(args, channelID.String(), amount.String(), eol.String())
+		channels, err = payerDaemon.PaychLs(ctx)
+		require.NoError(err)
 
-	redeemCmd := d.RunSuccess(args...)
-	messageCid, err := cid.Parse(strings.Trim(redeemCmd.ReadStdout(), "\n"))
-	require.NoError(err)
+		assert.Len(channels, 1)
 
-	var wg sync.WaitGroup
-
-	wg.Add(1)
-	go func() {
-		_ = d.RunSuccess("message", "wait",
-			"--return=false",
-			"--message=false",
-			"--receipt=false",
-			messageCid.String(),
-		)
-
-		wg.Done()
-	}()
-
-	d.RunSuccess("mining once")
-
-	wg.Wait()
-}
-
-func mustRedeemVoucher(t *testing.T, d *th.TestDaemon, voucher string, targetAddress *address.Address) {
-	require := require.New(t)
-
-	args := []string{"paych", "redeem", voucher}
-	args = append(args, "--from", targetAddress.String(), "--gas-price", "0", "--gas-limit", "300")
-
-	redeemCmd := d.RunSuccess(args...)
-	messageCid, err := cid.Parse(strings.Trim(redeemCmd.ReadStdout(), "\n"))
-	require.NoError(err)
-
-	var wg sync.WaitGroup
-
-	wg.Add(1)
-	go func() {
-		_ = d.RunSuccess("message", "wait",
-			"--return=false",
-			"--message=false",
-			"--receipt=false",
-			messageCid.String(),
-		)
-
-		wg.Done()
-	}()
-
-	d.RunSuccess("mining once")
-
-	wg.Wait()
-}
-
-func mustCloseChannel(t *testing.T, d *th.TestDaemon, voucher paymentbroker.PaymentVoucher, targetAddress *address.Address) {
-	require := require.New(t)
-
-	args := []string{"paych", "close", mustEncodeVoucherStr(t, voucher)}
-	args = append(args, "--from", targetAddress.String(), "--gas-price", "0", "--gas-limit", "300")
-
-	redeemCmd := d.RunSuccess(args...)
-	messageCid, err := cid.Parse(strings.Trim(redeemCmd.ReadStdout(), "\n"))
-	require.NoError(err)
-
-	var wg sync.WaitGroup
-
-	wg.Add(1)
-	go func() {
-		_ = d.RunSuccess("message", "wait",
-			"--return=false",
-			"--message=false",
-			"--receipt=false",
-			messageCid.String(),
-		)
-
-		wg.Done()
-	}()
-
-	d.RunSuccess("mining once")
-
-	wg.Wait()
-}
-
-func mustReclaimChannel(t *testing.T, d *th.TestDaemon, channelID *types.ChannelID, payerAddress *address.Address) {
-	require := require.New(t)
-
-	args := []string{"paych", "reclaim", channelID.String()}
-	args = append(args, "--from", payerAddress.String(), "--gas-price", "0", "--gas-limit", "300")
-
-	reclaimCmd := d.RunSuccess(args...)
-	messageCid, err := cid.Parse(strings.Trim(reclaimCmd.ReadStdout(), "\n"))
-	require.NoError(err)
-
-	var wg sync.WaitGroup
-
-	wg.Add(1)
-	go func() {
-		_ = d.RunSuccess("message", "wait",
-			"--return=false",
-			"--message=false",
-			"--receipt=true",
-			messageCid.String(),
-		)
-		wg.Done()
-	}()
-
-	d.RunSuccess("mining once")
-
-	wg.Wait()
-}
-
-func mustEncodeVoucherStr(t *testing.T, voucher paymentbroker.PaymentVoucher) string {
-	require := require.New(t)
-
-	bytes, err := cbor.DumpObject(voucher)
-	require.NoError(err)
-
-	encoded, err := multibase.Encode(multibase.Base58BTC, bytes)
-	require.NoError(err)
-
-	return encoded
+		channel = channels[chanid.String()]
+		assert.Equal(channelAmount.Add(extendAmount), channel.Amount)
+		assert.Equal(extendExpiry, channel.Eol)
+		assert.Equal(targetAddr, channel.Target)
+		assert.Equal(types.ZeroAttoFIL, channel.AmountRedeemed)
+	})
 }

--- a/commands/payment_channel_daemon_test.go
+++ b/commands/payment_channel_daemon_test.go
@@ -51,7 +51,10 @@ func TestPaymentChannelCreateSuccess(t *testing.T) {
 	env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
-	defer env.Teardown(ctx)
+	defer func() {
+		err := env.Teardown(ctx)
+		require.NoError(err)
+	}()
 
 	// Start test
 	targetDaemon := NewNode()
@@ -68,13 +71,13 @@ func TestPaymentChannelCreateSuccess(t *testing.T) {
 	channelExpiry := types.NewBlockHeight(20)
 	channelAmount := types.NewAttoFILFromFIL(1000)
 
-	WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+	WithPaymentChannel(ctx, t, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
 		require.NotNil(chanid)
 	})
 }
 
 // WithPaymentChannel takes a filecoin daemon and constructs a payment channel to the `target` for the `amt` for `eol`, and calls fn with the channel id
-func WithPaymentChannel(t *testing.T, ctx context.Context, p *fast.Filecoin, from, target address.Address, amt *types.AttoFIL, eol *types.BlockHeight, fn func(chanid *types.ChannelID)) {
+func WithPaymentChannel(ctx context.Context, t *testing.T, p *fast.Filecoin, from, target address.Address, amt *types.AttoFIL, eol *types.BlockHeight, fn func(chanid *types.ChannelID)) {
 	require := require.New(t)
 
 	mcid, err := p.PaychCreate(ctx, target, amt, eol, fast.AOFromAddr(from), fast.AOPrice(big.NewFloat(0)), fast.AOLimit(300))
@@ -103,7 +106,10 @@ func TestPaymentChannelLs(t *testing.T) {
 		env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
 
 		// Teardown after test ends
-		defer env.Teardown(ctx)
+		defer func() {
+			err := env.Teardown(ctx)
+			require.NoError(err)
+		}()
 
 		// Start test
 		targetDaemon := NewNode()
@@ -120,7 +126,7 @@ func TestPaymentChannelLs(t *testing.T) {
 		channelExpiry := types.NewBlockHeight(20)
 		channelAmount := types.NewAttoFILFromFIL(1000)
 
-		WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+		WithPaymentChannel(ctx, t, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
 			channels, err := payerDaemon.PaychLs(ctx)
 			require.NoError(err)
 
@@ -147,7 +153,10 @@ func TestPaymentChannelLs(t *testing.T) {
 		env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
 
 		// Teardown after test ends
-		defer env.Teardown(ctx)
+		defer func() {
+			err := env.Teardown(ctx)
+			require.NoError(err)
+		}()
 
 		// Start test
 		targetDaemon := NewNode()
@@ -164,7 +173,7 @@ func TestPaymentChannelLs(t *testing.T) {
 		channelExpiry := types.NewBlockHeight(20)
 		channelAmount := types.NewAttoFILFromFIL(1000)
 
-		WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+		WithPaymentChannel(ctx, t, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
 			channels, err := payerDaemon.PaychLs(ctx, fast.AOPayer(payerAddr))
 			require.NoError(err)
 
@@ -191,7 +200,10 @@ func TestPaymentChannelLs(t *testing.T) {
 		env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
 
 		// Teardown after test ends
-		defer env.Teardown(ctx)
+		defer func() {
+			err := env.Teardown(ctx)
+			require.NoError(err)
+		}()
 
 		// Start test
 		targetDaemon := NewNode()
@@ -208,7 +220,7 @@ func TestPaymentChannelLs(t *testing.T) {
 		channelExpiry := types.NewBlockHeight(20)
 		channelAmount := types.NewAttoFILFromFIL(1000)
 
-		WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+		WithPaymentChannel(ctx, t, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
 			channels, err := payerDaemon.PaychLs(ctx, fast.AOFromAddr(targetAddr))
 			require.NoError(err)
 
@@ -230,7 +242,10 @@ func TestPaymentChannelVoucherSuccess(t *testing.T) {
 	env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
-	defer env.Teardown(ctx)
+	defer func() {
+		err := env.Teardown(ctx)
+		require.NoError(err)
+	}()
 
 	// Start test
 	targetDaemon := NewNode()
@@ -247,7 +262,7 @@ func TestPaymentChannelVoucherSuccess(t *testing.T) {
 	channelExpiry := types.NewBlockHeight(20)
 	channelAmount := types.NewAttoFILFromFIL(1000)
 
-	WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+	WithPaymentChannel(ctx, t, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
 		voucherAmount := types.NewAttoFILFromFIL(10)
 		voucherValidAt := types.NewBlockHeight(0)
 		voucherStr, err := payerDaemon.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(payerAddr), fast.AOValidAt(voucherValidAt))
@@ -273,7 +288,10 @@ func TestPaymentChannelRedeemSuccess(t *testing.T) {
 	env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
-	defer env.Teardown(ctx)
+	defer func() {
+		err := env.Teardown(ctx)
+		require.NoError(err)
+	}()
 
 	// Start test
 	targetDaemon := NewNode()
@@ -290,7 +308,7 @@ func TestPaymentChannelRedeemSuccess(t *testing.T) {
 	channelExpiry := types.NewBlockHeight(20)
 	channelAmount := types.NewAttoFILFromFIL(1000)
 
-	WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+	WithPaymentChannel(ctx, t, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
 		voucherAmount := types.NewAttoFILFromFIL(10)
 		voucherValidAt := types.NewBlockHeight(0)
 		voucherStr, err := payerDaemon.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(payerAddr), fast.AOValidAt(voucherValidAt))
@@ -325,7 +343,10 @@ func TestPaymentChannelRedeemTooEarlyFails(t *testing.T) {
 	env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
-	defer env.Teardown(ctx)
+	defer func() {
+		err := env.Teardown(ctx)
+		require.NoError(err)
+	}()
 
 	// Start test
 	targetDaemon := NewNode()
@@ -342,7 +363,7 @@ func TestPaymentChannelRedeemTooEarlyFails(t *testing.T) {
 	channelExpiry := types.NewBlockHeight(20)
 	channelAmount := types.NewAttoFILFromFIL(1000)
 
-	WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+	WithPaymentChannel(ctx, t, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
 		voucherAmount := types.NewAttoFILFromFIL(10)
 		voucherValidAt := types.NewBlockHeight(10)
 		voucherStr, err := payerDaemon.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(payerAddr), fast.AOValidAt(voucherValidAt))
@@ -377,7 +398,10 @@ func TestPaymentChannelReclaimSuccess(t *testing.T) {
 	env, p, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
-	defer env.Teardown(ctx)
+	defer func() {
+		err := env.Teardown(ctx)
+		require.NoError(err)
+	}()
 
 	// Start test
 	targetDaemon := NewNode()
@@ -400,7 +424,7 @@ func TestPaymentChannelReclaimSuccess(t *testing.T) {
 	balanceBefore, err := payerDaemon.WalletBalance(ctx, payerAddr)
 	require.NoError(err)
 
-	WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+	WithPaymentChannel(ctx, t, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
 		voucherAmount := types.NewAttoFILFromFIL(10)
 		voucherValidAt := types.NewBlockHeight(0)
 		voucherStr, err := payerDaemon.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(payerAddr), fast.AOValidAt(voucherValidAt))
@@ -420,7 +444,8 @@ func TestPaymentChannelReclaimSuccess(t *testing.T) {
 		assert.Equal(channelAmount, channel.Amount)
 		assert.Equal(voucherAmount, channel.AmountRedeemed)
 
-		series.WaitForBlockHeight(ctx, payerDaemon, channel.Eol)
+		err = series.WaitForBlockHeight(ctx, payerDaemon, channel.Eol)
+		require.NoError(err)
 
 		mcid, err = payerDaemon.PaychReclaim(ctx, chanid, fast.AOFromAddr(payerAddr), fast.AOPrice(big.NewFloat(0)), fast.AOLimit(300))
 		require.NoError(err)
@@ -452,7 +477,10 @@ func TestPaymentChannelCloseSuccess(t *testing.T) {
 	env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
-	defer env.Teardown(ctx)
+	defer func() {
+		err := env.Teardown(ctx)
+		require.NoError(err)
+	}()
 
 	// Start test
 	targetDaemon := NewNode()
@@ -475,7 +503,7 @@ func TestPaymentChannelCloseSuccess(t *testing.T) {
 	targetBalanceBefore, err := targetDaemon.WalletBalance(ctx, targetAddr)
 	require.NoError(err)
 
-	WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+	WithPaymentChannel(ctx, t, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
 		voucherAmount := types.NewAttoFILFromFIL(10)
 		voucherValidAt := types.NewBlockHeight(0)
 		voucherStr, err := payerDaemon.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(payerAddr), fast.AOValidAt(voucherValidAt))
@@ -515,7 +543,10 @@ func TestPaymentChannelExtendSuccess(t *testing.T) {
 	env, _, NewNode, ctx := fasting.BasicFastSetup(ctx, t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
-	defer env.Teardown(ctx)
+	defer func() {
+		err := env.Teardown(ctx)
+		require.NoError(err)
+	}()
 
 	// Start test
 	targetDaemon := NewNode()
@@ -532,7 +563,7 @@ func TestPaymentChannelExtendSuccess(t *testing.T) {
 	require.NoError(err)
 	payerAddr := addrs[0]
 
-	WithPaymentChannel(t, ctx, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
+	WithPaymentChannel(ctx, t, payerDaemon, payerAddr, targetAddr, channelAmount, channelExpiry, func(chanid *types.ChannelID) {
 		channels, err := payerDaemon.PaychLs(ctx)
 		require.NoError(err)
 

--- a/tools/fast/action_chain.go
+++ b/tools/fast/action_chain.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/ipfs/go-cid"
+	cid "github.com/ipfs/go-cid"
 )
 
 // ChainHead runs the chain head command against the filecoin process.

--- a/tools/fast/action_paych.go
+++ b/tools/fast/action_paych.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/commands"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -15,7 +16,7 @@ func (f *Filecoin) PaychCreate(ctx context.Context,
 	target address.Address, amount *types.AttoFIL, eol *types.BlockHeight,
 	options ...ActionOption) (cid.Cid, error) {
 
-	var out cid.Cid
+	var out commands.CreateChannelResult
 	args := []string{"go-filecoin", "paych", "create", target.String(), amount.String(), eol.String()}
 
 	for _, option := range options {
@@ -26,12 +27,12 @@ func (f *Filecoin) PaychCreate(ctx context.Context,
 		return cid.Undef, err
 	}
 
-	return out, nil
+	return out.Cid, nil
 }
 
 // PaychClose runs the `paych close` command against the filecoin process.
 func (f *Filecoin) PaychClose(ctx context.Context, voucher string, options ...ActionOption) (cid.Cid, error) {
-	var out cid.Cid
+	var out commands.CloseResult
 	args := []string{"go-filecoin", "paych", "close", voucher}
 
 	for _, option := range options {
@@ -42,16 +43,16 @@ func (f *Filecoin) PaychClose(ctx context.Context, voucher string, options ...Ac
 		return cid.Undef, err
 	}
 
-	return out, nil
+	return out.Cid, nil
 
 }
 
 // PaychExtend runs the `paych extend` command against the filecoin process.
 func (f *Filecoin) PaychExtend(ctx context.Context,
-	channel types.ChannelID, amount *types.AttoFIL, eol types.BlockHeight,
+	channel *types.ChannelID, amount *types.AttoFIL, eol *types.BlockHeight,
 	options ...ActionOption) (cid.Cid, error) {
 
-	var out cid.Cid
+	var out commands.ExtendResult
 	args := []string{"go-filecoin", "paych", "extend", channel.String(), amount.String(), eol.String()}
 
 	for _, option := range options {
@@ -62,7 +63,7 @@ func (f *Filecoin) PaychExtend(ctx context.Context,
 		return cid.Undef, err
 	}
 
-	return out, nil
+	return out.Cid, nil
 
 }
 
@@ -84,7 +85,7 @@ func (f *Filecoin) PaychLs(ctx context.Context, options ...ActionOption) (map[st
 
 // PaychReclaim runs the `paych reclaim` command against the filecoin process.
 func (f *Filecoin) PaychReclaim(ctx context.Context, channel *types.ChannelID, options ...ActionOption) (cid.Cid, error) {
-	var out cid.Cid
+	var out commands.ReclaimResult
 	args := []string{"go-filecoin", "paych", "reclaim", channel.String()}
 
 	for _, option := range options {
@@ -95,12 +96,12 @@ func (f *Filecoin) PaychReclaim(ctx context.Context, channel *types.ChannelID, o
 		return cid.Undef, err
 	}
 
-	return out, nil
+	return out.Cid, nil
 }
 
 // PaychRedeem runs the `paych redeem` command against the filecoin process.
 func (f *Filecoin) PaychRedeem(ctx context.Context, voucher string, options ...ActionOption) (cid.Cid, error) {
-	var out cid.Cid
+	var out commands.RedeemResult
 	args := []string{"go-filecoin", "paych", "redeem", voucher}
 
 	for _, option := range options {
@@ -111,14 +112,11 @@ func (f *Filecoin) PaychRedeem(ctx context.Context, voucher string, options ...A
 		return cid.Undef, err
 	}
 
-	return out, nil
+	return out.Cid, nil
 }
 
 // PaychVoucher runs the `paych voucher` command against the filecoin process.
-func (f *Filecoin) PaychVoucher(ctx context.Context,
-	channel *types.ChannelID, amount *types.AttoFIL,
-	options ...ActionOption) (string, error) {
-
+func (f *Filecoin) PaychVoucher(ctx context.Context, channel *types.ChannelID, amount *types.AttoFIL, options ...ActionOption) (string, error) {
 	var out string
 
 	args := []string{"go-filecoin", "paych", "voucher", channel.String(), amount.String()}

--- a/tools/fast/bin/localnet/main.go
+++ b/tools/fast/bin/localnet/main.go
@@ -223,6 +223,12 @@ func main() {
 		return
 	}
 
+	err = genesis.MiningStart(ctx)
+	if err != nil {
+		exitcode = handleError(err, "failed to start mining on genesis node;")
+		return
+	}
+
 	// Create the processes that we will use to become miners
 	var miners []*fast.Filecoin
 	for i := 0; i < minerCount; i++ {

--- a/tools/fast/fasting/basic.go
+++ b/tools/fast/fasting/basic.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/ipfs/go-ipfs-files"
 	"github.com/stretchr/testify/require"
@@ -43,7 +42,7 @@ func BasicFastSetup(ctx context.Context, t *testing.T, fastenvOpts fast.Environm
 
 	fastenvOpts = fast.EnvironmentOpts{
 		InitOpts:   append([]fast.ProcessInitOption{fast.POGenesisFile(genesisURI)}, fastenvOpts.InitOpts...),
-		DaemonOpts: append([]fast.ProcessDaemonOption{fast.POBlockTime(time.Millisecond)}, fastenvOpts.DaemonOpts...),
+		DaemonOpts: append([]fast.ProcessDaemonOption{fast.POBlockTime(series.GlobalSleepDelay)}, fastenvOpts.DaemonOpts...),
 	}
 
 	// Create a node for the test
@@ -53,12 +52,8 @@ func BasicFastSetup(ctx context.Context, t *testing.T, fastenvOpts fast.Environm
 	err = series.SetupGenesisNode(ctx, genesis, genesisMiner.Address, files.NewReaderFile(genesisMiner.Owner))
 	require.NoError(err)
 
-	var MiningOnce series.MiningOnceFunc = func() {
-		_, err := genesis.MiningOnce(ctx)
-		require.NoError(err)
-	}
-
-	ctx = context.WithValue(ctx, series.CKMiningOnce, MiningOnce)
+	err = genesis.MiningStart(ctx)
+	require.NoError(err)
 
 	NewNode := func() *fast.Filecoin {
 		p, err := env.NewProcess(ctx, localplugin.PluginName, options, fastenvOpts)

--- a/tools/fast/fasting/basic.go
+++ b/tools/fast/fasting/basic.go
@@ -1,0 +1,80 @@
+package fasting
+
+import (
+	"context"
+	"io/ioutil"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-ipfs-files"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/testhelpers"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/tools/fast/series"
+	localplugin "github.com/filecoin-project/go-filecoin/tools/iptb-plugins/filecoin/local"
+)
+
+// BasicFastSetup creates a environment and a single node, and environment options
+func BasicFastSetup(ctx context.Context, t *testing.T, fastenvOpts fast.EnvironmentOpts) (fast.Environment, *fast.Filecoin, func() *fast.Filecoin, context.Context) {
+	require := require.New(t)
+
+	// Create a directory for the test using the test name (mostly for FAST)
+	// TODO(tperson) use a different TempDir that uses MkdirAll
+	dir, err := ioutil.TempDir("", strings.Replace(t.Name(), "/", ".", -1))
+	require.NoError(err)
+
+	// Create an environment that includes a genesis block with 1MM FIL
+	env, err := fast.NewEnvironmentMemoryGenesis(big.NewInt(1000000), dir)
+	require.NoError(err)
+
+	// Setup options for nodes.
+	options := make(map[string]string)
+	options[localplugin.AttrLogJSON] = "1"                                        // Enable JSON logs
+	options[localplugin.AttrLogLevel] = "5"                                       // Set log level to Debug
+	options[localplugin.AttrUseSmallSectors] = "true"                             // Enable small sectors
+	options[localplugin.AttrFilecoinBinary] = testhelpers.MustGetFilecoinBinary() // Get the filecoin binary
+
+	genesisURI := env.GenesisCar()
+	genesisMiner, err := env.GenesisMiner()
+	require.NoError(err)
+
+	fastenvOpts = fast.EnvironmentOpts{
+		InitOpts:   append([]fast.ProcessInitOption{fast.POGenesisFile(genesisURI)}, fastenvOpts.InitOpts...),
+		DaemonOpts: append([]fast.ProcessDaemonOption{fast.POBlockTime(time.Millisecond)}, fastenvOpts.DaemonOpts...),
+	}
+
+	// Create a node for the test
+	genesis, err := env.NewProcess(ctx, localplugin.PluginName, options, fastenvOpts)
+	require.NoError(err)
+
+	err = series.SetupGenesisNode(ctx, genesis, genesisMiner.Address, files.NewReaderFile(genesisMiner.Owner))
+	require.NoError(err)
+
+	var MiningOnce series.MiningOnceFunc = func() {
+		_, err := genesis.MiningOnce(ctx)
+		require.NoError(err)
+	}
+
+	ctx = context.WithValue(ctx, series.CKMiningOnce, MiningOnce)
+
+	NewNode := func() *fast.Filecoin {
+		p, err := env.NewProcess(ctx, localplugin.PluginName, options, fastenvOpts)
+		require.NoError(err)
+
+		err = series.InitAndStart(ctx, p)
+		require.NoError(err)
+
+		err = series.Connect(ctx, genesis, p)
+		require.NoError(err)
+
+		err = series.SendFilecoinDefaults(ctx, genesis, p, 10000)
+		require.NoError(err)
+
+		return p
+	}
+
+	return env, genesis, NewNode, ctx
+}

--- a/tools/fast/process_action_options.go
+++ b/tools/fast/process_action_options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/libp2p/go-libp2p-peer"
 
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 // ActionOption is used to pass optional arguments to actions.
@@ -96,5 +97,21 @@ func AOValue(value int) ActionOption {
 	sValue := fmt.Sprintf("%d", value)
 	return func() []string {
 		return []string{"--value", sValue}
+	}
+}
+
+// AOPayer provides the `--payer=<addr>` option to actions
+func AOPayer(payer address.Address) ActionOption {
+	sPayer := payer.String()
+	return func() []string {
+		return []string{"--payer", sPayer}
+	}
+}
+
+// AOValidAt provides the `--validat=<blockheight>` option to actions
+func AOValidAt(bh *types.BlockHeight) ActionOption {
+	sBH := bh.String()
+	return func() []string {
+		return []string{"--validat", sBH}
 	}
 }

--- a/tools/fast/series/get_head_block_height.go
+++ b/tools/fast/series/get_head_block_height.go
@@ -1,0 +1,23 @@
+package series
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// GetHeadBlockHeight will inspect the chain head and return the height
+func GetHeadBlockHeight(ctx context.Context, client *fast.Filecoin) (*types.BlockHeight, error) {
+	tipset, err := client.ChainHead(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := client.ShowBlock(ctx, tipset[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return types.NewBlockHeight(uint64(block.Height)), nil
+}

--- a/tools/fast/series/mining_once_from_ctx.go
+++ b/tools/fast/series/mining_once_from_ctx.go
@@ -1,0 +1,19 @@
+package series
+
+import (
+	"context"
+)
+
+// CKMiningOnce is the key used to store the MiningOnceFunc in a context
+var CKMiningOnce = struct{}{}
+
+// MiningOnceFunc is the type for the value stored under the CKMiningOnce key
+type MiningOnceFunc func()
+
+// MiningOnceFromCtx extracts the MiningOnceFunc through key CKMiningOnce
+func MiningOnceFromCtx(ctx context.Context) {
+	MiningOnce, ok := ctx.Value(CKMiningOnce).(MiningOnceFunc)
+	if ok {
+		MiningOnce()
+	}
+}

--- a/tools/fast/series/send_filecoin_from_default.go
+++ b/tools/fast/series/send_filecoin_from_default.go
@@ -22,6 +22,8 @@ func SendFilecoinFromDefault(ctx context.Context, node *fast.Filecoin, addr addr
 		return err
 	}
 
+	MiningOnceFromCtx(ctx)
+
 	if _, err := node.MessageWait(ctx, mcid); err != nil {
 		return err
 	}

--- a/tools/fast/series/setup_genesis_node.go
+++ b/tools/fast/series/setup_genesis_node.go
@@ -41,5 +41,5 @@ func SetupGenesisNode(ctx context.Context, node *fast.Filecoin, minerAddress add
 		return err
 	}
 
-	return node.MiningStart(ctx)
+	return nil
 }

--- a/tools/fast/series/wait_for_block_height.go
+++ b/tools/fast/series/wait_for_block_height.go
@@ -1,0 +1,28 @@
+package series
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// WaitForBlockHeight will inspect the chain head and wait till the height is equal to or
+// greater than the provide height `bh`
+func WaitForBlockHeight(ctx context.Context, client *fast.Filecoin, bh *types.BlockHeight) error {
+	for {
+
+		hh, err := GetHeadBlockHeight(ctx, client)
+		if err != nil {
+			return err
+		}
+
+		if hh.GreaterEqual(bh) {
+			break
+		}
+
+		SleepDelay()
+	}
+
+	return nil
+}

--- a/tools/fast/tests/retrieval_test.go
+++ b/tools/fast/tests/retrieval_test.go
@@ -90,6 +90,9 @@ func TestRetrieval(t *testing.T) {
 	err = series.SetupGenesisNode(ctx, genesis, genesisMiner.Address, files.NewReaderFile(genesisMiner.Owner))
 	require.NoError(err)
 
+	err = genesis.MiningStart(ctx)
+	require.NoError(err)
+
 	// Start Miner
 	err = series.InitAndStart(ctx, miner)
 	require.NoError(err)

--- a/tools/iptb-plugins/filecoin/local/localfilecoin.go
+++ b/tools/iptb-plugins/filecoin/local/localfilecoin.go
@@ -129,27 +129,15 @@ func init() {
 	}
 }
 
+// We can't copy the bits in go due to the following bug
+// https://github.com/golang/go/issues/22315
 func copyFileContents(src, dst string) (err error) {
-	in, err := os.Open(src)
-	if err != nil {
-		return
+	cmd := exec.Command("cp", src, dst)
+	if err := cmd.Start(); err != nil {
+		return err
 	}
-	defer in.Close() // nolint: errcheck
-	out, err := os.Create(dst)
-	if err != nil {
-		return
-	}
-	defer func() {
-		cerr := out.Close()
-		if err == nil {
-			err = cerr
-		}
-	}()
-	if _, err = io.Copy(out, in); err != nil {
-		return
-	}
-	err = out.Sync()
-	return
+
+	return cmd.Wait()
 }
 
 /** Core Interface **/


### PR DESCRIPTION
This is still a bit of a work in progress. There are some patterns that I think need to be worked out.

Also, currently tests written with FAST can flake due to the added local go-filecoin iptb plugin feature to copy the target binary (to ensure binary capability for all `go-filecoin` commands). This appears to be related to a bug being tracked in golang (https://github.com/golang/go/issues/22315) due to an issue around file descriptors being held onto longer than needed inside of threads.

A possible work around might be to use exec to run `cp` to ensure there are no open file descriptors being held by go threads.