### PR TITLE
Dockerfile genesis fix and tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.12.1-stretch AS builder
 MAINTAINER Filecoin Dev Team
 
-RUN apt-get update && apt-get install -y ca-certificates file sudo clang
+RUN apt-get update && apt-get install -y ca-certificates file sudo clang jq
 RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
 
 # This docker file is a modified version of
@@ -10,38 +10,32 @@ RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
 
 ENV SRC_DIR /go/src/github.com/filecoin-project/go-filecoin
 ENV GO111MODULE on
+ARG FILECOIN_PARAMETER_CACHE="./tmp/filecoin-proof-parameters"
+ARG FILECOIN_USE_PRECOMPILED_RUST_PROOFS=yes
+ARG FILECOIN_USE_PRECOMPILED_BLS_SIGNATURES=yes
 
 COPY . $SRC_DIR
 
 # Build the thing.
 RUN cd $SRC_DIR \
-&& . $HOME/.cargo/env \
-&& go run ./build/*go deps \
-&& go run ./build/*go build \
-&& go build -o ./faucet ./tools/faucet/main.go \
-&& go build -o ./genesis-file-server ./tools/genesis-file-server/main.go
-
-# Build gengen
-RUN cd
+  && . $HOME/.cargo/env \
+  && go run ./build/*go deps \
+  && go run ./build/*go build
 
 # Get su-exec, a very minimal tool for dropping privileges,
 # and tini, a very minimal init daemon for containers
 ENV SUEXEC_VERSION v0.2
 ENV TINI_VERSION v0.16.1
 RUN set -x \
-&& cd /tmp \
-&& git clone https://github.com/ncopa/su-exec.git \
-&& cd su-exec \
-&& git checkout -q $SUEXEC_VERSION \
-&& make \
-&& cd /tmp \
-&& wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini \
-&& chmod +x tini
+  && cd /tmp \
+  && git clone https://github.com/ncopa/su-exec.git \
+  && cd su-exec \
+  && git checkout -q $SUEXEC_VERSION \
+  && make \
+  && cd /tmp \
+  && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini \
+  && chmod +x tini
 
-# need jq for parsing genesis output
-RUN cd /tmp \
-&& wget -q -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-&& chmod +x jq
 
 # Now comes the actual target image, which aims to be as small as possible.
 FROM busybox:1-glibc AS filecoin
@@ -49,16 +43,15 @@ MAINTAINER Filecoin Dev Team
 
 # Get the filecoin binary, entrypoint script, and TLS CAs from the build container.
 ENV SRC_DIR /go/src/github.com/filecoin-project/go-filecoin
+COPY --from=builder $SRC_DIR/tmp/filecoin-proof-parameters/* /tmp/filecoin-proof-parameters/
 COPY --from=builder $SRC_DIR/go-filecoin /usr/local/bin/go-filecoin
 COPY --from=builder $SRC_DIR/bin/container_daemon /usr/local/bin/start_filecoin
 COPY --from=builder $SRC_DIR/bin/devnet_start /usr/local/bin/devnet_start
 COPY --from=builder $SRC_DIR/bin/node_restart /usr/local/bin/node_restart
+COPY --from=builder $SRC_DIR/fixtures/ /data/
 COPY --from=builder $SRC_DIR/gengen/gengen /usr/local/bin/gengen
-COPY --from=builder $SRC_DIR/fixtures/* /data/
 COPY --from=builder /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=builder /tmp/tini /sbin/tini
-COPY --from=builder /tmp/filecoin-proof-parameters/* /tmp/filecoin-proof-parameters/
-COPY --from=builder /tmp/jq /usr/local/bin/jq
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
 # This shared lib (part of glibc) doesn't seem to be included with busybox.
@@ -67,6 +60,10 @@ COPY --from=builder /lib/x86_64-linux-gnu/librt.so.1 /lib/librt.so.1
 COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/libgcc_s.so.1
 COPY --from=builder /lib/x86_64-linux-gnu/libutil.so.1 /lib/libutil.so.1
 
+# need jq for parsing genesis output
+RUN wget -q -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+  && chmod +x /usr/local/bin/jq
+
 # Ports for Swarm and CmdAPI
 EXPOSE 6000
 EXPOSE 3453
@@ -74,12 +71,8 @@ EXPOSE 3453
 # Create the fs-repo directory and switch to a non-privileged user.
 ENV FILECOIN_PATH /data/filecoin
 RUN mkdir -p $FILECOIN_PATH \
-&& adduser -D -h $FILECOIN_PATH -u 1000 -G users filecoin \
-&& chown filecoin:users $FILECOIN_PATH
-
-# There is only one bootstrapped miner
-RUN cat /data/gen.json | jq ".Miners[0].Address" > /data/minerAddr0 \
-&& cat /data/gen.json | jq ".Keys[0]" > /data/walletKey0
+  && adduser -D -h $FILECOIN_PATH -u 1000 -G users filecoin \
+  && chown filecoin:users $FILECOIN_PATH
 
 # Expose the fs-repo as a volume.
 # start_filecoin initializes an fs-repo if none is mounted.

--- a/Dockerfile.ci.base
+++ b/Dockerfile.ci.base
@@ -20,8 +20,3 @@ RUN set -x \
 && cd /tmp \
 && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini \
 && chmod +x tini
-
-# need jq for parsing genesis output
-RUN cd /tmp \
-&& wget -q -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-&& chmod +x jq

--- a/Dockerfile.ci.filecoin
+++ b/Dockerfile.ci.filecoin
@@ -8,11 +8,10 @@ COPY filecoin/go-filecoin /usr/local/bin/go-filecoin
 COPY bin/container_daemon /usr/local/bin/start_filecoin
 COPY bin/devnet_start /usr/local/bin/devnet_start
 COPY bin/node_restart /usr/local/bin/node_restart
-COPY fixtures/* /data/
+COPY fixtures/ /data/
 COPY gengen/gengen /usr/local/bin/gengen
 COPY --from=filecoin:all /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=filecoin:all /tmp/tini /sbin/tini
-COPY --from=filecoin:all /tmp/jq /usr/local/bin/jq
 COPY --from=filecoin:all /etc/ssl/certs /etc/ssl/certs
 
 RUN ln -sf /tmp/filecoin-proof-parameters/v9-zigzag-proof-of-replication-52431242c129794fe51d373ae29953f2ff52abd94c78756e318ce45f3e4946d8 /tmp/filecoin-proof-parameters/params.out
@@ -21,6 +20,10 @@ COPY --from=filecoin:all /lib/x86_64-linux-gnu/libdl-2.24.so /lib/libdl.so.2
 COPY --from=filecoin:all /lib/x86_64-linux-gnu/librt.so.1 /lib/librt.so.1
 COPY --from=filecoin:all /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/libgcc_s.so.1
 COPY --from=filecoin:all /lib/x86_64-linux-gnu/libutil.so.1 /lib/libutil.so.1
+
+# need jq for parsing genesis output
+RUN wget -q -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+  && chmod +x /usr/local/bin/jq
 
 # Ports for Swarm and CmdAPI
 EXPOSE 6000
@@ -31,10 +34,6 @@ ENV FILECOIN_PATH /data/filecoin
 RUN mkdir -p $FILECOIN_PATH \
 && adduser -D -h $FILECOIN_PATH -u 1000 -G users filecoin \
 && chown filecoin:users $FILECOIN_PATH
-
-# There is only one bootstrapped miner
-RUN cat /data/gen.json | jq ".Miners[0].Address" > /data/minerAddr0 \
-&& cat /data/gen.json | jq ".Keys[0]" > /data/walletKey0
 
 # Expose the fs-repo as a volume.
 # start_filecoin initializes an fs-repo if none is mounted.


### PR DESCRIPTION
- copy test and live genesis files to final image
- add build-time args (default to yes) for using precompiled rust-fil-proofs and bls-signatures
- reuse groth params if already downloaded under `$SRC_DIR/tmp/filecoin-proof-parameters
- don't build faucet and genesis-file-server since those have their own Dockerfile