### PR TITLE
Bugs/2315-and-2348 fix retrieval script + remove fmt.Printf

### DIFF
--- a/chain/default_syncer.go
+++ b/chain/default_syncer.go
@@ -2,7 +2,6 @@ package chain
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -326,7 +325,7 @@ func (syncer *DefaultSyncer) HandleNewBlocks(ctx context.Context, blkCids []cid.
 	// FYI the two biggest concurrency concerns at present would be addressed
 	// by locking after collectChain completes, so my hunch is this can be
 	// fixed by simply moving the lock call below collectChain.
-	fmt.Printf("trying to sync %v\n", blkCids)
+	logSyncer.Debugf("trying to sync %v\n", blkCids)
 	syncer.mu.Lock()
 	defer syncer.mu.Unlock()
 	// If the store already has all these blocks the syncer is finished.

--- a/functional-tests/lib/helpers.bash
+++ b/functional-tests/lib/helpers.bash
@@ -146,7 +146,7 @@ function wait_for_message_in_chain_by_method_and_sender {
     # dump chain state to stdout if we time out
     if [ $polls_remaining -eq 0 ]
     then
-        echo "timed out after waiting seconds=$4 for message=$1, sent from address=$2, to be included in repodir=$3 chain..."
+        echo "timed out after waiting seconds=$4 for method=$1, sent from address=$2, to be included in repodir=$3 chain..."
         chain_ls "$3"
         unset IFS
         exit 1
@@ -156,7 +156,7 @@ function wait_for_message_in_chain_by_method_and_sender {
 
     polls_remaining=$((polls_remaining - 1))
     local seconds_remaining=$((polls_remaining*10))
-    echo "$(date "+%T") - sleeping for 10 seconds ($seconds_remaining seconds remaining - message=$1, sent from address=$2)"
+    echo "$(date "+%T") - sleeping for 10 seconds ($seconds_remaining seconds remaining - method=$1, sent from address=$2)"
     echo "$__hodl"
     sleep 10
   done

--- a/functional-tests/lib/helpers.bash
+++ b/functional-tests/lib/helpers.bash
@@ -140,11 +140,11 @@ function wait_for_message_in_chain_by_method_and_sender {
   local __hodl=""
 
   # set the maximum number of chain polls to FLOOR(seconds/10)
-  local polls_remaining=$(($( printf "%.0f" "$4" )/10))
+  local __polls_remaining=$(($( printf "%.0f" "$4" )/10))
 
   while [ -z $__hodl ]; do
     # dump chain state to stdout if we time out
-    if [ $polls_remaining -eq 0 ]
+    if [ $__polls_remaining -eq 0 ]
     then
         echo "timed out after waiting seconds=$4 for method=$1, sent from address=$2, to be included in repodir=$3 chain..."
         chain_ls "$3"
@@ -154,8 +154,8 @@ function wait_for_message_in_chain_by_method_and_sender {
 
     __hodl=$(echo "$(chain_ls "$3")" | jq ".[] | select(.messages != null) | .messages[].meteredMessage.message | select(.method == \"$1\").from | select(. == \"$2\")" 2>/dev/null | head -n 1 || true)
 
-    polls_remaining=$((polls_remaining - 1))
-    local seconds_remaining=$((polls_remaining*10))
+    __polls_remaining=$((__polls_remaining - 1))
+    local seconds_remaining=$((__polls_remaining*10))
     echo "$(date "+%T") - sleeping for 10 seconds ($seconds_remaining seconds remaining - method=$1, sent from address=$2)"
     echo "$__hodl"
     sleep 10

--- a/functional-tests/retrieval
+++ b/functional-tests/retrieval
@@ -175,15 +175,15 @@ echo "client proposes a storage deal, which transfers piece 2..."
 
 echo ""
 echo "wait for commitSector sent by miner owner to be included in a block viewable by all nodes..."
-wait_for_message_in_chain_by_method_and_sender commitSector "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${CL_REPO_DIR}"
-wait_for_message_in_chain_by_method_and_sender commitSector "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${BOOTSTRAP_MN_REPO_DIR}"
-wait_for_message_in_chain_by_method_and_sender commitSector "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${STORAGE_MN_REPO_DIR}"
+wait_for_message_in_chain_by_method_and_sender commitSector "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${CL_REPO_DIR}" 120
+wait_for_message_in_chain_by_method_and_sender commitSector "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${BOOTSTRAP_MN_REPO_DIR}" 120
+wait_for_message_in_chain_by_method_and_sender commitSector "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${STORAGE_MN_REPO_DIR}" 120
 
 echo ""
 echo "wait for submitPoSt, too..."
-wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${CL_REPO_DIR}"
-wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${BOOTSTRAP_MN_REPO_DIR}"
-wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${STORAGE_MN_REPO_DIR}"
+wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${CL_REPO_DIR}" 120
+wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${BOOTSTRAP_MN_REPO_DIR}" 120
+wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${STORAGE_MN_REPO_DIR}" 120
 
 echo ""
 echo ""


### PR DESCRIPTION
Fixes #2315 

Fixes #2348 

## What's in this PR?

- modify chain synchronizing code to write to logger instead of stdout
- add timeout (seconds) to `wait_for_message_in_chain_by_method_and_sender` function
- query chain using single `jq` invocation on entirety of NDJSON response instead of one query per line
- fix bug in `wait_for_message_in_chain_by_method_and_sender` which caused it to ignore tip sets containing a block with a `null` `messages` property