### PR TITLE
fix chain head

### DIFF
--- a/commands/chain.go
+++ b/commands/chain.go
@@ -29,11 +29,20 @@ var chainHeadCmd = &cmds.Command{
 		Tagline: "Get heaviest tipset CIDs",
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
-		headTipset := GetPorcelainAPI(env).ChainHead(req.Context)
-		blocks := headTipset.ToSlice()
-		return re.Emit(blocks)
+		return re.Emit(GetPorcelainAPI(env).ChainHead(req.Context).ToSortedCidSet())
 	},
 	Type: []cid.Cid{},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res []cid.Cid) error {
+			for _, r := range res {
+				_, err := fmt.Fprintln(w, r.String())
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}),
+	},
 }
 
 var chainLsCmd = &cmds.Command{

--- a/commands/chain_daemon_test.go
+++ b/commands/chain_daemon_test.go
@@ -16,6 +16,23 @@ import (
 	"gx/ipfs/QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS/testify/require"
 )
 
+func TestChainHead(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+
+	d := th.NewDaemon(t).Start()
+	defer d.ShutdownSuccess()
+
+	op := d.RunSuccess("chain", "head")
+	result := op.ReadStdoutTrimNewlines()
+
+	maybeCid, err := cid.Decode(result)
+	require.NoError(err)
+
+	assert.Equal(result, maybeCid.String())
+}
+
 func TestChainDaemon(t *testing.T) {
 	t.Parallel()
 	t.Run("chain ls with json encoding returns the whole chain as json", func(t *testing.T) {


### PR DESCRIPTION
### Thoughts
The way this PR currently stands with commit 07f31c225fdafc6a497f3189ddf062c11ca56410 we get the following outputs:
```
frrist@pine ~/s/g/f/go-filecoin (feat/fix-chain-head-2392)> ./go-filecoin chain head
zDPWYqFCrMH36tQoVUiLrAaC4GCwK4KefHL9JZXxGkcDZq3gTKLt
frrist@pine ~/s/g/f/go-filecoin (feat/fix-chain-head-2392)> ./go-filecoin chain head --enc=json
[{"/":"zDPWYqFCrMH36tQoVUiLrAaC4GCwK4KefHL9JZXxGkcDZq3gTKLt"}]
```
The JSON encoding will fail if round tripped -- `[{"/":"zDPWYqFCrMH36tQoVUiLrAaC4GCwK4KefHL9JZXxGkcDZq3gTKLt"}]` isn't valid json

I propose that instead of returning a slice of CID's we return a slice of tipsets, gut check says this was the original behaviour, although I am not seeing that change reflected in the git history, was in a bit of a hurry could have missed it.

lets not merge this until there is some discussion around what's happened here.

#### Other Notes:
The command `chain head` has almost no test coverage, looks like it never had any to begin with, adding coverage is outside the scope of this PR, wanted to bring this to light, will file an issue to add some: https://github.com/filecoin-project/go-filecoin/issues/2398

