### PR TITLE
Repo migration functionality: Copy old repo, install new repo #2643

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/multiformats/go-multistream v0.0.1
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/otiai10/copy v1.0.1
 	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/polydawn/refmt v0.0.0-20190221155625-df39d6c2d992

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+bou.ke/monkey v1.0.1/go.mod h1:FgHuK96Rv2Nlf+0u1OOVDpCMdsWyOFmeeketDHE7LIg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
@@ -487,6 +488,9 @@ github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
+github.com/otiai10/copy v1.0.1 h1:gtBjD8aq4nychvRZ2CyJvFWAw0aja+VHazDdruZKGZA=
+github.com/otiai10/copy v1.0.1/go.mod h1:8bMCJrAqOtN/d9oyh5HR7HhLQMvcGMpGdwRDYsfOCHc=
+github.com/otiai10/mint v1.2.3/go.mod h1:YnfyPNhBvnY8bW4SGQHCs/aAFhkgySlMZbrF5U0bOVw=
 github.com/pelletier/go-toml v1.1.0 h1:cmiOvKzEunMsAxyhXSzpL5Q1CRKpVv0KQsnAIcSEVYM=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/tools/migration/internal/repo_fs_helpers.go
+++ b/tools/migration/internal/repo_fs_helpers.go
@@ -9,15 +9,28 @@ import (
 	rcopy "github.com/otiai10/copy"
 )
 
+// This is a set of file system helpers for repo migration.
+//
+// CloneRepo and InstallRepo expect a symlink that points to the entire filecoin home
+// directory, typically ~/.filecoin or whatever FIL_PATH is set to.
+//
+// This does touch sector data.
+
 // CloneRepo copies the old repo to the new repo dir with Read/Write access.
