### PR TITLE
FAST IPTB streaming

### DIFF
--- a/tools/fast/action_chain.go
+++ b/tools/fast/action_chain.go
@@ -2,7 +2,6 @@ package fast
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/ipfs/go-cid"
 )
@@ -18,6 +17,6 @@ func (f *Filecoin) ChainHead(ctx context.Context) ([]cid.Cid, error) {
 }
 
 // ChainLs runs the chain ls command against the filecoin process.
-func (f *Filecoin) ChainLs(ctx context.Context) (*json.Decoder, error) {
+func (f *Filecoin) ChainLs(ctx context.Context) (DecodeCloser, error) {
 	return f.RunCmdLDJSONWithStdin(ctx, nil, "go-filecoin", "chain", "ls")
 }

--- a/tools/fast/action_client.go
+++ b/tools/fast/action_client.go
@@ -2,7 +2,6 @@ package fast
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -62,6 +61,6 @@ func (f *Filecoin) ClientQueryStorageDeal(ctx context.Context, prop cid.Cid) (*s
 
 // ClientListAsks runs the client list-asks command against the filecoin process.
 // A json decoer is returned that asks may be decoded from.
-func (f *Filecoin) ClientListAsks(ctx context.Context) (*json.Decoder, error) {
+func (f *Filecoin) ClientListAsks(ctx context.Context) (DecodeCloser, error) {
 	return f.RunCmdLDJSONWithStdin(ctx, nil, "go-filecoin", "client", "list-asks")
 }

--- a/tools/fast/action_retrieval_client.go
+++ b/tools/fast/action_retrieval_client.go
@@ -15,5 +15,23 @@ func (f *Filecoin) RetrievalClientRetrievePiece(ctx context.Context, pieceCID ci
 	if err != nil {
 		return nil, err
 	}
-	return out.Stdout(), nil
+
+	stdout := out.Stdout()
+
+	rc := &readCloser{
+		r: stdout,
+		closer: func() error {
+			if err := stdout.Close(); err != nil {
+				return err
+			}
+
+			if err := getOutputError(out); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	return rc, nil
 }

--- a/tools/fast/process.go
+++ b/tools/fast/process.go
@@ -1,16 +1,19 @@
 package fast
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 
 	logging "github.com/ipfs/go-log"
 	iptb "github.com/ipfs/iptb/testbed"
 	"github.com/ipfs/iptb/testbed/interfaces"
 	"github.com/libp2p/go-libp2p-peer"
+	"golang.org/x/sync/errgroup"
 
 	fcconfig "github.com/filecoin-project/go-filecoin/config"
 	"github.com/filecoin-project/go-filecoin/tools/fast/fastutil"
@@ -182,6 +185,145 @@ func (f *Filecoin) DumpLastOutputJSON(w io.Writer) {
 	}
 }
 
+// outputMirror is used to store a copy of output lazily
+type outputMirror struct {
+	args     []string
+	err      error
+	exitcode int
+
+	stdout bytes.Buffer
+	stderr bytes.Buffer
+}
+
+func (o *outputMirror) Args() []string {
+	return o.args
+}
+
+func (o *outputMirror) Error() error {
+	return o.err
+}
+
+func (o *outputMirror) ExitCode() int {
+	return o.exitcode
+}
+
+func (o *outputMirror) Stdout() io.ReadCloser {
+	return ioutil.NopCloser(&o.stdout)
+}
+
+func (o *outputMirror) Stderr() io.ReadCloser {
+	return ioutil.NopCloser(&o.stderr)
+}
+
+type output struct {
+	out      testbedi.Output
+	mirrored *outputMirror
+
+	stdout io.ReadCloser
+	stderr io.ReadCloser
+}
+
+// newOutput is used to wrap an output mirring data read from stdout / stderr to the outputMirror
+func newOutput(out testbedi.Output) *output {
+	lastOutput := &outputMirror{}
+	lastOutput.args = out.Args()
+
+	// outputMirror contains a bytes.Buffer which we want to mirror any data read
+	// from the output.Stdxxx() to be written too. To do this we use a TeeReader
+	// which will write any data read from its reader to the writer. We want to
+	// limit the amount of data that is mirred, as it's primarily a debug tool,
+	// and we don't want to store a large file when performing actions such as
+	// client cat, or retrieval-client retrieve-piece.
+	wstdout := limitWriter(&lastOutput.stdout, 1024)
+	wstderr := limitWriter(&lastOutput.stderr, 1024)
+
+	stdout := out.Stdout()
+	stderr := out.Stderr()
+
+	rstdout := io.TeeReader(stdout, wstdout)
+	rstderr := io.TeeReader(stderr, wstderr)
+
+	return &output{
+		out:      out,
+		mirrored: lastOutput,
+		stdout: &readCloser{
+			r: rstdout,
+			closer: func() error {
+				return stdout.Close()
+			},
+		},
+		stderr: &readCloser{
+			r: rstderr,
+			closer: func() error {
+				return stderr.Close()
+			},
+		},
+	}
+}
+
+func (o *output) Args() []string {
+	o.mirrored.args = o.out.Args()
+	return o.mirrored.args
+}
+
+func (o *output) Error() error {
+	o.mirrored.err = o.out.Error()
+	return o.mirrored.err
+}
+
+func (o *output) ExitCode() int {
+	o.mirrored.exitcode = o.out.ExitCode()
+	return o.mirrored.exitcode
+}
+
+func (o *output) Stdout() io.ReadCloser {
+	return o.stdout
+}
+
+func (o *output) Stderr() io.ReadCloser {
+	return o.stderr
+}
+
+type limitedWriter struct {
+	w io.Writer
+	n int64
+}
+
+// Like io.LimitReader, but limits how much is written. The same effect can be
+// done with io.Pipe and a LimitReader, but requires a go-routine and some redirection
+// to dump data as the pipes are synchronous.
+func limitWriter(w io.Writer, n int64) io.Writer {
+	return &limitedWriter{w, n}
+}
+
+func (l *limitedWriter) Write(b []byte) (int, error) {
+	if l.n <= 0 {
+		return len(b), nil
+	}
+
+	if int64(len(b)) > l.n {
+		b = b[0:l.n]
+	}
+
+	n, err := l.w.Write(b)
+	l.n -= int64(n)
+	return n, err
+}
+
+// io.TeeReader remove the Closer from our reader, so we need to wrap it again
+type readCloser struct {
+	r      io.Reader
+	closer func() error
+}
+
+func (rc *readCloser) Read(b []byte) (int, error) {
+	return rc.r.Read(b)
+}
+
+func (rc *readCloser) Close() error {
+	return rc.closer()
+}
+
 // RunCmdWithStdin runs `args` against Filecoin process `f`, a testbedi.Output and an error are returned.
 func (f *Filecoin) RunCmdWithStdin(ctx context.Context, stdin io.Reader, args ...string) (testbedi.Output, error) {
 	if ctx == nil {
@@ -193,45 +335,98 @@ func (f *Filecoin) RunCmdWithStdin(ctx context.Context, stdin io.Reader, args ..
 		return nil, err
 	}
 
-	f.lastCmdOutput = out
-	return out, nil
+	output := newOutput(out)
+	f.lastCmdOutput = output.mirrored
+	return output, nil
 }
 
 // RunCmdJSONWithStdin runs `args` against Filecoin process `f`. The '--enc=json' flag
 // is appened to the command specified by `args`, the result of the command is marshaled into `v`.
 func (f *Filecoin) RunCmdJSONWithStdin(ctx context.Context, stdin io.Reader, v interface{}, args ...string) error {
 	args = append(args, "--enc=json")
-	out, err := f.RunCmdWithStdin(ctx, stdin, args...)
+	output, err := f.RunCmdWithStdin(ctx, stdin, args...)
 	if err != nil {
 		return err
 	}
 
-	// check command exit code
-	if out.ExitCode() > 0 {
-		return fmt.Errorf("filecoin command: %s, exited with non-zero exitcode: %d", out.Args(), out.ExitCode())
+	// To get an exit code the process must have exited.
+	// For the process to exit, we have to read all of the stdout / stderr, as
+	// the process may be blocked from finishing if the kernel buffer fills.
+	g, _ := errgroup.WithContext(ctx)
+
+	stdout := output.Stdout()
+	stderr := output.Stderr()
+
+	var bstdout []byte
+
+	g.Go(func() (err error) {
+		_, err = ioutil.ReadAll(stderr)
+		return
+	})
+
+	g.Go(func() (err error) {
+		bstdout, err = ioutil.ReadAll(stdout)
+		return
+	})
+
+	if err := g.Wait(); err != nil {
+		return err
 	}
 
-	dec := json.NewDecoder(out.Stdout())
-	return dec.Decode(v)
+	if err := getOutputError(output); err != nil {
+		return err
+	}
+
+	return json.Unmarshal(bstdout, &v)
+}
+
+type DecodeCloser interface {
+	Decode(v interface{}) error
+	Close() error
+}
+
+type decoderCloser struct {
+	d      *json.Decoder
+	closer func() error
+}
+
+func (dc *decoderCloser) Decode(v interface{}) error {
+	return dc.d.Decode(v)
+}
+
+func (dc *decoderCloser) Close() error {
+	return dc.closer()
 }
 
 // RunCmdLDJSONWithStdin runs `args` against Filecoin process `f`. The '--enc=json' flag
 // is appened to the command specified by `args`. The result of the command is returned
 // as a json.Decoder that may be used to read and decode JSON values from the result of
 // the command.
-func (f *Filecoin) RunCmdLDJSONWithStdin(ctx context.Context, stdin io.Reader, args ...string) (*json.Decoder, error) {
+func (f *Filecoin) RunCmdLDJSONWithStdin(ctx context.Context, stdin io.Reader, args ...string) (DecodeCloser, error) {
 	args = append(args, "--enc=json")
 	out, err := f.RunCmdWithStdin(ctx, stdin, args...)
 	if err != nil {
 		return nil, err
 	}
 
-	// check command exit code
-	if out.ExitCode() > 0 {
-		return nil, fmt.Errorf("filecoin command: %s, exited with non-zero exitcode: %d", out.Args(), out.ExitCode())
+	stdout := out.Stdout()
+
+	dec := json.NewDecoder(stdout)
+	closer := func() error {
+		if err := stdout.Close(); err != nil {
+			return err
+		}
+
+		if err := getOutputError(out); err != nil {
+			return err
+		}
+
+		return nil
 	}
 
-	return json.NewDecoder(out.Stdout()), nil
+	dc := &decoderCloser{dec, closer}
+
+	return dc, nil
 }
 
 // Config return the config file of the FAST process.
@@ -251,4 +446,15 @@ func (f *Filecoin) Config() (*fcconfig.Config, error) {
 // WriteConfig writes the config `cgf` to the FAST process's repo.
 func (f *Filecoin) WriteConfig(cfg *fcconfig.Config) error {
 	return f.core.WriteConfig(cfg)
+}
+
+func getOutputError(output testbedi.Output) error {
+	exitcode := output.ExitCode()
+	if exitcode > 0 {
+		return fmt.Errorf("filecoin command: %s, exited with non-zero exitcode: %d", output.Args(), exitcode)
+	} else if exitcode == -1 {
+		return output.Error()
+	}
+
+	return nil
 }

--- a/tools/fast/series/set_price_ask.go
+++ b/tools/fast/series/set_price_ask.go
@@ -56,6 +56,10 @@ func SetPriceGetAsk(ctx context.Context, miner *fast.Filecoin, price *big.Float,
 		}
 
 		if err == io.EOF {
+			if err := dec.Close(); err != nil {
+				return porcelain.Ask{}, err
+			}
+
 			break
 		}
 	}

--- a/tools/fast/tests/retrieval_test.go
+++ b/tools/fast/tests/retrieval_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 
@@ -84,6 +85,10 @@ func TestRetrieval(t *testing.T) {
 
 	client, err := env.NewProcess(ctx, localplugin.PluginName, options, fastenvOpts)
 	require.NoError(err)
+
+	defer client.DumpLastOutput(os.Stdout)
+	defer genesis.DumpLastOutput(os.Stdout)
+	defer miner.DumpLastOutput(os.Stdout)
 
 	// Start setting up the nodes
 	// Setup Genesis

--- a/tools/iptb-plugins/filecoin/local/filecoinutil.go
+++ b/tools/iptb-plugins/filecoin/local/filecoinutil.go
@@ -1,7 +1,6 @@
 package pluginlocalfilecoin
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -95,22 +94,13 @@ func (l *Localfilecoin) GetPeerID() (cid.Cid, error) {
 		return cid.Undef, err
 	}
 
-	if out.ExitCode() != 0 {
-		return cid.Undef, errors.New("Could not get PeerID, non-zero exit code")
+	stdout, stderr, err := readAllOutput(context.Background(), out)
+	if err != nil {
+		return cid.Undef, errors.Wrapf(err, string(stderr))
 	}
 
-	_, err = io.Copy(os.Stdout, out.Stderr())
-	if err != nil {
-		return cid.Undef, err
-	}
-
-	// convert the reader to a string TODO this is annoying
-	buf := new(bytes.Buffer)
-	_, err = buf.ReadFrom(out.Stdout())
-	if err != nil {
-		return cid.Undef, err
-	}
-	cidStr := strings.TrimSpace(buf.String())
+	rawcid := string(stdout)
+	cidStr := strings.TrimSpace(rawcid)
 
 	// decode the parsed string to a cid...maybe
 	return cid.Decode(cidStr)

--- a/tools/iptb-plugins/filecoin/local/output.go
+++ b/tools/iptb-plugins/filecoin/local/output.go
@@ -1,0 +1,75 @@
+package pluginlocalfilecoin
+
+import (
+	"context"
+	"io"
+	"os/exec"
+)
+
+type Output struct {
+	args     []string
+	err      error
+	exitcode int
+	exitset  bool
+
+	ctx context.Context
+
+	cmd *exec.Cmd
+
+	stdout io.ReadCloser
+	stderr io.ReadCloser
+}
+
+func (o *Output) Args() []string {
+	return o.args
+}
+
+func (o *Output) Error() error {
+	return o.err
+}
+
+func (o *Output) ExitCode() (exitcode int) {
+	defer func() {
+		o.exitset = true
+		exitcode = o.exitcode
+	}()
+
+	if o.exitset {
+		return
+	}
+
+	if o.err != nil {
+		o.exitcode = -1
+		return
+	}
+
+	exiterr := o.cmd.Wait()
+
+	// The command may exit because the deadline was exceeded while it was running
+	if o.ctx.Err() == context.DeadlineExceeded {
+		o.err = context.DeadlineExceeded
+		o.exitcode = -1
+		return
+	}
+
+	switch err := exiterr.(type) {
+	case *exec.ExitError:
+		o.exitcode = 1
+		return
+	case nil:
+		o.exitcode = 0
+		return
+	default:
+		o.err = err
+		o.exitcode = -1
+		return
+	}
+}
+
+func (o *Output) Stdout() io.ReadCloser {
+	return o.stdout
+}
+
+func (o *Output) Stderr() io.ReadCloser {
+	return o.stderr
+}


### PR DESCRIPTION
This still uses the `cmd.StdnnnPipe()` as I think the issue I was covering in #1701 around this isn't so much an issue because we have to read everything before Wait anyways. It will become clearer I think now. However, moving the buffering out of the plugin required a lot of stuff to move around as we can't call `ExitCode` before reading any output. This changed a few things around actions which used `RunCmdWithStdin` directly and `RunCmdLDJSONWithStdin`.

To around around this issue, I've made `RetrievalClientRetrievePiece` use the `io.ReadCloser` to fetch the exit code, and added a new interface `DecodeCloser` which exposes a `Decode` and `Close` method for use with LDJSON stuff (list-asks, chain ls, etc). When a user is done with the decode, they can close it to get any errors (error for exit code, or other errors returned by `output.Error()`).


In this Draft PR I'm looking for high level feedback on the interfaces changes / design, or high level implementation details. I'm not looking for any nit feedback as once I get feedback on the overall changes actual implementation may change.
