### PR TITLE
Moved Client Cat from node api to plum pork

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	cid "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-	uio "gx/ipfs/QmRDWTzVdbHXdtat7tVJ7YC7kRaW7rTZTEF79yykcLYa49/go-unixfs/io"
 	ipld "gx/ipfs/QmRL22E4paat7ky7vx9MLpR97JHHbFPrg3ytFQw6qp1y1s/go-ipld-format"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
@@ -15,7 +14,6 @@ import (
 
 // Client is the interface that defines methods to manage client operations.
 type Client interface {
-	Cat(ctx context.Context, c cid.Cid) (uio.DagReader, error)
 	ImportData(ctx context.Context, data io.Reader) (ipld.Node, error)
 	ProposeStorageDeal(ctx context.Context, data cid.Cid, miner address.Address, ask uint64, duration uint64, allowDuplicates bool) (*storagedeal.Response, error)
 	QueryStorageDeal(ctx context.Context, prop cid.Cid) (*storagedeal.Response, error)

--- a/api/impl/client.go
+++ b/api/impl/client.go
@@ -9,7 +9,6 @@ import (
 	dag "gx/ipfs/QmNRAuGmvnVw8urHkUZQirhu42VTiZjVWASa2aTznEMmpP/go-merkledag"
 	cid "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	imp "gx/ipfs/QmRDWTzVdbHXdtat7tVJ7YC7kRaW7rTZTEF79yykcLYa49/go-unixfs/importer"
-	uio "gx/ipfs/QmRDWTzVdbHXdtat7tVJ7YC7kRaW7rTZTEF79yykcLYa49/go-unixfs/io"
 	ipld "gx/ipfs/QmRL22E4paat7ky7vx9MLpR97JHHbFPrg3ytFQw6qp1y1s/go-ipld-format"
 	chunk "gx/ipfs/QmXivYDjgMqNQXbEQVC7TMuZnRADCa71ABQUQxWPZPTLbd/go-ipfs-chunker"
 
@@ -27,21 +26,6 @@ func newNodeClient(api *nodeAPI) *nodeClient {
 }
 
 var _ api.Client = &nodeClient{}
-
-func (api *nodeClient) Cat(ctx context.Context, c cid.Cid) (uio.DagReader, error) {
-	// TODO: this goes back to 'how is data stored and referenced'
-	// For now, lets just do things the ipfs way.
-
-	nd := api.api.node
-	ds := dag.NewDAGService(nd.BlockService())
-
-	data, err := ds.Get(ctx, c)
-	if err != nil {
-		return nil, err
-	}
-
-	return uio.NewDagReader(ctx, data, ds)
-}
 
 func (api *nodeClient) ImportData(ctx context.Context, data io.Reader) (ipld.Node, error) {
 	ds := dag.NewDAGService(api.api.node.BlockService())

--- a/commands/client.go
+++ b/commands/client.go
@@ -48,7 +48,7 @@ format was provided with the data initially.
 			return err
 		}
 
-		dr, err := GetAPI(env).Client().Cat(req.Context, c)
+		dr, err := GetPorcelainAPI(env).DAGCat(req.Context, c)
 		if err != nil {
 			return err
 		}

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -6,6 +6,7 @@ import (
 
 	ma "gx/ipfs/QmNTCey11oxhb1AxDnQBRHtdhap6Ctud872NjAYPYYXPuc/go-multiaddr"
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmRDWTzVdbHXdtat7tVJ7YC7kRaW7rTZTEF79yykcLYa49/go-unixfs/io"
 	pstore "gx/ipfs/QmRhFARzTHcFh8wUxwN5KvyTGq73FLC65EfFAhz8Ng7aGb/go-libp2p-peerstore"
 	"gx/ipfs/QmTu65MVbemtUxJEWgsTtzv9Zv9P8rvmqNA4eG9TrTRGYc/go-libp2p-peer"
 	"gx/ipfs/QmZZseAa9xcK6tT3YpaShNUAEpyRAoWmUL5ojH3uGNepAc/go-libp2p-metrics"
@@ -283,4 +284,10 @@ func (api *API) DAGGetNode(ctx context.Context, ref string) (interface{}, error)
 // DAGGetFileSize returns the file size for a given Cid
 func (api *API) DAGGetFileSize(ctx context.Context, c cid.Cid) (uint64, error) {
 	return api.dag.GetFileSize(ctx, c)
+}
+
+// DAGCat returns an iostream with a piece of data stored on the merkeldag with
+// the given cid.
+func (api *API) DAGCat(ctx context.Context, c cid.Cid) (io.DagReader, error) {
+	return api.dag.Cat(ctx, c)
 }

--- a/plumbing/dag/dag.go
+++ b/plumbing/dag/dag.go
@@ -7,6 +7,7 @@ import (
 	"gx/ipfs/QmNRAuGmvnVw8urHkUZQirhu42VTiZjVWASa2aTznEMmpP/go-merkledag"
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	"gx/ipfs/QmRDWTzVdbHXdtat7tVJ7YC7kRaW7rTZTEF79yykcLYa49/go-unixfs"
+	"gx/ipfs/QmRDWTzVdbHXdtat7tVJ7YC7kRaW7rTZTEF79yykcLYa49/go-unixfs/io"
 	ipld "gx/ipfs/QmRL22E4paat7ky7vx9MLpR97JHHbFPrg3ytFQw6qp1y1s/go-ipld-format"
 	"gx/ipfs/QmVUojkFtcsrVBa8kYZiM6LhxpYXaKDTxE4aF1NFj4RfBv/go-path"
 	"gx/ipfs/QmVUojkFtcsrVBa8kYZiM6LhxpYXaKDTxE4aF1NFj4RfBv/go-path/resolver"
@@ -69,4 +70,18 @@ func (dag *DAG) GetFileSize(ctx context.Context, c cid.Cid) (uint64, error) {
 	default:
 		return 0, fmt.Errorf("unrecognized node type: %T", fnode)
 	}
+}
+
+// Cat returns an iostream with a piece of data stored on the merkeldag with
+// the given cid.
+func (dag *DAG) Cat(ctx context.Context, c cid.Cid) (io.DagReader, error) {
+	// TODO: this goes back to 'how is data stored and referenced'
+	// For now, lets just do things the ipfs way.
+
+	data, err := dag.dserv.Get(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	return io.NewDagReader(ctx, data, dag.dserv)
 }

--- a/plumbing/dag/dag.go
+++ b/plumbing/dag/dag.go
@@ -75,13 +75,9 @@ func (dag *DAG) GetFileSize(ctx context.Context, c cid.Cid) (uint64, error) {
 // Cat returns an iostream with a piece of data stored on the merkeldag with
 // the given cid.
 func (dag *DAG) Cat(ctx context.Context, c cid.Cid) (io.DagReader, error) {
-	// TODO: this goes back to 'how is data stored and referenced'
-	// For now, lets just do things the ipfs way.
-
 	data, err := dag.dserv.Get(ctx, c)
 	if err != nil {
 		return nil, err
 	}
-
 	return io.NewDagReader(ctx, data, dag.dserv)
 }


### PR DESCRIPTION
# Problem

We want to remove the `api` directory, but `Client().Cat()` is part of it.

# Solution

Move `Client().Cat()` to DAG plumbing, where it makes sense.

Resolves #1955 