### PR TITLE
Feat/payment channel close 2574

### DIFF
--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -347,10 +347,10 @@ func (pb *Actor) Extend(vmctx exec.VMContext, chid *types.ChannelID, eol *types.
 	return 0, nil
 }
 
-// Cancel can be used to end a storage deal early. It lowers the EOL of the
-// payment channel to 1 blocktime from now and allows a client to reclaim their
-// payments. In the time before the channel is closed, a miner can potentially
-// dispute a closer.
+// Cancel can be used to end an off chain payment early. It lowers the EOL of
+// the payment channel to 1 blocktime from now and allows a caller to reclaim
+// their payments. In the time before the channel is closed, a target can
+// potentially dispute a closer.
 func (pb *Actor) Cancel(vmctx exec.VMContext, chid *types.ChannelID) (uint8, error) {
 	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
 		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -66,7 +66,11 @@ type PaymentChannel struct {
 	Target         address.Address    `json:"target"`
 	Amount         *types.AttoFIL     `json:"amount"`
 	AmountRedeemed *types.AttoFIL     `json:"amount_redeemed"`
+	// AgreedEol is the expiration for the payment channel agreed upon by the
+	// payer and payee upon initialization or extension
 	AgreedEol      *types.BlockHeight `json:"agreed_eol"`
+	// Eol is the actual expiration for the payment channel which can differ from
+	// AgreedEol when the payment channel is in dispute
 	Eol            *types.BlockHeight `json:"eol"`
 }
 

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -64,6 +64,7 @@ type PaymentChannel struct {
 	Target         address.Address    `json:"target"`
 	Amount         *types.AttoFIL     `json:"amount"`
 	AmountRedeemed *types.AttoFIL     `json:"amount_redeemed"`
+	AgreedEol      *types.BlockHeight `json:"agreed_eol"`
 	Eol            *types.BlockHeight `json:"eol"`
 }
 
@@ -154,6 +155,7 @@ func (pb *Actor) CreateChannel(vmctx exec.VMContext, target address.Address, eol
 			Target:         target,
 			Amount:         vmctx.Message().Value,
 			AmountRedeemed: types.NewAttoFILFromFIL(0),
+			AgreedEol:      eol,
 			Eol:            eol,
 		})
 		if err != nil {
@@ -319,6 +321,7 @@ func (pb *Actor) Extend(vmctx exec.VMContext, chid *types.ChannelID, eol *types.
 		}
 
 		// set new eol
+		channel.AgreedEol = eol
 		channel.Eol = eol
 
 		// increment the value

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -76,6 +76,7 @@ func TestPaymentBrokerCreateChannel(t *testing.T) {
 	assert.Equal(types.NewAttoFILFromFIL(1000), channel.Amount)
 	assert.Equal(types.NewAttoFILFromFIL(0), channel.AmountRedeemed)
 	assert.Equal(target, channel.Target)
+	assert.Equal(types.NewBlockHeight(10), channel.AgreedEol)
 	assert.Equal(types.NewBlockHeight(10), channel.Eol)
 }
 
@@ -412,6 +413,7 @@ func TestPaymentBrokerExtend(t *testing.T) {
 
 	assert.Equal(types.NewAttoFILFromFIL(2000), channel.Amount)
 	assert.Equal(types.NewAttoFILFromFIL(1100), channel.AmountRedeemed)
+	assert.Equal(types.NewBlockHeight(20), channel.AgreedEol)
 	assert.Equal(types.NewBlockHeight(20), channel.Eol)
 }
 
@@ -468,6 +470,7 @@ func TestPaymentBrokerCancel(t *testing.T) {
 	paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
 	channel := sys.retrieveChannel(paymentBroker)
 
+	assert.Equal(types.NewBlockHeight(10), channel.AgreedEol)
 	assert.Equal(types.NewBlockHeight(6), channel.Eol)
 }
 
@@ -510,6 +513,7 @@ func TestPaymentBrokerLs(t *testing.T) {
 		assert.Equal(target1, pc1.Target)
 		assert.Equal(types.NewAttoFILFromFIL(1000), pc1.Amount)
 		assert.Equal(types.NewAttoFILFromFIL(0), pc1.AmountRedeemed)
+		assert.Equal(types.NewBlockHeight(10), pc1.AgreedEol)
 		assert.Equal(types.NewBlockHeight(10), pc1.Eol)
 
 		pc2, found := channels[channelID2.String()]
@@ -517,7 +521,7 @@ func TestPaymentBrokerLs(t *testing.T) {
 		assert.Equal(target2, pc2.Target)
 		assert.Equal(types.NewAttoFILFromFIL(2000), pc2.Amount)
 		assert.Equal(types.NewAttoFILFromFIL(0), pc2.AmountRedeemed)
-		assert.Equal(types.NewBlockHeight(20), pc2.Eol)
+		assert.Equal(types.NewBlockHeight(20), pc2.AgreedEol)
 	})
 
 	t.Run("Returns empty map when payer has no channels", func(t *testing.T) {

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -450,6 +450,27 @@ func TestPaymentBrokerExtendRefusesToShortenTheEol(t *testing.T) {
 	assert.Contains(result.ExecutionError.Error(), "payment channel eol may not be decreased")
 }
 
+func TestPaymentBrokerCancel(t *testing.T) {
+	tf.UnitTest(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	sys := setup(t)
+
+	pdata := core.MustConvertParams(sys.channelID)
+	msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, types.NewAttoFILFromFIL(1000), "cancel", pdata)
+
+	result, err := sys.ApplyMessage(msg, 5)
+	require.NoError(result.ExecutionError)
+	require.NoError(err)
+	assert.Equal(uint8(0), result.Receipt.ExitCode)
+
+	paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+	channel := sys.retrieveChannel(paymentBroker)
+
+	assert.Equal(types.NewBlockHeight(6), channel.Eol)
+}
+
 func TestPaymentBrokerLs(t *testing.T) {
 	tf.UnitTest(t)
 

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -187,7 +187,7 @@ func TestPaymentBrokerUpdateErrorsWhenAtEol(t *testing.T) {
 	sys := setup(t)
 
 	// set block height to Eol
-	result, err := sys.ApplyRedeemMessageWithBlockHeight(sys.target, 500, 0, 10)
+	result, err := sys.ApplyRedeemMessageWithBlockHeight(sys.target, 500, 0, 20000)
 	require.NoError(err)
 
 	// expect an error
@@ -347,7 +347,7 @@ func TestPaymentBrokerReclaim(t *testing.T) {
 	pdata := core.MustConvertParams(sys.channelID)
 	msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, types.NewAttoFILFromFIL(0), "reclaim", pdata)
 	// block height is after Eol
-	res, err := sys.ApplyMessage(msg, 11)
+	res, err := sys.ApplyMessage(msg, 20001)
 	require.NoError(err)
 	require.NoError(res.ExecutionError)
 
@@ -388,7 +388,7 @@ func TestPaymentBrokerExtend(t *testing.T) {
 	sys := setup(t)
 
 	// extend channel
-	pdata := core.MustConvertParams(sys.channelID, types.NewBlockHeight(20))
+	pdata := core.MustConvertParams(sys.channelID, types.NewBlockHeight(30000))
 	msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, types.NewAttoFILFromFIL(1000), "extend", pdata)
 
 	result, err := sys.ApplyMessage(msg, 9)
@@ -413,8 +413,8 @@ func TestPaymentBrokerExtend(t *testing.T) {
 
 	assert.Equal(types.NewAttoFILFromFIL(2000), channel.Amount)
 	assert.Equal(types.NewAttoFILFromFIL(1100), channel.AmountRedeemed)
-	assert.Equal(types.NewBlockHeight(20), channel.AgreedEol)
-	assert.Equal(types.NewBlockHeight(20), channel.Eol)
+	assert.Equal(types.NewBlockHeight(30000), channel.AgreedEol)
+	assert.Equal(types.NewBlockHeight(30000), channel.Eol)
 }
 
 func TestPaymentBrokerExtendFailsWithNonExistentChannel(t *testing.T) {
@@ -425,7 +425,7 @@ func TestPaymentBrokerExtendFailsWithNonExistentChannel(t *testing.T) {
 	sys := setup(t)
 
 	// extend channel
-	pdata := core.MustConvertParams(types.NewChannelID(383), types.NewBlockHeight(20))
+	pdata := core.MustConvertParams(types.NewChannelID(383), types.NewBlockHeight(30000))
 	msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, types.NewAttoFILFromFIL(1000), "extend", pdata)
 
 	result, err := sys.ApplyMessage(msg, 9)
@@ -462,7 +462,7 @@ func TestPaymentBrokerCancel(t *testing.T) {
 	pdata := core.MustConvertParams(sys.channelID)
 	msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, types.NewAttoFILFromFIL(1000), "cancel", pdata)
 
-	result, err := sys.ApplyMessage(msg, 5)
+	result, err := sys.ApplyMessage(msg, 100)
 	require.NoError(result.ExecutionError)
 	require.NoError(err)
 	assert.Equal(uint8(0), result.Receipt.ExitCode)
@@ -470,8 +470,8 @@ func TestPaymentBrokerCancel(t *testing.T) {
 	paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
 	channel := sys.retrieveChannel(paymentBroker)
 
-	assert.Equal(types.NewBlockHeight(10), channel.AgreedEol)
-	assert.Equal(types.NewBlockHeight(6), channel.Eol)
+	assert.Equal(types.NewBlockHeight(20000), channel.AgreedEol)
+	assert.Equal(types.NewBlockHeight(10100), channel.Eol)
 }
 
 func TestPaymentBrokerLs(t *testing.T) {
@@ -667,7 +667,7 @@ func setup(t *testing.T) system {
 	payerActor := th.RequireNewAccountActor(require.New(t), types.NewAttoFILFromFIL(50000))
 	state.MustSetActor(st, payer, payerActor)
 
-	channelID := establishChannel(ctx, st, vms, payer, target, 0, types.NewAttoFILFromFIL(1000), types.NewBlockHeight(10))
+	channelID := establishChannel(ctx, st, vms, payer, target, 0, types.NewAttoFILFromFIL(1000), types.NewBlockHeight(20000))
 
 	return system{
 		t:              t,

--- a/commands/payment_channel_daemon_test.go
+++ b/commands/payment_channel_daemon_test.go
@@ -78,6 +78,7 @@ func TestPaymentChannelLs(t *testing.T) {
 
 		channel := channels[chanid.String()]
 		assert.Equal(channelAmount, channel.Amount)
+		assert.Equal(channelExpiry, channel.AgreedEol)
 		assert.Equal(channelExpiry, channel.Eol)
 		assert.Equal(rsrc.targetAddr, channel.Target)
 		assert.Equal(types.ZeroAttoFIL, channel.AmountRedeemed)
@@ -114,6 +115,7 @@ func TestPaymentChannelLs(t *testing.T) {
 
 		channel := channels[chanid.String()]
 		assert.Equal(channelAmount, channel.Amount)
+		assert.Equal(channelExpiry, channel.AgreedEol)
 		assert.Equal(channelExpiry, channel.Eol)
 		assert.Equal(rsrc.targetAddr, channel.Target)
 		assert.Equal(types.ZeroAttoFIL, channel.AmountRedeemed)
@@ -455,6 +457,7 @@ func TestPaymentChannelExtendSuccess(t *testing.T) {
 
 	channel := channels[chanid.String()]
 	assert.Equal(channelAmount, channel.Amount)
+	assert.Equal(channelExpiry, channel.AgreedEol)
 	assert.Equal(channelExpiry, channel.Eol)
 	assert.Equal(rsrc.targetAddr, channel.Target)
 	assert.Equal(types.ZeroAttoFIL, channel.AmountRedeemed)
@@ -478,6 +481,7 @@ func TestPaymentChannelExtendSuccess(t *testing.T) {
 
 	channel = channels[chanid.String()]
 	assert.Equal(channelAmount.Add(extendAmount), channel.Amount)
+	assert.Equal(extendExpiry, channel.AgreedEol)
 	assert.Equal(extendExpiry, channel.Eol)
 	assert.Equal(rsrc.targetAddr, channel.Target)
 	assert.Equal(types.ZeroAttoFIL, channel.AmountRedeemed)

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -460,6 +460,7 @@ func (mtp *minerTestPorcelain) messageQueryPaymentBrokerLs() ([][]byte, error) {
 			Target:         mtp.targetAddress,
 			Amount:         types.NewAttoFILFromFIL(100000),
 			AmountRedeemed: types.NewAttoFILFromFIL(0),
+			AgreedEol:      mtp.channelEol,
 			Eol:            mtp.channelEol,
 		}
 	}


### PR DESCRIPTION
# Problem

Payers have no way to stop a payment channel once opened meaning they risk losing money when opening long running storage deals.

# Solution

Add a Cancel method to the PaymentBroker allowing a payer to close a payment channel early.

Resolves #2574 