### PR TITLE
Re-added TODO comment removed from plumbing DAGCat

### DIFF
--- a/plumbing/dag/dag.go
+++ b/plumbing/dag/dag.go
@@ -77,6 +77,10 @@ func (dag *DAG) GetFileSize(ctx context.Context, c cid.Cid) (uint64, error) {
 
 // Cat returns an iostream with a piece of data stored on the merkeldag with
 // the given cid.
+//
+// TODO: this goes back to 'how is data stored and referenced'
+// For now, lets just do things the ipfs way.
+// https://github.com/filecoin-project/specs/issues/136
 func (dag *DAG) Cat(ctx context.Context, c cid.Cid) (uio.DagReader, error) {
 	data, err := dag.dserv.Get(ctx, c)
 	if err != nil {


### PR DESCRIPTION
# Problem

In #2321, I removed a TODO comment by mistake.

# Solution

Add it back with an additional link to it's associated github issue.