### PR TITLE
make binaries executable

### DIFF
--- a/Dockerfile.ci.faucet
+++ b/Dockerfile.ci.faucet
@@ -11,6 +11,8 @@ COPY --from=filecoin:all /lib/x86_64-linux-gnu/libdl-2.24.so /lib/libdl.so.2
 COPY --from=filecoin:all /lib/x86_64-linux-gnu/librt.so.1 /lib/librt.so.1
 COPY --from=filecoin:all /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/libgcc_s.so.1
 
+RUN chmod +x /usr/local/bin/faucet
+
 EXPOSE 9797
 
 # There's an fs-repo, and initializes one if there isn't.

--- a/Dockerfile.ci.genesis
+++ b/Dockerfile.ci.genesis
@@ -8,6 +8,8 @@ COPY --from=filecoin:all /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=filecoin:all /tmp/tini /sbin/tini
 COPY --from=filecoin:all /etc/ssl/certs /etc/ssl/certs
 
+RUN chmod +x /usr/local/bin/genesis-file-server
+
 EXPOSE 8080
 
 # There's an fs-repo, and initializes one if there isn't.


### PR DESCRIPTION
otherwise one gets permission denied errors in genesis-file-server and faucet docker images