### PR TITLE
Add pre-validation to message pool

### DIFF
--- a/chain/default_store.go
+++ b/chain/default_store.go
@@ -14,7 +14,9 @@ import (
 	logging "github.com/ipfs/go-log"
 	"github.com/pkg/errors"
 
+	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
+	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
@@ -385,6 +387,16 @@ func (store *DefaultStore) LatestState(ctx context.Context) (state.Tree, error) 
 		return nil, err
 	}
 	return state.LoadStateTree(ctx, store.stateStore, tsas.TipSetStateRoot, builtin.Actors)
+}
+
+// ActorFromLatestState gets the latest state and retrieves an actor from it.
+func (store *DefaultStore) ActorFromLatestState(ctx context.Context, addr address.Address) (*actor.Actor, error) {
+	st, err := store.LatestState(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return st.GetActor(ctx, addr)
 }
 
 // BlockHistory returns a channel of block pointers (or errors), starting with the input tipset

--- a/chain/store.go
+++ b/chain/store.go
@@ -2,6 +2,8 @@ package chain
 
 import (
 	"context"
+	"github.com/filecoin-project/go-filecoin/actor"
+	"github.com/filecoin-project/go-filecoin/address"
 
 	"github.com/cskr/pubsub"
 	"github.com/ipfs/go-cid"
@@ -39,6 +41,8 @@ type ReadStore interface {
 	Head() types.TipSet
 	// LatestState returns the latest state of the head
 	LatestState(ctx context.Context) (state.Tree, error)
+	// ActorFromLatestState tries to get an actor from the latest state
+	ActorFromLatestState(ctx context.Context, address address.Address) (*actor.Actor, error)
 
 	BlockHistory(ctx context.Context, tips types.TipSet) <-chan interface{}
 

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -6,8 +6,13 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
+	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/filecoin-project/go-filecoin/vm/errors"
 )
+
+// MaxNonceGap is the maximum nonce of a message past the last received on chain
+const MaxNonceGap = 100
 
 // SignedMessageValidator validates incoming signed messages.
 type SignedMessageValidator interface {
@@ -86,4 +91,49 @@ func (v *defaultMessageValidator) Validate(ctx context.Context, msg *types.Signe
 func canCoverGasLimit(msg *types.SignedMessage, actor *actor.Actor) bool {
 	maximumGasCharge := msg.GasPrice.MulBigInt(big.NewInt(int64(msg.GasLimit)))
 	return maximumGasCharge.LessEqual(actor.Balance.Sub(msg.Value))
+}
+
+// IngestionValidatorAPI allows the validator to access latest state
+type ingestionValidatorAPI interface {
+	LatestState(ctx context.Context) (state.Tree, error)
+}
+
+// IngestionValidator can access latest state and runs additional checks to mitigate DoS attacks
+type IngestionValidator struct {
+	api       ingestionValidatorAPI
+	validator defaultMessageValidator
+}
+
+// NewIngestionValidator creates a new validator with an api
+func NewIngestionValidator(api ingestionValidatorAPI) *IngestionValidator {
+	return &IngestionValidator{
+		api:       api,
+		validator: defaultMessageValidator{allowHighNonce: true},
+	}
+}
+
+// Validate validates the signed message.
+// Errors probably mean the validation failed, but possibly indicate a failure to retrieve state
+func (v *IngestionValidator) Validate(ctx context.Context, msg *types.SignedMessage) error {
+	// retrieve from actor
+	st, err := v.api.LatestState(ctx)
+	if err != nil {
+		return err
+	}
+
+	fromActor, err := st.GetActor(ctx, msg.From)
+	if err != nil {
+		if state.IsActorNotFoundError(err) {
+			fromActor = &actor.Actor{}
+		} else {
+			return err
+		}
+	}
+
+	// check that message nonce is not too high
+	if msg.Nonce > fromActor.Nonce && msg.Nonce-fromActor.Nonce > MaxNonceGap {
+		return errors.NewRevertErrorf("message nonce (%d) is too much greater than actor nonce (%d)", msg.Nonce, fromActor.Nonce)
+	}
+
+	return v.validator.Validate(ctx, msg, fromActor)
 }

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -3,11 +3,6 @@ package consensus_test
 import (
 	"context"
 	"fmt"
-	"github.com/filecoin-project/go-filecoin/actor/builtin"
-	"github.com/filecoin-project/go-filecoin/state"
-	"github.com/ipfs/go-hamt-ipld"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/filecoin-project/go-filecoin/actor"
@@ -15,6 +10,9 @@ import (
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var seed = types.GenerateKeyInfoSeed()
@@ -176,24 +174,21 @@ func attoFil(v int) *types.AttoFIL {
 	return val
 }
 
-// MockIngestionValidatorAPI provides a latest state
-type MockIngestionValidatorAPI struct {
+// FakeIngestionValidatorAPI provides a latest state
+type FakeIngestionValidatorAPI struct {
 	ActorAddr address.Address
 	Actor     *actor.Actor
 }
 
-// NewMockIngestionValidatorAPI creates a new MockIngestionValidatorAPI.
-func NewMockIngestionValidatorAPI() *MockIngestionValidatorAPI {
-	return &MockIngestionValidatorAPI{Actor: &actor.Actor{}}
+// NewMockIngestionValidatorAPI creates a new FakeIngestionValidatorAPI.
+func NewMockIngestionValidatorAPI() *FakeIngestionValidatorAPI {
+	return &FakeIngestionValidatorAPI{Actor: &actor.Actor{}}
 }
 
 // LatestState will be a state tree that only contains the test actor
-func (api *MockIngestionValidatorAPI) LatestState(ctx context.Context) (state.Tree, error) {
-	cst := hamt.NewCborStore()
-	st := state.NewEmptyStateTreeWithActors(cst, builtin.Actors)
-	err := st.SetActor(ctx, api.ActorAddr, api.Actor)
-	if err != nil {
-		return nil, err
+func (api *FakeIngestionValidatorAPI) ActorFromLatestState(ctx context.Context, address address.Address) (*actor.Actor, error) {
+	if address == api.ActorAddr {
+		return api.Actor, nil
 	}
-	return st, nil
+	return &actor.Actor{}, nil
 }

--- a/core/message_pool.go
+++ b/core/message_pool.go
@@ -93,8 +93,7 @@ func (pool *MessagePool) addTimedMessage(ctx context.Context, msg *timedmessage)
 		return c, nil
 	}
 
-	err = pool.ValidateMessage(ctx, msg.message)
-	if err != nil {
+	if err = pool.validateMessage(ctx, msg.message); err != nil {
 		return cid.Undef, errors.Wrap(err, "validation error adding message to pool")
 	}
 
@@ -247,9 +246,9 @@ func (pool *MessagePool) LargestNonce(address address.Address) (largest uint64, 
 	return
 }
 
-// ValidateMessage in message pool is a mechanism for preventing memory based DoS attacks.
+// validateMessage in message pool is a mechanism for preventing memory based DoS attacks.
 // As such, it will often fail silently.
-func (pool *MessagePool) ValidateMessage(ctx context.Context, message *types.SignedMessage) error {
+func (pool *MessagePool) validateMessage(ctx context.Context, message *types.SignedMessage) error {
 	if len(pool.pending) >= MaxMessagePoolSize {
 		return ErrMessagePoolFull
 	}
@@ -279,9 +278,5 @@ func (pool *MessagePool) ValidateMessage(ctx context.Context, message *types.Sig
 		return ErrNonceGapExceeded
 	}
 
-	if err = consensus.NewOutboundMessageValidator().Validate(ctx, message, fromActor); err != nil {
-		return err
-	}
-
-	return nil
+	return consensus.NewOutboundMessageValidator().Validate(ctx, message, fromActor)
 }

--- a/core/message_pool.go
+++ b/core/message_pool.go
@@ -7,25 +7,50 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/pkg/errors"
 
+	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/metrics"
+	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
 var mpSize = metrics.NewInt64Gauge("message_pool_size", "The size of the message pool")
 
+// MaxMessagePoolSize is the maximum number of pending messages will will allow in the message pool at any time
+const MaxMessagePoolSize = 10000
+
+// MaxNonceGap is the maximum nonce of a message past the last received on chain
+const MaxNonceGap = 100
+
 // MessageTimeOut is the number of tipsets we should receive before timing out messages
 const MessageTimeOut = 6
+
+var (
+	ErrMessagePoolFull  = errors.New("message pool is full")
+	ErrNonceGapExceeded = errors.New("message nonce is too much greater than highest nonce on chain")
+	ErrDuplicateNonce   = errors.New("different message with same from address and nonce is already in pool")
+)
 
 type timedmessage struct {
 	message *types.SignedMessage
 	addedAt uint64
 }
 
-// BlockTimer defines a interface to a struct that can give the current block height.
-type BlockTimer interface {
+// MessagePoolAPI defines a interface api resources the message pool needs.
+type MessagePoolAPI interface {
 	BlockHeight() (uint64, error)
+	LatestState(ctx context.Context) (state.Tree, error)
+}
+
+type addressNonce struct {
+	addr  address.Address
+	nonce uint64
+}
+
+func newAddressNonce(msg *types.SignedMessage) addressNonce {
+	return addressNonce{addr: msg.From, nonce: uint64(msg.Nonce)}
 }
 
 // MessagePool keeps an unordered, de-duplicated set of Messages and supports removal by CID.
@@ -38,21 +63,22 @@ type BlockTimer interface {
 type MessagePool struct {
 	lk sync.RWMutex
 
-	timer   BlockTimer
-	pending map[cid.Cid]*timedmessage // all pending messages
+	api           MessagePoolAPI
+	pending       map[cid.Cid]*timedmessage // all pending messages
+	addressNonces map[addressNonce]bool
 }
 
 // Add adds a message to the pool.
-func (pool *MessagePool) Add(msg *types.SignedMessage) (cid.Cid, error) {
-	blockTime, err := pool.timer.BlockHeight()
+func (pool *MessagePool) Add(ctx context.Context, msg *types.SignedMessage) (cid.Cid, error) {
+	blockTime, err := pool.api.BlockHeight()
 	if err != nil {
 		return cid.Undef, err
 	}
 
-	return pool.addTimedMessage(&timedmessage{message: msg, addedAt: blockTime})
+	return pool.addTimedMessage(ctx, &timedmessage{message: msg, addedAt: blockTime})
 }
 
-func (pool *MessagePool) addTimedMessage(msg *timedmessage) (cid.Cid, error) {
+func (pool *MessagePool) addTimedMessage(ctx context.Context, msg *timedmessage) (cid.Cid, error) {
 	pool.lk.Lock()
 	defer pool.lk.Unlock()
 
@@ -61,15 +87,21 @@ func (pool *MessagePool) addTimedMessage(msg *timedmessage) (cid.Cid, error) {
 		return cid.Undef, errors.Wrap(err, "failed to create CID")
 	}
 
-	// Reject messages with invalid signatires
-	if !msg.message.VerifySignature() {
-		return cid.Undef, errors.Errorf("failed to add message %s to pool: sig invalid", c.String())
+	// ignore message prior to validation if it is already in pool
+	_, found := pool.pending[c]
+	if found {
+		return c, nil
+	}
+
+	err = pool.ValidateMessage(ctx, msg.message)
+	if err != nil {
+		return cid.Undef, errors.Wrap(err, "validation error adding message to pool")
 	}
 
 	pool.pending[c] = msg
+	pool.addressNonces[newAddressNonce(msg.message)] = true
 	mpSize.Set(context.TODO(), int64(len(pool.pending)))
 	return c, nil
-
 }
 
 // Pending returns all pending messages.
@@ -102,15 +134,20 @@ func (pool *MessagePool) Remove(c cid.Cid) {
 	pool.lk.Lock()
 	defer pool.lk.Unlock()
 
+	msg, ok := pool.pending[c]
+	if ok {
+		delete(pool.addressNonces, newAddressNonce(msg.message))
+	}
 	delete(pool.pending, c)
 	mpSize.Set(context.TODO(), int64(len(pool.pending)))
 }
 
 // NewMessagePool constructs a new MessagePool.
-func NewMessagePool(timer BlockTimer) *MessagePool {
+func NewMessagePool(api MessagePoolAPI) *MessagePool {
 	return &MessagePool{
-		timer:   timer,
-		pending: make(map[cid.Cid]*timedmessage),
+		api:           api,
+		pending:       make(map[cid.Cid]*timedmessage),
+		addressNonces: make(map[addressNonce]bool),
 	}
 }
 
@@ -133,9 +170,9 @@ func (pool *MessagePool) UpdateMessagePool(ctx context.Context, store chain.Bloc
 	// Add all message from the old blocks to the message pool, so they can be mined again.
 	for _, blk := range oldBlocks {
 		for _, msg := range blk.Messages {
-			_, err = pool.addTimedMessage(&timedmessage{message: msg, addedAt: uint64(blk.Height)})
+			_, err = pool.addTimedMessage(ctx, &timedmessage{message: msg, addedAt: uint64(blk.Height)})
 			if err != nil {
-				return err
+				log.Info(err)
 			}
 		}
 	}
@@ -208,4 +245,43 @@ func (pool *MessagePool) LargestNonce(address address.Address) (largest uint64, 
 		}
 	}
 	return
+}
+
+// ValidateMessage in message pool is a mechanism for preventing memory based DoS attacks.
+// As such, it will often fail silently.
+func (pool *MessagePool) ValidateMessage(ctx context.Context, message *types.SignedMessage) error {
+	if len(pool.pending) >= MaxMessagePoolSize {
+		return ErrMessagePoolFull
+	}
+
+	// check that message with this nonce does not already exist
+	_, found := pool.addressNonces[newAddressNonce(message)]
+	if found {
+		return ErrDuplicateNonce
+	}
+
+	st, err := pool.api.LatestState(ctx)
+	if err != nil {
+		return err
+	}
+
+	fromActor, err := st.GetActor(ctx, message.From)
+	if err != nil {
+		if state.IsActorNotFoundError(err) {
+			fromActor = &actor.Actor{}
+		} else {
+			return err
+		}
+	}
+
+	// check that message nonce is not too high
+	if message.Nonce > fromActor.Nonce && message.Nonce-fromActor.Nonce > MaxNonceGap {
+		return ErrNonceGapExceeded
+	}
+
+	if err = consensus.NewOutboundMessageValidator().Validate(ctx, message, fromActor); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/core/message_pool_test.go
+++ b/core/message_pool_test.go
@@ -27,7 +27,7 @@ func TestMessagePoolAddRemove(t *testing.T) {
 	api := th.NewTestMessagePoolAPI(0)
 	pool := NewMessagePool(api, th.NewMockMessagePoolValidator())
 	msg1 := newSignedMessage()
-	msg2 := setNonce(mockSigner, newSignedMessage(), 1)
+	msg2 := mustSetNonce(mockSigner, newSignedMessage(), 1)
 
 	c1, err := msg1.Cid()
 	assert.NoError(err)
@@ -95,7 +95,7 @@ func TestMessagePoolValidate(t *testing.T) {
 		_, err := pool.Add(ctx, smsg1)
 		require.NoError(err)
 
-		smsg2 := setNonce(mockSigner, newSignedMessage(), smsg1.Nonce)
+		smsg2 := mustSetNonce(mockSigner, newSignedMessage(), smsg1.Nonce)
 		_, err = pool.Add(ctx, smsg2)
 		require.Error(err)
 		assert.Contains(err.Error(), "message with same actor and nonce")
@@ -111,7 +111,7 @@ func TestMessagePoolValidate(t *testing.T) {
 		validator.Valid = false
 		pool := NewMessagePool(api, validator)
 
-		smsg1 := setNonce(mockSigner, newSignedMessage(), 0)
+		smsg1 := mustSetNonce(mockSigner, newSignedMessage(), 0)
 		_, err := pool.Add(ctx, smsg1)
 		require.Error(err)
 		assert.Contains(err.Error(), "mock validation error")
@@ -618,13 +618,13 @@ func (p *storeBlockProvider) GetBlock(ctx context.Context, cid cid.Cid) (*types.
 	return &blk, nil
 }
 
-func setNonce(signer types.Signer, message *types.SignedMessage, nonce types.Uint64) *types.SignedMessage {
-	return resignMessage(signer, message, func(m *types.Message) {
+func mustSetNonce(signer types.Signer, message *types.SignedMessage, nonce types.Uint64) *types.SignedMessage {
+	return mustResignMessage(signer, message, func(m *types.Message) {
 		m.Nonce = nonce
 	})
 }
 
-func resignMessage(signer types.Signer, message *types.SignedMessage, f func(*types.Message)) *types.SignedMessage {
+func mustResignMessage(signer types.Signer, message *types.SignedMessage, f func(*types.Message)) *types.SignedMessage {
 	var msg types.Message
 	msg = message.Message
 	f(&msg)

--- a/core/testing.go
+++ b/core/testing.go
@@ -39,8 +39,9 @@ func MustGetNonce(st state.Tree, a address.Address) uint64 {
 
 // MustAdd adds the given messages to the messagepool or panics if it cannot.
 func MustAdd(p *MessagePool, msgs ...*types.SignedMessage) {
+	ctx := context.Background()
 	for _, m := range msgs {
-		if _, err := p.Add(m); err != nil {
+		if _, err := p.Add(ctx, m); err != nil {
 			panic(err)
 		}
 	}

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -98,7 +98,7 @@ func Test_Mine(t *testing.T) {
 
 func sharedSetupInitial() (*hamt.CborIpldStore, *core.MessagePool, cid.Cid) {
 	cst := hamt.NewCborStore()
-	pool := core.NewMessagePool(th.NewTestMessagePoolAPI(0))
+	pool := core.NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.AccountActorCodeCid
 	return cst, pool, fakeActorCodeCid

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -289,8 +289,8 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 
 	assert.Len(pool.Pending(), 4)
 
-	// Wet actor nonce past nonce of message in pool.
-	// We have to do this here to get a permanent error in the pool.
+	// Set actor nonce past nonce of message in pool.
+	// Have to do this here to get a permanent error in the pool.
 	act, err := st.GetActor(ctx, addrs[1])
 	require.NoError(err)
 

--- a/node/message.go
+++ b/node/message.go
@@ -21,6 +21,6 @@ func (node *Node) processMessage(ctx context.Context, pubSubMsg pubsub.Message) 
 
 	log.Debugf("Received new message from network: %s", unmarshaled)
 
-	_, err = node.MsgPool.Add(unmarshaled)
+	_, err = node.MsgPool.Add(ctx, unmarshaled)
 	return err
 }

--- a/node/node.go
+++ b/node/node.go
@@ -403,7 +403,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 
 	// only the syncer gets the storage which is online connected
 	chainSyncer := chain.NewDefaultSyncer(&cstOffline, nodeConsensus, chainStore, fetcher)
-	msgPool := core.NewMessagePool(chainStore)
+	msgPool := core.NewMessagePool(chainStore, consensus.NewIngestionValidator(chainStore))
 	outbox := core.NewMessageQueue()
 
 	// Set up libp2p pubsub

--- a/plumbing/msg/sender.go
+++ b/plumbing/msg/sender.go
@@ -29,6 +29,11 @@ type chainState interface {
 	LatestState(ctx context.Context) (state.Tree, error)
 }
 
+// BlockTimer defines a interface to a struct that can give the current block height.
+type BlockTimer interface {
+	BlockHeight() (uint64, error)
+}
+
 // PublishFunc is a function the Sender calls to publish a message to the network.
 type PublishFunc func(topic string, data []byte) error
 
@@ -39,7 +44,7 @@ type Sender struct {
 	// Provides actor state
 	chainState chainState
 	// Provides the current block height
-	blockTimer core.BlockTimer
+	blockTimer BlockTimer
 	// Tracks inbound messages for mining
 	inbox *core.MessagePool
 	// Tracks outbound messages
@@ -54,7 +59,7 @@ type Sender struct {
 
 // NewSender returns a new Sender. There should be exactly one of these per node because
 // sending locks to reduce nonce collisions.
-func NewSender(signer types.Signer, chainReader chain.ReadStore, blockTimer core.BlockTimer,
+func NewSender(signer types.Signer, chainReader chain.ReadStore, blockTimer BlockTimer,
 	msgQueue *core.MessageQueue, msgPool *core.MessagePool,
 	validator consensus.SignedMessageValidator, publish PublishFunc) *Sender {
 	return &Sender{
@@ -125,7 +130,7 @@ func (s *Sender) Send(ctx context.Context, from, to address.Address, value *type
 	if err := s.outbox.Enqueue(smsg, height); err != nil {
 		return cid.Undef, errors.Wrap(err, "failed to add message to outbound queue")
 	}
-	if _, err := s.inbox.Add(smsg); err != nil {
+	if _, err := s.inbox.Add(ctx, smsg); err != nil {
 		return cid.Undef, errors.Wrap(err, "failed to add message to message pool")
 	}
 

--- a/plumbing/msg/sender.go
+++ b/plumbing/msg/sender.go
@@ -29,8 +29,8 @@ type chainState interface {
 	LatestState(ctx context.Context) (state.Tree, error)
 }
 
-// BlockTimer defines a interface to a struct that can give the current block height.
-type BlockTimer interface {
+// BlockClock defines a interface to a struct that can give the current block height.
+type BlockClock interface {
 	BlockHeight() (uint64, error)
 }
 
@@ -44,7 +44,7 @@ type Sender struct {
 	// Provides actor state
 	chainState chainState
 	// Provides the current block height
-	blockTimer BlockTimer
+	blockTimer BlockClock
 	// Tracks inbound messages for mining
 	inbox *core.MessagePool
 	// Tracks outbound messages
@@ -59,7 +59,7 @@ type Sender struct {
 
 // NewSender returns a new Sender. There should be exactly one of these per node because
 // sending locks to reduce nonce collisions.
-func NewSender(signer types.Signer, chainReader chain.ReadStore, blockTimer BlockTimer,
+func NewSender(signer types.Signer, chainReader chain.ReadStore, blockTimer BlockClock,
 	msgQueue *core.MessageQueue, msgPool *core.MessagePool,
 	validator consensus.SignedMessageValidator, publish PublishFunc) *Sender {
 	return &Sender{

--- a/plumbing/msg/sender_test.go
+++ b/plumbing/msg/sender_test.go
@@ -33,7 +33,7 @@ func TestSend(t *testing.T) {
 		addr := w.Addresses()[0]
 		timer := testhelpers.NewTestMessagePoolAPI(1000)
 		queue := core.NewMessageQueue()
-		pool := core.NewMessagePool(timer)
+		pool := core.NewMessagePool(timer, testhelpers.NewMockMessagePoolValidator())
 		nopPublish := func(string, []byte) error { return nil }
 
 		s := NewSender(w, chainStore, timer, queue, pool, nullValidator{rejectMessages: true}, nopPublish)
@@ -50,7 +50,7 @@ func TestSend(t *testing.T) {
 		toAddr := address.NewForTestGetter()()
 		timer := testhelpers.NewTestMessagePoolAPI(1000)
 		queue := core.NewMessageQueue()
-		pool := core.NewMessagePool(timer)
+		pool := core.NewMessagePool(timer, testhelpers.NewMockMessagePoolValidator())
 
 		publishCalled := false
 		publish := func(topic string, data []byte) error {
@@ -80,7 +80,7 @@ func TestSend(t *testing.T) {
 		toAddr := address.NewForTestGetter()()
 		timer := testhelpers.NewTestMessagePoolAPI(1000)
 		queue := core.NewMessageQueue()
-		pool := core.NewMessagePool(timer)
+		pool := core.NewMessagePool(timer, testhelpers.NewMockMessagePoolValidator())
 		nopPublish := func(string, []byte) error { return nil }
 
 		s := NewSender(w, chainStore, timer, queue, pool, nullValidator{}, nopPublish)

--- a/plumbing/msg/sender_test.go
+++ b/plumbing/msg/sender_test.go
@@ -31,7 +31,7 @@ func TestSend(t *testing.T) {
 
 		w, chainStore := setupSendTest(require)
 		addr := w.Addresses()[0]
-		timer := testhelpers.NewTestBlockTimer(1000)
+		timer := testhelpers.NewTestMessagePoolAPI(1000)
 		queue := core.NewMessageQueue()
 		pool := core.NewMessagePool(timer)
 		nopPublish := func(string, []byte) error { return nil }
@@ -47,7 +47,8 @@ func TestSend(t *testing.T) {
 
 		w, chainStore := setupSendTest(require)
 		addr := w.Addresses()[0]
-		timer := testhelpers.NewTestBlockTimer(1000)
+		toAddr := address.NewForTestGetter()()
+		timer := testhelpers.NewTestMessagePoolAPI(1000)
 		queue := core.NewMessageQueue()
 		pool := core.NewMessagePool(timer)
 
@@ -62,7 +63,7 @@ func TestSend(t *testing.T) {
 		require.Empty(queue.List(addr))
 		require.Empty(pool.Pending())
 
-		_, err := s.Send(context.Background(), addr, addr, types.NewAttoFILFromFIL(2), types.NewGasPrice(0), types.NewGasUnits(0), "")
+		_, err := s.Send(context.Background(), addr, toAddr, types.NewZeroAttoFIL(), types.NewGasPrice(0), types.NewGasUnits(0), "")
 		require.NoError(err)
 		assert.Equal(uint64(1000), queue.List(addr)[0].Stamp)
 		assert.Equal(1, len(pool.Pending()))
@@ -76,7 +77,8 @@ func TestSend(t *testing.T) {
 
 		w, chainStore := setupSendTest(require)
 		addr := w.Addresses()[0]
-		timer := testhelpers.NewTestBlockTimer(1000)
+		toAddr := address.NewForTestGetter()()
+		timer := testhelpers.NewTestMessagePoolAPI(1000)
 		queue := core.NewMessageQueue()
 		pool := core.NewMessagePool(timer)
 		nopPublish := func(string, []byte) error { return nil }
@@ -87,7 +89,7 @@ func TestSend(t *testing.T) {
 		addTwentyMessages := func(batch int) {
 			defer wg.Done()
 			for i := 0; i < 20; i++ {
-				_, err := s.Send(ctx, addr, addr, types.NewZeroAttoFIL(), types.NewGasPrice(0), types.NewGasUnits(0), fmt.Sprintf("%d-%d", batch, i), []byte{})
+				_, err := s.Send(ctx, addr, toAddr, types.NewZeroAttoFIL(), types.NewGasPrice(0), types.NewGasUnits(0), fmt.Sprintf("%d-%d", batch, i), []byte{})
 				require.NoError(err)
 			}
 		}

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -109,7 +109,10 @@ func (tbt *TestMessagePoolAPI) BlockHeight() (uint64, error) {
 func (tbt *TestMessagePoolAPI) LatestState(ctx context.Context) (state.Tree, error) {
 	cst := hamt.NewCborStore()
 	st := state.NewEmptyStateTreeWithActors(cst, builtin.Actors)
-	st.SetActor(ctx, tbt.ActorAddr, tbt.Actor)
+	err := st.SetActor(ctx, tbt.ActorAddr, tbt.Actor)
+	if err != nil {
+		return nil, err
+	}
 	return st, nil
 }
 

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -88,19 +88,29 @@ func RequireRandomPeerID(require *require.Assertions) peer.ID {
 	return pid
 }
 
-// TestBlockTimer provides a simple BlockTimer interface implementation.
-type TestBlockTimer struct {
-	Height uint64
+// TestMessagePoolAPI provides a simple BlockTimer interface implementation.
+type TestMessagePoolAPI struct {
+	Height    uint64
+	ActorAddr address.Address
+	Actor     *actor.Actor
 }
 
-// NewTestBlockTimer creates a new TestBlockTimer.
-func NewTestBlockTimer(h uint64) *TestBlockTimer {
-	return &TestBlockTimer{Height: h}
+// NewTestMessagePoolAPI creates a new TestMessagePoolAPI.
+func NewTestMessagePoolAPI(h uint64) *TestMessagePoolAPI {
+	return &TestMessagePoolAPI{Height: h, Actor: &actor.Actor{}}
 }
 
 // BlockHeight represents the height of the highest tipset.
-func (tbt *TestBlockTimer) BlockHeight() (uint64, error) {
+func (tbt *TestMessagePoolAPI) BlockHeight() (uint64, error) {
 	return tbt.Height, nil
+}
+
+// LatestState will be a state tree that only contains the test actor
+func (tbt *TestMessagePoolAPI) LatestState(ctx context.Context) (state.Tree, error) {
+	cst := hamt.NewCborStore()
+	st := state.NewEmptyStateTreeWithActors(cst, builtin.Actors)
+	st.SetActor(ctx, tbt.ActorAddr, tbt.Actor)
+	return st, nil
 }
 
 // VMStorage creates a new storage object backed by an in memory datastore

--- a/types/helpers.go
+++ b/types/helpers.go
@@ -37,3 +37,10 @@ func GenerateKeyInfoSeed() io.Reader {
 	rand.Read(token)
 	return bytes.NewReader(token)
 }
+
+// GenerateBigKeyInfoSeed returns a really big random to be passed to MustGenerateKeyInfo
+func GenerateBigKeyInfoSeed() io.Reader {
+	token := make([]byte, 262144)
+	rand.Read(token)
+	return bytes.NewReader(token)
+}

--- a/types/helpers.go
+++ b/types/helpers.go
@@ -37,10 +37,3 @@ func GenerateKeyInfoSeed() io.Reader {
 	rand.Read(token)
 	return bytes.NewReader(token)
 }
-
-// GenerateBigKeyInfoSeed returns a really big random to be passed to MustGenerateKeyInfo
-func GenerateBigKeyInfoSeed() io.Reader {
-	token := make([]byte, 262144)
-	rand.Read(token)
-	return bytes.NewReader(token)
-}

--- a/types/testing.go
+++ b/types/testing.go
@@ -3,7 +3,6 @@ package types
 import (
 	"bytes"
 	"fmt"
-
 	"github.com/ipfs/go-cid"
 	"github.com/minio/blake2b-simd"
 	"github.com/pkg/errors"
@@ -230,6 +229,7 @@ func NewMsgs(n int) []*Message {
 	msgs := make([]*Message, n)
 	for i := 0; i < n; i++ {
 		msgs[i] = newMsg()
+		msgs[i].Nonce = Uint64(i)
 	}
 	return msgs
 }
@@ -238,10 +238,17 @@ func NewMsgs(n int) []*Message {
 // but are not unique globally (ie, a second call to NewSignedMsgs will return the same
 // set of messages).
 func NewSignedMsgs(n int, ms MockSigner) []*SignedMessage {
-	newSmsg := NewSignedMessageForTestGetter(ms)
+	var err error
+	newMsg := NewMessageForTestGetter()
 	smsgs := make([]*SignedMessage, n)
 	for i := 0; i < n; i++ {
-		smsgs[i] = newSmsg()
+		msg := newMsg()
+		msg.From = ms.Addresses[0]
+		msg.Nonce = Uint64(i)
+		smsgs[i], err = NewSignedMessage(*msg, ms, NewGasPrice(0), NewGasUnits(0))
+		if err != nil {
+			panic(err)
+		}
 	}
 	return smsgs
 }


### PR DESCRIPTION
closes #2517
partially addresses #2500
closes #2256

### Problem

We have no pre-validation on the message pool. This means any random message can land in the message pool and waste space. Because there are several types of message error that prevent us charging gas, an attacker can easily spam the message pool with message that they know will never cost any Filecoin.

### Solution

Add validation to the message pool. This:

1. Limit total number of messages allowed in message pool at any time.
2. Drop messages sent to self.
3. Drop messages with gas limit greater than block limit.
4. Drop messages where actor has insufficient funds to cover gas.
5. Drop messages with invalid actor cid.
6.  Drop messages without valid signatures.
7. Drop messages with duplicate nonce.
8. Drop messages with delta between nonce and current nonce greater than some limit

Most of this is accomplished by using the same validation we use when validating messages for processing.