### PR TITLE
Chore/2318 create nightly binary release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ commands:
           name: read and export nightly FILECOIN_BINARY_VERSION
           command: |
             echo "export FILECOIN_BINARY_VERSION="$(cat release-version-nightly.txt)"" >> $BASH_ENV
+
   trigger_infra_build:
     parameters:
       branch:
@@ -340,6 +341,8 @@ jobs:
     docker:
       - image: circleci/golang:latest
     resource_class: small
+    parameters:
+      <<: *nightly_param
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -351,6 +354,10 @@ jobs:
       - checkout
       - attach_workspace:
           at: "."
+      - when:
+          condition: << parameters.nightly >>
+          steps:
+            - get_nightly_version
       - run:
           name: Publish new release
           command: |
@@ -499,6 +506,7 @@ jobs:
       - update_badge:
           filename: "nightly-devnet.json"
 
+
   trigger_user_devnet_deploy:
     docker:
       - image: circleci/golang:latest
@@ -631,6 +639,7 @@ workflows:
     jobs:
       - build_linux:
           nightly: true
+      - build_macos
       - build_faucet_and_genesis:
           requires:
             - build_linux
@@ -642,6 +651,12 @@ workflows:
       - trigger_nightly_devnet_deploy:
           requires:
             - build_docker_img
+      - publish_release:
+          nightly: true
+          requires:
+            - build_linux
+            - build_macos
+            - trigger_nightly_devnet_deploy
 
   build_user_devnet:
     jobs:


### PR DESCRIPTION
- create prerelease binaries for Linux and OSX from each nightly build

<img width="1123" alt="Screen Shot 2019-03-19 at 4 12 47 PM" src="https://user-images.githubusercontent.com/42549113/54647997-e2458200-4a61-11e9-945e-08c9f3c867d8.png">
