### PR TITLE
Do not exclude any linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,9 @@ linters:
     - structcheck
     - deadcode
 
+issues:
+  exclude-use-default: false
+
 linters-settings:
   goconst:
     min-occurrences: 6

--- a/build/main.go
+++ b/build/main.go
@@ -21,7 +21,10 @@ func init() {
 		lineBreak = "\r\n"
 	}
 	// We build with go modules.
-	os.Setenv("GO111MODULE", "on")
+	if err := os.Setenv("GO111MODULE", "on"); err != nil {
+		fmt.Println("Failed to set GO111MODULE env")
+		os.Exit(1)
+	}
 }
 
 // command is a structure representing a shell command to be run in the

--- a/commands/address_daemon_test.go
+++ b/commands/address_daemon_test.go
@@ -134,7 +134,9 @@ func TestWalletExportImportRoundTrip(t *testing.T) {
 
 	wf, err := os.Create("walletFileTest")
 	require.NoError(t, err)
-	defer os.Remove("walletFileTest")
+	defer func() {
+		require.NoError(t, os.Remove("walletFileTest"))
+	}()
 	_, err = wf.WriteString(ki)
 	require.NoError(t, err)
 	require.NoError(t, wf.Close())

--- a/config/config.go
+++ b/config/config.go
@@ -169,7 +169,7 @@ func newDefaultMetricsConfig() *MetricsConfig {
 	}
 }
 
-// MetricsConfig holds all configuration options related to nodes message pool (mpool).
+// MessagePoolConfig holds all configuration options related to nodes message pool (mpool).
 type MessagePoolConfig struct {
 	// MaxPoolSize is the maximum number of pending messages will will allow in the message pool at any time
 	MaxPoolSize int `json:"maxPoolSize"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/address"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
@@ -29,7 +30,9 @@ func TestWriteFile(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "config")
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	cfg := NewDefaultConfig()
 
@@ -119,7 +122,9 @@ func TestConfigRoundtrip(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "config")
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	cfg := NewDefaultConfig()
 
@@ -147,7 +152,9 @@ func TestConfigReadFileDefaults(t *testing.T) {
 			}
 		}`)
 		assert.NoError(t, err)
-		defer cleaner()
+		defer func() {
+			require.NoError(t, cleaner())
+		}()
 		cfg, err := ReadFile(cfgpath)
 		assert.NoError(t, err)
 
@@ -164,7 +171,9 @@ func TestConfigReadFileDefaults(t *testing.T) {
 			}
 		}`)
 		assert.NoError(t, err)
-		defer cleaner()
+		defer func() {
+			require.NoError(t, cleaner())
+		}()
 		cfg, err := ReadFile(cfgpath)
 		assert.NoError(t, err)
 
@@ -175,7 +184,9 @@ func TestConfigReadFileDefaults(t *testing.T) {
 	t.Run("empty file", func(t *testing.T) {
 		cfgpath, cleaner, err := createConfigFile("")
 		assert.NoError(t, err)
-		defer cleaner()
+		defer func() {
+			require.NoError(t, cleaner())
+		}()
 		cfg, err := ReadFile(cfgpath)
 		assert.NoError(t, err)
 
@@ -272,7 +283,9 @@ func TestConfigSet(t *testing.T) {
 
 		cfg1path, cleaner, err := createConfigFile(fmt.Sprintf(`{"datastore": %s}`, jsonBlob))
 		assert.NoError(t, err)
-		defer cleaner()
+		defer func() {
+			require.NoError(t, cleaner())
+		}()
 
 		cfg1, err := ReadFile(cfg1path)
 		assert.NoError(t, err)
@@ -332,7 +345,7 @@ path = "mushroom-mushroom"}`
 	})
 }
 
