### PR TITLE
Payment Vouchers should be a first class type issue#2527

### DIFF
--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -392,7 +392,7 @@ func (pb *Actor) Voucher(vmctx exec.VMContext, chid *types.ChannelID, amount *ty
 	ctx := context.Background()
 	storage := vmctx.Storage()
 	payerAddress := vmctx.Message().From
-	var voucher PaymentVoucher
+	var voucher types.PaymentVoucher
 
 	err := withPayerChannelsForReading(ctx, storage, payerAddress, func(byChannelID exec.Lookup) error {
 		var channel *PaymentChannel
@@ -416,7 +416,7 @@ func (pb *Actor) Voucher(vmctx exec.VMContext, chid *types.ChannelID, amount *ty
 		}
 
 		// set voucher
-		voucher = PaymentVoucher{
+		voucher = types.PaymentVoucher{
 			Channel: *chid,
 			Payer:   vmctx.Message().From,
 			Target:  channel.Target,

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -541,7 +541,7 @@ func TestNewPaymentBrokerVoucher(t *testing.T) {
 		assert.NoError(res.ExecutionError)
 		assert.Equal(uint8(0), res.Receipt.ExitCode)
 
-		voucher := PaymentVoucher{}
+		voucher := types.PaymentVoucher{}
 		err = cbor.DecodeInto(res.Receipt.Return[0], &voucher)
 		require.NoError(err)
 

--- a/commands/client.go
+++ b/commands/client.go
@@ -10,10 +10,10 @@ import (
 	"github.com/ipfs/go-ipfs-cmds"
 	"github.com/ipfs/go-ipfs-files"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 var clientCmd = &cmds.Command{
@@ -251,9 +251,9 @@ var paymentsCmd = &cmds.Command{
 
 		return re.Emit(vouchers)
 	},
-	Type: []*paymentbroker.PaymentVoucher{},
+	Type: []*types.PaymentVoucher{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, vouchers []*paymentbroker.PaymentVoucher) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, vouchers []*types.PaymentVoucher) error {
 			if _, err := fmt.Println("Channel\tAmount\tValidAt\tEncoded Voucher"); err != nil {
 				return err
 			}

--- a/commands/payment_channel.go
+++ b/commands/payment_channel.go
@@ -271,7 +271,7 @@ var redeemCmd = &cmds.Command{
 				return err
 			}
 
-			var voucher paymentbroker.PaymentVoucher
+			var voucher types.PaymentVoucher
 			err = cbor.DecodeInto(cborVoucher, &voucher)
 			if err != nil {
 				return err
@@ -294,7 +294,7 @@ var redeemCmd = &cmds.Command{
 			})
 		}
 
-		voucher, err := paymentbroker.DecodeVoucher(req.Arguments[0])
+		voucher, err := types.DecodeVoucher(req.Arguments[0])
 		if err != nil {
 			return err
 		}
@@ -456,7 +456,7 @@ var closeCmd = &cmds.Command{
 				return err
 			}
 
-			var voucher paymentbroker.PaymentVoucher
+			var voucher types.PaymentVoucher
 			err = cbor.DecodeInto(cborVoucher, &voucher)
 			if err != nil {
 				return err
@@ -479,7 +479,7 @@ var closeCmd = &cmds.Command{
 			})
 		}
 
-		voucher, err := paymentbroker.DecodeVoucher(req.Arguments[0])
+		voucher, err := types.DecodeVoucher(req.Arguments[0])
 		if err != nil {
 			return err
 		}

--- a/commands/payment_channel_daemon_test.go
+++ b/commands/payment_channel_daemon_test.go
@@ -182,7 +182,7 @@ func TestPaymentChannelVoucherSuccess(t *testing.T) {
 	voucherStr, err := rsrc.payer.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(rsrc.payerAddr), fast.AOValidAt(voucherValidAt))
 	require.NoError(err)
 
-	voucher, err := paymentbroker.DecodeVoucher(voucherStr)
+	voucher, err := types.DecodeVoucher(voucherStr)
 	require.NoError(err)
 
 	assert.Equal(voucherAmount, &voucher.Amount)

--- a/plumbing/strgdls/store_test.go
+++ b/plumbing/strgdls/store_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"testing"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/plumbing/strgdls"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
@@ -38,7 +37,7 @@ func TestDealStoreRoundTrip(t *testing.T) {
 		Payer:         addressMaker(),
 		Channel:       &channelID,
 		ChannelMsgCid: &channelMessageCid,
-		Vouchers: []*paymentbroker.PaymentVoucher{{
+		Vouchers: []*types.PaymentVoucher{{
 			Channel: channelID,
 			Payer:   clientAddr,
 			Target:  minerAddr,

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -182,7 +182,7 @@ func (a *API) PaymentChannelVoucher(
 	channel *types.ChannelID,
 	amount *types.AttoFIL,
 	validAt *types.BlockHeight,
-) (voucher *paymentbroker.PaymentVoucher, err error) {
+) (voucher *types.PaymentVoucher, err error) {
 	return PaymentChannelVoucher(ctx, a, fromAddr, channel, amount, validAt)
 }
 

--- a/porcelain/payment_channel.go
+++ b/porcelain/payment_channel.go
@@ -65,7 +65,7 @@ func PaymentChannelVoucher(
 	channel *types.ChannelID,
 	amount *types.AttoFIL,
 	validAt *types.BlockHeight,
-) (voucher *paymentbroker.PaymentVoucher, err error) {
+) (voucher *types.PaymentVoucher, err error) {
 	if fromAddr.Empty() {
 		fromAddr, err = plumbing.WalletDefaultAddress()
 		if err != nil {

--- a/porcelain/payment_channel_test.go
+++ b/porcelain/payment_channel_test.go
@@ -54,7 +54,7 @@ func TestPaymentChannelLs(t *testing.T) {
 
 type testPaymentChannelVoucherPlumbing struct {
 	require *require.Assertions
-	voucher *paymentbroker.PaymentVoucher
+	voucher *types.PaymentVoucher
 }
 
 func (p *testPaymentChannelVoucherPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error) {
@@ -78,7 +78,7 @@ func TestPaymentChannelVoucher(t *testing.T) {
 		assert := assert.New(t)
 		require := require.New(t)
 
-		expectedVoucher := &paymentbroker.PaymentVoucher{
+		expectedVoucher := &types.PaymentVoucher{
 			Channel:   *types.NewChannelID(5),
 			Payer:     address.Undef,
 			Target:    address.Undef,

--- a/porcelain/payments.go
+++ b/porcelain/payments.go
@@ -69,7 +69,7 @@ type CreatePaymentsReturn struct {
 	GasAttoFIL *types.AttoFIL
 
 	// Vouchers are the payment vouchers created to pay the target at regular intervals.
-	Vouchers []*paymentbroker.PaymentVoucher
+	Vouchers []*types.PaymentVoucher
 }
 
 // CreatePayments establishes a payment channel and create multiple payments against it
@@ -136,7 +136,7 @@ func CreatePayments(ctx context.Context, plumbing cpPlumbing, config CreatePayme
 	valuePerPayment := *config.Value.MulBigInt(intervalAsBigInt).DivCeil(durationAsAttoFIL)
 
 	// generate payments
-	response.Vouchers = []*paymentbroker.PaymentVoucher{}
+	response.Vouchers = []*types.PaymentVoucher{}
 	voucherAmount := types.ZeroAttoFIL
 	for i := 0; uint64(i+1)*config.PaymentInterval < config.Duration; i++ {
 		voucherAmount = voucherAmount.Add(&valuePerPayment)
@@ -174,7 +174,7 @@ func createPayment(ctx context.Context, plumbing cpPlumbing, response *CreatePay
 		return err
 	}
 
-	var voucher paymentbroker.PaymentVoucher
+	var voucher types.PaymentVoucher
 	if err := cbor.DecodeInto(ret[0], &voucher); err != nil {
 		return err
 	}

--- a/porcelain/payments_test.go
+++ b/porcelain/payments_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/actor"
-	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	. "github.com/filecoin-project/go-filecoin/porcelain"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
@@ -55,7 +54,7 @@ func newTestCreatePaymentsPlumbing() *paymentsTestPlumbing {
 			})
 		},
 		messageQuery: func(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error) {
-			voucher := &paymentbroker.PaymentVoucher{
+			voucher := &types.PaymentVoucher{
 				Channel: *channelID,
 				Payer:   payer,
 				Target:  target,

--- a/protocol/storage/api.go
+++ b/protocol/storage/api.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/ipfs/go-cid"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 // API here is the API for a storage client.
@@ -33,6 +33,6 @@ func (a *API) QueryStorageDeal(ctx context.Context, prop cid.Cid) (*storagedeal.
 }
 
 // Payments calls the storage client LoadVouchersForDeal function
-func (a *API) Payments(ctx context.Context, dealCid cid.Cid) ([]*paymentbroker.PaymentVoucher, error) {
+func (a *API) Payments(ctx context.Context, dealCid cid.Cid) ([]*types.PaymentVoucher, error) {
 	return a.sc.LoadVouchersForDeal(dealCid)
 }

--- a/protocol/storage/client.go
+++ b/protocol/storage/client.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
-	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	cbu "github.com/filecoin-project/go-filecoin/cborutil"
 	"github.com/filecoin-project/go-filecoin/porcelain"
@@ -316,10 +315,10 @@ func (smc *Client) isMaybeDupDeal(p *storagedeal.Proposal) bool {
 }
 
 // LoadVouchersForDeal loads vouchers from disk for a given deal
-func (smc *Client) LoadVouchersForDeal(dealCid cid.Cid) ([]*paymentbroker.PaymentVoucher, error) {
+func (smc *Client) LoadVouchersForDeal(dealCid cid.Cid) ([]*types.PaymentVoucher, error) {
 	storageDeal := smc.api.DealGet(dealCid)
 	if storageDeal == nil {
-		return []*paymentbroker.PaymentVoucher{}, fmt.Errorf("could not retrieve deal with proposal CID %s", dealCid)
+		return []*types.PaymentVoucher{}, fmt.Errorf("could not retrieve deal with proposal CID %s", dealCid)
 	}
 	return storageDeal.Proposal.Payment.Vouchers, nil
 }

--- a/protocol/storage/client_test.go
+++ b/protocol/storage/client_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
-	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/porcelain"
 	. "github.com/filecoin-project/go-filecoin/protocol/storage"
@@ -152,11 +151,11 @@ func (ctp *clientTestAPI) CreatePayments(ctx context.Context, config porcelain.C
 		Channel:              ctp.channelID,
 		ChannelMsgCid:        ctp.msgCid,
 		GasAttoFIL:           types.NewAttoFILFromFIL(100),
-		Vouchers:             make([]*paymentbroker.PaymentVoucher, 10),
+		Vouchers:             make([]*types.PaymentVoucher, 10),
 	}
 
 	for i := 0; i < 10; i++ {
-		resp.Vouchers[i] = &paymentbroker.PaymentVoucher{
+		resp.Vouchers[i] = &types.PaymentVoucher{
 			Channel: *ctp.channelID,
 			Payer:   ctp.payer,
 			Target:  ctp.target,

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -132,7 +132,7 @@ func TestReceiveStorageProposal(t *testing.T) {
 		require := require.New(t)
 
 		porcelainAPI, miner, _ := defaultMinerTestSetup(require, VoucherInterval, defaultAmountInc)
-		proposal := testSignedDealProposal(porcelainAPI, []*paymentbroker.PaymentVoucher{}, defaultPieceSize)
+		proposal := testSignedDealProposal(porcelainAPI, []*types.PaymentVoucher{}, defaultPieceSize)
 
 		res, err := miner.receiveStorageProposal(context.Background(), proposal)
 		require.NoError(err)
@@ -505,8 +505,8 @@ func newMinerTestSetup(porcelainAPI *minerTestPorcelain, voucherInterval int, am
 	return newTestMiner(porcelainAPI), testSignedDealProposal(porcelainAPI, vouchers, 1000)
 }
 
-func testPaymentVouchers(porcelainAPI *minerTestPorcelain, voucherInterval int, amountInc uint64) []*paymentbroker.PaymentVoucher {
-	vouchers := make([]*paymentbroker.PaymentVoucher, 10)
+func testPaymentVouchers(porcelainAPI *minerTestPorcelain, voucherInterval int, amountInc uint64) []*types.PaymentVoucher {
+	vouchers := make([]*types.PaymentVoucher, 10)
 
 	for i := 0; i < 10; i++ {
 		validAt := porcelainAPI.paymentStart.Add(types.NewBlockHeight(uint64((i + 1) * voucherInterval)))
@@ -514,7 +514,7 @@ func testPaymentVouchers(porcelainAPI *minerTestPorcelain, voucherInterval int, 
 		signature, err := paymentbroker.SignVoucher(porcelainAPI.channelID, amount, validAt, porcelainAPI.payerAddress, porcelainAPI.signer)
 		porcelainAPI.require.NoError(err, "could not sign valid proposal")
 
-		vouchers[i] = &paymentbroker.PaymentVoucher{
+		vouchers[i] = &types.PaymentVoucher{
 			Channel:   *porcelainAPI.channelID,
 			Payer:     porcelainAPI.payerAddress,
 			Target:    porcelainAPI.targetAddress,
@@ -527,7 +527,7 @@ func testPaymentVouchers(porcelainAPI *minerTestPorcelain, voucherInterval int, 
 
 }
 
-func testSignedDealProposal(porcelainAPI *minerTestPorcelain, vouchers []*paymentbroker.PaymentVoucher, size uint64) *storagedeal.SignedDealProposal {
+func testSignedDealProposal(porcelainAPI *minerTestPorcelain, vouchers []*types.PaymentVoucher, size uint64) *storagedeal.SignedDealProposal {
 	duration := uint64(10000)
 	minerPrice, _ := types.NewAttoFILFromFILString(minerPriceString)
 	totalPrice := minerPrice.MulBigInt(big.NewInt(int64(size * duration)))

--- a/protocol/storage/storage_protocol_test.go
+++ b/protocol/storage/storage_protocol_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
@@ -26,7 +25,7 @@ func TestSerializeProposal(t *testing.T) {
 	cmc := cg()
 	p.Payment.ChannelMsgCid = &cmc
 	p.Payment.Channel = types.NewChannelID(4)
-	voucher := &paymentbroker.PaymentVoucher{
+	voucher := &types.PaymentVoucher{
 		Channel:   *types.NewChannelID(4),
 		Payer:     ag(),
 		Target:    ag(),
@@ -34,7 +33,7 @@ func TestSerializeProposal(t *testing.T) {
 		ValidAt:   *types.NewBlockHeight(3),
 		Signature: types.Signature{},
 	}
-	p.Payment.Vouchers = []*paymentbroker.PaymentVoucher{voucher}
+	p.Payment.Vouchers = []*types.PaymentVoucher{voucher}
 	v, _ := cid.Decode("QmcrriCMhjb5ZWzmPNxmP53px47tSPcXBNaMtLdgcKFJYk")
 	p.PieceRef = v
 	chunk, err := cbor.DumpObject(p)

--- a/protocol/storage/storagedeal/types.go
+++ b/protocol/storage/storagedeal/types.go
@@ -4,7 +4,6 @@ import (
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/types"
 )
@@ -38,7 +37,7 @@ type PaymentInfo struct {
 	// Vouchers is a set of payments from the client to the miner that can be
 	// cashed out contingent on the agreed upon data being provably within a
 	// live sector in the miners control on-chain
-	Vouchers []*paymentbroker.PaymentVoucher
+	Vouchers []*types.PaymentVoucher
 }
 
 // Proposal is the information sent over the wire, when a client proposes a deal to a miner.

--- a/types/payment_voucher.go
+++ b/types/payment_voucher.go
@@ -1,11 +1,10 @@
-package paymentbroker
+package types
 
 import (
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/multiformats/go-multibase"
 
 	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/types"
 )
 
 func init() {
@@ -14,12 +13,12 @@ func init() {
 
 // PaymentVoucher is a voucher for a payment channel that can be transferred off-chain but guarantees a future payment.
 type PaymentVoucher struct {
-	Channel   types.ChannelID   `json:"channel"`
+	Channel   ChannelID   `json:"channel"`
 	Payer     address.Address   `json:"payer"`
 	Target    address.Address   `json:"target"`
-	Amount    types.AttoFIL     `json:"amount"`
-	ValidAt   types.BlockHeight `json:"valid_at"`
-	Signature types.Signature   `json:"signature"`
+	Amount    AttoFIL     `json:"amount"`
+	ValidAt   BlockHeight `json:"valid_at"`
+	Signature Signature   `json:"signature"`
 }
 
 // DecodeVoucher creates a *PaymentVoucher from a base58, Cbor-encoded one

--- a/types/payment_voucher.go
+++ b/types/payment_voucher.go
@@ -13,12 +13,12 @@ func init() {
 
 // PaymentVoucher is a voucher for a payment channel that can be transferred off-chain but guarantees a future payment.
 type PaymentVoucher struct {
-	Channel   ChannelID   `json:"channel"`
-	Payer     address.Address   `json:"payer"`
-	Target    address.Address   `json:"target"`
-	Amount    AttoFIL     `json:"amount"`
-	ValidAt   BlockHeight `json:"valid_at"`
-	Signature Signature   `json:"signature"`
+	Channel   ChannelID       `json:"channel"`
+	Payer     address.Address `json:"payer"`
+	Target    address.Address `json:"target"`
+	Amount    AttoFIL         `json:"amount"`
+	ValidAt   BlockHeight     `json:"valid_at"`
+	Signature Signature       `json:"signature"`
 }
 
 // DecodeVoucher creates a *PaymentVoucher from a base58, Cbor-encoded one

--- a/types/payment_voucher_test.go
+++ b/types/payment_voucher_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/address"
 )
 
-func TestEncodeThenDecode(t *testing.T) {
+func TestPaymentVoucherEncodingRoundTrip(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -27,12 +27,12 @@ func TestEncodeThenDecode(t *testing.T) {
 
 	rawPaymentVoucher, err := paymentVoucher.Encode()
 	require.NoError(err)
-	DecodedPaymentVoucher, err := DecodeVoucher(rawPaymentVoucher)
+	decodedPaymentVoucher, err := DecodeVoucher(rawPaymentVoucher)
 	require.NoError(err)
 
-	assert.Equal((*paymentVoucher).Channel, DecodedPaymentVoucher.Channel)
-	assert.Equal((*paymentVoucher).Payer, DecodedPaymentVoucher.Payer)
-	assert.Equal((*paymentVoucher).Target, DecodedPaymentVoucher.Target)
-	assert.Equal((*paymentVoucher).Amount, DecodedPaymentVoucher.Amount)
-	assert.Equal((*paymentVoucher).ValidAt, DecodedPaymentVoucher.ValidAt)
+	assert.Equal((*paymentVoucher).Channel, decodedPaymentVoucher.Channel)
+	assert.Equal((*paymentVoucher).Payer, decodedPaymentVoucher.Payer)
+	assert.Equal((*paymentVoucher).Target, decodedPaymentVoucher.Target)
+	assert.Equal((*paymentVoucher).Amount, decodedPaymentVoucher.Amount)
+	assert.Equal((*paymentVoucher).ValidAt, decodedPaymentVoucher.ValidAt)
 }

--- a/types/payment_voucher_test.go
+++ b/types/payment_voucher_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/address"
 )
 
-func TestEncodeThenDecode(t *testing.T){
+func TestEncodeThenDecode(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -18,22 +18,21 @@ func TestEncodeThenDecode(t *testing.T){
 	addr2 := addrGetter()
 
 	paymentVoucher := &PaymentVoucher{
-		Channel:   *NewChannelID(5),
-		Payer:     addr1,
-		Target:    addr2,
-		Amount:    *NewAttoFILFromFIL(100),
-		ValidAt:   *NewBlockHeight(25),
+		Channel: *NewChannelID(5),
+		Payer:   addr1,
+		Target:  addr2,
+		Amount:  *NewAttoFILFromFIL(100),
+		ValidAt: *NewBlockHeight(25),
 	}
-	
-	rawPaymentVoucher,err:=paymentVoucher.Encode()
+
+	rawPaymentVoucher, err := paymentVoucher.Encode()
+	require.NoError(err)
+	DecodedPaymentVoucher, err := DecodeVoucher(rawPaymentVoucher)
 	require.NoError(err)
 
-	DecodedPaymentVoucher,err:=DecodeVoucher(rawPaymentVoucher)
-	require.NoError(err)
-
-	assert.Equal((*paymentVoucher).Channel,DecodedPaymentVoucher.Channel)
-	assert.Equal((*paymentVoucher).Payer,DecodedPaymentVoucher.Payer)
-	assert.Equal((*paymentVoucher).Target,DecodedPaymentVoucher.Target)
-	assert.Equal((*paymentVoucher).Amount,DecodedPaymentVoucher.Amount)
-	assert.Equal((*paymentVoucher).ValidAt,DecodedPaymentVoucher.ValidAt)
+	assert.Equal((*paymentVoucher).Channel, DecodedPaymentVoucher.Channel)
+	assert.Equal((*paymentVoucher).Payer, DecodedPaymentVoucher.Payer)
+	assert.Equal((*paymentVoucher).Target, DecodedPaymentVoucher.Target)
+	assert.Equal((*paymentVoucher).Amount, DecodedPaymentVoucher.Amount)
+	assert.Equal((*paymentVoucher).ValidAt, DecodedPaymentVoucher.ValidAt)
 }

--- a/types/payment_voucher_test.go
+++ b/types/payment_voucher_test.go
@@ -16,6 +16,7 @@ func TestEncodeThenDecode(t *testing.T){
 	addrGetter := address.NewForTestGetter()
 	addr1 := addrGetter()
 	addr2 := addrGetter()
+
 	paymentVoucher := &PaymentVoucher{
 		Channel:   *NewChannelID(5),
 		Payer:     addr1,
@@ -23,6 +24,7 @@ func TestEncodeThenDecode(t *testing.T){
 		Amount:    *NewAttoFILFromFIL(100),
 		ValidAt:   *NewBlockHeight(25),
 	}
+	
 	rawPaymentVoucher,err:=paymentVoucher.Encode()
 	require.NoError(err)
 

--- a/types/payment_voucher_test.go
+++ b/types/payment_voucher_test.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/address"
+)
+
+func TestEncodeThenDecode(t *testing.T){
+	require := require.New(t)
+	assert := assert.New(t)
+
+	addrGetter := address.NewForTestGetter()
+	addr1 := addrGetter()
+	addr2 := addrGetter()
+	paymentVoucher := &PaymentVoucher{
+		Channel:   *NewChannelID(5),
+		Payer:     addr1,
+		Target:    addr2,
+		Amount:    *NewAttoFILFromFIL(100),
+		ValidAt:   *NewBlockHeight(25),
+	}
+	rawPaymentVoucher,err:=paymentVoucher.Encode()
+	require.NoError(err)
+
+	DecodedPaymentVoucher,err:=DecodeVoucher(rawPaymentVoucher)
+	require.NoError(err)
+
+	assert.Equal((*paymentVoucher).Channel,DecodedPaymentVoucher.Channel)
+	assert.Equal((*paymentVoucher).Payer,DecodedPaymentVoucher.Payer)
+	assert.Equal((*paymentVoucher).Target,DecodedPaymentVoucher.Target)
+	assert.Equal((*paymentVoucher).Amount,DecodedPaymentVoucher.Amount)
+	assert.Equal((*paymentVoucher).ValidAt,DecodedPaymentVoucher.ValidAt)
+}


### PR DESCRIPTION
**What's in this PR?**
    move paymentVoucher to /types
    modify all paymentbroker.PaymentVoucher to types.PaymentVoucher in all files
    create a simple test for PaymentVoucher which encodes then decodes a PaymentVoucher and check 
    if it is equal to the original one

