### PR TITLE
Fix/mpool queue limit

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,15 +17,16 @@ import (
 
 // Config is an in memory representation of the filecoin configuration file
 type Config struct {
-	API       *APIConfig       `json:"api"`
-	Bootstrap *BootstrapConfig `json:"bootstrap"`
-	Datastore *DatastoreConfig `json:"datastore"`
-	Swarm     *SwarmConfig     `json:"swarm"`
-	Mining    *MiningConfig    `json:"mining"`
-	Wallet    *WalletConfig    `json:"wallet"`
-	Heartbeat *HeartbeatConfig `json:"heartbeat"`
-	Net       string           `json:"net"`
-	Metrics   *MetricsConfig   `json:"metrics"`
+	API       *APIConfig         `json:"api"`
+	Bootstrap *BootstrapConfig   `json:"bootstrap"`
+	Datastore *DatastoreConfig   `json:"datastore"`
+	Swarm     *SwarmConfig       `json:"swarm"`
+	Mining    *MiningConfig      `json:"mining"`
+	Wallet    *WalletConfig      `json:"wallet"`
+	Heartbeat *HeartbeatConfig   `json:"heartbeat"`
+	Net       string             `json:"net"`
+	Metrics   *MetricsConfig     `json:"metrics"`
+	Mpool     *MessagePoolConfig `json:"mpool"`
 }
 
 // APIConfig holds all configuration options related to the api.
@@ -167,6 +168,16 @@ func newDefaultMetricsConfig() *MetricsConfig {
 	}
 }
 
+type MessagePoolConfig struct {
+	Limit int `json:"limit"`
+}
+
+func newDefaultMessagePoolConfig() *MessagePoolConfig {
+	return &MessagePoolConfig{
+		Limit: 100,
+	}
+}
+
 // NewDefaultConfig returns a config object with all the fields filled out to
 // their default values
 func NewDefaultConfig() *Config {
@@ -180,6 +191,7 @@ func NewDefaultConfig() *Config {
 		Heartbeat: newDefaultHeartbeatConfig(),
 		Net:       "",
 		Metrics:   newDefaultMetricsConfig(),
+		Mpool:     newDefaultMessagePoolConfig(),
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -84,6 +84,9 @@ func TestWriteFile(t *testing.T) {
 		"prometheusEnabled": false,
 		"reportInterval": "5s",
 		"prometheusEndpoint": "/ip4/0.0.0.0/tcp/9400"
+	},
+	"mpool": {
+		"limit": 100
 	}
 }`,
 		string(content),

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/config"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/core"
 	"github.com/filecoin-project/go-filecoin/mining"
@@ -23,6 +24,12 @@ import (
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
 )
+
+func newTestMessagePoolConfig(limit int) *config.MessagePoolConfig {
+	return &config.MessagePoolConfig{
+		Limit: limit,
+	}
+}
 
 func Test_Mine(t *testing.T) {
 	assert := assert.New(t)
@@ -98,7 +105,7 @@ func Test_Mine(t *testing.T) {
 
 func sharedSetupInitial() (*hamt.CborIpldStore, *core.MessagePool, cid.Cid) {
 	cst := hamt.NewCborStore()
-	pool := core.NewMessagePool(th.NewTestBlockTimer(0))
+	pool := core.NewMessagePool(newTestMessagePoolConfig(100), th.NewTestBlockTimer(0))
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.AccountActorCodeCid
 	return cst, pool, fakeActorCodeCid

--- a/node/node.go
+++ b/node/node.go
@@ -403,7 +403,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 
 	// only the syncer gets the storage which is online connected
 	chainSyncer := chain.NewDefaultSyncer(&cstOffline, nodeConsensus, chainStore, fetcher)
-	msgPool := core.NewMessagePool(chainStore)
+	msgPool := core.NewMessagePool(nc.Repo.Config().Mpool, chainStore)
 	outbox := core.NewMessageQueue()
 
 	// Set up libp2p pubsub

--- a/plumbing/msg/sender_test.go
+++ b/plumbing/msg/sender_test.go
@@ -15,12 +15,19 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor/builtin/storagemarket"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/config"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/core"
 	"github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/wallet"
 )
+
+func newTestMessagePoolConfig(limit int) *config.MessagePoolConfig {
+	return &config.MessagePoolConfig{
+		Limit: limit,
+	}
+}
 
 func TestSend(t *testing.T) {
 	t.Parallel()
@@ -33,7 +40,7 @@ func TestSend(t *testing.T) {
 		addr := w.Addresses()[0]
 		timer := testhelpers.NewTestBlockTimer(1000)
 		queue := core.NewMessageQueue()
-		pool := core.NewMessagePool(timer)
+		pool := core.NewMessagePool(newTestMessagePoolConfig(100), timer)
 		nopPublish := func(string, []byte) error { return nil }
 
 		s := NewSender(w, chainStore, timer, queue, pool, nullValidator{rejectMessages: true}, nopPublish)
@@ -49,7 +56,7 @@ func TestSend(t *testing.T) {
 		addr := w.Addresses()[0]
 		timer := testhelpers.NewTestBlockTimer(1000)
 		queue := core.NewMessageQueue()
-		pool := core.NewMessagePool(timer)
+		pool := core.NewMessagePool(newTestMessagePoolConfig(100), timer)
 
 		publishCalled := false
 		publish := func(topic string, data []byte) error {
@@ -78,7 +85,7 @@ func TestSend(t *testing.T) {
 		addr := w.Addresses()[0]
 		timer := testhelpers.NewTestBlockTimer(1000)
 		queue := core.NewMessageQueue()
-		pool := core.NewMessagePool(timer)
+		pool := core.NewMessagePool(newTestMessagePoolConfig(100), timer)
 		nopPublish := func(string, []byte) error { return nil }
 
 		s := NewSender(w, chainStore, timer, queue, pool, nullValidator{}, nopPublish)

--- a/repo/fsrepo_test.go
+++ b/repo/fsrepo_test.go
@@ -63,6 +63,9 @@ const (
 		"prometheusEnabled": false,
 		"reportInterval": "5s",
 		"prometheusEndpoint": "/ip4/0.0.0.0/tcp/9400"
+	},
+	"mpool": {
+		"limit": 100
 	}
 }`
 )


### PR DESCRIPTION
### Description
This PR:
1. Adds a Message Pool config that contains a limit field, this is used to control the max size of the message pool.
2. Passes the Message Pool config to the message pool when it is created ensure the message pool cannot grow indefinitely.

### Notes:
I am unsure if the is the exact solution we want to go with, however since https://github.com/filecoin-project/go-filecoin/issues/2500 is a `P0` I wanted to get something up now that makes progress towards addressing this.