### PR TITLE
Add Functional Integration and Unit test flags

### DIFF
--- a/address/address_test.go
+++ b/address/address_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/bls-signatures"
 	"github.com/filecoin-project/go-filecoin/crypto"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 )
 
 func init() {
@@ -22,6 +23,8 @@ func init() {
 }
 
 func TestRandomIDAddress(t *testing.T) {
+	tf.UnitTest(t)
+
 	assert := assert.New(t)
 
 	addr, err := NewIDAddress(uint64(rand.Int()))
@@ -38,6 +41,8 @@ func TestRandomIDAddress(t *testing.T) {
 }
 
 func TestVectorsIDAddress(t *testing.T) {
+	tf.UnitTest(t)
+
 	testCases := []struct {
 		input    uint64
 		expected string
@@ -86,6 +91,8 @@ func TestVectorsIDAddress(t *testing.T) {
 }
 
 func TestSecp256k1Address(t *testing.T) {
+	tf.UnitTest(t)
+
 	assert := assert.New(t)
 
 	sk, err := crypto.GenerateKey()
@@ -105,6 +112,8 @@ func TestSecp256k1Address(t *testing.T) {
 }
 
 func TestVectorSecp256k1Address(t *testing.T) {
+	tf.UnitTest(t)
+
 	testCases := []struct {
 		input    []byte
 		expected string
@@ -180,6 +189,8 @@ func TestVectorSecp256k1Address(t *testing.T) {
 }
 
 func TestRandomActorAddress(t *testing.T) {
+	tf.UnitTest(t)
+
 	assert := assert.New(t)
 
 	actorMsg := make([]byte, 20)
@@ -199,6 +210,8 @@ func TestRandomActorAddress(t *testing.T) {
 }
 
 func TestVectorActorAddress(t *testing.T) {
+	tf.UnitTest(t)
+
 	testCases := []struct {
 		input    []byte
 		expected string
@@ -252,6 +265,8 @@ func TestVectorActorAddress(t *testing.T) {
 }
 
 func TestRandomBLSAddress(t *testing.T) {
+	tf.UnitTest(t)
+
 	assert := assert.New(t)
 
 	pk := bls.PrivateKeyPublicKey(bls.PrivateKeyGenerate())
@@ -270,6 +285,8 @@ func TestRandomBLSAddress(t *testing.T) {
 }
 
 func TestVectorBLSAddress(t *testing.T) {
+	tf.UnitTest(t)
+
 	testCases := []struct {
 		input    []byte
 		expected string
@@ -333,6 +350,8 @@ func TestVectorBLSAddress(t *testing.T) {
 }
 
 func TestInvalidStringAddresses(t *testing.T) {
+	tf.UnitTest(t)
+
 	testCases := []struct {
 		input    string
 		expetErr error
@@ -359,6 +378,8 @@ func TestInvalidStringAddresses(t *testing.T) {
 }
 
 func TestInvalidByteAddresses(t *testing.T) {
+	tf.UnitTest(t)
+
 	testCases := []struct {
 		input    []byte
 		expetErr error
@@ -393,6 +414,8 @@ func TestInvalidByteAddresses(t *testing.T) {
 }
 
 func TestChecksum(t *testing.T) {
+	tf.UnitTest(t)
+
 	assert := assert.New(t)
 
 	data := []byte("helloworld")
@@ -407,6 +430,8 @@ func TestChecksum(t *testing.T) {
 }
 
 func TestAddressFormat(t *testing.T) {
+	tf.UnitTest(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 

--- a/commands/address_daemon_test.go
+++ b/commands/address_daemon_test.go
@@ -6,17 +6,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/core"
 	"github.com/filecoin-project/go-filecoin/fixtures"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 )
 
 func TestAddrsNewAndList(t *testing.T) {
-	t.Parallel()
+	tf.IntegrationTest(t)
+
 	assert := assert.New(t)
 
 	d := th.NewDaemon(t).Start()
@@ -34,7 +36,8 @@ func TestAddrsNewAndList(t *testing.T) {
 }
 
 func TestWalletBalance(t *testing.T) {
-	t.Parallel()
+	tf.IntegrationTest(t)
+
 	assert := assert.New(t)
 
 	d := th.NewDaemon(t).Start()
@@ -56,6 +59,8 @@ func TestWalletBalance(t *testing.T) {
 }
 
 func TestAddrLookupAndUpdate(t *testing.T) {
+	tf.IntegrationTest(t)
+
 	assert := assert.New(t)
 
 	d := makeTestDaemonWithMinerAndStart(t)
@@ -102,6 +107,8 @@ func TestAddrLookupAndUpdate(t *testing.T) {
 }
 
 func TestWalletLoadFromFile(t *testing.T) {
+	tf.IntegrationTest(t)
+
 	assert := assert.New(t)
 
 	d := th.NewDaemon(t).Start()
@@ -124,6 +131,8 @@ func TestWalletLoadFromFile(t *testing.T) {
 }
 
 func TestWalletExportImportRoundTrip(t *testing.T) {
+	tf.IntegrationTest(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -147,6 +156,8 @@ func TestWalletExportImportRoundTrip(t *testing.T) {
 }
 
 func TestWalletExportPrivateKeyConsistentDisplay(t *testing.T) {
+	tf.IntegrationTest(t)
+
 	assert := assert.New(t)
 
 	d := th.NewDaemon(t).Start()

--- a/consensus/processor_test.go
+++ b/consensus/processor_test.go
@@ -41,7 +41,7 @@ func requireMakeStateTree(require *require.Assertions, cst *hamt.CborIpldStore, 
 }
 
 func TestProcessBlockSuccess(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -99,7 +99,7 @@ func TestProcessBlockSuccess(t *testing.T) {
 }
 
 func TestProcessTipSetSuccess(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -175,7 +175,7 @@ func TestProcessTipSetSuccess(t *testing.T) {
 }
 
 func TestProcessTipsConflicts(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -244,7 +244,7 @@ func TestProcessTipsConflicts(t *testing.T) {
 }
 
 func TestProcessBlockBadMsgSig(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -288,7 +288,7 @@ func TestProcessBlockBadMsgSig(t *testing.T) {
 
 // ProcessBlock should not fail with an unsigned block reward message.
 func TestProcessBlockReward(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -331,7 +331,7 @@ func TestProcessBlockReward(t *testing.T) {
 }
 
 func TestProcessBlockVMErrors(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -404,7 +404,7 @@ func TestProcessBlockVMErrors(t *testing.T) {
 }
 
 func TestProcessBlockParamsLengthError(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -433,7 +433,7 @@ func TestProcessBlockParamsLengthError(t *testing.T) {
 }
 
 func TestProcessBlockParamsError(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -459,7 +459,7 @@ func TestProcessBlockParamsError(t *testing.T) {
 }
 
 func TestApplyMessagesValidation(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	t.Run("Errors when nonce too high", func(t *testing.T) {
 		assert := assert.New(t)
@@ -639,7 +639,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 // in ApplyMessage's comments.
 
 func TestNestedSendBalance(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -693,7 +693,7 @@ func TestNestedSendBalance(t *testing.T) {
 }
 
 func TestReentrantTransferDoesntAllowMultiSpending(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -739,7 +739,7 @@ func TestReentrantTransferDoesntAllowMultiSpending(t *testing.T) {
 }
 
 func TestSendToNonexistentAddressThenSpendFromIt(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -785,7 +785,7 @@ func TestSendToNonexistentAddressThenSpendFromIt(t *testing.T) {
 }
 
 func TestApplyQueryMessageWillNotAlterState(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -831,7 +831,7 @@ func TestApplyQueryMessageWillNotAlterState(t *testing.T) {
 }
 
 func TestApplyMessageChargesGas(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -990,7 +990,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 }
 
 func TestBlockGasLimitBehavior(t *testing.T) {
-	tf.UnitTestWithSideEffectsThatIsBad(t)
+	tf.BadUnitTestWithSideEffects(t)
 
 	fakeActorCodeCid := types.NewCidForTestGetter()()
 	builtin.Actors[fakeActorCodeCid] = &actor.FakeActor{}

--- a/consensus/processor_test.go
+++ b/consensus/processor_test.go
@@ -19,6 +19,7 @@ import (
 	. "github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/state"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
 	"github.com/filecoin-project/go-filecoin/vm/errors"
@@ -40,6 +41,8 @@ func requireMakeStateTree(require *require.Assertions, cst *hamt.CborIpldStore, 
 }
 
 func TestProcessBlockSuccess(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -96,6 +99,8 @@ func TestProcessBlockSuccess(t *testing.T) {
 }
 
 func TestProcessTipSetSuccess(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -170,6 +175,8 @@ func TestProcessTipSetSuccess(t *testing.T) {
 }
 
 func TestProcessTipsConflicts(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -237,6 +244,8 @@ func TestProcessTipsConflicts(t *testing.T) {
 }
 
 func TestProcessBlockBadMsgSig(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -279,6 +288,8 @@ func TestProcessBlockBadMsgSig(t *testing.T) {
 
 // ProcessBlock should not fail with an unsigned block reward message.
 func TestProcessBlockReward(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -320,6 +331,8 @@ func TestProcessBlockReward(t *testing.T) {
 }
 
 func TestProcessBlockVMErrors(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -391,6 +404,8 @@ func TestProcessBlockVMErrors(t *testing.T) {
 }
 
 func TestProcessBlockParamsLengthError(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 	newAddress := address.NewForTestGetter()
@@ -418,6 +433,8 @@ func TestProcessBlockParamsLengthError(t *testing.T) {
 }
 
 func TestProcessBlockParamsError(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 	newAddress := address.NewForTestGetter()
@@ -442,6 +459,8 @@ func TestProcessBlockParamsError(t *testing.T) {
 }
 
 func TestApplyMessagesValidation(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	t.Run("Errors when nonce too high", func(t *testing.T) {
 		assert := assert.New(t)
 		require := require.New(t)
@@ -620,6 +639,8 @@ func TestApplyMessagesValidation(t *testing.T) {
 // in ApplyMessage's comments.
 
 func TestNestedSendBalance(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 	newAddress := address.NewForTestGetter()
@@ -672,6 +693,8 @@ func TestNestedSendBalance(t *testing.T) {
 }
 
 func TestReentrantTransferDoesntAllowMultiSpending(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 	newAddress := address.NewForTestGetter()
@@ -716,6 +739,8 @@ func TestReentrantTransferDoesntAllowMultiSpending(t *testing.T) {
 }
 
 func TestSendToNonexistentAddressThenSpendFromIt(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -760,6 +785,8 @@ func TestSendToNonexistentAddressThenSpendFromIt(t *testing.T) {
 }
 
 func TestApplyQueryMessageWillNotAlterState(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 	newAddress := address.NewForTestGetter()
@@ -804,6 +831,8 @@ func TestApplyQueryMessageWillNotAlterState(t *testing.T) {
 }
 
 func TestApplyMessageChargesGas(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := context.Background()
@@ -961,6 +990,8 @@ func TestApplyMessageChargesGas(t *testing.T) {
 }
 
 func TestBlockGasLimitBehavior(t *testing.T) {
+	tf.UnitTestWithSideEffectsThatIsBad(t)
+
 	fakeActorCodeCid := types.NewCidForTestGetter()()
 	builtin.Actors[fakeActorCodeCid] = &actor.FakeActor{}
 	defer delete(builtin.Actors, fakeActorCodeCid)

--- a/functional-tests/faucet_test.go
+++ b/functional-tests/faucet_test.go
@@ -2,7 +2,6 @@ package functional
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -18,9 +17,8 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/commands"
 	"github.com/filecoin-project/go-filecoin/testhelpers/iptbtester"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 )
-
-var runFunctionalTests = flag.Bool("functional", false, "Run the functional go tests")
 
 var faucetBinary = "../tools/faucet/faucet"
 
@@ -31,10 +29,8 @@ func init() {
 }
 
 func TestFaucetSendFunds(t *testing.T) {
-	// Only run this test if the "-functional" flag is passed to test command
-	if !*runFunctionalTests {
-		t.SkipNow()
-	}
+	tf.FunctionalTest(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 

--- a/testhelpers/testflags/flags.go
+++ b/testhelpers/testflags/flags.go
@@ -1,0 +1,64 @@
+package testflags
+
+import (
+	"flag"
+	"testing"
+)
+
+// Test enablement flags
+var functionalTest = flag.Bool("functional", false, "Run the functional go tests")
+var integrationTest = flag.Bool("integration", false, "Run the integration go tests")
+var unitTest = flag.Bool("unit", false, "Run the unit go tests")
+
+// Test modifiers
+// concurrent flag will cause tests to be ran in parallel, its default value is `true`.
+var concurrent = flag.Bool("concurrent", true, "Runs the go test in parallel")
+
+// FunctionalTest will run the test its called from iff the `-functional` flag
+// is passed when calling `go test`. Otherwise the test will be skipped. FunctionalTest
+// will run the test its called from in parallel, to disallow this behaviour see
+// the concurrent flag.
+func FunctionalTest(t *testing.T) {
+	if !*functionalTest {
+		t.SkipNow()
+	}
+	if *concurrent {
+		t.Parallel()
+	}
+}
+
+// IntegrationTest will run the test its called from iff the `-integration` flag
+// is passed when calling `go test`. Otherwise the test will be skipped. IntegrationTest
+// will run the test its called from in parallel, to disallow this behaviour see
+// the concurrent flag.
+func IntegrationTest(t *testing.T) {
+	if !*integrationTest {
+		t.SkipNow()
+	}
+	if *concurrent {
+		t.Parallel()
+	}
+}
+
+// UnitTest will run the test its called from iff the `-unit` or `-short` flag
+// is passed when calling `go test`. Otherwise the test will be skipped. UnitTest
+// will run the test its called from in parallel, to disallow this behaviour see
+// the concurrent flag.
+func UnitTest(t *testing.T) {
+	if !*unitTest && !testing.Short() {
+		t.SkipNow()
+	}
+	if *concurrent {
+		t.Parallel()
+	}
+}
+
+// UnitTestWithSideEffectsThatIsBad will run the test its called from iff the
+// `-unit` or `-short` flag is passed when calling `go test`. Otherwise the test
+// will be skipped. UnitTestWithSideEffectsThatIsBad will run the test its called
+// serially. Tests that use this flag are bad an should feel bad.
+func UnitTestWithSideEffectsThatIsBad(t *testing.T) {
+	if !*unitTest && !testing.Short() {
+		t.SkipNow()
+	}
+}

--- a/testhelpers/testflags/flags.go
+++ b/testhelpers/testflags/flags.go
@@ -6,58 +6,48 @@ import (
 )
 
 // Test enablement flags
-var functionalTest = flag.Bool("functional", false, "Run the functional go tests")
-var integrationTest = flag.Bool("integration", false, "Run the integration go tests")
-var unitTest = flag.Bool("unit", false, "Run the unit go tests")
-
-// Test modifiers
-// concurrent flag will cause tests to be ran in parallel, its default value is `true`.
-var concurrent = flag.Bool("concurrent", true, "Runs the go test in parallel")
+// TODO(frrist): All tests are enabled by default, this allows for changes to CI
+// to be pushed into a follow on. In the follow on these flags will be passed to
+// CI jobs and their default values will go back to false.
+var functionalTest = flag.Bool("functional", true, "Run the functional go tests")
+var integrationTest = flag.Bool("integration", true, "Run the integration go tests")
+var unitTest = flag.Bool("unit", true, "Run the unit go tests")
 
 // FunctionalTest will run the test its called from iff the `-functional` flag
 // is passed when calling `go test`. Otherwise the test will be skipped. FunctionalTest
-// will run the test its called from in parallel, to disallow this behaviour see
-// the concurrent flag.
+// will run the test its called from in parallel.
 func FunctionalTest(t *testing.T) {
 	if !*functionalTest {
 		t.SkipNow()
 	}
-	if *concurrent {
-		t.Parallel()
-	}
+	t.Parallel()
 }
 
 // IntegrationTest will run the test its called from iff the `-integration` flag
 // is passed when calling `go test`. Otherwise the test will be skipped. IntegrationTest
-// will run the test its called from in parallel, to disallow this behaviour see
-// the concurrent flag.
+// will run the test its called from in parallel.
 func IntegrationTest(t *testing.T) {
 	if !*integrationTest {
 		t.SkipNow()
 	}
-	if *concurrent {
-		t.Parallel()
-	}
+	t.Parallel()
 }
 
 // UnitTest will run the test its called from iff the `-unit` or `-short` flag
 // is passed when calling `go test`. Otherwise the test will be skipped. UnitTest
-// will run the test its called from in parallel, to disallow this behaviour see
-// the concurrent flag.
+// will run the test its called from in parallel.
 func UnitTest(t *testing.T) {
 	if !*unitTest && !testing.Short() {
 		t.SkipNow()
 	}
-	if *concurrent {
-		t.Parallel()
-	}
+	t.Parallel()
 }
 
-// UnitTestWithSideEffectsThatIsBad will run the test its called from iff the
+// BadUnitTestWithSideEffects will run the test its called from iff the
 // `-unit` or `-short` flag is passed when calling `go test`. Otherwise the test
-// will be skipped. UnitTestWithSideEffectsThatIsBad will run the test its called
+// will be skipped. BadUnitTestWithSideEffects will run the test its called
 // serially. Tests that use this flag are bad an should feel bad.
-func UnitTestWithSideEffectsThatIsBad(t *testing.T) {
+func BadUnitTestWithSideEffects(t *testing.T) {
 	if !*unitTest && !testing.Short() {
 		t.SkipNow()
 	}


### PR DESCRIPTION
### Description
This PR adds 3 flags that may be used to control when certain categories of tests run.
- `-functional`: used to run tests like the Retrieval test
-  `-integration`: used to run tests like `*test_daemon.go` or faucet tests
-  `-unit`: used to run tests like `address_test.go`. The `-short` flag may be used interchangeably here.

There are 4 methods that may be called from a test that allow it to run when one of these flags is passed.
- [`FunctionalTest`](https://github.com/filecoin-project/go-filecoin/pull/2542/files#diff-1333f33210e4ae54e705a0b204ce2632R21)
  - [Example Usage](https://github.com/filecoin-project/go-filecoin/pull/2542/files#diff-798479df3f7c6278d71f2744dd572c03R32)
- [`IntegrationTest`](https://github.com/filecoin-project/go-filecoin/pull/2542/files#diff-1333f33210e4ae54e705a0b204ce2632R34)
  - [Example Usage](https://github.com/filecoin-project/go-filecoin/pull/2542/files#diff-476c93ae2e2d8ffdcd28b21d05dd5ad0R20)
- [`UnitTest`](https://github.com/filecoin-project/go-filecoin/pull/2542/files#diff-1333f33210e4ae54e705a0b204ce2632R47)
  - [Example Usage](https://github.com/filecoin-project/go-filecoin/pull/2542/files#diff-b8caae3b8bfb04c2370daade503829d7R26)
- [`UnitTestWithSideEffectsThatIsBad`](https://github.com/filecoin-project/go-filecoin/pull/2542/files#diff-1333f33210e4ae54e705a0b204ce2632R60)
  - [Example Usage](https://github.com/filecoin-project/go-filecoin/pull/2542/files#diff-7ad10fdb35d42f8a5450bdffbd5c20d3R44)

### Proposal 

All methods except `UnitTestWithSideEffectsThatIsBad` will cause the tests they are placed in to run in parallel. This means we no longer need to decorate tests with calls to `t.Parallel()`, I believe this makes the testing code less cluttered, it also serves as a motivation to write tests that can be parallelized. 
This does mean that the tests inside `t.Run` calls will no longer run in parallel, I believe this is a reasonable tradeoff as those tests are typically short and don't benefit from the parallelism. 

Tests that us `UnitTestWithSideEffectsThatIsBad` will be run serially, while tinkering with https://github.com/filecoin-project/go-filecoin/pull/2537 I observed that there is a subset of our unit tests that cannot be ran in parallel due to shared global state. The flag is named this way to discourage the writing of tests that behave this way. It also allows us to easily see what test should be optimized.

I propose we instrument all tests with these method, and that we default the `-unit` flag to `true`. This means that only the unit tests will run when the command `go test` is issued. All other tests must be called out explicitly by passing their corresponding flags.