### PR TITLE
Streaming add piece through FFI

### DIFF
--- a/proofs/sectorbuilder/bytesink/fifo.go
+++ b/proofs/sectorbuilder/bytesink/fifo.go
@@ -1,0 +1,105 @@
+// +build !windows
+
+package bytesink
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+// Not safe for concurrent access, as writes to underlying pipe are atomic only
+// if len(buf) is less than the OS-specific PIPE_BUF value.
+type FifoByteSink struct {
+	file *os.File
+	path string
+}
+
+var _ ByteSink = (*FifoByteSink)(nil)
+
+// Open prepares the sink for writing by opening the backing FIFO file. Open
+// will block until someone opens the FIFO file for reading.
+func (s *FifoByteSink) Open() error {
+	file, err := os.OpenFile(s.path, os.O_WRONLY, os.ModeNamedPipe)
+	if err != nil {
+		return errors.Wrap(err, "failed to open pipe")
+	}
+
+	s.file = file
+
+	return nil
+}
+
+// Write writes the provided buffer to the underlying pipe. Write will block
+// until the provided buffer's bytes have been read from the read end of the
+// pipe.
+//
+// Warning: Writes are atomic only if len(buf) is less than the OS-specific
+// PIPE_BUF value. For more information, see:
+//
+// http://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html
+func (s *FifoByteSink) Write(buf []byte) (int, error) {
+	return s.file.Write(buf)
+}
+
+// Close ensures that the underlying file is closed and removed.
+func (s *FifoByteSink) Close() (retErr error) {
+	cerr := s.file.Close()
+	if cerr != nil {
+		return cerr
+	}
+
+	defer func() {
+		rerr := os.Remove(s.path)
+		if retErr == nil {
+			retErr = rerr
+		}
+	}()
+
+	return
+}
+
+// Id produces a string-identifier for this byte sink. For now, this is just the
+// path of the FIFO file. This string may get more structured in the future.
+func (s *FifoByteSink) ID() string {
+	return s.path
+}
+
+// NewFifo creates a FIFO pipe and returns a pointer to a FifoByteSink, which
+// satisfies the ByteSink interface. The FIFO pipe is used to stream bytes to
+// rust-fil-proofs from Go during the piece-adding flow. Writes to the pipe are
+// buffered automatically by the OS; the size of the buffer varies.
+func NewFifo() (*FifoByteSink, error) {
+	path, err := createTmpFifoPath()
+	if err != nil {
+		return nil, errors.Wrap(err, "creating FIFO path failed")
+	}
+
+	err = syscall.Mkfifo(path, 0600)
+	if err != nil {
+		return nil, errors.Wrap(err, "mkfifo failed")
+	}
+
+	return &FifoByteSink{
+		path: path,
+	}, nil
+}
+
+// createTmpFifoPath creates a path with which a temporary FIFO file may be
+// created.
+func createTmpFifoPath() (string, error) {
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		return "", err
+	}
+
+	err = file.Close()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s.fifo", file.Name()), nil
+}

--- a/proofs/sectorbuilder/bytesink/interface.go
+++ b/proofs/sectorbuilder/bytesink/interface.go
@@ -1,0 +1,12 @@
+package bytesink
+
+import "io"
+
+// ByteSink represents a location to which bytes can be written. The ByteSink
+// should be closed after all bytes have been written.
+type ByteSink interface {
+	io.Writer
+	io.Closer
+	Open() error
+	ID() string
+}

