### PR TITLE
Export payment channel result types

### DIFF
--- a/commands/payment_channel.go
+++ b/commands/payment_channel.go
@@ -31,7 +31,8 @@ var paymentChannelCmd = &cmds.Command{
 	},
 }
 
-type createChannelResult struct {
+// CreateChannelResult type returned from CreateChannel
+type CreateChannelResult struct {
 	Cid     cid.Cid
 	GasUsed types.GasUnits
 	Preview bool
@@ -91,7 +92,7 @@ message to be mined to get the channelID.`,
 			if err != nil {
 				return err
 			}
-			return re.Emit(&createChannelResult{
+			return re.Emit(&CreateChannelResult{
 				Cid:     cid.Cid{},
 				GasUsed: usedGas,
 				Preview: true,
@@ -113,15 +114,15 @@ message to be mined to get the channelID.`,
 			return err
 		}
 
-		return re.Emit(&createChannelResult{
+		return re.Emit(&CreateChannelResult{
 			Cid:     c,
 			GasUsed: types.NewGasUnits(0),
 			Preview: false,
 		})
 	},
-	Type: &createChannelResult{},
+	Type: &CreateChannelResult{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *createChannelResult) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *CreateChannelResult) error {
 			if res.Preview {
 				output := strconv.FormatUint(uint64(res.GasUsed), 10)
 				_, err := w.Write([]byte(output))
@@ -233,7 +234,8 @@ var voucherCmd = &cmds.Command{
 	},
 }
 
-type redeemResult struct {
+// RedeemResult type returned from Redeem
+type RedeemResult struct {
 	Cid     cid.Cid
 	GasUsed types.GasUnits
 	Preview bool
@@ -285,7 +287,7 @@ var redeemCmd = &cmds.Command{
 			if err != nil {
 				return err
 			}
-			return re.Emit(&redeemResult{
+			return re.Emit(&RedeemResult{
 				Cid:     cid.Cid{},
 				GasUsed: usedGas,
 				Preview: true,
@@ -311,15 +313,15 @@ var redeemCmd = &cmds.Command{
 			return err
 		}
 
-		return re.Emit(&redeemResult{
+		return re.Emit(&RedeemResult{
 			Cid:     c,
 			GasUsed: types.NewGasUnits(0),
 			Preview: false,
 		})
 	},
-	Type: &redeemResult{},
+	Type: &RedeemResult{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *redeemResult) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *RedeemResult) error {
 			if res.Preview {
 				output := strconv.FormatUint(uint64(res.GasUsed), 10)
 				_, err := w.Write([]byte(output))
@@ -330,7 +332,8 @@ var redeemCmd = &cmds.Command{
 	},
 }
 
-type reclaimResult struct {
+// ReclaimResult type returned from Reclaim
+type ReclaimResult struct {
 	Cid     cid.Cid
 	GasUsed types.GasUnits
 	Preview bool
@@ -376,7 +379,7 @@ var reclaimCmd = &cmds.Command{
 			if err != nil {
 				return err
 			}
-			return re.Emit(&reclaimResult{
+			return re.Emit(&ReclaimResult{
 				Cid:     cid.Cid{},
 				GasUsed: usedGas,
 				Preview: true,
@@ -397,15 +400,15 @@ var reclaimCmd = &cmds.Command{
 			return err
 		}
 
-		return re.Emit(&reclaimResult{
+		return re.Emit(&ReclaimResult{
 			Cid:     c,
 			GasUsed: types.NewGasUnits(0),
 			Preview: false,
 		})
 	},
-	Type: &reclaimResult{},
+	Type: &ReclaimResult{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *reclaimResult) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *ReclaimResult) error {
 			if res.Preview {
 				output := strconv.FormatUint(uint64(res.GasUsed), 10)
 				_, err := w.Write([]byte(output))
@@ -416,7 +419,8 @@ var reclaimCmd = &cmds.Command{
 	},
 }
 
-type closeResult struct {
+// CloseResult type returned from Close
+type CloseResult struct {
 	Cid     cid.Cid
 	GasUsed types.GasUnits
 	Preview bool
@@ -468,7 +472,7 @@ var closeCmd = &cmds.Command{
 			if err != nil {
 				return err
 			}
-			return re.Emit(&closeResult{
+			return re.Emit(&CloseResult{
 				Cid:     cid.Cid{},
 				GasUsed: usedGas,
 				Preview: true,
@@ -494,15 +498,15 @@ var closeCmd = &cmds.Command{
 			return err
 		}
 
-		return re.Emit(&closeResult{
+		return re.Emit(&CloseResult{
 			Cid:     c,
 			GasUsed: types.NewGasUnits(0),
 			Preview: false,
 		})
 	},
-	Type: &closeResult{},
+	Type: &CloseResult{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *closeResult) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *CloseResult) error {
 			if res.Preview {
 				output := strconv.FormatUint(uint64(res.GasUsed), 10)
 				_, err := w.Write([]byte(output))
@@ -513,7 +517,8 @@ var closeCmd = &cmds.Command{
 	},
 }
 
-type extendResult struct {
+// ExtendResult type returned from Extend
+type ExtendResult struct {
 	Cid     cid.Cid
 	GasUsed types.GasUnits
 	Preview bool
@@ -571,7 +576,7 @@ var extendCmd = &cmds.Command{
 			if err != nil {
 				return err
 			}
-			return re.Emit(&extendResult{
+			return re.Emit(&ExtendResult{
 				Cid:     cid.Cid{},
 				GasUsed: usedGas,
 				Preview: true,
@@ -592,15 +597,15 @@ var extendCmd = &cmds.Command{
 			return err
 		}
 
-		return re.Emit(&extendResult{
+		return re.Emit(&ExtendResult{
 			Cid:     c,
 			GasUsed: types.NewGasUnits(0),
 			Preview: false,
 		})
 	},
-	Type: &extendResult{},
+	Type: &ExtendResult{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *extendResult) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *ExtendResult) error {
 			if res.Preview {
 				output := strconv.FormatUint(uint64(res.GasUsed), 10)
 				_, err := w.Write([]byte(output))

--- a/tools/fast/action_paych.go
+++ b/tools/fast/action_paych.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/commands"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -15,7 +16,7 @@ func (f *Filecoin) PaychCreate(ctx context.Context,
 	target address.Address, amount *types.AttoFIL, eol *types.BlockHeight,
 	options ...ActionOption) (cid.Cid, error) {
 
-	var out cid.Cid
+	var out commands.CreateChannelResult
 	args := []string{"go-filecoin", "paych", "create", target.String(), amount.String(), eol.String()}
 
 	for _, option := range options {
@@ -26,12 +27,12 @@ func (f *Filecoin) PaychCreate(ctx context.Context,
 		return cid.Undef, err
 	}
 
-	return out, nil
+	return out.Cid, nil
 }
 
 // PaychClose runs the `paych close` command against the filecoin process.
 func (f *Filecoin) PaychClose(ctx context.Context, voucher string, options ...ActionOption) (cid.Cid, error) {
-	var out cid.Cid
+	var out commands.CloseResult
 	args := []string{"go-filecoin", "paych", "close", voucher}
 
 	for _, option := range options {
@@ -42,16 +43,16 @@ func (f *Filecoin) PaychClose(ctx context.Context, voucher string, options ...Ac
 		return cid.Undef, err
 	}
 
-	return out, nil
+	return out.Cid, nil
 
 }
 
 // PaychExtend runs the `paych extend` command against the filecoin process.
 func (f *Filecoin) PaychExtend(ctx context.Context,
-	channel types.ChannelID, amount *types.AttoFIL, eol types.BlockHeight,
+	channel *types.ChannelID, amount *types.AttoFIL, eol *types.BlockHeight,
 	options ...ActionOption) (cid.Cid, error) {
 
-	var out cid.Cid
+	var out commands.ExtendResult
 	args := []string{"go-filecoin", "paych", "extend", channel.String(), amount.String(), eol.String()}
 
 	for _, option := range options {
@@ -62,7 +63,7 @@ func (f *Filecoin) PaychExtend(ctx context.Context,
 		return cid.Undef, err
 	}
 
-	return out, nil
+	return out.Cid, nil
 
 }
 
@@ -84,7 +85,7 @@ func (f *Filecoin) PaychLs(ctx context.Context, options ...ActionOption) (map[st
 
 // PaychReclaim runs the `paych reclaim` command against the filecoin process.
 func (f *Filecoin) PaychReclaim(ctx context.Context, channel *types.ChannelID, options ...ActionOption) (cid.Cid, error) {
-	var out cid.Cid
+	var out commands.ReclaimResult
 	args := []string{"go-filecoin", "paych", "reclaim", channel.String()}
 
 	for _, option := range options {
@@ -95,12 +96,12 @@ func (f *Filecoin) PaychReclaim(ctx context.Context, channel *types.ChannelID, o
 		return cid.Undef, err
 	}
 
-	return out, nil
+	return out.Cid, nil
 }
 
 // PaychRedeem runs the `paych redeem` command against the filecoin process.
 func (f *Filecoin) PaychRedeem(ctx context.Context, voucher string, options ...ActionOption) (cid.Cid, error) {
-	var out cid.Cid
+	var out commands.RedeemResult
 	args := []string{"go-filecoin", "paych", "redeem", voucher}
 
 	for _, option := range options {
@@ -111,14 +112,11 @@ func (f *Filecoin) PaychRedeem(ctx context.Context, voucher string, options ...A
 		return cid.Undef, err
 	}
 
-	return out, nil
+	return out.Cid, nil
 }
 
 // PaychVoucher runs the `paych voucher` command against the filecoin process.
-func (f *Filecoin) PaychVoucher(ctx context.Context,
-	channel *types.ChannelID, amount *types.AttoFIL,
-	options ...ActionOption) (string, error) {
-
+func (f *Filecoin) PaychVoucher(ctx context.Context, channel *types.ChannelID, amount *types.AttoFIL, options ...ActionOption) (string, error) {
 	var out string
 
 	args := []string{"go-filecoin", "paych", "voucher", channel.String(), amount.String()}


### PR DESCRIPTION
Exports the payment channel types so we can parse the command responses in FAST.

None Goal: support preview.