### PR TITLE
Fix Flaky TestStorageDealsAfterRestart

### DIFF
--- a/commands/client_daemon_test.go
+++ b/commands/client_daemon_test.go
@@ -46,7 +46,8 @@ func TestStorageDealsAfterRestart(t *testing.T) {
 
 	minerDaemon.ConnectSuccess(clientDaemon)
 
-	minerDaemon.MinerSetPrice(fixtures.TestMiners[0], fixtures.TestAddresses[0], "20", "10")
+	addAskCid := minerDaemon.MinerSetPrice(fixtures.TestMiners[0], fixtures.TestAddresses[0], "20", "10")
+	clientDaemon.WaitForMessageRequireSuccess(addAskCid)
 	dataCid := clientDaemon.RunWithStdin(strings.NewReader("HODLHODLHODL"), "client", "import").ReadStdoutTrimNewlines()
 
 	proposeDealOutput := clientDaemon.RunSuccess("client", "propose-storage-deal", fixtures.TestMiners[0], dataCid, "0", "5").ReadStdoutTrimNewlines()

--- a/testhelpers/commands.go
+++ b/testhelpers/commands.go
@@ -487,9 +487,27 @@ func (td *TestDaemon) CreateMinerAddr(peer *TestDaemon, fromAddr string) address
 	return minerAddr
 }
 
-// MinerSetPrice creates an ask for a CURRENTLY MINING test daemon and waits for it to appears on chain
-func (td *TestDaemon) MinerSetPrice(minerAddr string, fromAddr string, price string, expiry string) {
-	td.RunSuccess("miner", "set-price", "--from", fromAddr, "--miner", minerAddr, "--gas-price", "0", "--gas-limit", "300", price, expiry)
+// MinerSetPrice creates an ask for a CURRENTLY MINING test daemon and waits for it to appears on chain. It returns the
+// cid of the AddAsk message so other daemons can `message wait` for it.
+func (td *TestDaemon) MinerSetPrice(minerAddr string, fromAddr string, price string, expiry string) cid.Cid {
+	setPriceReturn := td.RunSuccess("miner", "set-price",
+		"--from", fromAddr,
+		"--miner", minerAddr,
+		"--gas-price", "0",
+		"--gas-limit", "300",
+		"--enc", "json",
+		price, expiry).ReadStdout()
+
+	resultStruct := struct {
+		MinerSetPriceResponse struct {
+			AddAskCid cid.Cid
+		}
+	}{}
+
+	if err := json.Unmarshal([]byte(setPriceReturn), &resultStruct); err != nil {
+		require.NoError(td.test, err)
+	}
+	return resultStruct.MinerSetPriceResponse.AddAskCid
 }
 
 // UpdatePeerID updates a currently mining miner's peer ID


### PR DESCRIPTION
Resolves #1873 

## Problem

Test would fail with "ask not found" when the storage client would attempt to propose a storage deal

## Solution

Wait for the storage client node to see the AddAsk message generated by the storage miner node before making the storage deal proposal.

