### PR TITLE
check if xtrace is enabled in bash scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,6 +247,11 @@ jobs:
       # The first checkout ensures we have the files needed to restore the cache
       - checkout
 
+      - run:
+          name: Check if any bash script sets xtrace
+          command: |
+            grep -r '^set\ \-\w*[x]\w*' . && exit 1 || exit 0
+
       # Pull in all submodules (inc. rust-fil-proofs)
       - update_submodules
 


### PR DESCRIPTION
if any file sets xtrace, fail the build to prevent accidentally leaking credentials

tested regex like this:

```
$ echo "set -x" | grep '^set\ \-\w*[x]\w*' && echo "fail" || echo "pass"
set -x
fail
$ echo "set -ex" | grep '^set\ \-\w*[x]\w*' && echo "fail" || echo "pass"
set -ex
fail
$ echo "set -xtrace" | grep '^set\ \-\w*[x]\w*' && echo "fail" || echo "pass"
set -xtrace
fail
$ echo "set -e" | grep '^set\ \-\w*[x]\w*' && echo "fail" || echo "pass"
pass
```