### PR TITLE
rename "sector store type" to "proofs mode"

### DIFF
--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -463,9 +463,9 @@ func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR,
 		// It is undefined behavior for a miner in "Live" mode to verify a proof
 		// created by a miner in "ProofsTest" mode (and vice-versa).
 		//
-		sectorStoreType := proofs.Live
+		proofsMode := proofs.Live
 		if os.Getenv("FIL_USE_SMALL_SECTORS") == "true" {
-			sectorStoreType = proofs.Test
+			proofsMode = proofs.Test
 		}
 
 		req := proofs.VerifySealRequest{}
@@ -475,7 +475,7 @@ func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR,
 		copy(req.Proof[:], proof)
 		req.ProverID = sectorbuilder.AddressToProverID(ctx.Message().To)
 		req.SectorID = sectorbuilder.SectorIDToBytes(sectorID)
-		req.StoreType = sectorStoreType
+		req.ProofsMode = proofsMode
 
 		res, err := (&proofs.RustVerifier{}).VerifySeal(req)
 		if err != nil {
@@ -675,9 +675,9 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, postProofs []proofs.PoStProof) (
 			// It is undefined behavior for a miner in "Live" mode to verify a proof
 			// created by a miner in "ProofsTest" mode (and vice-versa).
 			//
-			sectorStoreType := proofs.Live
+			proofsMode := proofs.Live
 			if os.Getenv("FIL_USE_SMALL_SECTORS") == "true" {
-				sectorStoreType = proofs.Test
+				proofsMode = proofs.Test
 			}
 
 			seed, err := currentProvingPeriodPoStChallengeSeed(ctx, state)
@@ -695,7 +695,7 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, postProofs []proofs.PoStProof) (
 				CommRs:        commRs,
 				Faults:        []uint64{},
 				Proofs:        postProofs,
-				StoreType:     sectorStoreType,
+				ProofsMode:    proofsMode,
 			}
 
 			res, err := (&proofs.RustVerifier{}).VerifyPoST(req)

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -461,7 +461,7 @@ func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR,
 		// about the sector for which the proof was generated in order to verify.
 		//
 		// It is undefined behavior for a miner in "Live" mode to verify a proof