-func createConfigFile(content string) (string, func(), error) {
+func createConfigFile(content string) (string, func() error, error) {
 	dir, err := ioutil.TempDir("", "config")
 	if err != nil {
 		return "", nil, err
@@ -343,5 +356,7 @@ func createConfigFile(content string) (string, func(), error) {
 		return "", nil, err
 	}
 
-	return cfgpath, func() { os.RemoveAll(dir) }, nil
+	return cfgpath, func() error {
+		return os.RemoveAll(dir)
+	}, nil
 }

--- a/metrics/heartbeat_test.go
+++ b/metrics/heartbeat_test.go
@@ -143,7 +143,9 @@ func TestHeartbeatRunSuccess(t *testing.T) {
 
 	// The handle method will run the assertions for the test
 	aggregator.Host.SetStreamHandler(HeartbeatProtocol, func(s net.Stream) {
-		defer s.Close()
+		defer func() {
+			require.NoError(t, s.Close())
+		}()
 
 		dec := json.NewDecoder(s)
 		var hb Heartbeat

--- a/net/pinger.go
+++ b/net/pinger.go
@@ -13,7 +13,7 @@ import (
 // ErrPingSelf is returned if the pinger is instructed to ping itself.
 var ErrPingSelf = errors.New("cannot ping self")
 
-// This struct wraps a libp2p ping service.  It exists to serve more helpful
+// Pinger wraps a libp2p ping service.  It exists to serve more helpful
 // error messages in the case a node is pinging itself.
 type Pinger struct {
 	*ping.PingService

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -56,7 +56,7 @@ func StagingDir(sectorPath string) (string, error) {
 	return homedir.Expand(filepath.Join(sectorPath, defaultSectorStagingDir))
 }
 
-// StagingDir returns the path to the sector sealed directory given the sector
+// SealedDir returns the path to the sector sealed directory given the sector
 // storage directory path.
 func SealedDir(sectorPath string) (string, error) {
 	return homedir.Expand(filepath.Join(sectorPath, defaultSectorSealingDir))

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -339,6 +339,7 @@ func (api *API) DAGImportData(ctx context.Context, data io.Reader) (ipld.Node, e
 	return api.dag.ImportData(ctx, data)
 }
 
+// BitswapGetStats returns bitswaps stats.
 func (api *API) BitswapGetStats(ctx context.Context) (*bitswap.Stat, error) {
 	return api.bitswap.(*bitswap.Bitswap).Stat()
 }

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -151,7 +151,7 @@ func (a *API) MinerPreviewSetPrice(
 	return MinerPreviewSetPrice(ctx, a, from, miner, price, expiry)
 }
 
-// ProtocolParams fetches the current protocol configuration parameters.
+// ProtocolParameters fetches the current protocol configuration parameters.
 func (a *API) ProtocolParameters(ctx context.Context) (*ProtocolParams, error) {
 	return ProtocolParameters(ctx, a)
 }

--- a/porcelain/protocol.go
+++ b/porcelain/protocol.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
+// ProtocolParams TODO(rosa)
 type ProtocolParams struct {
 	AutoSealInterval uint
 	SectorSizes      []uint64
@@ -21,6 +22,7 @@ type protocolParamsPlumbing interface {
 	MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error)
 }
 
+// ProtocolParameters TODO(rosa)
 func ProtocolParameters(ctx context.Context, plumbing protocolParamsPlumbing) (*ProtocolParams, error) {
 	autoSealIntervalInterface, err := plumbing.ConfigGet("mining.autoSealIntervalSeconds")
 	if err != nil {

--- a/proofs/sectorbuilder/bytesink/fifo.go
+++ b/proofs/sectorbuilder/bytesink/fifo.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Not safe for concurrent access, as writes to underlying pipe are atomic only
+// FifoByteSink is not safe for concurrent access, as writes to underlying pipe are atomic only
 // if len(buf) is less than the OS-specific PIPE_BUF value.
 type FifoByteSink struct {
 	file *os.File
@@ -62,7 +62,7 @@ func (s *FifoByteSink) Close() (retErr error) {
 	return
 }
 
-// Id produces a string-identifier for this byte sink. For now, this is just the
+// ID produces a string-identifier for this byte sink. For now, this is just the
 // path of the FIFO file. This string may get more structured in the future.
 func (s *FifoByteSink) ID() string {
 	return s.path

--- a/repo/fsrepo.go
+++ b/repo/fsrepo.go
@@ -33,7 +33,9 @@ const (
 	dealsDatastorePrefix   = "deals"
 	snapshotStorePrefix    = "snapshots"
 	snapshotFilenamePrefix = "snapshot"
-	DefaultRepoDir         = "repo"
+
+	// DefaultRepoDir is the default directory of the filecoin repo
+	DefaultRepoDir = "repo"
 )
 
 // NoRepoError is returned when trying to open a repo where one does not exist
@@ -465,10 +467,12 @@ func (r *FSRepo) SetAPIAddr(maddr string) error {
 	return nil
 }
 
+// Path returns the path the fsrepo is at
 func (r *FSRepo) Path() (string, error) {
 	return r.path, nil
 }
 
+// APIAddrFromRepoPath returns the api addr from the filecoin repo
 func APIAddrFromRepoPath(repoPath string) (string, error) {
 	repoPath, err := homedir.Expand(repoPath)
 	if err != nil {

--- a/repo/fsrepo_test.go
+++ b/repo/fsrepo_test.go
@@ -80,8 +80,9 @@ func TestFSRepoInit(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
-
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	t.Log("init FSRepo")
 	assert.NoError(t, InitFSRepo(dir, config.NewDefaultConfig()))
@@ -125,7 +126,9 @@ func TestFSRepoOpen(t *testing.T) {
 	t.Run("[fail] repo version newer than binary", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "")
 		assert.NoError(t, err)
-		defer os.RemoveAll(dir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(dir))
+		}()
 
 		assert.NoError(t, InitFSRepo(dir, config.NewDefaultConfig()))
 		// set wrong version
@@ -137,7 +140,9 @@ func TestFSRepoOpen(t *testing.T) {
 	t.Run("[fail] binary version newer than repo", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "")
 		assert.NoError(t, err)
-		defer os.RemoveAll(dir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(dir))
+		}()
 
 		assert.NoError(t, InitFSRepo(dir, config.NewDefaultConfig()))
 		// set wrong version
@@ -149,8 +154,10 @@ func TestFSRepoOpen(t *testing.T) {
 	t.Run("[fail] version corrupt", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "")
 		assert.NoError(t, err)
+		defer func() {
+			require.NoError(t, os.RemoveAll(dir))
+		}()
 
-		defer os.RemoveAll(dir)
 		assert.NoError(t, InitFSRepo(dir, config.NewDefaultConfig()))
 		// set wrong version
 		assert.NoError(t, ioutil.WriteFile(filepath.Join(dir, versionFilename), []byte("v.8"), 0644))
@@ -165,7 +172,9 @@ func TestFSRepoRoundtrip(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	cfg := config.NewDefaultConfig()
 	cfg.API.Address = "foo" // testing that what we get back isnt just the default
@@ -194,7 +203,9 @@ func TestFSRepoReplaceAndSnapshotConfig(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	cfg := config.NewDefaultConfig()
 	cfg.API.Address = "foo"
@@ -233,7 +244,9 @@ func TestRepoLock(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	cfg := config.NewDefaultConfig()
 	assert.NoError(t, err, InitFSRepo(dir, cfg))
@@ -255,7 +268,9 @@ func TestRepoLockFail(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	cfg := config.NewDefaultConfig()
 	assert.NoError(t, err, InitFSRepo(dir, cfg))
@@ -322,7 +337,7 @@ func TestRepoAPIFile(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, apiFile, info.Name())
 
-			r.Close()
+			require.NoError(t, r.Close())
 
 			_, err = os.Stat(filepath.Join(r.path, apiFile))
 			assert.Error(t, err)
@@ -360,9 +375,10 @@ func TestCreateRepo(t *testing.T) {
 
 	t.Run("successfully creates when directory exists", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "init")
-
 		assert.NoError(t, err)
-		defer os.RemoveAll(dir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(dir))
+		}()
 
 		_, err = CreateRepo(dir, cfg)
 		assert.NoError(t, err)
@@ -372,7 +388,9 @@ func TestCreateRepo(t *testing.T) {
 	t.Run("successfully creates when directory does not exist", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "init")
 		assert.NoError(t, err)
-		defer os.RemoveAll(dir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(dir))
+		}()
 
 		dir = filepath.Join(dir, "nested")
 
@@ -385,7 +403,9 @@ func TestCreateRepo(t *testing.T) {
 	t.Run("fails with error if directory is not writeable", func(t *testing.T) {
 		parentDir, err := ioutil.TempDir("", "init")
 		assert.NoError(t, err)
-		defer os.RemoveAll(parentDir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(parentDir))
+		}()
 
 		// make read only dir
 		dir := filepath.Join(parentDir, "readonly")
@@ -399,13 +419,10 @@ func TestCreateRepo(t *testing.T) {
 
 	t.Run("fails with error if config file already exists", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "init")
-
 		assert.NoError(t, err)
-		defer os.RemoveAll(dir)
-
-		err = ioutil.WriteFile(filepath.Join(dir, "config.json"), []byte("hello"), 0644)
-		assert.NoError(t, err)
-		defer os.RemoveAll(dir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(dir))
+		}()
 
 		err = ioutil.WriteFile(filepath.Join(dir, "config.json"), []byte("hello"), 0644)
 		require.NoError(t, err)
@@ -419,7 +436,9 @@ func TestCreateRepo(t *testing.T) {
 func withFSRepo(t *testing.T, f func(*FSRepo)) {
 	dir, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	cfg := config.NewDefaultConfig()
 	require.NoError(t, err, InitFSRepo(dir, cfg))

--- a/state/tree_test.go
+++ b/state/tree_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-hamt-ipld"
 	mh "github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/address"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestStatePutGet(t *testing.T) {
@@ -126,9 +127,9 @@ func TestGetAllActors(t *testing.T) {
 
 	actor := actor.Actor{Code: types.AccountActorCodeCid, Nonce: 1234, Balance: types.NewAttoFILFromFIL(123)}
 	err := tree.SetActor(ctx, addr, &actor)
-	tree.Flush(ctx)
-
 	assert.NoError(t, err)
+	_, err = tree.Flush(ctx)
+	require.NoError(t, err)
 
 	results := GetAllActors(ctx, tree)
 

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -100,14 +100,17 @@ func NewTestMessagePoolAPI(h uint64) *TestMessagePoolAPI {
 	return &TestMessagePoolAPI{Height: h}
 }
 
+// MockMessagePoolValidator is a mock validator
 type MockMessagePoolValidator struct {
 	Valid bool
 }
 
+// NewMockMessagePoolValidator creates a MockMessagePoolValidator
 func NewMockMessagePoolValidator() *MockMessagePoolValidator {
 	return &MockMessagePoolValidator{Valid: true}
 }
 
+// Validate returns true if the mock validator is set to validate the message
 func (v *MockMessagePoolValidator) Validate(ctx context.Context, msg *types.SignedMessage) error {
 	if v.Valid {
 		return nil

--- a/tools/fast/environment_memory_genesis_test.go
+++ b/tools/fast/environment_memory_genesis_test.go
@@ -38,7 +38,9 @@ func TestEnvironmentMemoryGenesis(t *testing.T) {
 
 		testDir, err := ioutil.TempDir(".", "environmentTest")
 		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(testDir))
+		}()
 
 		env, err := NewEnvironmentMemoryGenesis(big.NewInt(100000), testDir, types.TestProofsMode)
 		localenv := env.(*EnvironmentMemoryGenesis)
@@ -61,7 +63,9 @@ func TestEnvironmentMemoryGenesis(t *testing.T) {
 
 		testDir, err := ioutil.TempDir(".", "environmentTest")
 		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(testDir))
+		}()
 
 		env, err := NewEnvironmentMemoryGenesis(big.NewInt(100000), testDir, types.TestProofsMode)
 		require.NoError(t, err)

--- a/tools/fast/fastesting/basic.go
+++ b/tools/fast/fastesting/basic.go
@@ -122,7 +122,7 @@ func (env *TestEnvironment) RequireNewNodeConnected() *fast.Filecoin {
 	return p
 }
 
-// RequireNodeNodeWithFunds builds a new node using RequireNewNodeStarted, then
+// RequireNewNodeWithFunds builds a new node using RequireNewNodeStarted, then
 // sends it funds from the environment GenesisMiner node
 func (env *TestEnvironment) RequireNewNodeWithFunds(funds int) *fast.Filecoin {
 	p := env.RequireNewNodeConnected()
@@ -153,6 +153,6 @@ func dumpEnvOutputOnFail(t *testing.T, procs []*fast.Filecoin) {
 		for _, node := range procs {
 			node.DumpLastOutput(w)
 		}
-		w.Close()
+		require.NoError(t, w.Close())
 	}
 }

--- a/tools/fast/fastesting/log_writer_test.go
+++ b/tools/fast/fastesting/log_writer_test.go
@@ -22,8 +22,6 @@ func (w *tlogWriter) Logf(format string, args ...interface{}) {
 func TestLogWriter(t *testing.T) {
 	tf.UnitTest(t)
 
-	require := require.New(t)
-
 	input := []string{
 		"line1\n",
 		"line2\n",
@@ -37,10 +35,10 @@ func TestLogWriter(t *testing.T) {
 
 	for _, line := range input {
 		_, err := lw.Write([]byte(fmt.Sprintf("%s", line)))
-		require.NoError(err)
+		require.NoError(t, err)
 	}
 
-	lw.Close()
+	require.NoError(t, lw.Close())
 
-	require.Equal(strings.Join(input, ""), out.buf.String())
+	require.Equal(t, strings.Join(input, ""), out.buf.String())
 }

--- a/tools/iptb-plugins/filecoin/local/localfilecoin.go
+++ b/tools/iptb-plugins/filecoin/local/localfilecoin.go
@@ -549,7 +549,7 @@ func (l *Localfilecoin) SwarmAddrs() ([]string, error) {
 
 /** Config Interface **/
 
-// GetConfig returns the nodes config.
+// Config returns the nodes config.
 func (l *Localfilecoin) Config() (interface{}, error) {
 	return config.ReadFile(filepath.Join(l.dir, "config.json"))
 }

--- a/tools/iptb-plugins/filecoin/mock/mockfilecoin.go
+++ b/tools/iptb-plugins/filecoin/mock/mockfilecoin.go
@@ -107,10 +107,12 @@ func (m *Mockfilecoin) SwarmAddrs() ([]string, error) {
 	panic("not implemented")
 }
 
+// Config is not implemented
 func (m *Mockfilecoin) Config() (interface{}, error) {
 	panic("not implemented")
 }
 
+// WriteConfig is not implemented
 func (m *Mockfilecoin) WriteConfig(interface{}) error {
 	panic("not implemented")
 }

--- a/tools/migration/internal/repo_fs_helpers.go
+++ b/tools/migration/internal/repo_fs_helpers.go
@@ -60,6 +60,7 @@ func InstallNewRepo(oldRepoLink, newRepoPath string) error {
 	return nil
 }
 
+// OpenRepo opens repoPath
 func OpenRepo(repoPath string) (*os.File, error) {
 	return os.Open(repoPath)
 }

--- a/tools/migration/internal/runner.go
+++ b/tools/migration/internal/runner.go
@@ -26,12 +26,14 @@ type Migration interface {
 	Validate(oldRepoPath, newRepoPath string) error
 }
 
+// MigrationRunner represent a migration command
 type MigrationRunner struct {
 	verbose    bool
 	command    string
 	oldRepoOpt string
 }
 
+// NewMigrationRunner builds a MirgrationRunner for the given command and repo options
 func NewMigrationRunner(verb bool, command, oldRepoOpt string) *MigrationRunner {
 	// TODO: Issue #2585 Implement repo migration version detection and upgrade decisioning
 
@@ -42,6 +44,7 @@ func NewMigrationRunner(verb bool, command, oldRepoOpt string) *MigrationRunner 
 	}
 }
 
+// Run executes the MigrationRunner
 func (m *MigrationRunner) Run() error {
 	// TODO: Issue #2595 Implement first repo migration
 	return nil

--- a/tools/migration/main.go
+++ b/tools/migration/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/tools/migration/internal"
 )
 
+// USAGE is the usage of the migration tool
 const USAGE = `
 USAGE
 	go-filecoin-migrate (describe|buildonly|migrate) --old-repo=<repodir> [-h|--help] [-v|--verbose]

--- a/types/porep_proof_partitions.go
+++ b/types/porep_proof_partitions.go
@@ -6,10 +6,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+// PoRepProofPartitions represents the number of partitions used when creating a
+// PoRep proof, and impacts the size of the proof.
 type PoRepProofPartitions int
 
 const (
+	// UnknownPoRepProofPartitions is an opaque value signaling that an unknown number
+	// of partitions were used when creating a PoRep proof in test mode.
 	UnknownPoRepProofPartitions = PoRepProofPartitions(iota)
+
+	// TwoPoRepProofPartitions indicates that two partitions were used to create a PoRep proof.
 	TwoPoRepProofPartitions
 )
 

--- a/types/post_proof_partitions.go
+++ b/types/post_proof_partitions.go
@@ -5,10 +5,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+// PoStProofPartitions represents the number of partitions used when creating a
+// PoSt proof, and impacts the size of the proof.
 type PoStProofPartitions int
 
 const (
+	// UnknownPoStProofPartitions is an opaque value signaling that an unknown number of
+	// partitions were used when creating a PoSt proof in test mode.
 	UnknownPoStProofPartitions = PoStProofPartitions(iota)
+
+	// OnePoStProofPartition indicates that a single partition was used to create a PoSt proof.
 	OnePoStProofPartition
 )
 

--- a/types/sector_size.go
+++ b/types/sector_size.go
@@ -8,8 +8,13 @@ import "fmt"
 type SectorSize int
 
 const (
+	// UnknownSectorSize sector size
 	UnknownSectorSize = SectorSize(iota)
-	OneKiBSectorSize
+
+	// OneKiBSectorSize indicates a sector which, after sealing, contains 1024 bytes.
+	OneKiBSectorSize = SectorSize(iota)
+
+	// TwoHundredFiftySixMiBSectorSize indicates a sector which, after sealing, contains 256MiB.
 	TwoHundredFiftySixMiBSectorSize
 )
 

--- a/wallet/dsbackend_test.go
+++ b/wallet/dsbackend_test.go
@@ -5,16 +5,19 @@ import (
 	"testing"
 
 	"github.com/ipfs/go-datastore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDSBackendSimple(t *testing.T) {
 	tf.UnitTest(t)
 
 	ds := datastore.NewMapDatastore()
-	defer ds.Close()
+	defer func() {
+		require.NoError(t, ds.Close())
+	}()
 
 	fs, err := NewDSBackend(ds)
 	assert.NoError(t, err)
@@ -40,7 +43,9 @@ func TestDSBackendKeyPairMatchAddress(t *testing.T) {
 	tf.UnitTest(t)
 
 	ds := datastore.NewMapDatastore()
-	defer ds.Close()
+	defer func() {
+		require.NoError(t, ds.Close())
+	}()
 
 	fs, err := NewDSBackend(ds)
 	assert.NoError(t, err)
@@ -68,12 +73,16 @@ func TestDSBackendErrorsForUnknownAddress(t *testing.T) {
 
 	// create 2 backends
 	ds1 := datastore.NewMapDatastore()
-	defer ds1.Close()
+	defer func() {
+		require.NoError(t, ds1.Close())
+	}()
 	fs1, err := NewDSBackend(ds1)
 	assert.NoError(t, err)
 
 	ds2 := datastore.NewMapDatastore()
-	defer ds2.Close()
+	defer func() {
+		require.NoError(t, ds2.Close())
+	}()
 	fs2, err := NewDSBackend(ds2)
 	assert.NoError(t, err)
 
@@ -102,7 +111,9 @@ func TestDSBackendParallel(t *testing.T) {
 	tf.UnitTest(t)
 
 	ds := datastore.NewMapDatastore()
-	defer ds.Close()
+	defer func() {
+		require.NoError(t, ds.Close())
+	}()
 
 	fs, err := NewDSBackend(ds)
 	assert.NoError(t, err)


### PR DESCRIPTION
golangci-lint chooses to ignore a few linter errors by default. One of these was the doc comments from golint which is why we haven't seen these issues fail ci. This PR disables this configuration and doesn't silent any linter errors.

There are a things that still need proper comments, I've noted these with a `TODO(author)`. Comment on the line with whatever I should replace the placeholder with and I'll update the PR.