### PR TITLE
clean up correct directory

### DIFF
--- a/functional-tests/lib/helpers.bash
+++ b/functional-tests/lib/helpers.bash
@@ -43,7 +43,7 @@ function finish {
   rm -f "${UNSEAL_PATH}"
   rm -rf "${CL_REPO_DIR}"
   rm -rf "${BOOTSTRAP_MN_REPO_DIR}"
-  rm -rf "${MN_REPO_DIR}"
+  rm -rf "${STORAGE_MN_REPO_DIR}"
 }
 
 function free_port {


### PR DESCRIPTION
## What's in this PR?

- clean up the storage miner's repo directory when script exits

## Why's this PR needed?

- We were deleting the wrong directory!