-		// created by a miner in "ProofsTest" mode (and vice-versa).
+		// created by a miner in "Test" mode (and vice-versa).
 		//
 		proofsMode := proofs.Live
 		if os.Getenv("FIL_USE_SMALL_SECTORS") == "true" {
@@ -673,7 +673,7 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, postProofs []proofs.PoStProof) (
 			// See comment above, in CommitSector.
 			//
 			// It is undefined behavior for a miner in "Live" mode to verify a proof
-			// created by a miner in "ProofsTest" mode (and vice-versa).
+			// created by a miner in "Test" mode (and vice-versa).
 			//
 			proofsMode := proofs.Live
 			if os.Getenv("FIL_USE_SMALL_SECTORS") == "true" {

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -460,12 +460,12 @@ func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR,
 		// the PoRep verification operation needs to know some things (e.g. size)
 		// about the sector for which the proof was generated in order to verify.
 		//
-		// It is undefined behavior for a miner in "Live" mode to verify a proof
-		// created by a miner in "Test" mode (and vice-versa).
+		// It is undefined behavior for a miner using "LiveMode" to verify a
+		// proof created by a miner using "TestMode" (and vice-versa).
 		//
-		proofsMode := proofs.Live
+		proofsMode := proofs.LiveMode
 		if os.Getenv("FIL_USE_SMALL_SECTORS") == "true" {
-			proofsMode = proofs.Test
+			proofsMode = proofs.TestMode
 		}
 
 		req := proofs.VerifySealRequest{}
@@ -672,12 +672,12 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, postProofs []proofs.PoStProof) (
 		if !ma.Bootstrap {
 			// See comment above, in CommitSector.
 			//
-			// It is undefined behavior for a miner in "Live" mode to verify a proof
-			// created by a miner in "Test" mode (and vice-versa).
+			// It is undefined behavior for a miner using "LiveMode" to verify a
+			// proof created by a miner using "TestMode" (and vice-versa).
 			//
-			proofsMode := proofs.Live
+			proofsMode := proofs.LiveMode
 			if os.Getenv("FIL_USE_SMALL_SECTORS") == "true" {
-				proofsMode = proofs.Test
+				proofsMode = proofs.TestMode
 			}
 
 			seed, err := currentProvingPeriodPoStChallengeSeed(ctx, state)

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.1.0
 	go.opencensus.io v0.19.2
+	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 	gotest.tools v2.2.0+incompatible // indirect

--- a/node/node.go
+++ b/node/node.go
@@ -586,9 +586,9 @@ func (node *Node) setupHeartbeatServices(ctx context.Context) error {
 
 func (node *Node) setupMining(ctx context.Context) error {
 	// configure the underlying sector store, defaulting to the non-test version
-	proofsMode := proofs.Live
+	proofsMode := proofs.LiveMode
 	if os.Getenv("FIL_USE_SMALL_SECTORS") == "true" {
-		proofsMode = proofs.Test
+		proofsMode = proofs.TestMode
 	}
 
 	// initialize a sector builder

--- a/node/node.go
+++ b/node/node.go
@@ -586,13 +586,13 @@ func (node *Node) setupHeartbeatServices(ctx context.Context) error {
 
 func (node *Node) setupMining(ctx context.Context) error {
 	// configure the underlying sector store, defaulting to the non-test version
-	sectorStoreType := proofs.Live
+	proofsMode := proofs.Live
 	if os.Getenv("FIL_USE_SMALL_SECTORS") == "true" {
-		sectorStoreType = proofs.Test
+		proofsMode = proofs.Test
 	}
 
 	// initialize a sector builder
-	sectorBuilder, err := initSectorBuilderForNode(ctx, node, sectorStoreType)
+	sectorBuilder, err := initSectorBuilderForNode(ctx, node, proofsMode)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize sector builder")
 	}
@@ -898,7 +898,7 @@ func (node *Node) getLastUsedSectorID(ctx context.Context, minerAddr address.Add
 	return lastUsedSectorID, nil
 }
 
-func initSectorBuilderForNode(ctx context.Context, node *Node, sectorStoreType proofs.SectorStoreType) (sectorbuilder.SectorBuilder, error) {
+func initSectorBuilderForNode(ctx context.Context, node *Node, proofsMode proofs.Mode) (sectorbuilder.SectorBuilder, error) {
 	minerAddr, err := node.miningAddress()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get node's mining address")
@@ -919,7 +919,7 @@ func initSectorBuilderForNode(ctx context.Context, node *Node, sectorStoreType p
 		MetadataDir:      node.Repo.StagingDir(),
 		MinerAddr:        minerAddr,
 		SealedSectorDir:  node.Repo.SealedDir(),
-		SectorStoreType:  sectorStoreType,
+		ProofsMode:       proofsMode,
 		StagedSectorDir:  node.Repo.StagingDir(),
 	}
 

--- a/proofs/interface.go
+++ b/proofs/interface.go
@@ -36,7 +36,9 @@ type Verifier interface {
 	VerifySeal(VerifySealRequest) (VerifySealResponse, error)
 }
 
-// Mode configures the behavior of the SectorStore used by the SectorBuilder.
+// Mode configures sealing, sector packing, PoSt generation and other behaviors
+// of libfilecoin_proofs. Use Test mode to seal and generate PoSts quickly over
+// tiny sectors. Use Live when operating a real Filecoin node.
 type Mode int
 
 const (

--- a/proofs/interface.go
+++ b/proofs/interface.go
@@ -2,13 +2,13 @@ package proofs
 
 // VerifySealRequest represents a request to verify the output of a Seal() operation.
 type VerifySealRequest struct {
-	CommD     CommD           // returned from seal
-	CommR     CommR           // returned from seal
-	CommRStar CommRStar       // returned from seal
-	Proof     SealProof       // returned from Seal
-	ProverID  [31]byte        // uniquely identifies miner
-	SectorID  [31]byte        // uniquely identifies sector
-	StoreType SectorStoreType // used to control sealing/verification performance
+	CommD      CommD     // returned from seal
+	CommR      CommR     // returned from seal
+	CommRStar  CommRStar // returned from seal
+	Proof      SealProof // returned from Seal
+	ProverID   [31]byte  // uniquely identifies miner
+	SectorID   [31]byte  // uniquely identifies sector
+	ProofsMode Mode      // used to control sealing/verification performance
 }
 
 // VerifyPoSTRequest represents a request to generate verify a proof-of-spacetime.
@@ -17,7 +17,7 @@ type VerifyPoSTRequest struct {
 	CommRs        []CommR
 	Faults        []uint64
 	Proofs        []PoStProof
-	StoreType     SectorStoreType // used to control sealing/verification performance
+	ProofsMode    Mode // used to control sealing/verification performance
 }
 
 // VerifyPoSTResponse communicates the validity of a provided proof-of-spacetime.
@@ -36,13 +36,13 @@ type Verifier interface {
 	VerifySeal(VerifySealRequest) (VerifySealResponse, error)
 }
 
-// SectorStoreType configures the behavior of the SectorStore used by the SectorBuilder.
-type SectorStoreType int
+// Mode configures the behavior of the SectorStore used by the SectorBuilder.
+type Mode int
 
 const (
 	// Live configures the SectorBuilder to be used by someone operating a real
 	// Filecoin node.
-	Live = SectorStoreType(iota)
+	Live = Mode(iota)
 	// Test configures the SectorBuilder to be used with large sectors, in tests.
 	Test
 )

--- a/proofs/interface.go
+++ b/proofs/interface.go
@@ -42,9 +42,9 @@ type Verifier interface {
 type Mode int
 
 const (
-	// Live configures the SectorBuilder to be used by someone operating a real
+	// TestMode configures the SectorBuilder to be used with large sectors, in tests.
+	TestMode = Mode(iota)
+	// LiveMode configures the SectorBuilder to be used by someone operating a real
 	// Filecoin node.
-	Live = Mode(iota)
-	// Test configures the SectorBuilder to be used with large sectors, in tests.
-	Test
+	LiveMode
 )

--- a/proofs/rustverifier.go
+++ b/proofs/rustverifier.go
@@ -50,14 +50,14 @@ func (rp *RustVerifier) VerifySeal(req VerifySealRequest) (VerifySealResponse, e
 	sectorIDCbytes := C.CBytes(req.SectorID[:])
 	defer C.free(sectorIDCbytes)
 
-	cfg, err := CSectorStoreType(req.StoreType)
+	mode, err := CProofsMode(req.ProofsMode)
 	if err != nil {
 		return VerifySealResponse{}, err
 	}
 
 	// a mutable pointer to a VerifySealResponse C-struct
 	resPtr := (*C.VerifySealResponse)(unsafe.Pointer(C.verify_seal(
-		cfg,
+		mode,
 		(*[32]C.uint8_t)(commRCBytes),
 		(*[32]C.uint8_t)(commDCBytes),
 		(*[32]C.uint8_t)(commRStarCBytes),
@@ -100,7 +100,7 @@ func (rp *RustVerifier) VerifyPoST(req VerifyPoSTRequest) (VerifyPoSTResponse, e
 	faultsPtr, faultsSize := cUint64s(req.Faults)
 	defer C.free(unsafe.Pointer(faultsPtr))
 
-	cfg, err := CSectorStoreType(req.StoreType)
+	cfg, err := CProofsMode(req.ProofsMode)
 	if err != nil {
 		return VerifyPoSTResponse{}, err
 	}
@@ -163,9 +163,8 @@ func cUint64s(src []uint64) (*C.uint64_t, C.size_t) {
 	return (*C.uint64_t)(cUint64s), srcCSizeT
 }
 
-// CSectorStoreType marshals from SectorStoreType to the FFI type
-// *C.ConfiguredStore.
-func CSectorStoreType(cfg SectorStoreType) (*C.ConfiguredStore, error) {
+// CProofsMode marshals from Mode to the FFI type *C.ConfiguredStore.
+func CProofsMode(cfg Mode) (*C.ConfiguredStore, error) {
 	var scfg C.ConfiguredStore
 	if cfg == Live {
 		scfg = C.ConfiguredStore(C.Live)

--- a/proofs/rustverifier.go
+++ b/proofs/rustverifier.go
@@ -166,9 +166,9 @@ func cUint64s(src []uint64) (*C.uint64_t, C.size_t) {
 // CProofsMode marshals from Mode to the FFI type *C.ConfiguredStore.
 func CProofsMode(cfg Mode) (*C.ConfiguredStore, error) {
 	var scfg C.ConfiguredStore
-	if cfg == Live {
+	if cfg == LiveMode {
 		scfg = C.ConfiguredStore(C.Live)
-	} else if cfg == Test {
+	} else if cfg == TestMode {
 		scfg = C.ConfiguredStore(C.Test)
 	} else {
 		return nil, errors.Errorf("unknown sector store type: %v", cfg)

--- a/proofs/sectorbuilder/rustsectorbuilder.go
+++ b/proofs/sectorbuilder/rustsectorbuilder.go
@@ -73,7 +73,7 @@ type RustSectorBuilderConfig struct {
 	MetadataDir      string
 	MinerAddr        address.Address
 	SealedSectorDir  string
-	SectorStoreType  proofs.SectorStoreType
+	ProofsMode       proofs.Mode
 	StagedSectorDir  string
 }
 
@@ -95,9 +95,9 @@ func NewRustSectorBuilder(cfg RustSectorBuilderConfig) (*RustSectorBuilder, erro
 	cSealedSectorDir := C.CString(cfg.SealedSectorDir)
 	defer C.free(unsafe.Pointer(cSealedSectorDir))
 
-	scfg, err := proofs.CSectorStoreType(cfg.SectorStoreType)
+	scfg, err := proofs.CProofsMode(cfg.ProofsMode)
 	if err != nil {
-		return nil, errors.Errorf("unknown sector store type: %v", cfg.SectorStoreType)
+		return nil, errors.Errorf("unknown sector store type: %v", cfg.ProofsMode)
 	}
 
 	resPtr := (*C.InitSectorBuilderResponse)(unsafe.Pointer(C.init_sector_builder(

--- a/proofs/sectorbuilder/rustsectorbuilder.go
+++ b/proofs/sectorbuilder/rustsectorbuilder.go
@@ -49,7 +49,7 @@ func elapsed(what string) func() {
 	}
 }
 
-// RustSectorBuilder is a struct which serves as a proxy for a SectorStore in Rust.
+// RustSectorBuilder is a struct which serves as a proxy for a SectorBuilder in Rust.
 type RustSectorBuilder struct {
 	blockService bserv.BlockService
 	ptr          unsafe.Pointer

--- a/proofs/sectorbuilder/testing/builder.go
+++ b/proofs/sectorbuilder/testing/builder.go
@@ -74,7 +74,7 @@ func (b *Builder) Build() Harness {
 		panic(err)
 	}
 
-	proofsMode := proofs.Test
+	proofsMode := proofs.TestMode
 
 	sb, err := sectorbuilder.NewRustSectorBuilder(sectorbuilder.RustSectorBuilderConfig{
 		BlockService:     blockService,

--- a/proofs/sectorbuilder/testing/builder.go
+++ b/proofs/sectorbuilder/testing/builder.go
@@ -74,9 +74,7 @@ func (b *Builder) Build() Harness {
 		panic(err)
 	}
 
-	// TODO: Replace this with proofs.Live plus a sector size (in this case,
-	// "small" or 127 (bytes).
-	sectorStoreType := proofs.Test
+	proofsMode := proofs.Test
 
 	sb, err := sectorbuilder.NewRustSectorBuilder(sectorbuilder.RustSectorBuilderConfig{
 		BlockService:     blockService,
@@ -84,7 +82,7 @@ func (b *Builder) Build() Harness {
 		MetadataDir:      memRepo.StagingDir(),
 		MinerAddr:        minerAddr,
 		SealedSectorDir:  memRepo.SealedDir(),
-		SectorStoreType:  sectorStoreType,
+		ProofsMode:       proofsMode,
 		StagedSectorDir:  memRepo.StagingDir(),
 	})
 	require.NoError(b.t, err)
@@ -99,6 +97,6 @@ func (b *Builder) Build() Harness {
 		SectorBuilder:     sb,
 		MinerAddr:         minerAddr,
 		MaxBytesPerSector: n,
-		SectorConfig:      sectorStoreType,
+		ProofsMode:        proofsMode,
 	}
 }

--- a/proofs/sectorbuilder/testing/harness.go
+++ b/proofs/sectorbuilder/testing/harness.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"github.com/ipfs/go-cid"
 	"io"
 	"strings"
 	"testing"
 
 	bserv "github.com/ipfs/go-blockservice"
-	"github.com/ipfs/go-cid"
 	dag "github.com/ipfs/go-merkledag"
 
 	"github.com/filecoin-project/go-filecoin/address"
@@ -27,7 +27,7 @@ type Harness struct {
 	MinerAddr         address.Address
 	repo              repo.Repo
 	SectorBuilder     sb.SectorBuilder
-	SectorConfig      proofs.SectorStoreType
+	ProofsMode        proofs.Mode
 	t                 *testing.T
 }
 

--- a/proofs/sectorbuilder/testing/harness.go
+++ b/proofs/sectorbuilder/testing/harness.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"github.com/ipfs/go-cid"
 	"io"
 	"strings"
 	"testing"
 
 	bserv "github.com/ipfs/go-blockservice"
+	"github.com/ipfs/go-cid"
 	dag "github.com/ipfs/go-merkledag"
 
 	"github.com/filecoin-project/go-filecoin/address"

--- a/proofs/sectorbuilder/testing/interface_test.go
+++ b/proofs/sectorbuilder/testing/interface_test.go
@@ -327,7 +327,7 @@ func TestSectorBuilder(t *testing.T) {
 				CommRs:        []proofs.CommR{val.SealingResult.CommR},
 				Faults:        gres.Faults,
 				Proofs:        gres.Proofs,
-				ProofsMode:    proofs.Test,
+				ProofsMode:    proofs.TestMode,
 			})
 
 			require.NoError(t, verr)

--- a/proofs/sectorbuilder/testing/interface_test.go
+++ b/proofs/sectorbuilder/testing/interface_test.go
@@ -203,13 +203,13 @@ func TestSectorBuilder(t *testing.T) {
 			require.Equal(t, sectorID, val.SealingResult.SectorID)
 
 			res, err := (&proofs.RustVerifier{}).VerifySeal(proofs.VerifySealRequest{
-				CommD:     val.SealingResult.CommD,
-				CommR:     val.SealingResult.CommR,
-				CommRStar: val.SealingResult.CommRStar,
-				Proof:     val.SealingResult.Proof,
-				ProverID:  sectorbuilder.AddressToProverID(h.MinerAddr),
-				SectorID:  sectorbuilder.SectorIDToBytes(val.SealingResult.SectorID),
-				StoreType: h.SectorConfig,
+				CommD:      val.SealingResult.CommD,
+				CommR:      val.SealingResult.CommR,
+				CommRStar:  val.SealingResult.CommRStar,
+				Proof:      val.SealingResult.Proof,
+				ProverID:   sectorbuilder.AddressToProverID(h.MinerAddr),
+				SectorID:   sectorbuilder.SectorIDToBytes(val.SealingResult.SectorID),
+				ProofsMode: h.ProofsMode,
 			})
 			require.NoError(t, err)
 			require.True(t, res.IsValid)
@@ -327,7 +327,7 @@ func TestSectorBuilder(t *testing.T) {
 				CommRs:        []proofs.CommR{val.SealingResult.CommR},
 				Faults:        gres.Faults,
 				Proofs:        gres.Proofs,
-				StoreType:     proofs.Test,
+				ProofsMode:    proofs.Test,
 			})
 
 			require.NoError(t, verr)

--- a/tools/fast/bin/localnet/main.go
+++ b/tools/fast/bin/localnet/main.go
@@ -401,9 +401,9 @@ func getSectorSize(smallSectors bool) (uint64, error) {
 
 	var proofsMode proofs.Mode
 	if smallSectors {
-		proofsMode = proofs.Test
+		proofsMode = proofs.TestMode
 	} else {
-		proofsMode = proofs.Live
+		proofsMode = proofs.LiveMode
 	}
 
 	// Not a typo

--- a/tools/fast/bin/localnet/main.go
+++ b/tools/fast/bin/localnet/main.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rand"
 	flg "flag"
 	"fmt"
+	"github.com/ipfs/go-ipfs-exchange-offline"
 	"io"
 	"io/ioutil"
 	"math/big"
@@ -24,7 +25,6 @@ import (
 
 	bserv "github.com/ipfs/go-blockservice"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
-	"github.com/ipfs/go-ipfs-exchange-offline"
 	"github.com/ipfs/go-ipfs-files"
 	logging "github.com/ipfs/go-log"
 	"github.com/mitchellh/go-homedir"
@@ -399,12 +399,11 @@ func getSectorSize(smallSectors bool) (uint64, error) {
 	blockstore := bstore.NewBlockstore(rp.Datastore())
 	blockservice := bserv.New(blockstore, offline.Exchange(blockstore))
 
-	var sectorStoreType proofs.SectorStoreType
-
+	var proofsMode proofs.Mode
 	if smallSectors {
-		sectorStoreType = proofs.Test
+		proofsMode = proofs.Test
 	} else {
-		sectorStoreType = proofs.Live
+		proofsMode = proofs.Live
 	}
 
 	// Not a typo
@@ -415,8 +414,8 @@ func getSectorSize(smallSectors bool) (uint64, error) {
 		LastUsedSectorID: 0,
 		MetadataDir:      "",
 		MinerAddr:        addr,
+		ProofsMode:       proofsMode,
 		SealedSectorDir:  "",
-		SectorStoreType:  sectorStoreType,
 		StagedSectorDir:  "",
 	}
 

--- a/tools/fast/bin/localnet/main.go
+++ b/tools/fast/bin/localnet/main.go
@@ -11,7 +11,6 @@ import (
 	"crypto/rand"
 	flg "flag"
 	"fmt"
-	"github.com/ipfs/go-ipfs-exchange-offline"
 	"io"
 	"io/ioutil"
 	"math/big"
@@ -25,6 +24,7 @@ import (
 
 	bserv "github.com/ipfs/go-blockservice"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
+	"github.com/ipfs/go-ipfs-exchange-offline"
 	"github.com/ipfs/go-ipfs-files"
 	logging "github.com/ipfs/go-log"
 	"github.com/mitchellh/go-homedir"


### PR DESCRIPTION
Makes incremental progress towards #2530.

## What's in this PR?

- rename "SectorStoreType" to "ProofsMode"

## Why is this PR needed?

- the old name didn't make sense