### PR TITLE
HOTFIX: need sudo to install jq and git and circle build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,10 +95,10 @@ commands:
         type: string
     steps:
       - run:
-          name: install jq
+          name: install jq and git
           command: |
-            apt-get update
-            apt-get install -y jq git
+            sudo apt-get update
+            sudo apt-get install -y jq git
       - run:
           name: Update badge << parameters.filename >>
           command: |


### PR DESCRIPTION
fails to install otherwise.
see failing build https://circleci.com/gh/filecoin-project/go-filecoin/12815