### PR TITLE
IPTB: Work around for golang bug #22315

### DIFF
--- a/tools/iptb-plugins/filecoin/local/copy_file.go
+++ b/tools/iptb-plugins/filecoin/local/copy_file.go
@@ -7,6 +7,7 @@ import (
 	"os"
 )
 
+// https://stackoverflow.com/a/21061062
 func copyFileContents(src, dst string) (err error) {
 	in, err := os.Open(src)
 	if err != nil {

--- a/tools/iptb-plugins/filecoin/local/copy_file.go
+++ b/tools/iptb-plugins/filecoin/local/copy_file.go
@@ -1,0 +1,35 @@
+// +build !linux
+
+package pluginlocalfilecoin
+
+import (
+	"io"
+	"os"
+)
+
+func copyFileContents(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return
+	}
+
+	defer in.Close() // nolint: errcheck
+	out, err := os.Create(dst)
+	if err != nil {
+		return
+	}
+
+	defer func() {
+		cerr := out.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	if _, err = io.Copy(out, in); err != nil {
+		return
+	}
+
+	err = out.Sync()
+	return
+}

--- a/tools/iptb-plugins/filecoin/local/copy_file_linux.go
+++ b/tools/iptb-plugins/filecoin/local/copy_file_linux.go
@@ -1,0 +1,18 @@
+// +build linux
+
+package pluginlocalfilecoin
+
+import (
+	"os/exec"
+)
+
+// We can't copy the bits in go due to the following bug
+// https://github.com/golang/go/issues/22315
+func copyFileContents(src, dst string) (err error) {
+	cmd := exec.Command("cp", src, dst)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	return cmd.Wait()
+}

--- a/tools/iptb-plugins/filecoin/local/localfilecoin.go
+++ b/tools/iptb-plugins/filecoin/local/localfilecoin.go
@@ -130,29 +130,6 @@ func init() {
 	}
 }
 
-func copyFileContents(src, dst string) (err error) {
-	in, err := os.Open(src)
-	if err != nil {
-		return
-	}
-	defer in.Close() // nolint: errcheck
-	out, err := os.Create(dst)
-	if err != nil {
-		return
-	}
-	defer func() {
-		cerr := out.Close()
-		if err == nil {
-			err = cerr
-		}
-	}()
-	if _, err = io.Copy(out, in); err != nil {
-		return
-	}
-	err = out.Sync()
-	return
-}
-
 /** Core Interface **/
 
 // Init runs the node init process.


### PR DESCRIPTION
When using FAST sometimes an error will be returned about a binary being busy. This appears to be related to a bug being tracked in golang (https://github.com/golang/go/issues/22315) due to an issue around file descriptors being held onto longer than needed inside of threads.

This fix uses the `cp` binary to due the copying in linux.