### PR TITLE
Add condition to payment voucher

### DIFF
--- a/commands/payment_channel.go
+++ b/commands/payment_channel.go
@@ -5,15 +5,12 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-ipfs-cmdkit"
-	"github.com/ipfs/go-ipfs-cmds"
-	cbor "github.com/ipfs/go-ipld-cbor"
-	"github.com/multiformats/go-multibase"
-
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-ipfs-cmdkit"
+	"github.com/ipfs/go-ipfs-cmds"
 )
 
 var paymentChannelCmd = &cmds.Command{
@@ -215,7 +212,7 @@ var voucherCmd = &cmds.Command{
 			return err
 		}
 
-		voucher, err := GetPorcelainAPI(env).PaymentChannelVoucher(req.Context, fromAddr, channel, amount, validAt)
+		voucher, err := GetPorcelainAPI(env).PaymentChannelVoucher(req.Context, fromAddr, channel, amount, validAt, nil)
 		if err != nil {
 			return err
 		}
@@ -266,59 +263,48 @@ var redeemCmd = &cmds.Command{
 			return err
 		}
 
-		if preview {
-			_, cborVoucher, err := multibase.Decode(req.Arguments[0])
-			if err != nil {
-				return err
-			}
-
-			var voucher types.PaymentVoucher
-			err = cbor.DecodeInto(cborVoucher, &voucher)
-			if err != nil {
-				return err
-			}
-
-			usedGas, err := GetPorcelainAPI(env).MessagePreview(
-				req.Context,
-				fromAddr,
-				address.PaymentBrokerAddress,
-				"redeem",
-				voucher.Payer, &voucher.Channel, &voucher.Amount, &voucher.ValidAt, []byte(voucher.Signature),
-			)
-			if err != nil {
-				return err
-			}
-			return re.Emit(&RedeemResult{
-				Cid:     cid.Cid{},
-				GasUsed: usedGas,
-				Preview: true,
-			})
-		}
-
 		voucher, err := types.DecodeVoucher(req.Arguments[0])
 		if err != nil {
 			return err
 		}
 
-		c, err := GetPorcelainAPI(env).MessageSendWithDefaultAddress(
-			req.Context,
-			fromAddr,
-			address.PaymentBrokerAddress,
-			types.NewAttoFILFromFIL(0),
-			gasPrice,
-			gasLimit,
-			"redeem",
-			voucher.Payer, &voucher.Channel, &voucher.Amount, &voucher.ValidAt, []byte(voucher.Signature),
-		)
+		result := &ReclaimResult{Preview: preview}
+
+		params := []interface{}{
+			voucher.Payer,
+			&voucher.Channel,
+			&voucher.Amount,
+			&voucher.ValidAt,
+			voucher.Condition,
+			[]byte(voucher.Signature),
+		}
+
+		if preview {
+			result.GasUsed, err = GetPorcelainAPI(env).MessagePreview(
+				req.Context,
+				fromAddr,
+				address.PaymentBrokerAddress,
+				"redeem",
+				params...,
+			)
+		} else {
+			result.Cid, err = GetPorcelainAPI(env).MessageSendWithDefaultAddress(
+				req.Context,
+				fromAddr,
+				address.PaymentBrokerAddress,
+				types.NewAttoFILFromFIL(0),
+				gasPrice,
+				gasLimit,
+				"redeem",
+				params...,
+			)
+		}
+
 		if err != nil {
 			return err
 		}
 
-		return re.Emit(&RedeemResult{
-			Cid:     c,
-			GasUsed: types.NewGasUnits(0),
-			Preview: false,
-		})
+		return re.Emit(result)
 	},
 	Type: &RedeemResult{},
 	Encoders: cmds.EncoderMap{
@@ -451,59 +437,48 @@ var closeCmd = &cmds.Command{
 			return err
 		}
 
-		if preview {
-			_, cborVoucher, err := multibase.Decode(req.Arguments[0])
-			if err != nil {
-				return err
-			}
-
-			var voucher types.PaymentVoucher
-			err = cbor.DecodeInto(cborVoucher, &voucher)
-			if err != nil {
-				return err
-			}
-
-			usedGas, err := GetPorcelainAPI(env).MessagePreview(
-				req.Context,
-				fromAddr,
-				address.PaymentBrokerAddress,
-				"close",
-				voucher.Payer, &voucher.Channel, &voucher.Amount, &voucher.ValidAt, []byte(voucher.Signature),
-			)
-			if err != nil {
-				return err
-			}
-			return re.Emit(&CloseResult{
-				Cid:     cid.Cid{},
-				GasUsed: usedGas,
-				Preview: true,
-			})
-		}
-
 		voucher, err := types.DecodeVoucher(req.Arguments[0])
 		if err != nil {
 			return err
 		}
 
-		c, err := GetPorcelainAPI(env).MessageSendWithDefaultAddress(
-			req.Context,
-			fromAddr,
-			address.PaymentBrokerAddress,
-			types.NewAttoFILFromFIL(0),
-			gasPrice,
-			gasLimit,
-			"close",
-			voucher.Payer, &voucher.Channel, &voucher.Amount, &voucher.ValidAt, []byte(voucher.Signature),
-		)
+		result := &CloseResult{Preview: preview}
+
+		params := []interface{}{
+			voucher.Payer,
+			&voucher.Channel,
+			&voucher.Amount,
+			&voucher.ValidAt,
+			voucher.Condition,
+			[]byte(voucher.Signature),
+		}
+
+		if preview {
+			result.GasUsed, err = GetPorcelainAPI(env).MessagePreview(
+				req.Context,
+				fromAddr,
+				address.PaymentBrokerAddress,
+				"close",
+				params...,
+			)
+		} else {
+			result.Cid, err = GetPorcelainAPI(env).MessageSendWithDefaultAddress(
+				req.Context,
+				fromAddr,
+				address.PaymentBrokerAddress,
+				types.NewAttoFILFromFIL(0),
+				gasPrice,
+				gasLimit,
+				"close",
+				params...,
+			)
+		}
+
 		if err != nil {
 			return err
 		}
 
-		return re.Emit(&CloseResult{
-			Cid:     c,
-			GasUsed: types.NewGasUnits(0),
-			Preview: false,
-		})
+		return re.Emit(result)
 	},
 	Type: &CloseResult{},
 	Encoders: cmds.EncoderMap{

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -183,8 +183,9 @@ func (a *API) PaymentChannelVoucher(
 	channel *types.ChannelID,
 	amount *types.AttoFIL,
 	validAt *types.BlockHeight,
+	condition *types.Predicate,
 ) (voucher *types.PaymentVoucher, err error) {
-	return PaymentChannelVoucher(ctx, a, fromAddr, channel, amount, validAt)
+	return PaymentChannelVoucher(ctx, a, fromAddr, channel, amount, validAt, condition)
 }
 
 // ClientListAsks returns a channel with asks from the latest chain state

--- a/porcelain/payment_channel.go
+++ b/porcelain/payment_channel.go
@@ -79,7 +79,7 @@ func PaymentChannelVoucher(
 		fromAddr,
 		address.PaymentBrokerAddress,
 		"voucher",
-		channel, amount, validAt,
+		channel, amount, validAt, condition,
 	)
 	if err != nil {
 		return nil, err

--- a/porcelain/payment_channel.go
+++ b/porcelain/payment_channel.go
@@ -65,6 +65,7 @@ func PaymentChannelVoucher(
 	channel *types.ChannelID,
 	amount *types.AttoFIL,
 	validAt *types.BlockHeight,
+	condition *types.Predicate,
 ) (voucher *types.PaymentVoucher, err error) {
 	if fromAddr.Empty() {
 		fromAddr, err = plumbing.WalletDefaultAddress()
@@ -88,7 +89,7 @@ func PaymentChannelVoucher(
 		return nil, err
 	}
 
-	sig, err := paymentbroker.SignVoucher(channel, amount, validAt, fromAddr, plumbing)
+	sig, err := paymentbroker.SignVoucher(channel, amount, validAt, fromAddr, condition, plumbing)
 	if err != nil {
 		return nil, err
 	}

--- a/porcelain/payment_channel_test.go
+++ b/porcelain/payment_channel_test.go
@@ -85,6 +85,11 @@ func TestPaymentChannelVoucher(t *testing.T) {
 			Amount:    *types.NewAttoFILFromFIL(10),
 			ValidAt:   *types.NewBlockHeight(0),
 			Signature: []byte{},
+			Condition: &types.Predicate{
+				To:     address.Undef,
+				Method: "someMethod",
+				Params: []byte("params"),
+			},
 		}
 
 		plumbing := &testPaymentChannelVoucherPlumbing{
@@ -100,7 +105,11 @@ func TestPaymentChannelVoucher(t *testing.T) {
 			types.NewChannelID(5),
 			types.NewAttoFILFromFIL(10),
 			types.NewBlockHeight(0),
-			nil,
+			&types.Predicate{
+				To:     address.Undef,
+				Method: "someMethod",
+				Params: []byte("params"),
+			},
 		)
 		require.NoError(err)
 		assert.Equal(expectedVoucher.Channel, voucher.Channel)
@@ -108,6 +117,9 @@ func TestPaymentChannelVoucher(t *testing.T) {
 		assert.Equal(expectedVoucher.Target, voucher.Target)
 		assert.Equal(expectedVoucher.Amount, voucher.Amount)
 		assert.Equal(expectedVoucher.ValidAt, voucher.ValidAt)
+		assert.Equal(expectedVoucher.Condition.To, voucher.Condition.To)
+		assert.Equal(expectedVoucher.Condition.Method, voucher.Condition.Method)
+		assert.Equal(expectedVoucher.Condition.Params, voucher.Condition.Params)
 		assert.NotEqual(expectedVoucher.Signature, voucher.Signature)
 	})
 }

--- a/porcelain/payment_channel_test.go
+++ b/porcelain/payment_channel_test.go
@@ -100,6 +100,7 @@ func TestPaymentChannelVoucher(t *testing.T) {
 			types.NewChannelID(5),
 			types.NewAttoFILFromFIL(10),
 			types.NewBlockHeight(0),
+			nil,
 		)
 		require.NoError(err)
 		assert.Equal(expectedVoucher.Channel, voucher.Channel)

--- a/porcelain/payments.go
+++ b/porcelain/payments.go
@@ -169,7 +169,9 @@ func createPayment(ctx context.Context, plumbing cpPlumbing, response *CreatePay
 		"voucher",
 		response.Channel,
 		amount,
-		validAt)
+		validAt,
+		condition,
+	)
 	if err != nil {
 		return err
 	}

--- a/porcelain/payments.go
+++ b/porcelain/payments.go
@@ -145,7 +145,7 @@ func CreatePayments(ctx context.Context, plumbing cpPlumbing, config CreatePayme
 		}
 
 		validAt := currentHeight.Add(types.NewBlockHeight(uint64(i+1) * config.PaymentInterval))
-		err = createPayment(ctx, plumbing, response, voucherAmount, validAt)
+		err = createPayment(ctx, plumbing, response, voucherAmount, validAt, nil)
 		if err != nil {
 			return response, err
 		}
@@ -153,7 +153,7 @@ func CreatePayments(ctx context.Context, plumbing cpPlumbing, config CreatePayme
 
 	if voucherAmount.LessThan(&config.Value) {
 		validAt := currentHeight.Add(types.NewBlockHeight(config.Duration))
-		err = createPayment(ctx, plumbing, response, &config.Value, validAt)
+		err = createPayment(ctx, plumbing, response, &config.Value, validAt, nil)
 		if err != nil {
 			return response, err
 		}
@@ -162,7 +162,7 @@ func CreatePayments(ctx context.Context, plumbing cpPlumbing, config CreatePayme
 	return response, nil
 }
 
-func createPayment(ctx context.Context, plumbing cpPlumbing, response *CreatePaymentsReturn, amount *types.AttoFIL, validAt *types.BlockHeight) error {
+func createPayment(ctx context.Context, plumbing cpPlumbing, response *CreatePaymentsReturn, amount *types.AttoFIL, validAt *types.BlockHeight, condition *types.Predicate) error {
 	ret, err := plumbing.MessageQuery(ctx,
 		response.From,
 		address.PaymentBrokerAddress,
@@ -179,7 +179,7 @@ func createPayment(ctx context.Context, plumbing cpPlumbing, response *CreatePay
 		return err
 	}
 
-	sig, err := paymentbroker.SignVoucher(&voucher.Channel, amount, validAt, voucher.Payer, plumbing)
+	sig, err := paymentbroker.SignVoucher(&voucher.Channel, amount, validAt, voucher.Payer, condition, plumbing)
 	if err != nil {
 		return err
 	}

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -237,7 +237,7 @@ func (sm *Miner) validateDealPayment(ctx context.Context, p *storagedeal.Proposa
 	lastValidAt := expectedFirstPayment
 	for _, v := range p.Payment.Vouchers {
 		// confirm signature is valid against expected actor and channel id
-		if !paymentbroker.VerifyVoucherSignature(p.Payment.Payer, p.Payment.Channel, &v.Amount, &v.ValidAt, v.Signature) {
+		if !paymentbroker.VerifyVoucherSignature(p.Payment.Payer, p.Payment.Channel, &v.Amount, &v.ValidAt, v.Condition, v.Signature) {
 			return errors.New("invalid signature in voucher")
 		}
 

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -512,7 +512,7 @@ func testPaymentVouchers(porcelainAPI *minerTestPorcelain, voucherInterval int, 
 	for i := 0; i < 10; i++ {
 		validAt := porcelainAPI.paymentStart.Add(types.NewBlockHeight(uint64((i + 1) * voucherInterval)))
 		amount := types.NewAttoFILFromFIL(uint64(i+1) * amountInc)
-		signature, err := paymentbroker.SignVoucher(porcelainAPI.channelID, amount, validAt, porcelainAPI.payerAddress, porcelainAPI.signer)
+		signature, err := paymentbroker.SignVoucher(porcelainAPI.channelID, amount, validAt, porcelainAPI.payerAddress, nil, porcelainAPI.signer)
 		porcelainAPI.require.NoError(err, "could not sign valid proposal")
 
 		vouchers[i] = &types.PaymentVoucher{

--- a/types/payment_voucher.go
+++ b/types/payment_voucher.go
@@ -11,6 +11,13 @@ func init() {
 	cbor.RegisterCborType(PaymentVoucher{})
 }
 
+// Predicate is an optional message that is sent to another actor and must return true for the voucher to be valid.
+type Predicate struct {
+	To     address.Address `json:"to"`
+	Method string          `json:"method"`
+	Params []byte          `json:"params"`
+}
+
 // PaymentVoucher is a voucher for a payment channel that can be transferred off-chain but guarantees a future payment.
 type PaymentVoucher struct {
 	Channel   ChannelID       `json:"channel"`
@@ -19,6 +26,7 @@ type PaymentVoucher struct {
 	Amount    AttoFIL         `json:"amount"`
 	ValidAt   BlockHeight     `json:"valid_at"`
 	Signature Signature       `json:"signature"`
+	Condition *Predicate      `json:"condition"`
 }
 
 // DecodeVoucher creates a *PaymentVoucher from a base58, Cbor-encoded one

--- a/types/payment_voucher.go
+++ b/types/payment_voucher.go
@@ -8,6 +8,7 @@ import (
 )
 
 func init() {
+	cbor.RegisterCborType(Predicate{})
 	cbor.RegisterCborType(PaymentVoucher{})
 }
 

--- a/types/payment_voucher.go
+++ b/types/payment_voucher.go
@@ -14,20 +14,38 @@ func init() {
 
 // Predicate is an optional message that is sent to another actor and must return true for the voucher to be valid.
 type Predicate struct {
-	To     address.Address `json:"to"`
-	Method string          `json:"method"`
-	Params []byte          `json:"params"`
+	// To is the address of the actor to which this predicate is addressed.
+	To address.Address `json:"to"`
+
+	// Method is the actor method this predicate will call.
+	Method string `json:"method"`
+
+	// Params are the parameters (or a subset of the parameters) used to call the actor method.
+	Params []byte `json:"params"`
 }
 
 // PaymentVoucher is a voucher for a payment channel that can be transferred off-chain but guarantees a future payment.
 type PaymentVoucher struct {
-	Channel   ChannelID       `json:"channel"`
-	Payer     address.Address `json:"payer"`
-	Target    address.Address `json:"target"`
-	Amount    AttoFIL         `json:"amount"`
-	ValidAt   BlockHeight     `json:"valid_at"`
-	Signature Signature       `json:"signature"`
-	Condition *Predicate      `json:"condition"`
+	// Channel is the id of this voucher's payment channel.
+	Channel ChannelID `json:"channel"`
+
+	// Payer is the address of the account that created the channel.
+	Payer address.Address `json:"payer"`
+
+	// Target is the address of the account that will receive funds from the channel.
+	Target address.Address `json:"target"`
+
+	// Amount is the FIL this voucher authorizes the target to redeemed from the channel.
+	Amount AttoFIL `json:"amount"`
+
+	// ValidAt is the earliest block height at which this voucher is valid.
+	ValidAt BlockHeight `json:"valid_at"`
+
+	// Condition defines a optional message that will be called and must return true before this voucher can be redeemed.
+	Condition *Predicate `json:"condition"`
+
+	// Signature is the signature of all the data in this voucher.
+	Signature Signature `json:"signature"`
 }
 
 // DecodeVoucher creates a *PaymentVoucher from a base58, Cbor-encoded one

--- a/types/payment_voucher_test.go
+++ b/types/payment_voucher_test.go
@@ -17,12 +17,19 @@ func TestPaymentVoucherEncodingRoundTrip(t *testing.T) {
 	addr1 := addrGetter()
 	addr2 := addrGetter()
 
+	condition := &Predicate{
+		To:     addrGetter(),
+		Method: "someMethod",
+		Params: []byte("some encoded parameters"),
+	}
+
 	paymentVoucher := &PaymentVoucher{
-		Channel: *NewChannelID(5),
-		Payer:   addr1,
-		Target:  addr2,
-		Amount:  *NewAttoFILFromFIL(100),
-		ValidAt: *NewBlockHeight(25),
+		Channel:   *NewChannelID(5),
+		Payer:     addr1,
+		Target:    addr2,
+		Amount:    *NewAttoFILFromFIL(100),
+		ValidAt:   *NewBlockHeight(25),
+		Condition: condition,
 	}
 
 	rawPaymentVoucher, err := paymentVoucher.Encode()
@@ -35,4 +42,8 @@ func TestPaymentVoucherEncodingRoundTrip(t *testing.T) {
 	assert.Equal((*paymentVoucher).Target, decodedPaymentVoucher.Target)
 	assert.Equal((*paymentVoucher).Amount, decodedPaymentVoucher.Amount)
 	assert.Equal((*paymentVoucher).ValidAt, decodedPaymentVoucher.ValidAt)
+
+	assert.Equal(condition.To, decodedPaymentVoucher.Condition.To)
+	assert.Equal(condition.Method, decodedPaymentVoucher.Condition.Method)
+	assert.Equal(condition.Params, decodedPaymentVoucher.Condition.Params)
 }


### PR DESCRIPTION
### Problem

In general the payers of payment channels should be able to make payments conditional on something provable on chain. In specific clients need to make payments to miner conditional on whether miners are storing their files.

### Solution

This PR lays the groundwork for conditional vouchers by introducing a `condition` field to payment vouchers. It saves testing conditions and creating meaningful conditions for future work.

All of the domain specific work of proving storage will happen in the miner actor, so the payment broker (and payment voucher) don't need to know any of the details about storing files. The payment voucher just needs to contain enough information so that the payment broker can send a message to another actor (the miner.Actor) and get a true/false value back to let it know if the condition is true.

This PR introduces the `Predicate` type that contains the minimal amount of information needed to send a message from within the VM (to address, method, and parameters). Since it is a parameter to the `Redeem` and `Close` methods, it needs to be an `abi` type.