### PR TITLE
make version command not depend on daemon

### DIFF
--- a/commands/main.go
+++ b/commands/main.go
@@ -144,8 +144,9 @@ var rootCmdDaemon = &cmds.Command{
 
 // all top level commands, not available to daemon
 var rootSubcmdsLocal = map[string]*cmds.Command{
-	"daemon": daemonCmd,
-	"init":   initCmd,
+	"daemon":  daemonCmd,
+	"init":    initCmd,
+	"version": versionCmd,
 }
 
 // all top level commands, available on daemon. set during init() to avoid configuration loops.
@@ -171,7 +172,6 @@ var rootSubcmdsDaemon = map[string]*cmds.Command{
 	"show":             showCmd,
 	"stats":            statsCmd,
 	"swarm":            swarmCmd,
-	"version":          versionCmd,
 	"wallet":           walletCmd,
 }
 
@@ -294,14 +294,11 @@ func getAPIAddress(req *cmds.Request) (string, error) {
 }
 
 func requiresDaemon(req *cmds.Request) bool {
-	if req.Command == daemonCmd {
-		return false
+	for _, cmd := range rootSubcmdsLocal {
+		if req.Command == cmd {
+			return false
+		}
 	}
-
-	if req.Command == initCmd {
-		return false
-	}
-
 	return true
 }
 

--- a/commands/version_daemon_test.go
+++ b/commands/version_daemon_test.go
@@ -13,18 +13,17 @@ func TestVersion(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	var gitOut []byte
+	var gitOut, verOut []byte
 	var err error
 	gitArgs := []string{"rev-parse", "--verify", "HEAD"}
-
 	if gitOut, err = exec.Command("git", gitArgs...).Output(); err != nil {
 		assert.NoError(err)
 	}
 	commit := string(gitOut)
 
-	d := th.NewDaemon(t).Start()
-	defer d.ShutdownSuccess()
-
-	out := d.RunSuccess("version")
-	assert.Exactly(out.ReadStdout(), fmt.Sprintf("commit: %s", commit))
+	if verOut, err = exec.Command(th.MustGetFilecoinBinary(), "version").Output(); err != nil {
+		assert.NoError(err)
+	}
+	version := string(verOut)
+	assert.Exactly(version, fmt.Sprintf("commit: %s", commit))
 }


### PR DESCRIPTION
Currently, `go-filecoin version` command has to run after daemon has
started.
This is undesirable.