### PR TITLE
remove dependency on porcelain for retrieval protocol api

### DIFF
--- a/commands/retrieval_client.go
+++ b/commands/retrieval_client.go
@@ -36,7 +36,12 @@ var clientRetrievePieceCmd = &cmds.Command{
 			return err
 		}
 
-		readCloser, err := GetRetrievalAPI(env).RetrievePiece(req.Context, pieceCID, minerAddr)
+		mpid, err := GetPorcelainAPI(env).MinerGetPeerID(req.Context, minerAddr)
+		if err != nil {
+			return err
+		}
+
+		readCloser, err := GetRetrievalAPI(env).RetrievePiece(req.Context, pieceCID, mpid, minerAddr)
 		if err != nil {
 			return err
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -1063,7 +1063,7 @@ func (node *Node) setupProtocols() error {
 	node.BlockAPI = &blockAPI
 
 	// set up retrieval client and api
-	retapi := retrieval.NewAPI(retrieval.NewClient(node), node.PorcelainAPI)
+	retapi := retrieval.NewAPI(retrieval.NewClient(node))
 	node.RetrievalAPI = &retapi
 
 	// set up storage client and api

--- a/protocol/retrieval/api.go
+++ b/protocol/retrieval/api.go
@@ -12,24 +12,15 @@ import (
 
 // API here is the API for a retrieval client.
 type API struct {
-	rc        *Client
-	porcelain retrievalClientPorcelainAPI
-}
-
-type retrievalClientPorcelainAPI interface {
-	MinerGetPeerID(ctx context.Context, minerAddr address.Address) (peer.ID, error)
+	rc *Client
 }
 
 // NewAPI creates a new API for a retrieval client.
-func NewAPI(rc *Client, minerPorc retrievalClientPorcelainAPI) API {
-	return API{rc: rc, porcelain: minerPorc}
+func NewAPI(rc *Client) API {
+	return API{rc: rc}
 }
 
 // RetrievePiece retrieves bytes referenced by CID pieceCID
-func (a *API) RetrievePiece(ctx context.Context, pieceCID cid.Cid, minerAddr address.Address) (io.ReadCloser, error) {
-	mpid, err := a.porcelain.MinerGetPeerID(ctx, minerAddr)
-	if err != nil {
-		return nil, err
-	}
+func (a *API) RetrievePiece(ctx context.Context, pieceCID cid.Cid, mpid peer.ID, minerAddr address.Address) (io.ReadCloser, error) {
 	return a.rc.RetrievePiece(ctx, mpid, pieceCID)
 }

--- a/protocol/retrieval/retrieval_protocol_test.go
+++ b/protocol/retrieval/retrieval_protocol_test.go
@@ -7,6 +7,7 @@ import (
 
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmTu65MVbemtUxJEWgsTtzv9Zv9P8rvmqNA4eG9TrTRGYc/go-libp2p-peer"
 
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/node"
@@ -30,12 +31,15 @@ func TestRetrievalProtocolPieceNotFound(t *testing.T) {
 
 	someRandomCid := types.NewCidForTestGetter()()
 
-	_, err := retrievePieceBytes(ctx, minerNode.RetrievalAPI, someRandomCid, minerAddr)
+	minerPID, err := minerNode.PorcelainAPI.MinerGetPeerID(ctx, minerAddr)
+	require.NoError(err)
+
+	_, err = retrievePieceBytes(ctx, minerNode.RetrievalAPI, someRandomCid, minerPID, minerAddr)
 	require.Error(err)
 }
 
-func retrievePieceBytes(ctx context.Context, retrievalAPI *retrieval.API, data cid.Cid, addr address.Address) ([]byte, error) {
-	r, err := retrievalAPI.RetrievePiece(ctx, data, addr)
+func retrievePieceBytes(ctx context.Context, retrievalAPI *retrieval.API, data cid.Cid, minerPID peer.ID, addr address.Address) ([]byte, error) {
+	r, err := retrievalAPI.RetrievePiece(ctx, data, minerPID, addr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #2304 : remove the dependency on porcelain and add the miner peerid as a parameter to retrievalAPI.RetrievePiece. Opted to leave the API there instead of getting rid of it since we will likely add other functions, and also because symmetry.