### PR TITLE
support variable length PoSt and PoRep proofs

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -52,6 +52,10 @@ const (
 	Boolean
 	// ProofsMode is an enumeration of possible modes of proof operation
 	ProofsMode
+	// PoRepProof is a dynamic length array of the PoRep proof-bytes
+	PoRepProof
+	// PoStProof is a dynamic length array of the PoSt proof-bytes
+	PoStProof
 	// Predicate is subset of a message used to ask an actor about a condition
 	Predicate
 	// Parameters is a slice of individually encodable parameters
@@ -92,6 +96,10 @@ func (t Type) String() string {
 		return "bool"
 	case ProofsMode:
 		return "types.ProofsMode"
+	case PoRepProof:
+		return "types.PoRepProof"
+	case PoStProof:
+		return "types.PoStProof"
 	case Predicate:
 		return "*types.Predicate"
 	case Parameters:
@@ -141,6 +149,10 @@ func (av *Value) String() string {
 		return fmt.Sprint(av.Val.(bool))
 	case ProofsMode:
 		return fmt.Sprint(av.Val.(types.ProofsMode))
+	case PoRepProof:
+		return fmt.Sprint(av.Val.(types.PoRepProof))
+	case PoStProof:
+		return fmt.Sprint(av.Val.(types.PoStProof))
 	case Predicate:
 		return fmt.Sprint(av.Val.(*types.Predicate))
 	case Parameters:
@@ -270,6 +282,18 @@ func (av *Value) Serialize() ([]byte, error) {
 		}
 
 		return []byte{byte(v)}, nil
+	case PoRepProof:
+		b, ok := av.Val.(types.PoRepProof)
+		if !ok {
+			return nil, &typeError{types.PoRepProof{}, av.Val}
+		}
+		return b, nil
+	case PoStProof:
+		b, ok := av.Val.(types.PoStProof)
+		if !ok {
+			return nil, &typeError{types.PoStProof{}, av.Val}
+		}
+		return b, nil
 	case Predicate:
 		p, ok := av.Val.(*types.Predicate)
 		if !ok {
@@ -329,6 +353,10 @@ func ToValues(i []interface{}) ([]*Value, error) {
 			out = append(out, &Value{Type: Boolean, Val: v})
 		case types.ProofsMode:
 			out = append(out, &Value{Type: ProofsMode, Val: v})
+		case types.PoRepProof:
+			out = append(out, &Value{Type: PoRepProof, Val: v})
+		case types.PoStProof:
+			out = append(out, &Value{Type: PoStProof, Val: v})
 		case *types.Predicate:
 			out = append(out, &Value{Type: Predicate, Val: v})
 		case []interface{}:
@@ -459,6 +487,16 @@ func Deserialize(data []byte, t Type) (*Value, error) {
 			Type: t,
 			Val:  types.ProofsMode(int(data[0])),
 		}, nil
+	case PoRepProof:
+		return &Value{
+			Type: t,
+			Val:  append(types.PoRepProof{}, data[:]...),
+		}, nil
+	case PoStProof:
+		return &Value{
+			Type: t,
+			Val:  append(types.PoStProof{}, data[:]...),
+		}, nil
 	case Predicate:
 		var predicate *types.Predicate
 		if err := cbor.DecodeInto(data, &predicate); err != nil {
@@ -500,6 +538,8 @@ var typeTable = map[Type]reflect.Type{
 	PoStProofs:     reflect.TypeOf([]types.PoStProof{}),
 	Boolean:        reflect.TypeOf(false),
 	ProofsMode:     reflect.TypeOf(types.TestProofsMode),
+	PoRepProof:     reflect.TypeOf(types.PoRepProof{}),
+	PoStProof:      reflect.TypeOf(types.PoStProof{}),
 	Predicate:      reflect.TypeOf(&types.Predicate{}),
 	Parameters:     reflect.TypeOf([]interface{}{}),
 }

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -209,7 +209,7 @@ var minerExports = exec.Exports{
 		Return: []abi.Type{abi.SectorID},
 	},
 	"commitSector": &exec.FunctionSignature{
-		Params: []abi.Type{abi.SectorID, abi.Bytes, abi.Bytes, abi.Bytes, abi.Bytes},
+		Params: []abi.Type{abi.SectorID, abi.Bytes, abi.Bytes, abi.Bytes, abi.PoRepProof},
 		Return: []abi.Type{},
 	},
 	"getKey": &exec.FunctionSignature{
@@ -451,7 +451,7 @@ func (ma *Actor) GetSectorCommitments(ctx exec.VMContext) (map[string]types.Comm
 
 // CommitSector adds a commitment to the specified sector. The sector must not
 // already be committed.
-func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR, commRStar, proof []byte) (uint8, error) {
+func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR, commRStar []byte, proof types.PoRepProof) (uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -493,7 +493,7 @@ func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR,
 		copy(req.CommD[:], commD)
 		copy(req.CommR[:], commR)
 		copy(req.CommRStar[:], commRStar)
-		req.Proof = append(types.PoRepProof{}, proof...)
+		req.Proof = proof
 		req.ProverID = sectorbuilder.AddressToProverID(ctx.Message().To)
 		req.SectorID = sectorbuilder.SectorIDToBytes(sectorID)
 		req.SectorSize = sectorSize

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -711,7 +711,7 @@ func (ma *Actor) GetPower(ctx exec.VMContext) (*big.Int, uint8, error) {
 
 // SubmitPoSt is used to submit a coalesced PoST to the chain to convince the chain
 // that you have been actually storing the files you claim to be.
-func (ma *Actor) SubmitPoSt(ctx exec.VMContext, postProofs []types.PoStProof) (uint8, error) {
+func (ma *Actor) SubmitPoSt(ctx exec.VMContext, poStProofs []types.PoStProof) (uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -770,7 +770,7 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, postProofs []types.PoStProof) (u
 				ChallengeSeed: seed,
 				SortedCommRs:  sortedCommRs,
 				Faults:        []uint64{},
-				Proofs:        postProofs,
+				Proofs:        poStProofs,
 				SectorSize:    sectorSize,
 			}
 

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -493,7 +493,7 @@ func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR,
 		copy(req.CommD[:], commD)
 		copy(req.CommR[:], commR)
 		copy(req.CommRStar[:], commRStar)
-		copy(req.Proof[:], proof)
+		req.Proof = append(types.PoRepProof{}, proof...)
 		req.ProverID = sectorbuilder.AddressToProverID(ctx.Message().To)
 		req.SectorID = sectorbuilder.SectorIDToBytes(sectorID)
 		req.SectorSize = sectorSize

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -283,7 +283,7 @@ func TestMinerCommitSector(t *testing.T) {
 	commRStar := th.MakeCommitment()
 	commD := th.MakeCommitment()
 
-	res, err := th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 3, "commitSector", nil, uint64(1), commD, commR, commRStar, th.MakeRandomBytes(int(types.SealBytesLen)))
+	res, err := th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 3, "commitSector", nil, uint64(1), commD, commR, commRStar, th.MakeRandomBytes(types.TwoPoRepProofPartitions.ProofLen()))
 	require.NoError(t, err)
 	require.NoError(t, res.ExecutionError)
 	require.Equal(t, uint8(0), res.Receipt.ExitCode)
@@ -296,7 +296,7 @@ func TestMinerCommitSector(t *testing.T) {
 	require.Equal(t, types.NewBlockHeight(3), types.NewBlockHeightFromBytes(res.Receipt.Return[0]))
 
 	// fail because commR already exists
-	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 4, "commitSector", nil, uint64(1), commD, commR, commRStar, th.MakeRandomBytes(int(types.SealBytesLen)))
+	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 4, "commitSector", nil, uint64(1), commD, commR, commRStar, th.MakeRandomBytes(types.TwoPoRepProofPartitions.ProofLen()))
 	require.NoError(t, err)
 	require.EqualError(t, res.ExecutionError, "sector already committed")
 	require.Equal(t, uint8(0x23), res.Receipt.ExitCode)
@@ -314,13 +314,13 @@ func TestMinerSubmitPoSt(t *testing.T) {
 	minerAddr := createTestMiner(t, st, vms, address.TestAddress, []byte("my public key"), origPid)
 
 	// add a sector
-	res, err := th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 3, "commitSector", ancestors, uint64(1), th.MakeCommitment(), th.MakeCommitment(), th.MakeCommitment(), th.MakeRandomBytes(int(types.SealBytesLen)))
+	res, err := th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 3, "commitSector", ancestors, uint64(1), th.MakeCommitment(), th.MakeCommitment(), th.MakeCommitment(), th.MakeRandomBytes(types.TwoPoRepProofPartitions.ProofLen()))
 	require.NoError(t, err)
 	require.NoError(t, res.ExecutionError)
 	require.Equal(t, uint8(0), res.Receipt.ExitCode)
 
 	// add another sector
-	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 4, "commitSector", ancestors, uint64(2), th.MakeCommitment(), th.MakeCommitment(), th.MakeCommitment(), th.MakeRandomBytes(int(types.SealBytesLen)))
+	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 4, "commitSector", ancestors, uint64(2), th.MakeCommitment(), th.MakeCommitment(), th.MakeCommitment(), th.MakeRandomBytes(types.TwoPoRepProofPartitions.ProofLen()))
 	require.NoError(t, err)
 	require.NoError(t, res.ExecutionError)
 	require.Equal(t, uint8(0), res.Receipt.ExitCode)
@@ -360,7 +360,7 @@ func TestVerifyPIP(t *testing.T) {
 	commD := th.MakeCommitment()
 
 	// add a sector
-	res, err := th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 3, "commitSector", ancestors, sectorId, commD, th.MakeCommitment(), th.MakeCommitment(), th.MakeRandomBytes(int(types.SealBytesLen)))
+	res, err := th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 3, "commitSector", ancestors, sectorId, commD, th.MakeCommitment(), th.MakeCommitment(), th.MakeRandomBytes(types.TwoPoRepProofPartitions.ProofLen()))
 	require.NoError(t, err)
 	require.NoError(t, res.ExecutionError)
 	require.Equal(t, uint8(0), res.Receipt.ExitCode)

--- a/commands/schema/filecoin_block.schema.json
+++ b/commands/schema/filecoin_block.schema.json
@@ -48,10 +48,10 @@
           "type": "string"
         },
         "proof": {
-          "items": {
-            "type": "integer"
-          },
-          "type": "array"
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "reward": {
           "type": "string"

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -272,7 +272,7 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 			commD := make([]byte, 32)
 			commR := make([]byte, 32)
 			commRStar := make([]byte, 32)
-			sealProof := make([]byte, types.OnePoStProofPartition.ProofLen())
+			sealProof := make([]byte, types.TwoPoRepProofPartitions.ProofLen())
 			if _, err := pnrg.Read(commD[:]); err != nil {
 				return nil, err
 			}

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -272,7 +272,7 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 			commD := make([]byte, 32)
 			commR := make([]byte, 32)
 			commRStar := make([]byte, 32)
-			sealProof := make([]byte, types.SealBytesLen)
+			sealProof := make([]byte, types.OnePoStProofPartition.ProofLen())
 			if _, err := pnrg.Read(commD[:]); err != nil {
 				return nil, err
 			}

--- a/mining/worker.go
+++ b/mining/worker.go
@@ -212,7 +212,7 @@ func (w *DefaultWorker) Mine(ctx context.Context, base types.TipSet, nullBlkCoun
 			log.Errorf("Worker.Mine got zero value from channel prChRead")
 			return false
 		}
-		copy(proof[:], prChRead[:])
+		proof := append(types.PoStProof{}, prChRead[:]...)
 		ticket, err = consensus.CreateTicket(proof, w.minerPubKey, w.workerSigner)
 		if err != nil {
 			log.Errorf("failed to create ticket: %s", err)

--- a/proofs/interface.go
+++ b/proofs/interface.go
@@ -6,12 +6,12 @@ import (
 
 // VerifySealRequest represents a request to verify the output of a Seal() operation.
 type VerifySealRequest struct {
-	CommD      types.CommD     // returned from seal
-	CommR      types.CommR     // returned from seal
-	CommRStar  types.CommRStar // returned from seal
-	Proof      types.SealProof // returned from seal
-	ProverID   [31]byte        // uniquely identifies miner
-	SectorID   [31]byte        // uniquely identifies sector
+	CommD      types.CommD      // returned from seal
+	CommR      types.CommR      // returned from seal
+	CommRStar  types.CommRStar  // returned from seal
+	Proof      types.PoRepProof // returned from seal
+	ProverID   [31]byte         // uniquely identifies miner
+	SectorID   [31]byte         // uniquely identifies sector
 	SectorSize types.SectorSize
 }
 

--- a/proofs/rustverifier.go
+++ b/proofs/rustverifier.go
@@ -52,15 +52,9 @@ func (rp *RustVerifier) VerifySeal(req VerifySealRequest) (VerifySealResponse, e
 	sectorIDCbytes := C.CBytes(req.SectorID[:])
 	defer C.free(sectorIDCbytes)
 
-	ppp, err := req.Proof.ProofPartitions()
-	if err != nil {
-		return VerifySealResponse{}, errors.Wrap(err, "failed to get proof partitions")
-	}
-
 	// a mutable pointer to a VerifySealResponse C-struct
 	resPtr := (*C.VerifySealResponse)(unsafe.Pointer(C.verify_seal(
 		C.uint64_t(req.SectorSize.Uint64()),
-		C.uint8_t(ppp.Int()),
 		(*[32]C.uint8_t)(commRCBytes),
 		(*[32]C.uint8_t)(commDCBytes),
 		(*[32]C.uint8_t)(commRStarCBytes),

--- a/proofs/rustverifier.go
+++ b/proofs/rustverifier.go
@@ -55,7 +55,7 @@ func (rp *RustVerifier) VerifySeal(req VerifySealRequest) (VerifySealResponse, e
 	// a mutable pointer to a VerifySealResponse C-struct
 	resPtr := (*C.VerifySealResponse)(unsafe.Pointer(C.verify_seal(
 		C.uint64_t(req.SectorSize.Uint64()),
-		C.uint8_t(req.Proof.ProofPartitions().Uint8()),
+		C.uint8_t(req.Proof.ProofPartitions().Int()),
 		(*[32]C.uint8_t)(commRCBytes),
 		(*[32]C.uint8_t)(commDCBytes),
 		(*[32]C.uint8_t)(commRStarCBytes),

--- a/proofs/rustverifier.go
+++ b/proofs/rustverifier.go
@@ -55,7 +55,7 @@ func (rp *RustVerifier) VerifySeal(req VerifySealRequest) (VerifySealResponse, e
 	// a mutable pointer to a VerifySealResponse C-struct
 	resPtr := (*C.VerifySealResponse)(unsafe.Pointer(C.verify_seal(
 		C.uint64_t(req.SectorSize.Uint64()),
-		C.uint8_t(req.Proof.ProofPartitions().Int()),
+		C.uint8_t(req.Proof.ProofPartitions().Uint8()),
 		(*[32]C.uint8_t)(commRCBytes),
 		(*[32]C.uint8_t)(commDCBytes),
 		(*[32]C.uint8_t)(commRStarCBytes),

--- a/proofs/rustverifier.go
+++ b/proofs/rustverifier.go
@@ -52,10 +52,15 @@ func (rp *RustVerifier) VerifySeal(req VerifySealRequest) (VerifySealResponse, e
 	sectorIDCbytes := C.CBytes(req.SectorID[:])
 	defer C.free(sectorIDCbytes)
 
+	ppp, err := req.Proof.ProofPartitions()
+	if err != nil {
+		return VerifySealResponse{}, errors.Wrap(err, "failed to get proof partitions")
+	}
+
 	// a mutable pointer to a VerifySealResponse C-struct
 	resPtr := (*C.VerifySealResponse)(unsafe.Pointer(C.verify_seal(
 		C.uint64_t(req.SectorSize.Uint64()),
-		C.uint8_t(req.Proof.ProofPartitions().Int()),
+		C.uint8_t(ppp.Int()),
 		(*[32]C.uint8_t)(commRCBytes),
 		(*[32]C.uint8_t)(commDCBytes),
 		(*[32]C.uint8_t)(commRStarCBytes),

--- a/proofs/sectorbuilder/interface.go
+++ b/proofs/sectorbuilder/interface.go
@@ -78,7 +78,7 @@ type SealedSectorMetadata struct {
 	CommR     types.CommR // deprecated (will be removed soon)
 	CommRStar types.CommRStar
 	Pieces    []*PieceInfo // deprecated (will be removed soon)
-	Proof     types.SealProof
+	Proof     types.PoRepProof
 	SectorID  uint64
 }
 

--- a/proofs/sectorbuilder/rustsectorbuilder.go
+++ b/proofs/sectorbuilder/rustsectorbuilder.go
@@ -266,23 +266,21 @@ func (sb *RustSectorBuilder) findSealedSectorMetadata(sectorID uint64) (*SealedS
 	} else if resPtr.seal_status_code == C.Sealing {
 		return nil, nil
 	} else if resPtr.seal_status_code == C.Sealed {
-		commRSlice := C.GoBytes(unsafe.Pointer(&resPtr.comm_r[0]), 32)
+		commRSlice := goBytes(&resPtr.comm_r[0], 32)
 		var commR types.CommR
 		copy(commR[:], commRSlice)
 
-		commDSlice := C.GoBytes(unsafe.Pointer(&resPtr.comm_d[0]), 32)
+		commDSlice := goBytes(&resPtr.comm_d[0], 32)
 		var commD types.CommD
 		copy(commD[:], commDSlice)
 
-		commRStarSlice := C.GoBytes(unsafe.Pointer(&resPtr.comm_r_star[0]), 32)
+		commRStarSlice := goBytes(&resPtr.comm_r_star[0], 32)
 		var commRStar types.CommRStar
 		copy(commRStar[:], commRStarSlice)
 
-		proofSlice := C.GoBytes(unsafe.Pointer(&resPtr.snark_proof[0]), 384)
-		var proof types.SealProof
-		copy(proof[:], proofSlice)
+		proof := goBytes(resPtr.proof_ptr, resPtr.proof_len)
 
-		ps, err := goPieceInfos((*C.FFIPieceMetadata)(unsafe.Pointer(resPtr.pieces_ptr)), resPtr.pieces_len)
+		ps, err := goPieceInfos(resPtr.pieces_ptr, resPtr.pieces_len)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to marshal from string to cid")
 		}
@@ -314,7 +312,7 @@ func (sb *RustSectorBuilder) ReadPieceFromSealedSector(pieceCid cid.Cid) (io.Rea
 		return nil, errors.New(C.GoString(resPtr.error_msg))
 	}
 
-	return bytes.NewReader(C.GoBytes(unsafe.Pointer(resPtr.data_ptr), C.int(resPtr.data_len))), nil
+	return bytes.NewReader(goBytes(resPtr.data_ptr, resPtr.data_len)), nil
 }
 
 // SealAllStagedSectors schedules sealing of all staged sectors.
@@ -360,7 +358,7 @@ func (sb *RustSectorBuilder) Close() error {
 
 // GeneratePoSt produces a proof-of-spacetime for the provided commitment replicas.
 func (sb *RustSectorBuilder) GeneratePoSt(req GeneratePoStRequest) (GeneratePoStResponse, error) {
-	defer elapsed("GeneratePoSt")()
+	defer elapsed("Generate  PoSt")()
 
 	// flattening the byte slice makes it easier to copy into the C heap
 	commRs := req.SortedCommRs.Values()
@@ -383,9 +381,9 @@ func (sb *RustSectorBuilder) GeneratePoSt(req GeneratePoStRequest) (GeneratePoSt
 		return GeneratePoStResponse{}, errors.New(C.GoString(resPtr.error_msg))
 	}
 
-	proofs, err := goPoStProofs(resPtr.flattened_proofs_ptr, resPtr.flattened_proofs_len)
+	proofs, err := goPoStProofs(resPtr.proof_partitions, resPtr.flattened_proofs_ptr, resPtr.flattened_proofs_len)
 	if err != nil {
-		return GeneratePoStResponse{}, err
+		return GeneratePoStResponse{}, errors.Wrap(err, "failed to convert to []PoStProof")
 	}
 
 	return GeneratePoStResponse{
@@ -394,149 +392,8 @@ func (sb *RustSectorBuilder) GeneratePoSt(req GeneratePoStRequest) (GeneratePoSt
 	}, nil
 }
 
-// goPoStProofs accepts a pointer to a C-allocated byte array and a size and
-// produces a Go-managed slice of PoStProof. Note that this function copies
-// values into the Go heap from C.
-func goPoStProofs(src *C.uint8_t, size C.size_t) ([]types.PoStProof, error) {
-	chunkSize := int(types.PoStBytesLen)
-	arrSize := int(size)
-
-	if src == nil {
-		return []types.PoStProof{}, nil
-	}
-
-	if arrSize%chunkSize != 0 {
-		msg := "PoSt proof array invalid size (arrSize=%d % PoStBytesLen=%d != 0)"
-		return nil, errors.Errorf(msg, arrSize, types.PoStBytesLen)
-	}
-
-	out := make([]types.PoStProof, arrSize/chunkSize)
-
-	// Create a slice from a pointer to an array on the C heap by slicing to
-	// the appropriate size. We can then copy from this slice into the Go heap.
-	//
-	// https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
-	tmp := (*(*[1 << 30]byte)(unsafe.Pointer(src)))[:size:size]
-
-	for i := 0; i < len(out); i++ {
-		copy(out[i][:], tmp[i*chunkSize:(i+1)*chunkSize])
-	}
-
-	return out, nil
-}
-
-// goUint64s accepts a pointer to a C-allocated uint64 and a size and produces
-// a Go-managed slice of uint64. Note that this function copies values into the
-// Go heap from C.
-func goUint64s(src *C.uint64_t, size C.size_t) []uint64 {
-	out := make([]uint64, size)
-	if src != nil {
-		copy(out, (*(*[1 << 30]uint64)(unsafe.Pointer(src)))[:size:size])
-	}
-	return out
-}
-
-// destroy deallocates and destroys a RustSectorBuilder.
 func (sb *RustSectorBuilder) destroy() {
 	C.destroy_sector_builder((*C.SectorBuilder)(sb.ptr))
 
 	sb.ptr = nil
-}
-
-func goStagedSectorMetadata(src *C.FFIStagedSectorMetadata, size C.size_t) ([]*stagedSectorMetadata, error) {
-	sectors := make([]*stagedSectorMetadata, size)
-	if src == nil || size == 0 {
-		return sectors, nil
-	}
-
-	sectorPtrs := (*[1 << 30]C.FFIStagedSectorMetadata)(unsafe.Pointer(src))[:size:size]
-	for i := 0; i < int(size); i++ {
-		sectors[i] = &stagedSectorMetadata{
-			sectorID: uint64(sectorPtrs[i].sector_id),
-		}
-	}
-
-	return sectors, nil
-}
-
-func goPieceInfos(src *C.FFIPieceMetadata, size C.size_t) ([]*PieceInfo, error) {
-	ps := make([]*PieceInfo, size)
-	if src == nil || size == 0 {
-		return ps, nil
-	}
-
-	ptrs := (*[1 << 30]C.FFIPieceMetadata)(unsafe.Pointer(src))[:size:size]
-	for i := 0; i < int(size); i++ {
-		ref, err := cid.Decode(C.GoString(ptrs[i].piece_key))
-		if err != nil {
-			return nil, err
-		}
-
-		ps[i] = &PieceInfo{
-			Ref:  ref,
-			Size: uint64(ptrs[i].num_bytes),
-		}
-	}
-
-	return ps, nil
-}
-
-func cFFISealProofPartitions(spp types.PoRepProofPartitions) (C.FFISealProofPartitions, error) {
-	switch spp {
-	case types.TestPoRepProofPartitions:
-		return C.FFISealProofPartitions(0), nil
-	case types.TwoPoRepPartitions:
-		return C.FFISealProofPartitions(C.SPP_Two), nil
-	default:
-		return C.FFISealProofPartitions(0), errors.Errorf("unhandled value: %v", spp)
-	}
-}
-
-func cFFIPoStProofPartitions(ppp types.PoStProofPartitions) (C.FFIPoStProofPartitions, error) {
-	switch ppp {
-	case types.TestPoStPartitions:
-		return C.FFIPoStProofPartitions(0), nil
-	case types.OnePoStPartition:
-		return C.FFIPoStProofPartitions(C.PPP_One), nil
-	default:
-		return C.FFIPoStProofPartitions(0), errors.Errorf("unhandled value: %v", ppp)
-	}
-}
-
-func cSectorClass(c types.SectorClass) (C.FFISectorClass, error) {
-	size, err := cFFISectorSizeFrom(c.SectorSize())
-	if err != nil {
-		return C.FFISectorClass{}, nil
-	}
-
-	seal, err := cFFISealProofPartitions(c.PoRepProofPartitions())
-	if err != nil {
-		return C.FFISectorClass{}, nil
-	}
-
-	post, err := cFFIPoStProofPartitions(c.PoStProofPartitions())
-	if err != nil {
-		return C.FFISectorClass{}, nil
-	}
-
-	return C.FFISectorClass{
-		sector_size:           size,
-		seal_proof_partitions: seal,
-		post_proof_partitions: post,
-	}, nil
-}
-
-// cFFISectorSizeFrom produces an FFI-compatible FFISectorSize from a
-// SectorSize. This function's return type includes a C type, so it cannot be
-// exported. See: https://golang.org/cmd/cgo/#hdr-Go_references_to_C for more
-// information.
-func cFFISectorSizeFrom(ss types.SectorSize) (C.FFISectorSize, error) {
-	switch ss {
-	case types.OneKiBSectorSize:
-		return C.FFISectorSize(C.SSB_OneKiB), nil
-	case types.TwoHundredFiftySixMiBSectorSize:
-		return C.FFISectorSize(C.SSB_TwoHundredFiftySixMiB), nil
-	default:
-		return C.FFISectorSize(0), errors.Errorf("unhandled value: %v", ss)
-	}
 }

--- a/proofs/sectorbuilder/rustsectorbuilder.go
+++ b/proofs/sectorbuilder/rustsectorbuilder.go
@@ -358,7 +358,7 @@ func (sb *RustSectorBuilder) Close() error {
 
 // GeneratePoSt produces a proof-of-spacetime for the provided commitment replicas.
 func (sb *RustSectorBuilder) GeneratePoSt(req GeneratePoStRequest) (GeneratePoStResponse, error) {
-	defer elapsed("Generate  PoSt")()
+	defer elapsed("GeneratePoSt")()
 
 	// flattening the byte slice makes it easier to copy into the C heap
 	commRs := req.SortedCommRs.Values()

--- a/proofs/sectorbuilder/testing/interface_test.go
+++ b/proofs/sectorbuilder/testing/interface_test.go
@@ -9,11 +9,10 @@ import (
 	"testing"
 	"time"
 
-	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
-	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
 
 	"github.com/stretchr/testify/require"
@@ -30,7 +29,7 @@ const MaxTimeToSealASector = time.Second * 360
 const MaxTimeToGenerateSectorPoSt = time.Second * 360
 
 func TestSectorBuilder(t *testing.T) {
-	tf.SectorBuilderTest(t)
+	// tf.SectorBuilderTest(t)
 
 	t.Run("concurrent AddPiece and SealAllStagedSectors", func(t *testing.T) {
 		h := NewBuilder(t).Build()
@@ -310,6 +309,18 @@ func TestSectorBuilder(t *testing.T) {
 		case val := <-h.SectorBuilder.SectorSealResults():
 			require.NoError(t, val.SealingErr)
 			require.Equal(t, sectorID, val.SealingResult.SectorID)
+
+			sres, serr := (&proofs.RustVerifier{}).VerifySeal(proofs.VerifySealRequest{
+				CommD:      val.SealingResult.CommD,
+				CommR:      val.SealingResult.CommR,
+				CommRStar:  val.SealingResult.CommRStar,
+				Proof:      val.SealingResult.Proof,
+				ProverID:   sectorbuilder.AddressToProverID(h.MinerAddr),
+				SectorID:   sectorbuilder.SectorIDToBytes(val.SealingResult.SectorID),
+				SectorSize: types.OneKiBSectorSize,
+			})
+			require.NoError(t, serr, "seal proof-verification produced an error")
+			require.True(t, sres.IsValid, "seal proof was not valid")
 
 			// TODO: This should be generates from some standard source of
 			// entropy, e.g. the blockchain

--- a/proofs/sectorbuilder/testing/interface_test.go
+++ b/proofs/sectorbuilder/testing/interface_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
 
 	"github.com/stretchr/testify/require"
@@ -29,7 +30,7 @@ const MaxTimeToSealASector = time.Second * 360
 const MaxTimeToGenerateSectorPoSt = time.Second * 360
 
 func TestSectorBuilder(t *testing.T) {
-	// tf.SectorBuilderTest(t)
+	tf.SectorBuilderTest(t)
 
 	t.Run("concurrent AddPiece and SealAllStagedSectors", func(t *testing.T) {
 		h := NewBuilder(t).Build()

--- a/proofs/sectorbuilder/transforms.go
+++ b/proofs/sectorbuilder/transforms.go
@@ -19,8 +19,13 @@ func goBytes(src *C.uint8_t, size C.size_t) []byte {
 func goPoStProofs(partitions C.uint8_t, src *C.uint8_t, size C.size_t) ([]types.PoStProof, error) {
 	tmp := goBytes(src, size)
 
+	ppp, err := goPoStProofPartitions(partitions)
+	if err != nil {
+		return nil, err
+	}
+
 	arraySize := len(tmp)
-	chunkSize := goPoStProofPartitions(partitions).ProofLen()
+	chunkSize := ppp.ProofLen()
 
 	out := make([]types.PoStProof, arraySize/chunkSize)
 	for i := 0; i < len(out); i++ {
@@ -76,7 +81,7 @@ func goPieceInfos(src *C.FFIPieceMetadata, size C.size_t) ([]*PieceInfo, error) 
 	return ps, nil
 }
 
-func goPoStProofPartitions(partitions C.uint8_t) types.PoStProofPartitions {
+func goPoStProofPartitions(partitions C.uint8_t) (types.PoStProofPartitions, error) {
 	return types.NewPoStProofPartitions(int(partitions))
 }
 

--- a/proofs/sectorbuilder/transforms.go
+++ b/proofs/sectorbuilder/transforms.go
@@ -88,7 +88,7 @@ func goPoStProofPartitions(partitions C.uint8_t) types.PoStProofPartitions {
 func cSectorClass(c types.SectorClass) (C.FFISectorClass, error) {
 	return C.FFISectorClass{
 		sector_size:            C.uint64_t(c.SectorSize().Uint64()),
-		porep_proof_partitions: C.uint8_t(c.PoRepProofPartitions().Int()),
-		post_proof_partitions:  C.uint8_t(c.PoStProofPartitions().Int()),
+		porep_proof_partitions: C.uint8_t(c.PoRepProofPartitions().Uint8()),
+		post_proof_partitions:  C.uint8_t(c.PoStProofPartitions().Uint8()),
 	}, nil
 }

--- a/proofs/sectorbuilder/transforms.go
+++ b/proofs/sectorbuilder/transforms.go
@@ -1,0 +1,94 @@
+package sectorbuilder
+
+import (
+	"unsafe"
+
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/ipfs/go-cid"
+)
+
+// #cgo LDFLAGS: -L${SRCDIR}/../lib -lfilecoin_proofs
+// #cgo pkg-config: ${SRCDIR}/../lib/pkgconfig/libfilecoin_proofs.pc
+// #include "../include/libfilecoin_proofs.h"
+import "C"
+
+func goBytes(src *C.uint8_t, size C.size_t) []byte {
+	return C.GoBytes(unsafe.Pointer(src), C.int(size))
+}
+
+func goPoStProofs(partitions C.uint8_t, src *C.uint8_t, size C.size_t) ([]types.PoStProof, error) {
+	tmp := goBytes(src, size)
+
+	arraySize := len(tmp)
+	chunkSize := goPoStProofPartitions(partitions).ProofLen()
+
+	out := make([]types.PoStProof, arraySize/chunkSize)
+	for i := 0; i < len(out); i++ {
+		out[i] = append(types.PoStProof{}, tmp[i*chunkSize:(i+1)*chunkSize]...)
+	}
+
+	return out, nil
+}
+
+func goUint64s(src *C.uint64_t, size C.size_t) []uint64 {
+	out := make([]uint64, size)
+	if src != nil {
+		copy(out, (*(*[1 << 30]uint64)(unsafe.Pointer(src)))[:size:size])
+	}
+	return out
+}
+
+func goStagedSectorMetadata(src *C.FFIStagedSectorMetadata, size C.size_t) ([]*stagedSectorMetadata, error) {
+	sectors := make([]*stagedSectorMetadata, size)
+	if src == nil || size == 0 {
+		return sectors, nil
+	}
+
+	sectorPtrs := (*[1 << 30]C.FFIStagedSectorMetadata)(unsafe.Pointer(src))[:size:size]
+	for i := 0; i < int(size); i++ {
+		sectors[i] = &stagedSectorMetadata{
+			sectorID: uint64(sectorPtrs[i].sector_id),
+		}
+	}
+
+	return sectors, nil
+}
+
+func goPieceInfos(src *C.FFIPieceMetadata, size C.size_t) ([]*PieceInfo, error) {
+	ps := make([]*PieceInfo, size)
+	if src == nil || size == 0 {
+		return ps, nil
+	}
+
+	ptrs := (*[1 << 30]C.FFIPieceMetadata)(unsafe.Pointer(src))[:size:size]
+	for i := 0; i < int(size); i++ {
+		ref, err := cid.Decode(C.GoString(ptrs[i].piece_key))
+		if err != nil {
+			return nil, err
+		}
+
+		ps[i] = &PieceInfo{
+			Ref:  ref,
+			Size: uint64(ptrs[i].num_bytes),
+		}
+	}
+
+	return ps, nil
+}
+
+func goPoStProofPartitions(partitions C.uint8_t) types.PoStProofPartitions {
+	switch int(partitions) {
+	case 1:
+		return types.OnePoStProofPartition
+	default:
+		return types.UnknownPoStProofPartitions
+	}
+}
+
+func cSectorClass(c types.SectorClass) (C.FFISectorClass, error) {
+	return C.FFISectorClass{
+		sector_size:            C.uint64_t(c.SectorSize().Uint64()),
+		porep_proof_partitions: C.uint8_t(c.PoRepProofPartitions().Int()),
+		post_proof_partitions:  C.uint8_t(c.PoStProofPartitions().Int()),
+	}, nil
+}

--- a/proofs/sectorbuilder/transforms.go
+++ b/proofs/sectorbuilder/transforms.go
@@ -77,12 +77,7 @@ func goPieceInfos(src *C.FFIPieceMetadata, size C.size_t) ([]*PieceInfo, error) 
 }
 
 func goPoStProofPartitions(partitions C.uint8_t) types.PoStProofPartitions {
-	switch int(partitions) {
-	case 1:
-		return types.OnePoStProofPartition
-	default:
-		return types.UnknownPoStProofPartitions
-	}
+	return types.NewPoStProofPartitions(int(partitions))
 }
 
 func cSectorClass(c types.SectorClass) (C.FFISectorClass, error) {

--- a/proofs/sectorbuilder/transforms.go
+++ b/proofs/sectorbuilder/transforms.go
@@ -88,7 +88,7 @@ func goPoStProofPartitions(partitions C.uint8_t) types.PoStProofPartitions {
 func cSectorClass(c types.SectorClass) (C.FFISectorClass, error) {
 	return C.FFISectorClass{
 		sector_size:            C.uint64_t(c.SectorSize().Uint64()),
-		porep_proof_partitions: C.uint8_t(c.PoRepProofPartitions().Uint8()),
-		post_proof_partitions:  C.uint8_t(c.PoStProofPartitions().Uint8()),
+		porep_proof_partitions: C.uint8_t(c.PoRepProofPartitions().Int()),
+		post_proof_partitions:  C.uint8_t(c.PoStProofPartitions().Int()),
 	}, nil
 }

--- a/proofs/sectorbuilder/utils.go
+++ b/proofs/sectorbuilder/utils.go
@@ -32,7 +32,7 @@ func AddressToProverID(addr address.Address) [31]byte {
 	return prid
 }
 
-// SectorIDToBytes creates a prover id by padding an address hash to 31 bytes
+// SectorIDToBytes encodes the uint64 sector id as a fixed length byte array.
 func SectorIDToBytes(sectorID uint64) [31]byte {
 	slice := make([]byte, 31)
 	binary.LittleEndian.PutUint64(slice, sectorID)

--- a/proofs/transforms.go
+++ b/proofs/transforms.go
@@ -1,0 +1,41 @@
+package proofs
+
+import (
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// #cgo LDFLAGS: -L${SRCDIR}/lib -lfilecoin_proofs
+// #cgo pkg-config: ${SRCDIR}/lib/pkgconfig/libfilecoin_proofs.pc
+// #include "./include/libfilecoin_proofs.h"
+import "C"
+
+func cPoStProofs(src []types.PoStProof) (C.uint8_t, *C.uint8_t, C.size_t) {
+	proofSize := len(src[0])
+
+	flattenedLen := C.size_t(proofSize * len(src))
+
+	// flattening the byte slice makes it easier to copy into the C heap
+	flattened := make([]byte, flattenedLen)
+	for idx, proof := range src {
+		copy(flattened[(proofSize*idx):(proofSize*(1+idx))], proof[:])
+	}
+
+	proofPartitions := proofSize / types.OnePoStProofPartition.ProofLen()
+
+	return C.uint8_t(proofPartitions), (*C.uint8_t)(C.CBytes(flattened)), flattenedLen
+}
+
+func cUint64s(src []uint64) (*C.uint64_t, C.size_t) {
+	srcCSizeT := C.size_t(len(src))
+
+	// allocate array in C heap
+	cUint64s := C.malloc(srcCSizeT * C.sizeof_uint64_t)
+
+	// create a Go slice backed by the C-array
+	pp := (*[1 << 30]C.uint64_t)(cUint64s)
+	for i, v := range src {
+		pp[i] = C.uint64_t(v)
+	}
+
+	return (*C.uint64_t)(cUint64s), srcCSizeT
+}

--- a/testhelpers/chain.go
+++ b/testhelpers/chain.go
@@ -181,22 +181,22 @@ func RequirePutTsas(ctx context.Context, t *testing.T, chn chain.Store, tsas *ch
 // MakeProofAndWinningTicket generates a proof and ticket that will pass validateMining.
 func MakeProofAndWinningTicket(signerPubKey []byte, minerPower uint64, totalPower uint64, signer consensus.TicketSigner) (types.PoStProof, types.Signature, error) {
 
-	postProof := make([]byte, types.OnePoStProofPartition.ProofLen())
+	poStProof := make([]byte, types.OnePoStProofPartition.ProofLen())
 	var ticket types.Signature
 
 	if totalPower/minerPower > 100000 {
-		return postProof, ticket, errors.New("MakeProofAndWinningTicket: minerPower is too small for totalPower to generate a winning ticket")
+		return poStProof, ticket, errors.New("MakeProofAndWinningTicket: minerPower is too small for totalPower to generate a winning ticket")
 	}
 
 	for {
-		postProof = MakeRandomPoSTProofForTest()
-		ticket, err := consensus.CreateTicket(postProof, signerPubKey, signer)
+		poStProof = MakeRandomPoSTProofForTest()
+		ticket, err := consensus.CreateTicket(poStProof, signerPubKey, signer)
 		if err != nil {
 			errStr := fmt.Sprintf("error creating ticket: %s", err)
 			panic(errStr)
 		}
 		if consensus.CompareTicketPower(ticket, minerPower, totalPower) {
-			return postProof, ticket, nil
+			return poStProof, ticket, nil
 		}
 	}
 }

--- a/testhelpers/chain.go
+++ b/testhelpers/chain.go
@@ -181,7 +181,7 @@ func RequirePutTsas(ctx context.Context, t *testing.T, chn chain.Store, tsas *ch
 // MakeProofAndWinningTicket generates a proof and ticket that will pass validateMining.
 func MakeProofAndWinningTicket(signerPubKey []byte, minerPower uint64, totalPower uint64, signer consensus.TicketSigner) (types.PoStProof, types.Signature, error) {
 
-	var postProof types.PoStProof
+	postProof := make([]byte, types.OnePoStProofPartition.ProofLen())
 	var ticket types.Signature
 
 	if totalPower/minerPower > 100000 {

--- a/testhelpers/consensus.go
+++ b/testhelpers/consensus.go
@@ -96,10 +96,11 @@ func NewValidTestBlockFromTipSet(baseTipSet types.TipSet, stateRootCid cid.Cid, 
 }
 
 // MakeRandomPoSTProofForTest creates a random proof.
-func MakeRandomPoSTProofForTest() types.PoStProof {
-	p := MakeRandomBytes(192)
+func MakeRandomPoSTProofForTest() []byte {
+	proofSize := types.OnePoStProofPartition.ProofLen()
+	p := MakeRandomBytes(proofSize)
 	p[0] = 42
-	var postProof types.PoStProof
+	postProof := make([]byte, proofSize)
 	for idx, elem := range p {
 		postProof[idx] = elem
 	}

--- a/testhelpers/consensus.go
+++ b/testhelpers/consensus.go
@@ -80,8 +80,8 @@ func (tv *TestPowerTableView) HasPower(ctx context.Context, st state.Tree, bstor
 // NewValidTestBlockFromTipSet creates a block for when proofs & power table don't need
 // to be correct
 func NewValidTestBlockFromTipSet(baseTipSet types.TipSet, stateRootCid cid.Cid, height uint64, minerAddr address.Address, minerPubKey []byte, signer consensus.TicketSigner) *types.Block {
-	postProof := MakeRandomPoSTProofForTest()
-	ticket, _ := consensus.CreateTicket(postProof, minerPubKey, signer)
+	poStProof := MakeRandomPoSTProofForTest()
+	ticket, _ := consensus.CreateTicket(poStProof, minerPubKey, signer)
 
 	return &types.Block{
 		Miner:        minerAddr,
@@ -91,7 +91,7 @@ func NewValidTestBlockFromTipSet(baseTipSet types.TipSet, stateRootCid cid.Cid, 
 		Height:       types.Uint64(height),
 		Nonce:        types.Uint64(height),
 		StateRoot:    stateRootCid,
-		Proof:        postProof,
+		Proof:        poStProof,
 	}
 }
 
@@ -100,11 +100,11 @@ func MakeRandomPoSTProofForTest() []byte {
 	proofSize := types.OnePoStProofPartition.ProofLen()
 	p := MakeRandomBytes(proofSize)
 	p[0] = 42
-	postProof := make([]byte, proofSize)
+	poStProof := make([]byte, proofSize)
 	for idx, elem := range p {
-		postProof[idx] = elem
+		poStProof[idx] = elem
 	}
-	return postProof
+	return poStProof
 }
 
 // TestSignedMessageValidator is a validator that doesn't validate to simplify message creation in tests.

--- a/types/commitments.go
+++ b/types/commitments.go
@@ -16,23 +16,11 @@ type Commitments struct {
 	CommRStar CommRStar
 }
 
-// PoStBytesLen is the length of the Proof of SpaceTime proof.
-const PoStBytesLen uint = 192
-
-// SealBytesLen is the length of the proof of Seal Proof of Replication.
-const SealBytesLen uint = 384
-
 // PoStChallengeSeedBytesLen is the number of bytes in the Proof of SpaceTime challenge seed.
 const PoStChallengeSeedBytesLen uint = 32
 
 // CommitmentBytesLen is the number of bytes in a CommR, CommD, CommP, and CommRStar.
 const CommitmentBytesLen uint = 32
-
-// PoStProof is the byte representation of the Proof of SpaceTime proof
-type PoStProof [PoStBytesLen]byte
-
-// SealProof is the byte representation of the Seal Proof of Replication
-type SealProof [SealBytesLen]byte
 
 // PoStChallengeSeed is an input to the proof-of-spacetime generation and verification methods.
 type PoStChallengeSeed [PoStChallengeSeedBytesLen]byte

--- a/types/porep_proof_partitions.go
+++ b/types/porep_proof_partitions.go
@@ -7,7 +7,7 @@ const (
 	TwoPoRepProofPartitions
 )
 
-func (p PoRepProofPartitions) Int() int {
+func (p PoRepProofPartitions) Uint8() uint8 {
 	switch p {
 	case TwoPoRepProofPartitions:
 		return 2

--- a/types/porep_proof_partitions.go
+++ b/types/porep_proof_partitions.go
@@ -1,5 +1,7 @@
 package types
 
+import "fmt"
+
 type PoRepProofPartitions int
 
 const (
@@ -13,7 +15,7 @@ func (p PoRepProofPartitions) Int() int {
 	case TwoPoRepProofPartitions:
 		return 2
 	default:
-		return 0
+		panic(fmt.Sprintf("unexpected value %v", p))
 	}
 }
 
@@ -24,17 +26,17 @@ func (p PoRepProofPartitions) ProofLen() int {
 	case TwoPoRepProofPartitions:
 		return SinglePartitionProofLen * 2
 	default:
-		return 0
+		panic(fmt.Sprintf("unexpected value %v", p))
 	}
 }
 
 // NewPoRepProofPartitions produces the PoRepProofPartitions corresponding to
 // the provided integer.
-func NewPoRepProofPartitions(partitions int) PoRepProofPartitions {
-	switch partitions {
+func NewPoRepProofPartitions(numPartitions int) PoRepProofPartitions {
+	switch numPartitions {
 	case 2:
 		return TwoPoRepProofPartitions
 	default:
-		return UnknownPoRepProofPartitions
+		panic(fmt.Sprintf("unexpected value %v", numPartitions))
 	}
 }

--- a/types/porep_proof_partitions.go
+++ b/types/porep_proof_partitions.go
@@ -7,6 +7,7 @@ const (
 	TwoPoRepProofPartitions
 )
 
+// Int returns an integer representing the number of PoRep partitions
 func (p PoRepProofPartitions) Int() int {
 	switch p {
 	case TwoPoRepProofPartitions:
@@ -16,6 +17,8 @@ func (p PoRepProofPartitions) Int() int {
 	}
 }
 
+// ProofLen returns an integer representing the number of bytes in a PoRep proof
+// created with this number of partitions.
 func (p PoRepProofPartitions) ProofLen() int {
 	switch p {
 	case TwoPoRepProofPartitions:
@@ -25,6 +28,8 @@ func (p PoRepProofPartitions) ProofLen() int {
 	}
 }
 
+// NewPoRepProofPartitions produces the PoRepProofPartitions corresponding to
+// the provided integer.
 func NewPoRepProofPartitions(partitions int) PoRepProofPartitions {
 	switch partitions {
 	case 2:

--- a/types/porep_proof_partitions.go
+++ b/types/porep_proof_partitions.go
@@ -7,7 +7,7 @@ const (
 	TwoPoRepProofPartitions
 )
 
-func (p PoRepProofPartitions) Uint8() uint8 {
+func (p PoRepProofPartitions) Int() int {
 	switch p {
 	case TwoPoRepProofPartitions:
 		return 2

--- a/types/porep_proof_partitions.go
+++ b/types/porep_proof_partitions.go
@@ -1,8 +1,35 @@
 package types
 
-type PoRepProofPartitions uint64
+type PoRepProofPartitions int
 
 const (
-	TestPoRepProofPartitions = PoRepProofPartitions(iota)
-	TwoPoRepPartitions
+	UnknownPoRepProofPartitions = PoRepProofPartitions(iota)
+	TwoPoRepProofPartitions
 )
+
+func (p PoRepProofPartitions) Int() int {
+	switch p {
+	case TwoPoRepProofPartitions:
+		return 2
+	default:
+		return 0
+	}
+}
+
+func (p PoRepProofPartitions) ProofLen() int {
+	switch p {
+	case TwoPoRepProofPartitions:
+		return SinglePartitionProofLen * 2
+	default:
+		return 0
+	}
+}
+
+func NewPoRepProofPartitions(partitions int) PoRepProofPartitions {
+	switch partitions {
+	case 2:
+		return TwoPoRepProofPartitions
+	default:
+		return UnknownPoRepProofPartitions
+	}
+}

--- a/types/porep_proof_partitions.go
+++ b/types/porep_proof_partitions.go
@@ -1,6 +1,10 @@
 package types
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
 
 type PoRepProofPartitions int
 
@@ -32,11 +36,11 @@ func (p PoRepProofPartitions) ProofLen() int {
 
 // NewPoRepProofPartitions produces the PoRepProofPartitions corresponding to
 // the provided integer.
-func NewPoRepProofPartitions(numPartitions int) PoRepProofPartitions {
+func NewPoRepProofPartitions(numPartitions int) (PoRepProofPartitions, error) {
 	switch numPartitions {
 	case 2:
-		return TwoPoRepProofPartitions
+		return TwoPoRepProofPartitions, nil
 	default:
-		panic(fmt.Sprintf("unexpected value %v", numPartitions))
+		return UnknownPoRepProofPartitions, errors.Errorf("unexpected value %v", numPartitions)
 	}
 }

--- a/types/post_proof_partitions.go
+++ b/types/post_proof_partitions.go
@@ -7,7 +7,7 @@ const (
 	OnePoStProofPartition
 )
 
-func (p PoStProofPartitions) Int() int {
+func (p PoStProofPartitions) Uint8() uint8 {
 	switch p {
 	case OnePoStProofPartition:
 		return 1

--- a/types/post_proof_partitions.go
+++ b/types/post_proof_partitions.go
@@ -1,6 +1,9 @@
 package types
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/pkg/errors"
+)
 
 type PoStProofPartitions int
 
@@ -32,11 +35,11 @@ func (p PoStProofPartitions) ProofLen() int {
 
 // NewPoStProofPartitions produces the PoStProofPartitions corresponding to the
 // provided integer.
-func NewPoStProofPartitions(numPartitions int) PoStProofPartitions {
+func NewPoStProofPartitions(numPartitions int) (PoStProofPartitions, error) {
 	switch numPartitions {
 	case 1:
-		return OnePoStProofPartition
+		return OnePoStProofPartition, nil
 	default:
-		panic(fmt.Sprintf("unexpected value %v", numPartitions))
+		return UnknownPoStProofPartitions, errors.Errorf("unexpected value %v", numPartitions)
 	}
 }

--- a/types/post_proof_partitions.go
+++ b/types/post_proof_partitions.go
@@ -7,6 +7,7 @@ const (
 	OnePoStProofPartition
 )
 
+// Int returns an integer representing the number of PoSt partitions
 func (p PoStProofPartitions) Int() int {
 	switch p {
 	case OnePoStProofPartition:
@@ -16,6 +17,8 @@ func (p PoStProofPartitions) Int() int {
 	}
 }
 
+// ProofLen returns an integer representing the number of bytes in a PoSt proof
+// created with this number of partitions.
 func (p PoStProofPartitions) ProofLen() int {
 	switch p {
 	case OnePoStProofPartition:
@@ -25,6 +28,8 @@ func (p PoStProofPartitions) ProofLen() int {
 	}
 }
 
+// NewPoStProofPartitions produces the PoStProofPartitions corresponding to the
+// provided integer.
 func NewPoStProofPartitions(partitions int) PoStProofPartitions {
 	switch partitions {
 	case 1:

--- a/types/post_proof_partitions.go
+++ b/types/post_proof_partitions.go
@@ -1,8 +1,35 @@
 package types
 
-type PoStProofPartitions uint64
+type PoStProofPartitions int
 
 const (
-	TestPoStPartitions = PoStProofPartitions(iota)
-	OnePoStPartition
+	UnknownPoStProofPartitions = PoStProofPartitions(iota)
+	OnePoStProofPartition
 )
+
+func (p PoStProofPartitions) Int() int {
+	switch p {
+	case OnePoStProofPartition:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func (p PoStProofPartitions) ProofLen() int {
+	switch p {
+	case OnePoStProofPartition:
+		return SinglePartitionProofLen
+	default:
+		return 0
+	}
+}
+
+func NewPoStProofPartitions(partitions int) PoStProofPartitions {
+	switch partitions {
+	case 1:
+		return OnePoStProofPartition
+	default:
+		return UnknownPoStProofPartitions
+	}
+}

--- a/types/post_proof_partitions.go
+++ b/types/post_proof_partitions.go
@@ -1,5 +1,7 @@
 package types
 
+import "fmt"
+
 type PoStProofPartitions int
 
 const (
@@ -13,7 +15,7 @@ func (p PoStProofPartitions) Int() int {
 	case OnePoStProofPartition:
 		return 1
 	default:
-		return 0
+		panic(fmt.Sprintf("unexpected value %v", p))
 	}
 }
 
@@ -24,17 +26,17 @@ func (p PoStProofPartitions) ProofLen() int {
 	case OnePoStProofPartition:
 		return SinglePartitionProofLen
 	default:
-		return 0
+		panic(fmt.Sprintf("unexpected value %v", p))
 	}
 }
 
 // NewPoStProofPartitions produces the PoStProofPartitions corresponding to the
 // provided integer.
-func NewPoStProofPartitions(partitions int) PoStProofPartitions {
-	switch partitions {
+func NewPoStProofPartitions(numPartitions int) PoStProofPartitions {
+	switch numPartitions {
 	case 1:
 		return OnePoStProofPartition
 	default:
-		return UnknownPoStProofPartitions
+		panic(fmt.Sprintf("unexpected value %v", numPartitions))
 	}
 }

--- a/types/post_proof_partitions.go
+++ b/types/post_proof_partitions.go
@@ -7,7 +7,7 @@ const (
 	OnePoStProofPartition
 )
 
-func (p PoStProofPartitions) Uint8() uint8 {
+func (p PoStProofPartitions) Int() int {
 	switch p {
 	case OnePoStProofPartition:
 		return 1

--- a/types/proofs.go
+++ b/types/proofs.go
@@ -1,6 +1,8 @@
 package types
 
-import "fmt"
+import (
+	"github.com/pkg/errors"
+)
 
 // SinglePartitionProofLen represents the number of bytes in a single partition
 // PoRep or PoSt proof. The total length of a PoSt or PoRep proof equals the
@@ -14,24 +16,24 @@ type PoStProof []byte
 type PoRepProof []byte
 
 // ProofPartitions returns the number of partitions used to create the PoRep
-// proof.
-func (s PoRepProof) ProofPartitions() PoRepProofPartitions {
+// proof, or an error if the PoRep proof has an unsupported length.
+func (s PoRepProof) ProofPartitions() (PoRepProofPartitions, error) {
 	n := len(s)
 
 	if n%SinglePartitionProofLen != 0 {
-		panic(fmt.Sprintf("unexpected value %v", n))
+		return UnknownPoRepProofPartitions, errors.Errorf("invalid PoRep proof length %d", n)
 	}
 
 	return NewPoRepProofPartitions(n / SinglePartitionProofLen)
 }
 
 // ProofPartitions returns the number of partitions used to create the PoSt
-// proof.
-func (s PoStProof) ProofPartitions() PoStProofPartitions {
+// proof, or an error if the PoSt proof has an unsupported length.
+func (s PoStProof) ProofPartitions() (PoStProofPartitions, error) {
 	n := len(s)
 
 	if n%SinglePartitionProofLen != 0 {
-		panic(fmt.Sprintf("unexpected value %v", n))
+		return UnknownPoStProofPartitions, errors.Errorf("invalid PoSt proof length %d", n)
 	}
 
 	return NewPoStProofPartitions(n / SinglePartitionProofLen)

--- a/types/proofs.go
+++ b/types/proofs.go
@@ -1,0 +1,24 @@
+package types
+
+// SinglePartitionProofLen represents the number of bytes in a single partition
+// PoRep or PoSt proof. The total length of a PoSt or PoRep proof equals the
+// product of SinglePartitionProofLen and the number of partitions.
+const SinglePartitionProofLen int = 192
+
+// PoStProof is the byte representation of the Proof of SpaceTime proof
+type PoStProof []byte
+
+// PoRepProof is the byte representation of the Seal Proof of Replication
+type PoRepProof []byte
+
+// ProofPartitions returns the number of partitions used to create the PoRep
+// proof.
+func (s PoRepProof) ProofPartitions() PoRepProofPartitions {
+	return NewPoRepProofPartitions(len(s) / SinglePartitionProofLen)
+}
+
+// ProofPartitions returns the number of partitions used to create the PoSt
+// proof.
+func (s PoStProof) ProofPartitions() PoStProofPartitions {
+	return NewPoStProofPartitions(len(s) / SinglePartitionProofLen)
+}

--- a/types/proofs.go
+++ b/types/proofs.go
@@ -1,5 +1,7 @@
 package types
 
+import "fmt"
+
 // SinglePartitionProofLen represents the number of bytes in a single partition
 // PoRep or PoSt proof. The total length of a PoSt or PoRep proof equals the
 // product of SinglePartitionProofLen and the number of partitions.
@@ -14,11 +16,23 @@ type PoRepProof []byte
 // ProofPartitions returns the number of partitions used to create the PoRep
 // proof.
 func (s PoRepProof) ProofPartitions() PoRepProofPartitions {
-	return NewPoRepProofPartitions(len(s) / SinglePartitionProofLen)
+	n := len(s)
+
+	if n%SinglePartitionProofLen != 0 {
+		panic(fmt.Sprintf("unexpected value %v", n))
+	}
+
+	return NewPoRepProofPartitions(n / SinglePartitionProofLen)
 }
 
 // ProofPartitions returns the number of partitions used to create the PoSt
 // proof.
 func (s PoStProof) ProofPartitions() PoStProofPartitions {
-	return NewPoStProofPartitions(len(s) / SinglePartitionProofLen)
+	n := len(s)
+
+	if n%SinglePartitionProofLen != 0 {
+		panic(fmt.Sprintf("unexpected value %v", n))
+	}
+
+	return NewPoStProofPartitions(n / SinglePartitionProofLen)
 }

--- a/types/sector_class.go
+++ b/types/sector_class.go
@@ -3,7 +3,7 @@ package types
 // SectorClass represents the miner's chosen sector size and PoSt/seal proof
 // partitions.
 type SectorClass struct {
-	postProofPartitions  PoStProofPartitions
+	poStProofPartitions  PoStProofPartitions
 	poRepProofPartitions PoRepProofPartitions
 	sectorSize           SectorSize
 }
@@ -12,7 +12,7 @@ type SectorClass struct {
 func NewTestSectorClass() SectorClass {
 	return SectorClass{
 		poRepProofPartitions: TwoPoRepProofPartitions,
-		postProofPartitions:  OnePoStProofPartition,
+		poStProofPartitions:  OnePoStProofPartition,
 		sectorSize:           OneKiBSectorSize,
 	}
 }
@@ -21,7 +21,7 @@ func NewTestSectorClass() SectorClass {
 // go-filecoin node.
 func NewLiveSectorClass() SectorClass {
 	return SectorClass{
-		postProofPartitions:  OnePoStProofPartition,
+		poStProofPartitions:  OnePoStProofPartition,
 		poRepProofPartitions: TwoPoRepProofPartitions,
 		sectorSize:           TwoHundredFiftySixMiBSectorSize,
 	}
@@ -34,7 +34,7 @@ func (sc *SectorClass) PoRepProofPartitions() PoRepProofPartitions {
 
 // PoStProofPartitions returns the sector class's PoSt proof partitions
 func (sc *SectorClass) PoStProofPartitions() PoStProofPartitions {
-	return sc.postProofPartitions
+	return sc.poStProofPartitions
 }
 
 // SectorSize returns the size of this sector class's sectors after bit-padding

--- a/types/sector_class.go
+++ b/types/sector_class.go
@@ -11,8 +11,8 @@ type SectorClass struct {
 // NewTestSectorClass returns a SectorClass suitable for testing.
 func NewTestSectorClass() SectorClass {
 	return SectorClass{
-		poRepProofPartitions: TestPoRepProofPartitions,
-		postProofPartitions:  TestPoStPartitions,
+		poRepProofPartitions: TwoPoRepProofPartitions,
+		postProofPartitions:  OnePoStProofPartition,
 		sectorSize:           OneKiBSectorSize,
 	}
 }
@@ -21,8 +21,8 @@ func NewTestSectorClass() SectorClass {
 // go-filecoin node.
 func NewLiveSectorClass() SectorClass {
 	return SectorClass{
-		postProofPartitions:  OnePoStPartition,
-		poRepProofPartitions: TwoPoRepPartitions,
+		postProofPartitions:  OnePoStProofPartition,
+		poRepProofPartitions: TwoPoRepProofPartitions,
 		sectorSize:           TwoHundredFiftySixMiBSectorSize,
 	}
 }

--- a/types/sector_class.go
+++ b/types/sector_class.go
@@ -21,8 +21,8 @@ func NewTestSectorClass() SectorClass {
 // go-filecoin node.
 func NewLiveSectorClass() SectorClass {
 	return SectorClass{
-		poStProofPartitions:  OnePoStProofPartition,
 		poRepProofPartitions: TwoPoRepProofPartitions,
+		poStProofPartitions:  OnePoStProofPartition,
 		sectorSize:           TwoHundredFiftySixMiBSectorSize,
 	}
 }

--- a/types/sector_size.go
+++ b/types/sector_size.go
@@ -1,5 +1,7 @@
 package types
 
+import "fmt"
+
 // SectorSize is the amount of bytes in a sector. This amount will be slightly
 // greater than the number of user bytes which can be written to a sector due to
 // bit-padding.
@@ -20,6 +22,6 @@ func (s SectorSize) Uint64() uint64 {
 	case TwoHundredFiftySixMiBSectorSize:
 		return 1 << 28
 	default:
-		return 0
+		panic(fmt.Sprintf("unexpected value %v", s))
 	}
 }

--- a/types/sector_size.go
+++ b/types/sector_size.go
@@ -11,6 +11,8 @@ const (
 	TwoHundredFiftySixMiBSectorSize
 )
 
+// Uint64 produces the number of bytes which the miner will get power for when
+// committing a sector of this size to the network.
 func (s SectorSize) Uint64() uint64 {
 	switch s {
 	case OneKiBSectorSize:

--- a/types/sector_size.go
+++ b/types/sector_size.go
@@ -18,7 +18,7 @@ func (s SectorSize) Uint64() uint64 {
 	case OneKiBSectorSize:
 		return 1024
 	case TwoHundredFiftySixMiBSectorSize:
-		return 266338304
+		return 1 << 28
 	default:
 		return 0
 	}

--- a/types/sector_size.go
+++ b/types/sector_size.go
@@ -3,9 +3,21 @@ package types
 // SectorSize is the amount of bytes in a sector. This amount will be slightly
 // greater than the number of user bytes which can be written to a sector due to
 // bit-padding.
-type SectorSize uint64
+type SectorSize int
 
 const (
-	OneKiBSectorSize = SectorSize(iota)
+	UnknownSectorSize = SectorSize(iota)
+	OneKiBSectorSize
 	TwoHundredFiftySixMiBSectorSize
 )
+
+func (s SectorSize) Uint64() uint64 {
+	switch s {
+	case OneKiBSectorSize:
+		return 1024
+	case TwoHundredFiftySixMiBSectorSize:
+		return 266338304
+	default:
+		return 0
+	}
+}

--- a/types/testing.go
+++ b/types/testing.go
@@ -16,9 +16,8 @@ import (
 )
 
 // NewTestPoSt creates a trivial, right-sized byte slice for a Proof of Spacetime.
-func NewTestPoSt() [192]byte {
-	var newProof [192]byte
-	return newProof
+func NewTestPoSt() []byte {
+	return make([]byte, OnePoStProofPartition.ProofLen())
 }
 
 // MockRecoverer implements the Recoverer interface


### PR DESCRIPTION
Blocked by [this upstream rust-fil-proofs PR](https://github.com/filecoin-project/rust-fil-proofs/pull/623).

Fixes #2591.

## Why's this PR needed?

Miners can choose proof partitions in order to trade off between RAM usage and on-chain proof size. What this means for go-filecoin is that the number of bytes in a PoSt or PoRep proof is no longer fixed.

## What's in this PR?

- Make PoSt and PoRep (seal) proofs `[]byte` instead of `[192]byte` and `[384]byte`
- **BREAKING CHANGE**: JSON encode the `types.PoStProof` in the `types.Block`, using [the default encoder](https://golang.org/pkg/encoding/json/#Marshal). This will produce a base64-encoded string (or null) instead of a JSON array.