--- a/proofs/sectorbuilder/interface.go
+++ b/proofs/sectorbuilder/interface.go
@@ -23,11 +23,7 @@ type SectorBuilder interface {
 	// method returns. In the real world this should not happen, as sealing
 	// takes a long time to complete. In tests, where sealing happens
 	// near-instantaneously, it is possible to exercise this race.
-	//
-	// TODO: Replace this method with something that accepts a piece cid and a
-	// value which represents the number of bytes in the piece and returns a
-	// sector id (to which piece bytes will be written) and a Writer.
-	AddPiece(ctx context.Context, pi *PieceInfo) (sectorID uint64, err error)
+	AddPiece(ctx context.Context, pieceRef cid.Cid, pieceSize uint64, pieceReader io.Reader) (sectorID uint64, err error)
 
 	// ReadPieceFromSealedSector produces a Reader used to get original
 	// piece-bytes from a sealed sector.
@@ -38,9 +34,9 @@ type SectorBuilder interface {
 
 	// SectorSealResults returns an unbuffered channel that is sent a value
 	// whenever sealing completes. All calls to SectorSealResults will get the
-	// same channel. Values will be either a *SealedSectorMetadata or an error. A
-	// *SealedSectorMetadata will be sent to the returned channel only once, regardless
-	// of the number of times SectorSealResults is called.
+	// same channel. Values will be either a *SealedSectorMetadata or an error.
+	// A *SealedSectorMetadata will be sent to the returned channel only once,
+	// regardless of the number of times SectorSealResults is called.
 	SectorSealResults() <-chan SectorSealResult
 
 	// GetMaxUserBytesPerStagedSector produces the number of user piece-bytes

--- a/proofs/sectorbuilder/testing/interface_test.go
+++ b/proofs/sectorbuilder/testing/interface_test.go
@@ -10,12 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-cid"
+	cid "github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
-
-	"github.com/stretchr/testify/require"
 )
 
 // MaxTimeToSealASector represents the maximum amount of time the test should
@@ -188,10 +187,10 @@ func TestSectorBuilder(t *testing.T) {
 		defer h.Close()
 
 		inputBytes := RequireRandomBytes(t, h.MaxBytesPerSector)
-		info, err := h.CreatePieceInfo(inputBytes)
+		ref, size, reader, err := h.CreateAddPieceArgs(inputBytes)
 		require.NoError(t, err)
 
-		sectorID, err := h.SectorBuilder.AddPiece(context.Background(), info)
+		sectorID, err := h.SectorBuilder.AddPiece(context.Background(), ref, size, reader)
 		require.NoError(t, err)
 
 		// Sealing can take 180+ seconds on an i7 MacBook Pro. We are sealing
@@ -218,7 +217,7 @@ func TestSectorBuilder(t *testing.T) {
 			t.Fatalf("timed out waiting for seal to complete")
 		}
 
-		reader, err := h.SectorBuilder.ReadPieceFromSealedSector(info.Ref)
+		reader, err = h.SectorBuilder.ReadPieceFromSealedSector(ref)
 		require.NoError(t, err)
 
 		outputBytes, err := ioutil.ReadAll(reader)
@@ -298,10 +297,10 @@ func TestSectorBuilder(t *testing.T) {
 		defer h.Close()
 
 		inputBytes := RequireRandomBytes(t, h.MaxBytesPerSector)
-		info, err := h.CreatePieceInfo(inputBytes)
+		ref, size, reader, err := h.CreateAddPieceArgs(inputBytes)
 		require.NoError(t, err)
 
-		sectorID, err := h.SectorBuilder.AddPiece(context.Background(), info)
+		sectorID, err := h.SectorBuilder.AddPiece(context.Background(), ref, size, reader)
 		require.NoError(t, err)
 
 		timeout := time.After(MaxTimeToSealASector + MaxTimeToGenerateSectorPoSt)

--- a/tools/fast/tests/retrieval_test.go
+++ b/tools/fast/tests/retrieval_test.go
@@ -36,10 +36,10 @@ func init() {
 	series.GlobalSleepDelay = time.Second * 5
 }
 
-// TestRetrieval exercises storing and retreiving with the filecoin protocols
+// TestRetrieval exercises storing and retrieving with the filecoin protocols
 func TestRetrieval(t *testing.T) {
-	// This test should run in 20 block times, with 60 seconds for sealing, and no longer
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(20*series.GlobalSleepDelay).Add(60*time.Second))
+	// This test should run in 20 block times, with 120 seconds for sealing, and no longer
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(20*series.GlobalSleepDelay).Add(120*time.Second))
 	defer cancel()
 
 	require := require.New(t)


### PR DESCRIPTION
Fixes #2463 

**This PR cannot be merged until [this upstream rust-fil-proofs PR is merged](https://github.com/filecoin-project/rust-fil-proofs/pull/580)**!

## What's in this PR?

1. `SectorBuilder#AddPiece` now provisions named pipe and passes path to CGO call.
1. Rust function (CGO call) now opens path and streams bytes from file to its preprocessor

## Why is this PR needed?

Previously, go-filecoin would copy piece-bytes from block store into buffer, then allocate buffer in Rust heap, then copy from Go heap into Rust heap, then make CGO call. That took a lot of RAM.

## Findings

- Running through the add-piece flow (via `client propose-storage-deal`) for a 254MiB piece would cause the storage miner process to spike RAM to ~1260MiB on my laptop.
- With streaming in place, that number reduces to ~800MiB.
- My idle miner consumes ~600MiB (by comparison).

## Caveats

The mkfifo syscall isn't going to work with Windows, but we can implement the `ByteSink` interface pretty easily using [this named pipe package](https://github.com/natefinch/npipe) to give Windows folks some love. Alternatively, we could implement `ByteSink` with a regular file. Either way, I'll create a follow-up issue after this PR is approved.