### PR TITLE
Temporarily target test rather than user devnet to dry run parameterized deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,11 @@ params:
       description: "job is being invoked from nightly workflow"
       type: boolean
       default: false
+  user_devnet_param: &user_devnet_param
+    user_devnet:
+      description: "job is being invoked from user devnet workflow"
+      type: boolean
+      default: false
 
 commands:
   rust_fil_proofs_checksum:
@@ -73,6 +78,12 @@ commands:
           name: read and export nightly FILECOIN_BINARY_VERSION
           command: |
             echo "export FILECOIN_BINARY_VERSION="$(cat release-version-nightly.txt)"" >> $BASH_ENV
+  get_user_devnet_version:
+    steps:
+      - run:
+          name: read and export user devnet FILECOIN_BINARY_VERSION
+          command: |
+            echo "export FILECOIN_BINARY_VERSION="${CIRCLE_TAG}"" >> $BASH_ENV
 
   trigger_infra_build:
     parameters:
@@ -398,6 +409,7 @@ jobs:
     resource_class: xlarge
     parameters:
       <<: *nightly_param
+      <<: *user_devnet_param
     working_directory: "~/docker_build"
     steps:
       - add_ssh_keys:
@@ -440,6 +452,11 @@ jobs:
           condition: << parameters.nightly >>
           steps:
             - get_nightly_version
+
+      - when:
+          condition: << parameters.user_devnet >>
+          steps:
+            - get_user_devnet_version
 
       - run:
           name: build & push image - genesis file server
@@ -512,45 +529,17 @@ jobs:
       - image: circleci/golang:latest
     resource_class: small
     steps:
-      - setup_remote_docker
       - checkout
-      - run:
-          name: Install AWS CLI
-          command: |
-            sudo apt-get install -y python-pip libyaml-dev python-dev jq
-            sudo pip install awscli
-      - run:
-          name: login to ECR
-          command: |
-            export AWS_ACCESS_KEY_ID=$AWS_ECR_ACCESS_KEY_ID
-            export AWS_SECRET_ACCESS_KEY=$AWS_ECR_SECRET_ACCESS_KEY
-            eval $(aws --region us-east-1 ecr --no-include-email get-login)
-      - run:
-          name: Tag filecoin image with devnet-user
-          command: |
-            export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
-            docker pull 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA
-            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:devnet-user
-            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:devnet-user
-      - run:
-          name: Tag filecoin-faucet image with devnet-user
-          command: |
-            export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
-            docker pull 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA
-            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:devnet-user
-            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:devnet-user
-      - run:
-          name: Tag filecoin-genesis-file-server image with devnet-user
-          command: |
-            export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
-            docker pull 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA
-            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:devnet-user
-            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:devnet-user
-      - run:
-          name: Trigger user deploy in go-filecoin-infra
-          command: |
-            sudo apt-get install -y curl jq
-            curl -X POST --header "Content-Type: application/json" -d '{"branch":"filecoin-usernet"}' https://circleci.com/api/v1.1/project/github/filecoin-project/go-filecoin-infra/build?circle-token=$CIRCLE_API_TOKEN
+      - get_user_devnet_version
+      - trigger_infra_build:
+          job: deploy_user_devnet
+          branch: filecoin-testnet
+          # @TODO Remove the line above and uncomment below when testing complete
+          # branch: filecoin-usernet
+      - update_badge:
+          filename: "test-devnet.json"
+          # @TODO Remove the line above and uncomment below when testing complete
+          # filename: "user-devnet.json"
 
 workflows:
   version: 2
@@ -607,6 +596,9 @@ workflows:
             tags:
               only:
                 - /^\d+\.\d+\.\d+$/
+                # @TODO remove the following line after deploy testing complete
+                - /^testnet\-\d+\.\d+\.\d+$/
+
       - build_linux:
           filters:
             branches:
@@ -615,6 +607,8 @@ workflows:
             tags:
               only:
                 - /^\d+\.\d+\.\d+$/
+                # @TODO remove the following line after deploy testing complete
+                - /^testnet\-\d+\.\d+\.\d+$/
       - publish_release:
           requires:
             - build_linux
@@ -626,6 +620,8 @@ workflows:
             tags:
               only:
                 - /^\d+\.\d+\.\d+$/
+                # @TODO remove the following line after deploy testing complete
+                - /^testnet\-\d+\.\d+\.\d+$/
 
   build_nightly_devnet:
     triggers:
@@ -667,7 +663,9 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^devnet-user$/
+                - /^\d+\.\d+\.\d+$/
+                # @TODO remove the following line after deploy testing complete
+                - /^testnet\-\d+\.\d+\.\d+$/
 
       - build_faucet_and_genesis:
           requires:
