### PR TITLE
[DOCKER] copy binaries from tools directory

### DIFF
--- a/Dockerfile.ci.faucet
+++ b/Dockerfile.ci.faucet
@@ -2,7 +2,7 @@ FROM busybox:1-glibc
 MAINTAINER Filecoin Dev Team
 
 # Get the binary, entrypoint script, and TLS CAs from the build container.
-COPY faucet /usr/local/bin/faucet
+COPY tools/faucet /usr/local/bin/faucet
 COPY --from=filecoin:all /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=filecoin:all /tmp/tini /sbin/tini
 COPY --from=filecoin:all /etc/ssl/certs /etc/ssl/certs

--- a/Dockerfile.ci.genesis
+++ b/Dockerfile.ci.genesis
@@ -2,7 +2,7 @@ FROM busybox:1-glibc
 MAINTAINER Filecoin Dev Team
 
 # Get the binary, entrypoint script, and TLS CAs from the build container.
-COPY genesis-file-server /usr/local/bin/genesis-file-server
+COPY tools/genesis-file-server /usr/local/bin/genesis-file-server
 COPY fixtures/* /data/
 COPY --from=filecoin:all /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=filecoin:all /tmp/tini /sbin/tini


### PR DESCRIPTION
as part of the recent refactor, the faucet and genesis CI job was eliminated, as the binaries were already in 'tools' directory.
update Docker files accordingly.