### PR TITLE
Implement Equals() method for Message, MeteredMessage and SignedMessage

### DIFF
--- a/types/block_test.go
+++ b/types/block_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 	cid "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	cbor "gx/ipfs/QmcZLyosDwMKdB6NLRsiss9HXzDPhVhhRtPy67JFKTDQDX/go-ipld-cbor"
 
 	"github.com/filecoin-project/go-filecoin/address"
-	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
-	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 )
 
 func TestTriangleEncoding(t *testing.T) {
@@ -31,6 +31,7 @@ func TestTriangleEncoding(t *testing.T) {
 	// see: https://github.com/filecoin-project/go-filecoin/issues/599
 
 	newAddress := address.NewForTestGetter()
+	newSignedMessage := NewSignedMessageForTestGetter(mockSigner)
 
 	// REVIVE AFTER https://github.com/filecoin-project/go-filecoin/issues/599 is fixed.
 	//
@@ -152,6 +153,7 @@ func cidFromString(input string) (cid.Cid, error) {
 }
 
 func TestDecodeBlock(t *testing.T) {
+	newSignedMessage := NewSignedMessageForTestGetter(mockSigner)
 	t.Run("successfully decodes raw bytes to a Filecoin block", func(t *testing.T) {
 		assert := assert.New(t)
 
@@ -227,6 +229,7 @@ func TestParanoidPanic(t *testing.T) {
 
 func TestBlockJsonMarshal(t *testing.T) {
 	assert := assert.New(t)
+	newSignedMessage := NewSignedMessageForTestGetter(mockSigner)
 
 	var parent, child Block
 	child.Miner = address.NewForTestGetter()()

--- a/types/message.go
+++ b/types/message.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -37,6 +38,19 @@ type Message struct {
 
 	Method string `json:"method"`
 	Params []byte `json:"params"`
+	// Pay attention to Equals() if updating this struct.
+}
+
+// NewMessage creates a new message.
+func NewMessage(from, to address.Address, nonce uint64, value *AttoFIL, method string, params []byte) *Message {
+	return &Message{
+		From:   from,
+		To:     to,
+		Nonce:  Uint64(nonce),
+		Value:  value,
+		Method: method,
+		Params: params,
+	}
 }
 
 // Unmarshal a message from the given bytes.
@@ -84,14 +98,12 @@ func (msg *Message) String() string {
 	return fmt.Sprintf("Message cid=[%v]: %s", cid, string(js))
 }
 
-// NewMessage creates a new message.
-func NewMessage(from, to address.Address, nonce uint64, value *AttoFIL, method string, params []byte) *Message {
-	return &Message{
-		From:   from,
-		To:     to,
-		Nonce:  Uint64(nonce),
-		Value:  value,
-		Method: method,
-		Params: params,
-	}
+// Equals tests whether two messages are equal
+func (msg *Message) Equals(other *Message) bool {
+	return msg.To == other.To &&
+		msg.From == other.From &&
+		msg.Nonce == other.Nonce &&
+		msg.Value.Equal(other.Value) &&
+		msg.Method == other.Method &&
+		bytes.Equal(msg.Params, other.Params)
 }

--- a/types/message_test.go
+++ b/types/message_test.go
@@ -1,11 +1,13 @@
 package types
 
 import (
+	"reflect"
 	"testing"
 
-	"github.com/filecoin-project/go-filecoin/address"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/address"
 )
 
 func TestMessageMarshal(t *testing.T) {
@@ -18,16 +20,22 @@ func TestMessageMarshal(t *testing.T) {
 	msg := NewMessage(
 		addrGetter(),
 		addrGetter(),
-		0,
+		42,
 		NewAttoFILFromFIL(17777),
 		"send",
 		[]byte("foobar"),
 	)
 
+	// This check requests that you add a non-zero value for new fields above,
+	// then update the field count below.
+	require.Equal(t, 6, reflect.TypeOf(*msg).NumField())
+
 	marshalled, err := msg.Marshal()
 	assert.NoError(err)
 
 	msgBack := Message{}
+	assert.False(msg.Equals(&msgBack))
+
 	err = msgBack.Unmarshal(marshalled)
 	assert.NoError(err)
 
@@ -36,6 +44,7 @@ func TestMessageMarshal(t *testing.T) {
 	assert.Equal(msg.Value, msgBack.Value)
 	assert.Equal(msg.Method, msgBack.Method)
 	assert.Equal(msg.Params, msgBack.Params)
+	assert.True(msg.Equals(&msgBack))
 }
 
 func TestMessageCid(t *testing.T) {

--- a/types/metered_message.go
+++ b/types/metered_message.go
@@ -21,16 +21,7 @@ type MeteredMessage struct {
 	Message  `json:"message"`
 	GasPrice AttoFIL  `json:"gasPrice"`
 	GasLimit GasUnits `json:"gasLimit"`
-}
-
-// Unmarshal a message from the given bytes.
-func (msg *MeteredMessage) Unmarshal(b []byte) error {
-	return cbor.DecodeInto(b, msg)
-}
-
-// Marshal the message into bytes.
-func (msg *MeteredMessage) Marshal() ([]byte, error) {
-	return cbor.DumpObject(msg)
+	// Pay attention to Equals() if updating this struct.
 }
 
 // NewMeteredMessage accepts a message `msg`, a gas price `gasPrice` and a `gasLimit`.
@@ -43,6 +34,16 @@ func NewMeteredMessage(msg Message, gasPrice AttoFIL, gasLimit GasUnits) *Metere
 	}
 }
 
+// Unmarshal a message from the given bytes.
+func (msg *MeteredMessage) Unmarshal(b []byte) error {
+	return cbor.DecodeInto(b, msg)
+}
+
+// Marshal the message into bytes.
+func (msg *MeteredMessage) Marshal() ([]byte, error) {
+	return cbor.DumpObject(msg)
+}
+
 // NewGasPrice constructs a gas price (in AttoFIL) from the given number.
 func NewGasPrice(price int64) AttoFIL {
 	return *NewAttoFIL(big.NewInt(price))
@@ -51,4 +52,11 @@ func NewGasPrice(price int64) AttoFIL {
 // NewGasUnits constructs a new GasUnits from the given number.
 func NewGasUnits(cost uint64) GasUnits {
 	return Uint64(cost)
+}
+
+// Equals tests whether two metered messages are equal
+func (msg *MeteredMessage) Equals(other *MeteredMessage) bool {
+	return msg.Message.Equals(&other.Message) &&
+		msg.GasPrice.Equal(&other.GasPrice) &&
+		msg.GasLimit == other.GasLimit
 }

--- a/types/metered_message_test.go
+++ b/types/metered_message_test.go
@@ -1,0 +1,53 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/assert"
+	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/address"
+)
+
+func TestMeteredMessageMessage(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	addrGetter := address.NewForTestGetter()
+
+	t.Run("marshal and equality", func(t *testing.T) {
+		inner := NewMessage(
+			addrGetter(),
+			addrGetter(),
+			42,
+			NewAttoFILFromFIL(17777),
+			"send",
+			[]byte("foobar"),
+		)
+
+		mmsg := NewMeteredMessage(*inner, *NewAttoFILFromFIL(2), NewGasUnits(300))
+
+		// This check requests that you add a non-zero value for new fields above,
+		// then update the field count below.
+		require.Equal(t, 3, reflect.TypeOf(*mmsg).NumField())
+
+		marshalled, err := mmsg.Marshal()
+		assert.NoError(err)
+
+		msgBack := MeteredMessage{}
+		assert.False(mmsg.Equals(&msgBack))
+
+		err = msgBack.Unmarshal(marshalled)
+		assert.NoError(err)
+
+		assert.Equal(mmsg.To, msgBack.To)
+		assert.Equal(mmsg.From, msgBack.From)
+		assert.Equal(mmsg.Value, msgBack.Value)
+		assert.Equal(mmsg.Method, msgBack.Method)
+		assert.Equal(mmsg.Params, msgBack.Params)
+		assert.Equal(mmsg.GasPrice, msgBack.GasPrice)
+		assert.Equal(mmsg.GasLimit, msgBack.GasLimit)
+
+		assert.True(mmsg.Equals(&msgBack))
+	})
+}

--- a/types/signed_message.go
+++ b/types/signed_message.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -28,6 +29,28 @@ func init() {
 type SignedMessage struct {
 	MeteredMessage `json:"meteredMessage"`
 	Signature      Signature `json:"signature"`
+	// Pay attention to Equals() if updating this struct.
+}
+
+// NewSignedMessage accepts a message `msg` and a signer `s`. NewSignedMessage returns a `SignedMessage` containing
+// a signature derived from the serialized `msg` and `msg.From`
+func NewSignedMessage(msg Message, s Signer, gasPrice AttoFIL, gasLimit GasUnits) (*SignedMessage, error) {
+	meteredMsg := NewMeteredMessage(msg, gasPrice, gasLimit)
+
+	mmsg, err := meteredMsg.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	sig, err := s.SignBytes(mmsg, msg.From)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SignedMessage{
+		MeteredMessage: *meteredMsg,
+		Signature:      sig,
+	}, nil
 }
 
 // Unmarshal a SignedMessage from the given bytes.
@@ -95,23 +118,8 @@ func (smsg *SignedMessage) String() string {
 	return fmt.Sprintf("SignedMessage cid=[%v]: %s", cid, string(js))
 }
 
-// NewSignedMessage accepts a message `msg` and a signer `s`. NewSignedMessage returns a `SignedMessage` containing
-// a signature derived from the serialized `msg` and `msg.From`
-func NewSignedMessage(msg Message, s Signer, gasPrice AttoFIL, gasLimit GasUnits) (*SignedMessage, error) {
-	meteredMsg := NewMeteredMessage(msg, gasPrice, gasLimit)
-
-	bmsg, err := meteredMsg.Marshal()
-	if err != nil {
-		return nil, err
-	}
-
-	sig, err := s.SignBytes(bmsg, msg.From)
-	if err != nil {
-		return nil, err
-	}
-
-	return &SignedMessage{
-		MeteredMessage: *meteredMsg,
-		Signature:      sig,
-	}, nil
+// Equals tests whether two signed messages are equal.
+func (smsg *SignedMessage) Equals(other *SignedMessage) bool {
+	return smsg.MeteredMessage.Equals(&other.MeteredMessage) &&
+		bytes.Equal(smsg.Signature, other.Signature)
 }

--- a/types/testing.go
+++ b/types/testing.go
@@ -59,8 +59,8 @@ func NewMockSigner(kis []KeyInfo) MockSigner {
 	return ms
 }
 
-// NewMockSignersAndKeyInfo is a convenience function to generate a given number of (mock)
-// signers with their KeyInfo
+// NewMockSignersAndKeyInfo is a convenience function to generate a mock
+// signers with some keys.
 func NewMockSignersAndKeyInfo(numSigners int) (MockSigner, []KeyInfo) {
 	ki := MustGenerateKeyInfo(numSigners, GenerateKeyInfoSeed())
 	signer := NewMockSigner(ki)


### PR DESCRIPTION
I need this for runtime checks that messages mined into blocks are identical to the message sent by a node.

I could alternatively use `CID()` for the inner Message, but it looks like that would be slower with adding extra complexity to cache the CID etc.

CC @whyrusleeping 