### PR TITLE
message pool max size config based

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -172,11 +172,14 @@ func newDefaultMetricsConfig() *MetricsConfig {
 type MessagePoolConfig struct {
 	// MaxPoolSize is the maximum number of pending messages will will allow in the message pool at any time
 	MaxPoolSize int `json:"maxPoolSize"`
+	// MaxNonceGap is the maximum nonce of a message past the last received on chain
+	MaxNonceGap types.Uint64 `json:"maxNonceGap"`
 }
 
 func newDefaultMessagePoolConfig() *MessagePoolConfig {
 	return &MessagePoolConfig{
 		MaxPoolSize: 10000,
+		MaxNonceGap: 100,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,15 +17,16 @@ import (
 
 // Config is an in memory representation of the filecoin configuration file
 type Config struct {
-	API       *APIConfig       `json:"api"`
-	Bootstrap *BootstrapConfig `json:"bootstrap"`
-	Datastore *DatastoreConfig `json:"datastore"`
-	Swarm     *SwarmConfig     `json:"swarm"`
-	Mining    *MiningConfig    `json:"mining"`
-	Wallet    *WalletConfig    `json:"wallet"`
-	Heartbeat *HeartbeatConfig `json:"heartbeat"`
-	Net       string           `json:"net"`
-	Metrics   *MetricsConfig   `json:"metrics"`
+	API       *APIConfig         `json:"api"`
+	Bootstrap *BootstrapConfig   `json:"bootstrap"`
+	Datastore *DatastoreConfig   `json:"datastore"`
+	Swarm     *SwarmConfig       `json:"swarm"`
+	Mining    *MiningConfig      `json:"mining"`
+	Wallet    *WalletConfig      `json:"wallet"`
+	Heartbeat *HeartbeatConfig   `json:"heartbeat"`
+	Net       string             `json:"net"`
+	Metrics   *MetricsConfig     `json:"metrics"`
+	Mpool     *MessagePoolConfig `json:"mpool"`
 }
 
 // APIConfig holds all configuration options related to the api.
@@ -167,6 +168,18 @@ func newDefaultMetricsConfig() *MetricsConfig {
 	}
 }
 
+// MetricsConfig holds all configuration options related to nodes message pool (mpool).
+type MessagePoolConfig struct {
+	// MaxPoolSize is the maximum number of pending messages will will allow in the message pool at any time
+	MaxPoolSize int `json:"maxPoolSize"`
+}
+
+func newDefaultMessagePoolConfig() *MessagePoolConfig {
+	return &MessagePoolConfig{
+		MaxPoolSize: 10000,
+	}
+}
+
 // NewDefaultConfig returns a config object with all the fields filled out to
 // their default values
 func NewDefaultConfig() *Config {
@@ -180,6 +193,7 @@ func NewDefaultConfig() *Config {
 		Heartbeat: newDefaultHeartbeatConfig(),
 		Net:       "",
 		Metrics:   newDefaultMetricsConfig(),
+		Mpool:     newDefaultMessagePoolConfig(),
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -86,7 +86,8 @@ func TestWriteFile(t *testing.T) {
 		"prometheusEndpoint": "/ip4/0.0.0.0/tcp/9400"
 	},
 	"mpool": {
-		"maxPoolSize": 10000
+		"maxPoolSize": 10000,
+		"maxNonceGap": "100"
 	}
 }`,
 		string(content),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -84,6 +84,9 @@ func TestWriteFile(t *testing.T) {
 		"prometheusEnabled": false,
 		"reportInterval": "5s",
 		"prometheusEndpoint": "/ip4/0.0.0.0/tcp/9400"
+	},
+	"mpool": {
+		"maxPoolSize": 10000
 	}
 }`,
 		string(content),

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/config"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/types"
 
@@ -120,7 +121,8 @@ func TestIngestionValidator(t *testing.T) {
 	api.ActorAddr = alice
 	api.Actor = act
 
-	validator := consensus.NewIngestionValidator(api)
+	mpoolCfg := config.NewDefaultConfig().Mpool
+	validator := consensus.NewIngestionValidator(api, mpoolCfg)
 	ctx := context.Background()
 
 	t.Run("Validates extreme nonce gaps", func(t *testing.T) {
@@ -130,7 +132,7 @@ func TestIngestionValidator(t *testing.T) {
 		msg := newMessage(t, alice, bob, 100, 5, 0, 0)
 		assert.NoError(validator.Validate(ctx, msg))
 
-		highNonce := uint64(act.Nonce + consensus.MaxNonceGap + 10)
+		highNonce := uint64(act.Nonce + mpoolCfg.MaxNonceGap + 10)
 		msg = newMessage(t, alice, bob, highNonce, 5, 0, 0)
 		err := validator.Validate(ctx, msg)
 		require.Error(err)

--- a/core/message_pool_test.go
+++ b/core/message_pool_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/config"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
 )
@@ -24,8 +25,7 @@ func TestMessagePoolAddRemove(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 
-	api := th.NewTestMessagePoolAPI(0)
-	pool := NewMessagePool(api, th.NewMockMessagePoolValidator())
+	pool := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 	msg1 := newSignedMessage()
 	msg2 := mustSetNonce(mockSigner, newSignedMessage(), 1)
 
@@ -65,23 +65,25 @@ func TestMessagePoolValidate(t *testing.T) {
 		require := require.New(t)
 		assert := assert.New(t)
 
+		// pull the default size from the default config value
+		maxMessagePoolSize := config.NewDefaultConfig().Mpool.MaxPoolSize
 		ctx := context.Background()
-		pool := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		pool := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(maxMessagePoolSize), th.NewMockMessagePoolValidator())
 
-		smsgs := types.NewSignedMsgs(MaxMessagePoolSize+1, mockSigner)
-		for _, smsg := range smsgs[:MaxMessagePoolSize] {
+		smsgs := types.NewSignedMsgs(maxMessagePoolSize+1, mockSigner)
+		for _, smsg := range smsgs[:maxMessagePoolSize] {
 			_, err := pool.Add(ctx, smsg)
 			require.NoError(err)
 		}
 
-		assert.Len(pool.Pending(), MaxMessagePoolSize)
+		assert.Len(pool.Pending(), maxMessagePoolSize)
 
 		// attempt to add one more
-		_, err := pool.Add(ctx, smsgs[MaxMessagePoolSize])
+		_, err := pool.Add(ctx, smsgs[maxMessagePoolSize])
 		require.Error(err)
 		assert.Contains(err.Error(), "message pool is full")
 
-		assert.Len(pool.Pending(), MaxMessagePoolSize)
+		assert.Len(pool.Pending(), maxMessagePoolSize)
 	})
 
 	t.Run("validates no two messages are added with same nonce", func(t *testing.T) {
@@ -89,7 +91,7 @@ func TestMessagePoolValidate(t *testing.T) {
 		assert := assert.New(t)
 
 		ctx := context.Background()
-		pool := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		pool := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		smsg1 := newSignedMessage()
 		_, err := pool.Add(ctx, smsg1)
@@ -109,7 +111,7 @@ func TestMessagePoolValidate(t *testing.T) {
 		api := th.NewTestMessagePoolAPI(0)
 		validator := th.NewMockMessagePoolValidator()
 		validator.Valid = false
-		pool := NewMessagePool(api, validator)
+		pool := NewMessagePool(api, th.NewTestMessagePoolConfig(10), validator)
 
 		smsg1 := mustSetNonce(mockSigner, newSignedMessage(), 0)
 		_, err := pool.Add(ctx, smsg1)
@@ -122,7 +124,7 @@ func TestMessagePoolDedup(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 
-	pool := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+	pool := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 	msg1 := newSignedMessage()
 
 	assert.Len(pool.Pending(), 0)
@@ -142,7 +144,7 @@ func TestMessagePoolAsync(t *testing.T) {
 	count := 400
 	msgs := types.NewSignedMsgs(count, mockSigner)
 
-	pool := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+	pool := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(count), th.NewMockMessagePoolValidator())
 	var wg sync.WaitGroup
 
 	for i := 0; i < 4; i++ {
@@ -212,7 +214,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m0],     Chain: b[m1]
 		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewSignedMsgs(2, mockSigner)
 		MustAdd(p, m[0], m[1])
@@ -236,7 +238,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m0, m1], Chain: b[m2]
 		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewSignedMsgs(3, mockSigner)
 		MustAdd(p, m[0], m[1])
@@ -253,7 +255,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m1],         Chain: b[m2, m3] -> b[m4] -> b[m0] -> b[] -> b[m5, m6]
 		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewSignedMsgs(7, mockSigner)
 		MustAdd(p, m[2], m[5])
@@ -279,7 +281,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m1],         Chain: b[m2, m3] -> {b[m4], b[m0], b[], b[]} -> {b[], b[m6,m5]}
 		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewSignedMsgs(7, mockSigner)
 		MustAdd(p, m[2], m[5])
@@ -303,7 +305,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m1, m2],     Chain: b[m0] -> b[m3] -> b[m4, m5]
 		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewSignedMsgs(6, mockSigner)
 		MustAdd(p, m[3], m[5])
@@ -323,7 +325,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m6],         Chain: b[m0] -> b[m3] -> b[m4] -> b[m5] -> b[m1, m2]
 		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewSignedMsgs(7, mockSigner)
 		MustAdd(p, m[6])
@@ -352,7 +354,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m6],         Chain: {b[m0], b[m1]} -> b[m3] -> b[m4] -> {b[m5], b[m1, m2]}
 		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewSignedMsgs(7, mockSigner)
 		MustAdd(p, m[6])
@@ -379,7 +381,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m3, m5],     Chain: {b[m0], b[m1], b[m2]}
 		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewSignedMsgs(6, mockSigner)
 		MustAdd(p, m[3], m[5])
@@ -405,7 +407,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m2, m3],         Chain: b[m0] -> b[m1]
 		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 		m := types.NewSignedMsgs(4, mockSigner)
 
 		oldChain := NewChainWithMessages(store, types.TipSet{},
@@ -426,7 +428,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [m0],     Chain: b[] -> b[m1, m2]
 		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewSignedMsgs(3, mockSigner)
 		MustAdd(p, m[0], m[1])
@@ -446,7 +448,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		// to
 		// Msg pool: [],           Chain: b[m0] -> b[m1] -> b[m2, m3] -> b[m4] -> b[m5, m6]
 		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewSignedMsgs(7, mockSigner)
 		MustAdd(p, m[2], m[5])
@@ -471,7 +473,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		var err error
 		store := hamt.NewCborStore()
 		api := th.NewTestMessagePoolAPI(0)
-		p := NewMessagePool(api, th.NewMockMessagePoolValidator())
+		p := NewMessagePool(api, th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewSignedMsgs(MessageTimeOut, mockSigner)
 
@@ -514,7 +516,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		var err error
 		store := hamt.NewCborStore()
 		blockTimer := th.NewTestMessagePoolAPI(0)
-		p := NewMessagePool(blockTimer, th.NewMockMessagePoolValidator())
+		p := NewMessagePool(blockTimer, th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewSignedMsgs(MessageTimeOut, mockSigner)
 
@@ -562,7 +564,7 @@ func TestLargestNonce(t *testing.T) {
 	require := require.New(t)
 
 	t.Run("No matches", func(t *testing.T) {
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewSignedMsgs(2, mockSigner)
 		MustAdd(p, m[0], m[1])
@@ -572,7 +574,7 @@ func TestLargestNonce(t *testing.T) {
 	})
 
 	t.Run("Match, largest is zero", func(t *testing.T) {
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewMsgsWithAddrs(1, mockSigner.Addresses)
 		m[0].Nonce = 0
@@ -588,7 +590,7 @@ func TestLargestNonce(t *testing.T) {
 	})
 
 	t.Run("Match", func(t *testing.T) {
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+		p := NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 
 		m := types.NewMsgsWithAddrs(3, mockSigner.Addresses)
 		m[1].Nonce = 1

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/config"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/core"
 	"github.com/filecoin-project/go-filecoin/mining"
@@ -98,7 +99,7 @@ func Test_Mine(t *testing.T) {
 
 func sharedSetupInitial() (*hamt.CborIpldStore, *core.MessagePool, cid.Cid) {
 	cst := hamt.NewCborStore()
-	pool := core.NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
+	pool := core.NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.AccountActorCodeCid
 	return cst, pool, fakeActorCodeCid

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -98,7 +98,7 @@ func Test_Mine(t *testing.T) {
 
 func sharedSetupInitial() (*hamt.CborIpldStore, *core.MessagePool, cid.Cid) {
 	cst := hamt.NewCborStore()
-	pool := core.NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewMockMessagePoolValidator())
+	pool := core.NewMessagePool(th.NewTestMessagePoolAPI(0), th.NewTestMessagePoolConfig(10), th.NewMockMessagePoolValidator())
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.AccountActorCodeCid
 	return cst, pool, fakeActorCodeCid

--- a/node/node.go
+++ b/node/node.go
@@ -403,7 +403,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 
 	// only the syncer gets the storage which is online connected
 	chainSyncer := chain.NewDefaultSyncer(&cstOffline, nodeConsensus, chainStore, fetcher)
-	msgPool := core.NewMessagePool(chainStore, nc.Repo.Config().Mpool, consensus.NewIngestionValidator(chainStore))
+	msgPool := core.NewMessagePool(chainStore, nc.Repo.Config().Mpool, consensus.NewIngestionValidator(chainStore, nc.Repo.Config().Mpool))
 	outbox := core.NewMessageQueue()
 
 	// Set up libp2p pubsub

--- a/node/node.go
+++ b/node/node.go
@@ -403,7 +403,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 
 	// only the syncer gets the storage which is online connected
 	chainSyncer := chain.NewDefaultSyncer(&cstOffline, nodeConsensus, chainStore, fetcher)
-	msgPool := core.NewMessagePool(chainStore, consensus.NewIngestionValidator(chainStore))
+	msgPool := core.NewMessagePool(chainStore, nc.Repo.Config().Mpool, consensus.NewIngestionValidator(chainStore))
 	outbox := core.NewMessageQueue()
 
 	// Set up libp2p pubsub

--- a/plumbing/msg/sender_test.go
+++ b/plumbing/msg/sender_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor/builtin/storagemarket"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/config"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/core"
 	"github.com/filecoin-project/go-filecoin/testhelpers"
@@ -33,7 +34,7 @@ func TestSend(t *testing.T) {
 		addr := w.Addresses()[0]
 		timer := testhelpers.NewTestMessagePoolAPI(1000)
 		queue := core.NewMessageQueue()
-		pool := core.NewMessagePool(timer, testhelpers.NewTestMessagePoolConfig(10), testhelpers.NewMockMessagePoolValidator())
+		pool := core.NewMessagePool(timer, config.NewDefaultConfig().Mpool, testhelpers.NewMockMessagePoolValidator())
 		nopPublish := func(string, []byte) error { return nil }
 
 		s := NewSender(w, chainStore, timer, queue, pool, nullValidator{rejectMessages: true}, nopPublish)
@@ -50,7 +51,7 @@ func TestSend(t *testing.T) {
 		toAddr := address.NewForTestGetter()()
 		timer := testhelpers.NewTestMessagePoolAPI(1000)
 		queue := core.NewMessageQueue()
-		pool := core.NewMessagePool(timer, testhelpers.NewTestMessagePoolConfig(10), testhelpers.NewMockMessagePoolValidator())
+		pool := core.NewMessagePool(timer, config.NewDefaultConfig().Mpool, testhelpers.NewMockMessagePoolValidator())
 
 		publishCalled := false
 		publish := func(topic string, data []byte) error {
@@ -80,13 +81,15 @@ func TestSend(t *testing.T) {
 		// number of of concurrent message sends
 		sendConcurrent := 3
 		// total messages sent == msgCount * sendConcurrent
+		mpoolCfg := config.NewDefaultConfig().Mpool
+		mpoolCfg.MaxPoolSize = msgCount * sendConcurrent
 
 		w, chainStore := setupSendTest(require)
 		addr := w.Addresses()[0]
 		toAddr := address.NewForTestGetter()()
 		timer := testhelpers.NewTestMessagePoolAPI(1000)
 		queue := core.NewMessageQueue()
-		pool := core.NewMessagePool(timer, testhelpers.NewTestMessagePoolConfig(msgCount*sendConcurrent), testhelpers.NewMockMessagePoolValidator())
+		pool := core.NewMessagePool(timer, mpoolCfg, testhelpers.NewMockMessagePoolValidator())
 		nopPublish := func(string, []byte) error { return nil }
 
 		s := NewSender(w, chainStore, timer, queue, pool, nullValidator{}, nopPublish)

--- a/repo/fsrepo_test.go
+++ b/repo/fsrepo_test.go
@@ -65,7 +65,8 @@ const (
 		"prometheusEndpoint": "/ip4/0.0.0.0/tcp/9400"
 	},
 	"mpool": {
-		"maxPoolSize": 10000
+		"maxPoolSize": 10000,
+		"maxNonceGap": "100"
 	}
 }`
 )

--- a/repo/fsrepo_test.go
+++ b/repo/fsrepo_test.go
@@ -63,6 +63,9 @@ const (
 		"prometheusEnabled": false,
 		"reportInterval": "5s",
 		"prometheusEndpoint": "/ip4/0.0.0.0/tcp/9400"
+	},
+	"mpool": {
+		"maxPoolSize": 10000
 	}
 }`
 )

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -16,7 +16,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/config"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
@@ -118,12 +117,6 @@ func (v *MockMessagePoolValidator) Validate(ctx context.Context, msg *types.Sign
 // BlockHeight represents the height of the highest tipset.
 func (tbt *TestMessagePoolAPI) BlockHeight() (uint64, error) {
 	return tbt.Height, nil
-}
-
-func NewTestMessagePoolConfig(size int) *config.MessagePoolConfig {
-	return &config.MessagePoolConfig{
-		MaxPoolSize: size,
-	}
 }
 
 // VMStorage creates a new storage object backed by an in memory datastore

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/config"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
@@ -117,6 +118,12 @@ func (v *MockMessagePoolValidator) Validate(ctx context.Context, msg *types.Sign
 // BlockHeight represents the height of the highest tipset.
 func (tbt *TestMessagePoolAPI) BlockHeight() (uint64, error) {
 	return tbt.Height, nil
+}
+
+func NewTestMessagePoolConfig(size int) *config.MessagePoolConfig {
+	return &config.MessagePoolConfig{
+		MaxPoolSize: size,
+	}
 }
 
 // VMStorage creates a new storage object backed by an in memory datastore


### PR DESCRIPTION
This PR is a follow on to https://github.com/filecoin-project/go-filecoin/pull/2522, it allows the message pools max size to be set via the configuration file.