### PR TITLE
Update bug report template to include version info request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,11 +30,21 @@ Steps to reproduce the behavior:
 <!-- If applicable, add logging output or screenshots to help explain your problem. -->
 
 **Version information**
+<!-- please fill out this information below completely, it will help us solve your issue faster -->
 <!-- if you are trying to build go-filecoin -->
 - Go: <!-- go version -->
 - Rust: <!-- rustc --version -->
 - Cargo: <!-- cargo --version -->
 - Commit: <!--  git rev-parse HEAD -->
+
+_go env_
+```
+<!-- go env -->
+```
+_cc_
+```
+<!-- $(go env | grep -E "^CC" |  sed -e 's/.*\=//' | sed -e 's/^"//' -e 's/"$//') --version -->
+```
 <!-- if you are running go-filecoin -->
 - Version: <!-- go-filecoin version -->
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,27 +6,37 @@ labels: C-bug, candidate
 assignees: ''
 
 ---
+<!--
 Please first see README for how to get help before filing a new bug report. 
 
+If you have a *QUESTION* about Filecoin, please ask on our forum at https://discuss.filecoin.io/
+-->
+
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
+<!--
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Run this command '...'
 3. See error
+-->
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Screenshots**
-If applicable, add logging output or screenshots to help explain your problem.
+<!-- If applicable, add logging output or screenshots to help explain your problem. -->
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [if applicable, e.g. chrome, safari]
- - Version [e.g. 22]
+**Version information**
+<!-- if you are trying to build go-filecoin -->
+- Go: <!-- go version -->
+- Rust: <!-- rustc --version -->
+- Cargo: <!-- cargo --version -->
+- Commit: <!--  git rev-parse HEAD -->
+<!-- if you are running go-filecoin -->
+- Version: <!-- go-filecoin version -->
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
When bugs deal with building a lot of the time the build errors are due to incorrect versions of dependencies, and requests for this information is commonly the first comment. To help reduce the time to resolving the issue I think we should request this information up-front in the issue template.

Another common issue is around connecting to the network, and most issues do not properly fill out the steps to reproduce. I've added explicit request for the `init` and `daemon` commands in the steps.

Are there any additional information we would like to add to the bug report form to help reduce the time to resolve issues?

/cc @anorth @laser @mishmosh 