### PR TITLE
Update Dockerfiles to use go 1.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.2-stretch AS builder
+FROM golang:1.12.1-stretch AS builder
 MAINTAINER Filecoin Dev Team
 
 RUN apt-get update && apt-get install -y ca-certificates file sudo clang

--- a/Dockerfile.faucet
+++ b/Dockerfile.faucet
@@ -1,4 +1,4 @@
-FROM golang:1.11.2-stretch
+FROM golang:1.12.1-stretch
 MAINTAINER Filecoin Dev Team
 
 RUN apt-get update && apt-get install -y ca-certificates file sudo clang jq

--- a/Dockerfile.genesis
+++ b/Dockerfile.genesis
@@ -1,4 +1,4 @@
-FROM golang:1.11.2-stretch
+FROM golang:1.12.1-stretch
 MAINTAINER Filecoin Dev Team
 
 RUN apt-get update && apt-get install -y ca-certificates file sudo clang

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "gx": {
     "dvcsimport": "github.com/filecoin-project/go-filecoin",
-    "goversion": "1.11.1"
+    "goversion": "1.12.1"
   },
   "gxDependencies": [
     {


### PR DESCRIPTION
Update Dockerfiles to use go 1.12.1 because a previous PR has upgraded
the version of go required to build.

Resolves #2322 