### PR TITLE
FAST: support synchronous mining in FAST series

### DIFF
--- a/tools/fast/bin/localnet/main.go
+++ b/tools/fast/bin/localnet/main.go
@@ -228,8 +228,7 @@ func main() {
 		return
 	}
 
-	err = genesis.MiningStart(ctx)
-	if err != nil {
+	if err := genesis.MiningStart(ctx); err != nil {
 		exitcode = handleError(err, "failed to start mining on genesis node;")
 		return
 	}

--- a/tools/fast/bin/localnet/main.go
+++ b/tools/fast/bin/localnet/main.go
@@ -228,6 +228,12 @@ func main() {
 		return
 	}
 
+	err = genesis.MiningStart(ctx)
+	if err != nil {
+		exitcode = handleError(err, "failed to start mining on genesis node;")
+		return
+	}
+
 	// Create the processes that we will use to become miners
 	var miners []*fast.Filecoin
 	for i := 0; i < minerCount; i++ {

--- a/tools/fast/series/ctx_mining_once.go
+++ b/tools/fast/series/ctx_mining_once.go
@@ -1,0 +1,28 @@
+package series
+
+import (
+	"context"
+)
+
+type ctxMiningOnceKey struct{}
+
+// Key used to store the MiningOnceFunc in the context
+var miningOnceKey = ctxMiningOnceKey{}
+
+// MiningOnceFunc is the type for the value used when calling SetCtxMiningOnce
+type MiningOnceFunc func()
+
+// SetCtxMiningOnce returns a context with `fn` set in the context. To run the
+// MiningOnceFunc value, call CtxMiningOnce.
+func SetCtxMiningOnce(ctx context.Context, fn MiningOnceFunc) context.Context {
+	return context.WithValue(ctx, miningOnceKey, fn)
+}
+
+// CtxMiningOnce will call the MiningOnceFunc set on the context using
+// SetMiningOnceFunc. If no value is set on the context, the call is a noop.
+func CtxMiningOnce(ctx context.Context) {
+	miningOnce, ok := ctx.Value(miningOnceKey).(MiningOnceFunc)
+	if ok {
+		miningOnce()
+	}
+}

--- a/tools/fast/series/ctx_sleep_delay.go
+++ b/tools/fast/series/ctx_sleep_delay.go
@@ -7,9 +7,11 @@ import (
 	"github.com/filecoin-project/go-filecoin/mining"
 )
 
+type ctxSleepDelayKey struct{}
+
 var (
 	// Key used to set the time.Duration in the context
-	ctxSleepDelayKey = struct{}{}
+	sleepDelayKey = ctxSleepDelayKey{}
 
 	// Default delay
 	defaultSleepDelay = mining.DefaultBlockTime
@@ -18,14 +20,14 @@ var (
 // SetCtxSleepDelay returns a context with `d` set in the context. To sleep with
 // the value, call CtxSleepDelay with the context.
 func SetCtxSleepDelay(ctx context.Context, d time.Duration) context.Context {
-	return context.WithValue(ctx, ctxSleepDelayKey, d)
+	return context.WithValue(ctx, sleepDelayKey, d)
 }
 
 // CtxSleepDelay is a helper method to make sure people don't call `time.Sleep`
 // themselves in series. It will use the time.Duration in the context, or
 // default to `mining.DefaultBlockTime` from the go-filecoin/mining package.
 func CtxSleepDelay(ctx context.Context) {
-	d, ok := ctx.Value(ctxSleepDelayKey).(time.Duration)
+	d, ok := ctx.Value(sleepDelayKey).(time.Duration)
 	if !ok {
 		d = defaultSleepDelay
 	}

--- a/tools/fast/series/send_filecoin_from_default.go
+++ b/tools/fast/series/send_filecoin_from_default.go
@@ -22,6 +22,8 @@ func SendFilecoinFromDefault(ctx context.Context, node *fast.Filecoin, addr addr
 		return err
 	}
 
+	CtxMiningOnce(ctx)
+
 	if _, err := node.MessageWait(ctx, mcid); err != nil {
 		return err
 	}

--- a/tools/fast/series/set_price_ask.go
+++ b/tools/fast/series/set_price_ask.go
@@ -21,6 +21,8 @@ func SetPriceGetAsk(ctx context.Context, miner *fast.Filecoin, price *big.Float,
 		return porcelain.Ask{}, err
 	}
 
+	CtxMiningOnce(ctx)
+
 	response, err := miner.MessageWait(ctx, pinfo.AddAskCid)
 	if err != nil {
 		return porcelain.Ask{}, err

--- a/tools/fast/series/setup_genesis_node.go
+++ b/tools/fast/series/setup_genesis_node.go
@@ -37,9 +37,6 @@ func SetupGenesisNode(ctx context.Context, node *fast.Filecoin, minerAddress add
 	}
 
 	_, err = node.MinerUpdatePeerid(ctx, minerAddress, node.PeerID, fast.AOFromAddr(wallet[0]), fast.AOPrice(big.NewFloat(300)), fast.AOLimit(300))
-	if err != nil {
-		return err
-	}
 
-	return node.MiningStart(ctx)
+	return err
 }

--- a/tools/fast/tests/retrieval_test.go
+++ b/tools/fast/tests/retrieval_test.go
@@ -87,6 +87,9 @@ func TestRetrieval(t *testing.T) {
 	err = series.SetupGenesisNode(ctx, genesis, genesisMiner.Address, files.NewReaderFile(genesisMiner.Owner))
 	require.NoError(err)
 
+	err = genesis.MiningStart(ctx)
+	require.NoError(err)
+
 	// Start Miner
 	err = series.InitAndStart(ctx, miner)
 	require.NoError(err)


### PR DESCRIPTION
FAST is design to be a multi-purpose library for controlling Filecoin daemon for use in automation and testing. When writing some test we need explicit control over when mining occurs. To enable the use of series across synchronous and asynchronous mining (`mining start` vs `mining once`) we need to be able to call `mining once` inside of series when a block is required to be mined.

This PR supports this by providing a way for consumers to set a function on a context which when called will mine a block. Series can use the `MiningOnceFromCtx` to ensure that a block is mined when required.