### PR TITLE
Moved Client ImportData from node api to plum pork

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -2,10 +2,8 @@ package api
 
 import (
 	"context"
-	"io"
 
 	cid "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-	ipld "gx/ipfs/QmRL22E4paat7ky7vx9MLpR97JHHbFPrg3ytFQw6qp1y1s/go-ipld-format"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
@@ -14,7 +12,6 @@ import (
 
 // Client is the interface that defines methods to manage client operations.
 type Client interface {
-	ImportData(ctx context.Context, data io.Reader) (ipld.Node, error)
 	ProposeStorageDeal(ctx context.Context, data cid.Cid, miner address.Address, ask uint64, duration uint64, allowDuplicates bool) (*storagedeal.Response, error)
 	QueryStorageDeal(ctx context.Context, prop cid.Cid) (*storagedeal.Response, error)
 	Payments(ctx context.Context, dealCid cid.Cid) ([]*paymentbroker.PaymentVoucher, error)

--- a/api/impl/client.go
+++ b/api/impl/client.go
@@ -2,15 +2,10 @@ package impl
 
 import (
 	"context"
-	"io"
 
 	"github.com/filecoin-project/go-filecoin/api"
 
-	dag "gx/ipfs/QmNRAuGmvnVw8urHkUZQirhu42VTiZjVWASa2aTznEMmpP/go-merkledag"
 	cid "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-	imp "gx/ipfs/QmRDWTzVdbHXdtat7tVJ7YC7kRaW7rTZTEF79yykcLYa49/go-unixfs/importer"
-	ipld "gx/ipfs/QmRL22E4paat7ky7vx9MLpR97JHHbFPrg3ytFQw6qp1y1s/go-ipld-format"
-	chunk "gx/ipfs/QmXivYDjgMqNQXbEQVC7TMuZnRADCa71ABQUQxWPZPTLbd/go-ipfs-chunker"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
@@ -26,19 +21,6 @@ func newNodeClient(api *nodeAPI) *nodeClient {
 }
 
 var _ api.Client = &nodeClient{}
-
-func (api *nodeClient) ImportData(ctx context.Context, data io.Reader) (ipld.Node, error) {
-	ds := dag.NewDAGService(api.api.node.BlockService())
-	bufds := ipld.NewBufferedDAG(ctx, ds)
-
-	spl := chunk.DefaultSplitter(data)
-
-	nd, err := imp.BuildDagFromReader(bufds, spl)
-	if err != nil {
-		return nil, err
-	}
-	return nd, bufds.Commit()
-}
 
 func (api *nodeClient) ProposeStorageDeal(ctx context.Context, data cid.Cid, miner address.Address, askid uint64, duration uint64, allowDuplicates bool) (*storagedeal.Response, error) {
 	return api.api.node.StorageMinerClient.ProposeDeal(ctx, miner, data, askid, duration, allowDuplicates)

--- a/commands/client.go
+++ b/commands/client.go
@@ -80,7 +80,7 @@ See the go-filecoin client cat command for more details.
 			return fmt.Errorf("given file was not a files.File")
 		}
 
-		out, err := GetAPI(env).Client().ImportData(req.Context, fi)
+		out, err := GetPorcelainAPI(env).DAGImportData(req.Context, fi)
 		if err != nil {
 			return err
 		}

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -294,8 +294,9 @@ func (api *API) DAGCat(ctx context.Context, c cid.Cid) (uio.DagReader, error) {
 	return api.dag.Cat(ctx, c)
 }
 
-// DAGImportData adds data from an io stream to the merkledag and returns the
-// Cid of the given data
+// DAGImportData adds data from an io reader to the merkledag and returns the
+// Cid of the given data. Once the data is in the DAG, it can fetched from the
+// node via Bitswap and a copy will be kept in the blockstore.
 func (api *API) DAGImportData(ctx context.Context, data io.Reader) (ipld.Node, error) {
 	return api.dag.ImportData(ctx, data)
 }

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -2,11 +2,13 @@ package plumbing
 
 import (
 	"context"
+	"io"
 	"time"
 
 	ma "gx/ipfs/QmNTCey11oxhb1AxDnQBRHtdhap6Ctud872NjAYPYYXPuc/go-multiaddr"
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-	"gx/ipfs/QmRDWTzVdbHXdtat7tVJ7YC7kRaW7rTZTEF79yykcLYa49/go-unixfs/io"
+	uio "gx/ipfs/QmRDWTzVdbHXdtat7tVJ7YC7kRaW7rTZTEF79yykcLYa49/go-unixfs/io"
+	ipld "gx/ipfs/QmRL22E4paat7ky7vx9MLpR97JHHbFPrg3ytFQw6qp1y1s/go-ipld-format"
 	pstore "gx/ipfs/QmRhFARzTHcFh8wUxwN5KvyTGq73FLC65EfFAhz8Ng7aGb/go-libp2p-peerstore"
 	"gx/ipfs/QmTu65MVbemtUxJEWgsTtzv9Zv9P8rvmqNA4eG9TrTRGYc/go-libp2p-peer"
 	"gx/ipfs/QmZZseAa9xcK6tT3YpaShNUAEpyRAoWmUL5ojH3uGNepAc/go-libp2p-metrics"
@@ -288,6 +290,12 @@ func (api *API) DAGGetFileSize(ctx context.Context, c cid.Cid) (uint64, error) {
 
 // DAGCat returns an iostream with a piece of data stored on the merkeldag with
 // the given cid.
-func (api *API) DAGCat(ctx context.Context, c cid.Cid) (io.DagReader, error) {
+func (api *API) DAGCat(ctx context.Context, c cid.Cid) (uio.DagReader, error) {
 	return api.dag.Cat(ctx, c)
+}
+
+// DAGImportData adds data from an io stream to the merkledag and returns the
+// Cid of the given data
+func (api *API) DAGImportData(ctx context.Context, data io.Reader) (ipld.Node, error) {
+	return api.dag.ImportData(ctx, data)
 }


### PR DESCRIPTION
# Problem

We want to remove the `api` directory, but `Client().ImportData()` is a part of it.

# Solution

Move `Client().ImportData()` to DAG plumbing, where it makes sense.

Resolves #1956 