### PR TITLE
Badge update shouldn't be point of failure in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -609,15 +609,15 @@ workflows:
             - unit_test_linux
             - integration_test_linux
             - functional_test_linux
-      - trigger_nightly_devnet_deploy:
-          requires:
-            - build_docker_img
       - publish_release:
           nightly: true
           requires:
             - build_linux
             - build_macos
             - trigger_nightly_devnet_deploy
+      - trigger_nightly_devnet_deploy:
+          requires:
+            - build_docker_img
 
   build_user_devnet:
     jobs:
@@ -822,14 +822,7 @@ commands:
       - run:
           name: Update badge << parameters.filename >>
           command: |
-            git config --global user.email dev-helper@filecoin.io
-            git config --global user.name filecoin-helper
-            git clone https://${GITHUB_TOKEN}@github.com/filecoin-project/go-filecoin-badges.git
-            cd go-filecoin-badges
-            cat << parameters.filename >> | jq --arg FILECOIN_BINARY_VERSION "${FILECOIN_BINARY_VERSION}" -r '.message = $FILECOIN_BINARY_VERSION' | tee << parameters.filename >>
-            git add << parameters.filename >>
-            git commit -m "badge update bot: update << parameters.filename >> to ${FILECOIN_BINARY_VERSION}"
-            git push https://${GITHUB_TOKEN}@github.com/filecoin-project/go-filecoin-badges.git
+            ./scripts/update-badge.sh << parameters.filename >>
   update_submodules:
     steps:
       - run:

--- a/scripts/update-badge.sh
+++ b/scripts/update-badge.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# this script updates go-filecoin status badges in https://github.com/filecoin-project/go-filecoin-badges
+# with latest binary release version
 set -e
 FILENAME="${1}"
 if [[ -z "${FILENAME}" ]]; then

--- a/scripts/update-badge.sh
+++ b/scripts/update-badge.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+FILENAME="${1}"
+if [[ -z "${FILENAME}" ]]; then
+	echo "filename argument must be provided"
+	exit 1
+fi
+git config --global user.email dev-helper@filecoin.io
+git config --global user.name filecoin-helper
+git clone "https://${GITHUB_TOKEN}@github.com/filecoin-project/go-filecoin-badges.git"
+cd go-filecoin-badges
+jq --arg FILECOIN_BINARY_VERSION "${FILECOIN_BINARY_VERSION}" -r '.message = $FILECOIN_BINARY_VERSION' < "${FILENAME}" | tee "${FILENAME}.new"
+if [[ ! -s ${FILENAME}.new ]]; then
+	echo "badge update was not successful. file is empty"
+	exit 1
+fi
+mv "${FILENAME}.new" "${FILENAME}"
+git add "${FILENAME}"
+git commit -m "badge update bot: update ${FILENAME} to ${FILECOIN_BINARY_VERSION}"
+git push "https://${GITHUB_TOKEN}@github.com/filecoin-project/go-filecoin-badges.git"


### PR DESCRIPTION
Moves badge update functionality to a bash script and re-orders CircleCI jobs. See commit messages and linked issue for details.