### PR TITLE
Feat/pork-swarm-follow-up-2382

### DIFF
--- a/net/network.go
+++ b/net/network.go
@@ -106,14 +106,13 @@ func (network *Network) GetBandwidthStats() metrics.Stats {
 }
 
 // ConnectionResult represents the result of an attempted connection from the
-// Connect method
+// Connect method.
 type ConnectionResult struct {
 	PeerID peer.ID
 	Err    error
 }
 
-// Connect connects to peers at the given addresses. Does not retry, and does not
-// try to connect to any more peers if any connection fails.
+// Connect connects to peers at the given addresses. Does not retry.
 func (network *Network) Connect(ctx context.Context, addrs []string) (<-chan ConnectionResult, error) {
 	outCh := make(chan ConnectionResult)
 

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -277,7 +277,7 @@ func (api *API) NetworkFindPeer(ctx context.Context, peerID peer.ID) (pstore.Pee
 }
 
 // NetworkConnect connects to peers at the given addresses
-func (api *API) NetworkConnect(ctx context.Context, addrs []string) ([]peer.ID, error) {
+func (api *API) NetworkConnect(ctx context.Context, addrs []string) (<-chan net.ConnectionResult, error) {
 	return api.network.Connect(ctx, addrs)
 }
 

--- a/tools/fast/actions_swarm.go
+++ b/tools/fast/actions_swarm.go
@@ -11,8 +11,8 @@ import (
 )
 
 // SwarmConnect runs the `swarm connect` command against the filecoin process
-func (f *Filecoin) SwarmConnect(ctx context.Context, addrs ...multiaddr.Multiaddr) ([]peer.ID, error) {
-	var out []peer.ID
+func (f *Filecoin) SwarmConnect(ctx context.Context, addrs ...multiaddr.Multiaddr) (*net.ConnectionResult, error) {
+	var out net.ConnectionResult
 
 	args := []string{"go-filecoin", "swarm", "connect"}
 
@@ -24,7 +24,7 @@ func (f *Filecoin) SwarmConnect(ctx context.Context, addrs ...multiaddr.Multiadd
 		return nil, err
 	}
 
-	return out, nil
+	return &out, nil
 }
 
 // DhtFindpeer runs the `dht findpeer` command against the filecoin process


### PR DESCRIPTION
# Problem

`go-filecoin swarm connect` stops after the first address to fail rather than trying other addresses.

# Solution

Change swarm connect to return a channel with errors and peer ids for each attempted connection.

Resolves #2382 