### PR TITLE
update docs on testing flags pass in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,12 +53,21 @@ commands:
   go_test:
     parameters:
       <<: *sector_builder_tests_param
+      unit:
+        type: string
+        default: "true"
+      integration:
+        type: string
+        default: "true"
+      functional:
+        type: string
+        default: "false"
     steps:
       - run:
           name: Test
           no_output_timeout: 30m
           command: "trap \"go run github.com/jstemmer/go-junit-report < test-results/go-test-suite/go-test.out > test-results/go-test-suite/go-test-report.xml\" EXIT;
-            FILECOIN_RUN_SECTOR_BUILDER_TESTS=<< parameters.sector_builder_tests >> go run ./build/*.go test -functional=false -integration=true -unit=true -v 2>&1 | tee test-results/go-test-suite/go-test.out"
+            FILECOIN_RUN_SECTOR_BUILDER_TESTS=<< parameters.sector_builder_tests >> go run ./build/*.go test -functional=<< parameters.functional >> -integration=<< parameters.integration >> -unit=<< parameters.unit >> -v 2>&1 | tee test-results/go-test-suite/go-test.out"
 
   git_fetch_all_tags:
     steps:
@@ -340,6 +349,7 @@ jobs:
 
       - go_test:
           sector_builder_tests: "<< parameters.sector_builder_tests >>"
+
       - run:
           name: Functional Tests
           command: ./functional-tests/run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ commands:
           name: Test
           no_output_timeout: 30m
           command: "trap \"go run github.com/jstemmer/go-junit-report < test-results/go-test-suite/go-test.out > test-results/go-test-suite/go-test-report.xml\" EXIT;
-            FILECOIN_RUN_SECTOR_BUILDER_TESTS=<< parameters.sector_builder_tests >> go run ./build/*.go test -functional=<< parameters.functional >> -integration=<< parameters.integration >> -unit=<< parameters.unit >> -v 2>&1 | tee test-results/go-test-suite/go-test.out"
+            go run ./build/*.go test -functional=<< parameters.functional >> -integration=<< parameters.integration >> -sectorbuilder=<< parameters.sector_builder_tests >>  -unit=<< parameters.unit >> -v 2>&1 | tee test-results/go-test-suite/go-test.out"
 
   git_fetch_all_tags:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ commands:
       - run:
           name: Create directories for test results
           command: mkdir -p test-results/go-test-suite
+
   go_test:
     parameters:
       <<: *sector_builder_tests_param
@@ -57,7 +58,8 @@ commands:
           name: Test
           no_output_timeout: 30m
           command: "trap \"go run github.com/jstemmer/go-junit-report < test-results/go-test-suite/go-test.out > test-results/go-test-suite/go-test-report.xml\" EXIT;
-            FILECOIN_RUN_SECTOR_BUILDER_TESTS=<< parameters.sector_builder_tests >> go run ./build/*.go test -v 2>&1 | tee test-results/go-test-suite/go-test.out"
+            FILECOIN_RUN_SECTOR_BUILDER_TESTS=<< parameters.sector_builder_tests >> go run ./build/*.go test -functional=false -integration=true -unit=true -v 2>&1 | tee test-results/go-test-suite/go-test.out"
+
   git_fetch_all_tags:
     steps:
       - run:

--- a/CODEWALK.md
+++ b/CODEWALK.md
@@ -28,6 +28,7 @@ It is complemented by specs (link forthcoming) that describe the key concepts im
   - [Plumbing & porcelain](#plumbing--porcelain)
   - [Commands](#commands)
   - [Protocols](#protocols)
+      - [Protocol Mining APIs](#protocol-mining-apis)
   - [Actors](#actors)
   - [The state tree](#the-state-tree)
   - [Messages and state transitions](#messages-and-state-transitions)
@@ -45,6 +46,10 @@ It is complemented by specs (link forthcoming) that describe the key concepts im
   - [Datastores](#datastores)
   - [Keystore](#keystore)
 - [Testing](#testing)
+    - [Test Categorization](#test-categorization)
+      - [Unit Tests (`-unit`)](#unit-tests--unit)
+      - [Integration Tests (`-integration`)](#integration-tests--integration)
+      - [Functional Tests (`-functional`)](#functional-tests--functional)
 - [Dependencies](#dependencies)
 - [Patterns](#patterns)
   - [Plumbing and porcelain](#plumbing-and-porcelain)
@@ -553,8 +558,25 @@ The goal of this is to unify duplicated code paths which bootstrap and drive `go
 and network deployment verification, providing a common library for filecoin automation in Go. 
 
 Tests are typically run with `go run ./build/*.go test`. 
-It passes flags to `go test` under the hood, so you can provide `-run <regex>` to run a subset of tests. 
+It passes flags to `go test` under the hood, so you can provide `-run <regex>` to run a subset of tests. By default it will only run unit tests, to run functional or integration tests you will need to pass their corresponding flags, for a complete description of testing flags see [Test Categorization](#test-categorization).
 Vanilla `go test` also works, after build scripts have built and installed appropriate dependencies.
+
+#### Test Categorization
+
+##### Unit Tests (`-unit`)
+By default unit tests are enabled when issuing the `go test` command.
+To disable pass `-unit=false`.
+A unit test exercises one or a few code modules exhaustively. Unit tests do not involve complex integrations or non-trivial communication, disk access, or artificial delays. A unit test should complete in well under a second, frequently <10 milliseconds. Unit tests should have no side effects and be executable in parallel
+
+##### Integration Tests (`-integration`)
+By default integration tests are enabled when issuing the `go test` command.
+To disable pass `-integration=false`.
+An integration test exercises integrated functionality and/or multiple nodes and may include multiple processes, inter-node communication, delays for consensus, nontrivial disk access and other expensive operations. Integration tests may involve multiple processes (daemon tests) or in-process integrations. An individual integration test should complete in seconds.
+
+##### Functional Tests (`-functional`)
+By default functional tests are disabled when issuing the `go test` command.
+To enable pass `-functional`.
+A functional test is an extensive multi-node orchestration or resource-intensive test that may take minutes to run.
 
 ## Dependencies
 

--- a/CODEWALK.md
+++ b/CODEWALK.md
@@ -558,7 +558,9 @@ The goal of this is to unify duplicated code paths which bootstrap and drive `go
 and network deployment verification, providing a common library for filecoin automation in Go. 
 
 Tests are typically run with `go run ./build/*.go test`. 
-It passes flags to `go test` under the hood, so you can provide `-run <regex>` to run a subset of tests. By default it will only run unit tests, to run functional or integration tests you will need to pass their corresponding flags, for a complete description of testing flags see [Test Categorization](#test-categorization).
+It passes flags to `go test` under the hood, so you can provide `-run <regex>` to run a subset of tests.
+By default it will run unit and integration tests, but skip more expensive functional and sectorbuilder tests.
+For a complete description of testing flags see [Test Categorization](#test-categorization).
 Vanilla `go test` also works, after build scripts have built and installed appropriate dependencies.
 
 #### Test Categorization
@@ -577,6 +579,11 @@ An integration test exercises integrated functionality and/or multiple nodes and
 By default functional tests are disabled when issuing the `go test` command.
 To enable pass `-functional`.
 A functional test is an extensive multi-node orchestration or resource-intensive test that may take minutes to run.
+
+##### Sector Builder Tests (`-sectorbuilder`)
+By default sectorbuilder tests are disabled when issuing the `go test` command.
+To enable pass `-sectorbuilder`.
+A sectorbuilder test is a resource-intensive test that may take minutes to run.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ go run ./build build
 # Install go-filecoin to ${GOPATH}/bin (necessary for tests)
 go run ./build install
 
-# Then, run the tests.
+# Then, run the unit tests.
 go run ./build test
 
 # Build and test can be combined!
@@ -131,6 +131,9 @@ Other handy build commands include:
 ```sh
 # Check the code for style and correctness issues
 go run ./build lint
+
+# Run different categories of tests by toggling their flags
+go run ./build test -unit=false -integration=true -functional=true
 
 # Test with a coverage report
 go run ./build test -cover

--- a/gengen/util/gengen_test.go
+++ b/gengen/util/gengen_test.go
@@ -34,7 +34,7 @@ var testConfig = &GenesisCfg{
 }
 
 func TestGenGenLoading(t *testing.T) {
-	tf.UnitTest(t)
+	tf.IntegrationTest(t)
 
 	assert := assert.New(t)
 	fi, err := ioutil.TempFile("", "gengentest")

--- a/proofs/sectorbuilder/testing/interface_test.go
+++ b/proofs/sectorbuilder/testing/interface_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"io/ioutil"
-	"os"
 	"sort"
 	"sync"
 	"testing"
@@ -31,11 +30,7 @@ const MaxTimeToSealASector = time.Second * 360
 const MaxTimeToGenerateSectorPoSt = time.Second * 360
 
 func TestSectorBuilder(t *testing.T) {
-	tf.FunctionalTest(t)
-
-	if os.Getenv("FILECOIN_RUN_SECTOR_BUILDER_TESTS") != "true" {
-		t.SkipNow()
-	}
+	tf.SectorBuilderTest(t)
 
 	t.Run("concurrent AddPiece and SealAllStagedSectors", func(t *testing.T) {
 		h := NewBuilder(t).Build()

--- a/testhelpers/testflags/flags.go
+++ b/testhelpers/testflags/flags.go
@@ -6,10 +6,8 @@ import (
 )
 
 // Test enablement flags
-// TODO(frrist): All tests are enabled by default, this allows for changes to CI
-// to be pushed into a follow on. In the follow on these flags will be passed to
-// CI jobs and their default values will go back to false.
-var functionalTest = flag.Bool("functional", true, "Run the functional go tests")
+// Only run unit and integration tests by default, all others require their flags to be set.
+var functionalTest = flag.Bool("functional", false, "Run the functional go tests")
 var integrationTest = flag.Bool("integration", true, "Run the integration go tests")
 var unitTest = flag.Bool("unit", true, "Run the unit go tests")
 

--- a/testhelpers/testflags/flags.go
+++ b/testhelpers/testflags/flags.go
@@ -7,9 +7,10 @@ import (
 
 // Test enablement flags
 // Only run unit and integration tests by default, all others require their flags to be set.
-var functionalTest = flag.Bool("functional", false, "Run the functional go tests")
 var integrationTest = flag.Bool("integration", true, "Run the integration go tests")
 var unitTest = flag.Bool("unit", true, "Run the unit go tests")
+var functionalTest = flag.Bool("functional", false, "Run the functional go tests")
+var sectorBuilderTest = flag.Bool("sectorbuilder", false, "Run the sector builder tests")
 
 // FunctionalTest will run the test its called from iff the `-functional` flag
 // is passed when calling `go test`. Otherwise the test will be skipped. FunctionalTest
@@ -47,6 +48,14 @@ func UnitTest(t *testing.T) {
 // serially. Tests that use this flag are bad an should feel bad.
 func BadUnitTestWithSideEffects(t *testing.T) {
 	if !*unitTest && !testing.Short() {
+		t.SkipNow()
+	}
+}
+
+// SectorBuilderTest will run the test its called from iff the `-sectorbuilder` flag
+// is passed when calling `go test`. Otherwise the test will be skipped.
+func SectorBuilderTest(t *testing.T) {
+	if !*sectorBuilderTest {
 		t.SkipNow()
 	}
 }


### PR DESCRIPTION
This PR disable `integration` and `functional` tests by default, updates CI to pass the required flags, and updates the documentation on testing flags.