### PR TITLE
extend block retrieval timeout

### DIFF
--- a/chain/default_syncer.go
+++ b/chain/default_syncer.go
@@ -19,7 +19,7 @@ import (
 
 // The amount of time the syncer will wait while fetching the blocks of a
 // tipset over the network.
-var blkWaitTime = time.Second // TODO set this parameter in an informed way too
+var blkWaitTime = 30 * time.Second
 var (
 	// ErrChainHasBadTipSet is returned when the syncer traverses a chain with a cached bad tipset.
 	ErrChainHasBadTipSet = errors.New("input chain contains a cached bad tipset")

--- a/chain/default_syncer.go
+++ b/chain/default_syncer.go
@@ -321,6 +321,10 @@ func (syncer *DefaultSyncer) widen(ctx context.Context, ts types.TipSet) (types.
 // help prevent DOS.
 func (syncer *DefaultSyncer) HandleNewTipset(ctx context.Context, tipsetCids types.SortedCidSet) error {
 	logSyncer.Debugf("trying to sync %v\n", tipsetCids)
+
+	// This lock could last a long time as we fetch all the blocks needed to block the chain.
+	// This is justified because the app is pretty useless until it is synced.
+	// It's better for multiple calls to wait here than to try to fetch the chain independently.
 	syncer.mu.Lock()
 	defer syncer.mu.Unlock()
 

--- a/chain/syncer.go
+++ b/chain/syncer.go
@@ -2,8 +2,7 @@ package chain
 
 import (
 	"context"
-
-	"github.com/ipfs/go-cid"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 // Syncer handles new blocks, either from the network or the local node's
@@ -18,5 +17,5 @@ import (
 // example a syncer might decide to cut off traversal of an unknown fork
 // after too many blocks.
 type Syncer interface {
-	HandleNewBlocks(ctx context.Context, blkCids []cid.Cid) error
+	HandleNewTipset(ctx context.Context, tipsetCids types.SortedCidSet) error
 }

--- a/node/block.go
+++ b/node/block.go
@@ -3,7 +3,6 @@ package node
 import (
 	"context"
 
-	"github.com/ipfs/go-cid"
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/net/pubsub"
@@ -24,7 +23,7 @@ func (node *Node) AddNewBlock(ctx context.Context, b *types.Block) (err error) {
 	}
 
 	log.Debugf("syncing new block: %s", b.Cid().String())
-	if err := node.Syncer.HandleNewBlocks(ctx, []cid.Cid{blkCid}); err != nil {
+	if err := node.Syncer.HandleNewTipset(ctx, types.NewSortedCidSet(blkCid)); err != nil {
 		return err
 	}
 
@@ -47,7 +46,7 @@ func (node *Node) processBlock(ctx context.Context, pubSubMsg pubsub.Message) (e
 	log.Infof("Received new block from network cid: %s", blk.Cid().String())
 	log.Debugf("Received new block from network: %s", blk)
 
-	err = node.Syncer.HandleNewBlocks(ctx, []cid.Cid{blk.Cid()})
+	err = node.Syncer.HandleNewTipset(ctx, types.NewSortedCidSet(blk.Cid()))
 	if err != nil {
 		return errors.Wrap(err, "processing block from network")
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -500,9 +500,6 @@ func (node *Node) Start(ctx context.Context) error {
 
 	// Start up 'hello' handshake service
 	syncCallBack := func(pid libp2ppeer.ID, cids []cid.Cid, height uint64) {
-		// TODO it is possible the syncer interface should be modified to
-		// make use of the additional context not used here (from addr + height).
-		// To keep things simple for now this info is not used.
 		cidSet := types.NewSortedCidSet(cids...)
 		err := node.Syncer.HandleNewTipset(context.Background(), cidSet)
 		if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -503,9 +503,10 @@ func (node *Node) Start(ctx context.Context) error {
 		// TODO it is possible the syncer interface should be modified to
 		// make use of the additional context not used here (from addr + height).
 		// To keep things simple for now this info is not used.
-		err := node.Syncer.HandleNewBlocks(context.Background(), cids)
+		cidSet := types.NewSortedCidSet(cids...)
+		err := node.Syncer.HandleNewTipset(context.Background(), cidSet)
 		if err != nil {
-			log.Infof("error handling blocks: %s", types.NewSortedCidSet(cids...).String())
+			log.Infof("error handling blocks: %s", cidSet.String())
 		}
 	}
 	node.HelloSvc = hello.New(node.Host(), node.ChainReader.GenesisCid(), syncCallBack, node.ChainReader.Head, node.Repo.Config().Net, flags.Commit)


### PR DESCRIPTION
closes #2424

### Problem

We currently only wait for 1 second before timing out when fetching a block for chain syncing. This is a network call and should be increased on principle. We have observed many of these timeouts when bringing up the new user net, so we now know it should be longer.

### Solution

Increase the timeout to 30 seconds. We don't know of any reason why this should not be 30 times longer and it should greatly reduce these timeouts.