### PR TITLE
Improve repo version checking

### DIFF
--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -55,13 +55,13 @@ func daemonRun(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment)
 	}
 
 	// second highest precedence is env vars.
-	if envapi := os.Getenv("FIL_API"); envapi != "" {
-		rep.Config().API.Address = envapi
+	if envAPI := os.Getenv("FIL_API"); envAPI != "" {
+		rep.Config().API.Address = envAPI
 	}
 
 	// highest precedence is cmd line flag.
-	if apiAddress, ok := req.Options[OptionAPI].(string); ok && apiAddress != "" {
-		rep.Config().API.Address = apiAddress
+	if flagAPI, ok := req.Options[OptionAPI].(string); ok && flagAPI != "" {
+		rep.Config().API.Address = flagAPI
 	}
 
 	if swarmAddress, ok := req.Options[SwarmAddress].(string); ok && swarmAddress != "" {
@@ -130,7 +130,7 @@ func runAPIAndWait(ctx context.Context, nd *node.Node, config *config.Config, re
 	defer nd.Stop(ctx)
 
 	servenv := &Env{
-		// TODO: should this be the passed in context?
+		// TODO: should this be the passed in context?  Issue 2641
 		blockMiningAPI: nd.BlockMiningAPI,
 		ctx:            context.Background(),
 		porcelainAPI:   nd.PorcelainAPI,

--- a/repo/fsrepo.go
+++ b/repo/fsrepo.go
@@ -131,8 +131,12 @@ func (r *FSRepo) loadFromDisk() error {
 		return errors.Wrap(err, "failed to load version")
 	}
 
-	if localVersion != Version {
-		return fmt.Errorf("invalid repo version, got %d expected %d", localVersion, Version)
+	if localVersion < Version {
+		return fmt.Errorf("out of date repo version, got %d expected %d. Migrate with tools/migration/go-filecoin-migrate", localVersion, Version)
+	}
+
+	if localVersion > Version {
+		return fmt.Errorf("binary needs update to handle repo version, got %d expected %d. Update binary to latest release", localVersion, Version)
 	}
 
 	r.version = localVersion
@@ -336,7 +340,7 @@ func (r *FSRepo) loadVersion() (uint, error) {
 
 	version, err := strconv.Atoi(strings.Trim(string(file), "\n"))
 	if err != nil {
-		return 0, err
+		return 0, errors.New("corrupt version file: version is not an integer")
 	}
 
 	return uint(version), nil


### PR DESCRIPTION
Closes #2587 

A lot of this was already done.
This PR simply improves error messages in the case the version is invalid for a given binary.
(It also does some unrelated cleanup)