-//   Returns an error if the directory exists.
-func CloneRepo(oldRepoPath string) (string, error) {
-	realRepoPath, err := os.Readlink(oldRepoPath)
+//	 oldRepoLink must be a symlink. The symlink will be resolved and used for
+//   copying.
+//
+//   The new repo dir name will look like: /Users/davonte/.filecoin-20190806-150455-001
+//   If there is an existing dir by that name, the integer at the end will be
+//   incremented until there is a free one or a new timestamp.
+//
+func CloneRepo(oldRepoLink string) (string, error) {
+	realRepoPath, err := os.Readlink(oldRepoLink)
 	if err != nil {
 		return "", fmt.Errorf("old-repo must be a symbolic link: %s", err)
 	}
 
-	newRepoPath, err := getNewRepoPath(oldRepoPath, "")
+	newRepoPath, err := getNewRepoPath(oldRepoLink, "")
 	if err != nil {
 		return "", err
 	}
@@ -32,25 +45,19 @@ func CloneRepo(oldRepoPath string) (string, error) {
 }
 
 // InstallNewRepo archives the old repo, and symlinks the new repo in its place.
-// returns the new path to the old repo and any error.
-func InstallNewRepo(oldRepoLink, newRepoPath string) (string, error) {
-	realRepoPath, err := os.Readlink(oldRepoLink)
-	if err != nil {
-		return "", err
+// returns any error.
+func InstallNewRepo(oldRepoLink, newRepoPath string) error {
+	if _, err := os.Readlink(oldRepoLink); err != nil {
+		return err
 	}
 
-	archivedRepoPath := strings.Join([]string{realRepoPath, "archived", NowString()}, "-")
-
-	if err := os.Rename(realRepoPath, archivedRepoPath); err != nil {
-		return archivedRepoPath, err
-	}
 	if err := os.Remove(oldRepoLink); err != nil {
-		return archivedRepoPath, err
+		return err
 	}
 	if err := os.Symlink(newRepoPath, oldRepoLink); err != nil {
-		return archivedRepoPath, err
+		return err
 	}
-	return archivedRepoPath, nil
+	return nil
 }
 
 func OpenRepo(repoPath string) (*os.File, error) {
@@ -63,8 +70,9 @@ func OpenRepo(repoPath string) (*os.File, error) {
 //     newRepoOpt:  whatever was passed in by the CLI (can be blank)
 // Returns:
 //     a path generated using the above information plus tmp_<timestamp>.
+//     error
 // Example output:
-//     /Users/davonte/.filecoin_tmp_20190806-150455-001
+//     /Users/davonte/.filecoin-20190806-150455-001
 func getNewRepoPath(oldPath, newRepoOpt string) (string, error) {
 	var newRepoPrefix string
 	if newRepoOpt != "" {

--- a/tools/migration/internal/repo_fs_helpers_test.go
+++ b/tools/migration/internal/repo_fs_helpers_test.go
@@ -67,8 +67,8 @@ func TestRepoMigrationHelper_CloneRepo(t *testing.T) {
 		// this test fails because the index restarts, due to the timestamp
 		// updating, which is correct behavior. Programmatically proving it restarts
 		// in this test was more trouble than it was worth.
-		repos := []string{}
-		for i := 1; i < 50; i++ {
+		var repos []string
+		for i := 1; i < 10; i++ {
 			result, err := CloneRepo(linkedRepoPath)
 			require.NoError(t, err)
 			repos = append(repos, result)
@@ -84,13 +84,10 @@ func TestRepoMigrationHelper_CloneRepo(t *testing.T) {
 	})
 }
 
-func TestRepoFSWrangler_InstallNewRepo(t *testing.T) {
+func TestRepoFSHelpers_InstallNewRepo(t *testing.T) {
 	tf.UnitTest(t)
 
 	oldRepo := requireMakeTempDir(t, "")
-	// put something in each repo dir so we know which is which
-	_, err := os.Create(path.Join(oldRepo, "oldRepoFile"))
-	require.NoError(t, err)
 
 	linkedRepoPath := oldRepo + "something"
 	require.NoError(t, os.Symlink(oldRepo, oldRepo+"something"))
@@ -103,20 +100,12 @@ func TestRepoFSWrangler_InstallNewRepo(t *testing.T) {
 	_, err = os.Create(path.Join(newRepoPath, "newRepoFile"))
 	require.NoError(t, err)
 
-	archivedRepo, err := InstallNewRepo(linkedRepoPath, newRepoPath)
-	require.NoError(t, err)
+	require.NoError(t, InstallNewRepo(linkedRepoPath, newRepoPath))
 
-	// check that the archive is there
-	dir, err := os.Open(archivedRepo)
+	// check that the new repo is at the old link location.
+	dir, err := os.Open(newRepoPath)
 	require.NoError(t, err)
 	contents, err := dir.Readdirnames(0)
-	require.NoError(t, err)
-	assert.Contains(t, contents, "oldRepoFile")
-
-	// check that the new repo is at the old location.
-	dir, err = os.Open(newRepoPath)
-	require.NoError(t, err)
-	contents, err = dir.Readdirnames(0)
 	require.NoError(t, err)
 	assert.Contains(t, contents, "newRepoFile")
 }

--- a/tools/migration/internal/repo_fs_wrangler_test.go
+++ b/tools/migration/internal/repo_fs_wrangler_test.go
@@ -45,7 +45,6 @@ func TestRepoMigrationHelper_MakeNewRepo(t *testing.T) {
 		expectedPerms := "drwxr--r--"
 		assert.Equal(t, expectedPerms, stat.Mode().String())
 	})
-
 }
 
 func TestGetNewRepoPath(t *testing.T) {
@@ -56,7 +55,7 @@ func TestGetNewRepoPath(t *testing.T) {
 	t.Run("Uses the new repo opt as a prefix if provided", func(t *testing.T) {
 		rmh := NewRepoFSWrangler(dirname, "/tmp/somethingelse")
 		newpath := rmh.GetNewRepoPath()
-		rgx, err := regexp.Compile("/tmp/somethingelse_1_2_[0-9]{8}-[0-9]{6}$")
+		rgx, err := regexp.Compile("/tmp/somethingelse_tmp_[0-9]{8}-[0-9]{6}$")
 		require.NoError(t, err)
 		assert.Regexp(t, rgx, newpath)
 	})
@@ -64,24 +63,10 @@ func TestGetNewRepoPath(t *testing.T) {
 	t.Run("Adds a timestamp to the new repo dir", func(t *testing.T) {
 		rmh := NewRepoFSWrangler(dirname, "")
 		newpath := rmh.GetNewRepoPath()
-		rgx, err := regexp.Compile("/tmp/myfilecoindir_1_2_[0-9]{8}-[0-9]{6}$")
+		rgx, err := regexp.Compile("/tmp/myfilecoindir_tmp_[0-9]{8}-[0-9]{6}$")
 		require.NoError(t, err)
 		assert.Regexp(t, rgx, newpath)
 	})
-}
-
-func TestRepoFSWrangler_MakeNewRepo(t *testing.T) {
-	tf.UnitTest(t)
-
-	dirname := requireMakeTempDir(t, "")
-	rmh := NewRepoFSWrangler(dirname, "")
-	require.NoError(t, rmh.CloneRepo())
-	dir, err := os.Open(rmh.GetNewRepoPath())
-	require.NoError(t, err)
-	stat, err := dir.Stat()
-	require.NoError(t, err)
-	expectedPerms := "drwxr--r--"
-	assert.Equal(t, expectedPerms, stat.Mode().String())
 }
 
 func TestRepoFSWrangler_InstallNewRepo(t *testing.T) {
@@ -104,7 +89,7 @@ func TestRepoFSWrangler_InstallNewRepo(t *testing.T) {
 	require.NoError(t, err)
 	stat, err := dir.Stat()
 	require.NoError(t, err)
-	expectedPerms := "dr--r--r--"
+	expectedPerms := "drwx------"
 	assert.Equal(t, expectedPerms, stat.Mode().String())
 	contents, err := dir.Readdirnames(0)
 	require.NoError(t, err)

--- a/tools/migration/internal/runner.go
+++ b/tools/migration/internal/runner.go
@@ -35,8 +35,8 @@ type Migration interface {
 type RepoWrangler interface {
 	// GetOldRepo opens and returns the old repo with read-only access
 	GetOldRepo() (*os.File, error)
-	// MakeNewRepo creates and returns the new repo dir with read/write permissions
-	MakeNewRepo() error
+	// CloneRepo creates and returns the new repo dir with read/write permissions
+	CloneRepo() error
 	// GetOldRepoPath returns the full path of the old repo
 	GetOldRepoPath() string
 	// GetNewRepoPath returns the full path of the old repo

--- a/tools/migration/internal/runner.go
+++ b/tools/migration/internal/runner.go
@@ -51,10 +51,8 @@ type MigrationRunner struct {
 
 func NewMigrationRunner(verb bool, command, oldRepoOpt, newRepoPrefixOpt string) *MigrationRunner {
 	// TODO: Issue #2585 Implement repo migration version detection and upgrade decisioning
-	oldVersion := "1"
-	newVersion := "2"
 
-	helper := NewRepoFSWrangler(oldRepoOpt, newRepoPrefixOpt, oldVersion, newVersion)
+	helper := NewRepoFSWrangler(oldRepoOpt, newRepoPrefixOpt)
 	return &MigrationRunner{
 		verbose: verb,
 		command: command,

--- a/tools/migration/internal/runner.go
+++ b/tools/migration/internal/runner.go
@@ -1,9 +1,5 @@
 package internal
 
-import (
-	"os"
-)
-
 // Migration is the interface to all repo migration versions.
 type Migration interface {
 	// Migrate performs all migration steps for the Migration that implements the interface.
@@ -30,33 +26,19 @@ type Migration interface {
 	Validate(oldRepoPath, newRepoPath string) error
 }
 
-// RepoWrangler is a helper that manages filesystem operations and figures out what the correct paths
-// are for everything.
-type RepoWrangler interface {
-	// GetOldRepo opens and returns the old repo with read-only access
-	GetOldRepo() (*os.File, error)
-	// CloneRepo creates and returns the new repo dir with read/write permissions
-	CloneRepo() error
-	// GetOldRepoPath returns the full path of the old repo
-	GetOldRepoPath() string
-	// GetNewRepoPath returns the full path of the old repo
-	GetNewRepoPath() string
-}
-
 type MigrationRunner struct {
-	verbose bool
-	command string
-	helper  RepoWrangler
+	verbose    bool
+	command    string
+	oldRepoOpt string
 }
 
-func NewMigrationRunner(verb bool, command, oldRepoOpt, newRepoPrefixOpt string) *MigrationRunner {
+func NewMigrationRunner(verb bool, command, oldRepoOpt string) *MigrationRunner {
 	// TODO: Issue #2585 Implement repo migration version detection and upgrade decisioning
 
-	helper := NewRepoFSWrangler(oldRepoOpt, newRepoPrefixOpt)
 	return &MigrationRunner{
-		verbose: verb,
-		command: command,
-		helper:  helper,
+		verbose:    verb,
+		command:    command,
+		oldRepoOpt: oldRepoOpt,
 	}
 }
 

--- a/tools/migration/internal/runner.go
+++ b/tools/migration/internal/runner.go
@@ -36,7 +36,7 @@ type RepoWrangler interface {
 	// GetOldRepo opens and returns the old repo with read-only access
 	GetOldRepo() (*os.File, error)
 	// MakeNewRepo creates and returns the new repo dir with read/write permissions
-	MakeNewRepo() (*os.File, error)
+	MakeNewRepo() error
 	// GetOldRepoPath returns the full path of the old repo
 	GetOldRepoPath() string
 	// GetNewRepoPath returns the full path of the old repo

--- a/tools/migration/internal/runner_test.go
+++ b/tools/migration/internal/runner_test.go
@@ -3,7 +3,7 @@ package internal_test
 import (
 	"testing"
 
-	ast "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	. "github.com/filecoin-project/go-filecoin/tools/migration/internal"
@@ -12,8 +12,7 @@ import (
 // TODO: Issue #2595 Implement first repo migration
 func TestMigrationRunner_Run(t *testing.T) {
 	tf.UnitTest(t)
-	assert := ast.New(t)
 
 	runner := NewMigrationRunner(false, "describe", "1", "2")
-	assert.NoError(runner.Run())
+	assert.NoError(t, runner.Run())
 }

--- a/tools/migration/internal/runner_test.go
+++ b/tools/migration/internal/runner_test.go
@@ -13,6 +13,6 @@ import (
 func TestMigrationRunner_Run(t *testing.T) {
 	tf.UnitTest(t)
 
-	runner := NewMigrationRunner(false, "describe", "1", "2")
+	runner := NewMigrationRunner(false, "describe", "/home/filecoin-symlink")
 	assert.NoError(t, runner.Run())
 }

--- a/tools/migration/internal/utils.go
+++ b/tools/migration/internal/utils.go
@@ -1,8 +1,6 @@
 package internal
 
 import (
-	"os/user"
-	"strings"
 	"time"
 )
 
@@ -10,16 +8,4 @@ import (
 func NowString() string {
 	now := time.Now()
 	return now.Format("20060102-150405")
-}
-
-// expandHomedir replaces an initial tilde in a dirname to the home dir.
-// if there is no initial ~ , it returns dirname.
-func ExpandHomedir(dirname string) string {
-	if strings.LastIndex(dirname, "~") != 0 {
-		return dirname
-	}
-
-	usr, _ := user.Current()
-	home := usr.HomeDir
-	return strings.Replace(dirname, "~", home, 1)
 }

--- a/tools/migration/internal/utils_test.go
+++ b/tools/migration/internal/utils_test.go
@@ -3,7 +3,7 @@ package internal_test
 import (
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	. "github.com/filecoin-project/go-filecoin/tools/migration/internal"
-	ast "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"regexp"
 	"strings"
@@ -12,19 +12,17 @@ import (
 
 func TestNowString(t *testing.T) {
 	tf.UnitTest(t)
-	assert := ast.New(t)
 	adateStr := NowString()
 	rg, _ := regexp.Compile("^[0-9]{8}-[0-9]{6}$")
-	assert.Regexp(rg, adateStr)
+	assert.Regexp(t, rg, adateStr)
 }
 
 func TestExpandHomedir(t *testing.T) {
 	tf.UnitTest(t)
-	assert := ast.New(t)
-	assert.Equal(ExpandHomedir("/tmp/foo"), "/tmp/foo")
+	assert.Equal(t, ExpandHomedir("/tmp/foo"), "/tmp/foo")
 
 	home := os.Getenv("HOME")
 	expected := strings.Join([]string{home, "/foo"}, "")
 
-	assert.Equal(expected, ExpandHomedir("~/foo"))
+	assert.Equal(t, expected, ExpandHomedir("~/foo"))
 }

--- a/tools/migration/internal/utils_test.go
+++ b/tools/migration/internal/utils_test.go
@@ -16,13 +16,3 @@ func TestNowString(t *testing.T) {
 	rg, _ := regexp.Compile("^[0-9]{8}-[0-9]{6}$")
 	assert.Regexp(t, rg, adateStr)
 }
-
-func TestExpandHomedir(t *testing.T) {
-	tf.UnitTest(t)
-	assert.Equal(t, ExpandHomedir("/tmp/foo"), "/tmp/foo")
-
-	home := os.Getenv("HOME")
-	expected := strings.Join([]string{home, "/foo"}, "")
-
-	assert.Equal(t, expected, ExpandHomedir("~/foo"))
-}

--- a/tools/migration/internal/utils_test.go
+++ b/tools/migration/internal/utils_test.go
@@ -4,9 +4,7 @@ import (
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	. "github.com/filecoin-project/go-filecoin/tools/migration/internal"
 	"github.com/stretchr/testify/assert"
-	"os"
 	"regexp"
-	"strings"
 	"testing"
 )
 

--- a/tools/migration/main.go
+++ b/tools/migration/main.go
@@ -26,7 +26,7 @@ REQUIRED ARGUMENTS
 	--old-repo
 		The symlink location of this node's filecoin home directory. This is required even for the
 		'describe' command, as its repo version helps determine which migration to run. This
-		must be a symlink or migration will not proceed.  The symlink will be followed.
+		must be a symbolic link or migration will not proceed.
 
 OPTIONS
 	-h, --help

--- a/tools/migration/main.go
+++ b/tools/migration/main.go
@@ -11,7 +11,7 @@ import (
 
 const USAGE = `
 USAGE
-	go-filecoin-migrate (describe|buildonly|migrate) --old-repo=<repodir> [--new-repo=<newrepo-prefix] [-h|--help] [-v|--verbose]
+	go-filecoin-migrate (describe|buildonly|migrate) --old-repo=<repodir> [-h|--help] [-v|--verbose]
 
 COMMANDS
 	describe
@@ -24,35 +24,29 @@ COMMANDS
 
 REQUIRED ARGUMENTS
 	--old-repo
-		The location of this node's filecoin home directory. This is required even for the
-		'describe' command, as the its repo version helps determine which migration to run.
+		The symlink location of this node's filecoin home directory. This is required even for the
+		'describe' command, as its repo version helps determine which migration to run. This
+		must be a symlink or migration will not proceed.  The symlink will be followed.
 
 OPTIONS
 	-h, --help
 		This message
 	-v --verbose
 		Print diagnostic messages to stdout
-	--new-repo
-		The prefix for the migrated repo. A directory prefixed with this 
-		path will be created to hold the copy of the old repo for migration, named 
-		with a timestamp and migration versions. 
-
-		Provide this if you want the migrated repo to be in a different directory, on a 
-        different device, or you just prefer a different naming scheme.
-
-		Ensure the parent directory exists; go-filecoin-migrate will not create tree
-        structure.
 
 EXAMPLES
 	for a migration from version 1 to 2:
 	go-filecoin-migrate migrate --old-repo=~/.filecoin
 		Migrates then installs the repo. Migrated repo will be in ~/.filecoin_1_2_<timestamp>
+		and symlinked to ~/.filecoin
 
 	go-filecoin-migrate migrate --old-repo=/opt/filecoin
 		Migrates then installs the repo. Migrated repo will be in /opt/filecoin_1_2_<timestamp> 
+		and symlinked to /opt/filecoin
 
-	go-filecoin-migrate build-only --old-repo=/opt/filecoin --new-repo=/tmp/somedir
-		Runs migration steps only. Migrated repo will be in /tmp/somedir_1_2_<timestamp>
+	go-filecoin-migrate build-only --old-repo=/opt/filecoin 
+		Runs migration steps only. Migrated repo will be in /opt/filecoin_1_2_<timestamp>
+		and symlinked to /opt/filecoin
 `
 
 func main() { // nolint: deadcode
@@ -71,8 +65,7 @@ func main() { // nolint: deadcode
 			exitErr(fmt.Sprintf("Error: --old-repo is required\n%s\n", USAGE))
 		}
 
-		newRepoPrefixOpt, _ := findOpt("new-repo", os.Args)
-		runner := internal.NewMigrationRunner(getVerbose(), command, oldRepoOpt, newRepoPrefixOpt)
+		runner := internal.NewMigrationRunner(getVerbose(), command, oldRepoOpt)
 		if err := runner.Run(); err != nil {
 			exitErr(err.Error())
 		}

--- a/tools/migration/main_test.go
+++ b/tools/migration/main_test.go
@@ -7,80 +7,76 @@ import (
 	"testing"
 
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
-	ast "github.com/stretchr/testify/assert"
-	req "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/testhelpers"
 )
 
 func TestUsage(t *testing.T) {
 	tf.IntegrationTest(t) // because we're using exec.Command
-	require := req.New(t)
-	assert := ast.New(t)
-	command := mustGetMigrationBinary(require)
+	command := mustGetMigrationBinary(t)
 	expected := "go-filecoin-migrate (describe|buildonly|migrate) --old-repo=<repodir> [--new-repo=<newrepo-prefix] [-h|--help] [-v|--verbose]"
 
 	t.Run("bare invocation prints usage but exits with 1", func(t *testing.T) {
 		out, err := exec.Command(command).CombinedOutput()
-		assert.Contains(string(out), expected)
-		assert.Error(err)
+		assert.Contains(t, string(out), expected)
+		assert.Error(t, err)
 	})
 
 	t.Run("-h prints usage", func(t *testing.T) {
 		out, err := exec.Command(command, "-h").CombinedOutput()
-		assert.Contains(string(out), expected)
-		assert.NoError(err)
+		assert.Contains(t, string(out), expected)
+		assert.NoError(t, err)
 	})
 
 	t.Run("--help prints usage", func(t *testing.T) {
 		out, err := exec.Command(command, "--help").CombinedOutput()
-		assert.Contains(string(out), expected)
-		assert.NoError(err)
+		assert.Contains(t, string(out), expected)
+		assert.NoError(t, err)
 	})
 }
 
 func TestOptions(t *testing.T) {
 	tf.IntegrationTest(t) // because we're using exec.Command
-	require := req.New(t)
-	assert := ast.New(t)
-	command := mustGetMigrationBinary(require)
+	command := mustGetMigrationBinary(t)
 	usage := "go-filecoin-migrate (describe|buildonly|migrate) --old-repo=<repodir> [--new-repo=<newrepo-prefix] [-h|--help] [-v|--verbose]"
 
 	t.Run("error when calling with invalid command", func(t *testing.T) {
 		out, err := exec.Command(command, "foo", "--old-repo=something").CombinedOutput()
-		assert.Contains(string(out), "Error: Invalid command: foo")
-		assert.Contains(string(out), usage)
-		assert.Error(err)
+		assert.Contains(t, string(out), "Error: Invalid command: foo")
+		assert.Contains(t, string(out), usage)
+		assert.Error(t, err)
 	})
 
 	t.Run("accepts --verbose with valid command", func(t *testing.T) {
 		out, err := exec.Command(command, "describe", "--old-repo=something", "--verbose").CombinedOutput()
-		assert.NoError(err)
-		assert.Contains(string(out), "") // should include describe output when implemented
+		assert.NoError(t, err)
+		assert.Contains(t, string(out), "") // should include describe output when implemented
 	})
 
 	t.Run("accepts -v with valid command", func(t *testing.T) {
 		out, err := exec.Command(command, "describe", "--old-repo=something", "-v").CombinedOutput()
-		assert.NoError(err)
-		assert.Contains(string(out), "") // should include describe output when implemented
+		assert.NoError(t, err)
+		assert.Contains(t, string(out), "") // should include describe output when implemented
 	})
 
 	t.Run("requires --old-repo argument", func(t *testing.T) {
 		out, err := exec.Command(command, "describe").CombinedOutput()
 		expected := "Error: --old-repo is required"
-		assert.Error(err)
-		assert.Contains(string(out), expected) // should include describe output when implemented
-		assert.Contains(string(out), usage)
+		assert.Error(t, err)
+		assert.Contains(t, string(out), expected) // should include describe output when implemented
+		assert.Contains(t, string(out), usage)
 	})
 }
 
-func mustGetMigrationBinary(require *req.Assertions) string {
+func mustGetMigrationBinary(t *testing.T) string {
 	gopath, err := testhelpers.GetGoPath()
-	require.NoError(err)
+	require.NoError(t, err)
 
 	bin := filepath.Join(gopath, "/src/github.com/filecoin-project/go-filecoin/tools/migration/go-filecoin-migrate")
 	_, err = os.Stat(bin)
-	require.NoError(err)
+	require.NoError(t, err)
 
 	return bin
 }

--- a/tools/migration/main_test.go
+++ b/tools/migration/main_test.go
@@ -16,7 +16,7 @@ import (
 func TestUsage(t *testing.T) {
 	tf.IntegrationTest(t) // because we're using exec.Command
 	command := requireGetMigrationBinary(t)
-	expected := "go-filecoin-migrate (describe|buildonly|migrate) --old-repo=<repodir> [--new-repo=<newrepo-prefix] [-h|--help] [-v|--verbose]"
+	expected := "go-filecoin-migrate (describe|buildonly|migrate) --old-repo=<repodir> [-h|--help] [-v|--verbose]"
 
 	t.Run("bare invocation prints usage but exits with 1", func(t *testing.T) {
 		out, err := exec.Command(command).CombinedOutput()
@@ -40,7 +40,7 @@ func TestUsage(t *testing.T) {
 func TestOptions(t *testing.T) {
 	tf.IntegrationTest(t) // because we're using exec.Command
 	command := requireGetMigrationBinary(t)
-	usage := "go-filecoin-migrate (describe|buildonly|migrate) --old-repo=<repodir> [--new-repo=<newrepo-prefix] [-h|--help] [-v|--verbose]"
+	usage := "go-filecoin-migrate (describe|buildonly|migrate) --old-repo=<repodir> [-h|--help] [-v|--verbose]"
 
 	t.Run("error when calling with invalid command", func(t *testing.T) {
 		out, err := exec.Command(command, "foo", "--old-repo=something").CombinedOutput()

--- a/tools/migration/main_test.go
+++ b/tools/migration/main_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestUsage(t *testing.T) {
 	tf.IntegrationTest(t) // because we're using exec.Command
-	command := mustGetMigrationBinary(t)
+	command := requireGetMigrationBinary(t)
 	expected := "go-filecoin-migrate (describe|buildonly|migrate) --old-repo=<repodir> [--new-repo=<newrepo-prefix] [-h|--help] [-v|--verbose]"
 
 	t.Run("bare invocation prints usage but exits with 1", func(t *testing.T) {
@@ -39,7 +39,7 @@ func TestUsage(t *testing.T) {
 
 func TestOptions(t *testing.T) {
 	tf.IntegrationTest(t) // because we're using exec.Command
-	command := mustGetMigrationBinary(t)
+	command := requireGetMigrationBinary(t)
 	usage := "go-filecoin-migrate (describe|buildonly|migrate) --old-repo=<repodir> [--new-repo=<newrepo-prefix] [-h|--help] [-v|--verbose]"
 
 	t.Run("error when calling with invalid command", func(t *testing.T) {
@@ -70,7 +70,7 @@ func TestOptions(t *testing.T) {
 	})
 }
 
-func mustGetMigrationBinary(t *testing.T) string {
+func requireGetMigrationBinary(t *testing.T) string {
 	gopath, err := testhelpers.GetGoPath()
 	require.NoError(t, err)
 


### PR DESCRIPTION
Closes #2643 
This updates and adds more file system wrangling functionality to `RepoFSWrangler`:

* Changes `MakeNewRepo` to do the actual copying and permissions setting on the new repo.
* Adds `InstallNewRepo` which renames the old repo and symlinks the new repo to the old repo dir.  The new name for the old repo dir is returned so that it can be logged.
* Updates the require/assert usage to stop calling `New`
* changes some of the unit tests to use different functions for file system operations
* deletes the `ExpandHomedir` function since it's not used any more, because the `--old-repo` CLI param is required now.

Open questions:
* @ZenGround0 and I tried to come up with less vague names than `RepoMigrationHelper` and `RepoFSWrangler` is what we "settled" on as good enough for now. It does cover what it's doing: convenience functions for touching the file system, but seriously, ??? 
* I feel like I'm trying to predict what will be required of the wrangler before it has been used.  This is my best guess at the interface.  Input requested.