@@ -678,7 +676,9 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^devnet-user$/
+                - /^\d+\.\d+\.\d+$/
+                # @TODO remove the following line after deploy testing complete
+                - /^testnet\-\d+\.\d+\.\d+$/
 
       - build_docker_img:
           requires:
@@ -690,7 +690,9 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^devnet-user$/
+                - /^\d+\.\d+\.\d+$/
+                # @TODO remove the following line after deploy testing complete
+                - /^testnet\-\d+\.\d+\.\d+$/
 
       - trigger_user_devnet_deploy:
           requires:
@@ -701,4 +703,6 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^devnet-user$/
+                - /^\d+\.\d+\.\d+$/
+                # @TODO remove the following line after deploy testing complete
+                - /^testnet\-\d+\.\d+\.\d+$/

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,72 @@
+<!--
+ This document is formatted one-sentence-per-line, breaking very long sentences at phrase boundaries.
+ This format makes diffs clean and review comments easy to target.
+-->
+
+# Releasing and Deploying go-filecoin
+
+Building, releasing and deploying go-filecoin binaries is handled entirely by CI (CircleCI).
+
+There are two primary release and deploy paths, `User` and `Nightly`.
+
+Linux and MacOS binaries are built and distributed in a Github release for each. For Nightly, the release is marked as a pre-release.
+Additionally, a Docker image is published to ECR containing fixtures and rust-fil-proofs groth parameters.
+
+The binary version is passed as a parameter to trigger the `go-filecoin-infra` [Nightly Devnet deploy](https://github.com/filecoin-project/go-filecoin-infra/blob/filecoin-nightly/.circleci/config.yml) or [Test Devnet deploy](https://github.com/filecoin-project/go-filecoin-infra/blob/filecoin-testnet/.circleci/config.yml).
+@TODO replace 'Test Devnet' with 'User Devnet' after testing
+
+Badges can be found in go-filecoin README.md listing current releases.
+
+## User
+
+The User release channel is intended as a quasi-stable (no SLA or guarantees at this time) release and testing bed
+for Filecoin Developers, Infrastructure Engineers and Testers.
+
+A release and deploy to the User Devnet is triggered by pushing a git tag meeting the following regex patterns
+- `/^\d+\.\d+\.\d+$/`
+- `/^testnet\-\d+\.\d+\.\d+$/ # @TODO remove this after deploy testing complete`
+
+### Deploy instructions
+
+1. Create a release branch eg. `release-0.1.0` based on the commit SHA of a test nightly release you would like to promote.
+The nightly release should be tested prior to this.
+	```
+	git branch release-0.1.0 <sha1-of-nightly-release-commit>
+	```
+	The branch name should not match the tag versioning schema listed above.
+	All subsequent work related to the release should be done here, while keeping master branch free for further development.
+
+2. Create and push a git tag conforming to the expected tag schema listed above
+	```
+	git tag -a testnet-0.1.0 <sha1-of-commit>
+	OR
+	git tag -a 0.1.0 <sha1-of-commit>
+	git push origin testnet-0.1.0
+	```
+	This will commence the release and deploy process in [CircleCI project](https://circleci.com/gh/filecoin-project/go-filecoin)
+
+3. After the `go-filecoin` build successfully completes in CircleCI, you must manually approve the [Terraform deploy workflow](https://circleci.com/gh/filecoin-project/workflows/go-filecoin-infra/tree/filecoin-testnet).
+View the most recent workflow and approve the `hold` job which will subsequently trigger the `deploy_user_devnet`.
+This manual approval gate is to prevent unintentional destructive deployments of the User Devnet.
+@TODO replace the link above with `filecoin-usernet` branch after testing
+
+That's it! The release and deploy process should be complete.
+
+During release testing, bug fixes or changes should be cherry picked from master in to the release branch as needed.
+When releasing and deploying bug fixes or changes from the release branch, create and push a new git tag with incremented patch version ie. `0.1.1`
+
+While release is still in `0.x.x`, it is acceptable for minor version bumps to contain breaking changes. Full semantic versioning will only be enforced on MainNet launch when the version will become `1.0.0.`
+
+*NOTE:* CircleCI build is configured to deploy to the Test Devnet rather than the User Devnet to allow a dry run
+before formally introducing new release and deploy process to User Devnet
+
+ ## Nightly
+
+The Nightly release channel is intended to allow daily iteration and testing without impacting the more stable User Devnet.
+
+Triggered at 6:00 UTC daily in CircleCI scheduled job, no human intervention is needed to trigger the nightly release and deploy to the Nightly Devnet.
+
+The following versioning scheme is utilized in Nightly
+```
+nightly-{circle-build-num}-{short-sha}
+```


### PR DESCRIPTION
re-uses circleci commands introduced by new nightly deploy process.
uses git tag for docker image and deploy docker tag to devnet.
makes user/test devnet deploy be triggered by git tag