### PR TITLE
Feat/uncancel payment channel 2622

### DIFF
--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -245,15 +245,13 @@ func (pb *Actor) Redeem(vmctx exec.VMContext, payer address.Address, chid *types
 			return errors.NewFaultError("Expected PaymentChannel from channels lookup")
 		}
 
-		if channel.Eol.GreaterThan(vmctx.BlockHeight()) {
-			channel.Eol = channel.AgreedEol
-		}
-
 		// validate the amount can be sent to the target and send payment to that address.
 		err = updateChannel(vmctx, vmctx.Message().From, channel, amt, validAt)
 		if err != nil {
 			return err
 		}
+
+		channel.Eol = channel.AgreedEol
 
 		return byChannelID.Set(ctx, chid.KeyString(), channel)
 	})

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -251,6 +251,8 @@ func (pb *Actor) Redeem(vmctx exec.VMContext, payer address.Address, chid *types
 			return err
 		}
 
+		// Reset the EOL to the originally agreed upon EOL in the event that the
+		// channel has been cancelled.
 		channel.Eol = channel.AgreedEol
 
 		return byChannelID.Set(ctx, chid.KeyString(), channel)

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -245,6 +245,10 @@ func (pb *Actor) Redeem(vmctx exec.VMContext, payer address.Address, chid *types
 			return errors.NewFaultError("Expected PaymentChannel from channels lookup")
 		}
 
+		if channel.Eol.GreaterThan(vmctx.BlockHeight()) {
+			channel.Eol = channel.AgreedEol
+		}
+
 		// validate the amount can be sent to the target and send payment to that address.
 		err = updateChannel(vmctx, vmctx.Message().From, channel, amt, validAt)
 		if err != nil {

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -200,20 +200,28 @@ func TestPaymentBrokerRedeemReversesCancellations(t *testing.T) {
 
 	sys := setup(t)
 
+	// Cancel the payment channel
 	pdata := core.MustConvertParams(sys.channelID)
 	msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, types.NewAttoFILFromFIL(1000), "cancel", pdata)
-
 	result, err := sys.ApplyMessage(msg, 100)
 	require.NoError(t, result.ExecutionError)
 	require.NoError(t, err)
 	require.Equal(t, uint8(0), result.Receipt.ExitCode)
 
+	// Expect that the EOL of the payment channel now reflects the cancellation
+	paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+	channel := sys.retrieveChannel(paymentBroker)
+	assert.Equal(t, types.NewBlockHeight(20000), channel.AgreedEol)
+	assert.Equal(t, types.NewBlockHeight(10100), channel.Eol)
+
+	// Redeem the payment channel
 	result, err = sys.ApplyRedeemMessageWithBlockHeight(sys.target, 500, 0, 10000)
 	require.NoError(t, err)
 
-	paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
-	channel := sys.retrieveChannel(paymentBroker)
-
+	// Expect that the EOL has been reset to its originally agreed upon value
+	// meaning that the cancellation has been reversed
+	paymentBroker = state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+	channel = sys.retrieveChannel(paymentBroker)
 	assert.Equal(t, types.NewBlockHeight(20000), channel.AgreedEol)
 	assert.Equal(t, types.NewBlockHeight(20000), channel.Eol)
 }

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -198,47 +198,24 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 func TestPaymentBrokerRedeemReversesCancellations(t *testing.T) {
 	tf.UnitTest(t)
 
-	t.Run("resets EOL on success", func(t *testing.T) {
-		sys := setup(t)
+	sys := setup(t)
 
-		pdata := core.MustConvertParams(sys.channelID)
-		msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, types.NewAttoFILFromFIL(1000), "cancel", pdata)
+	pdata := core.MustConvertParams(sys.channelID)
+	msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, types.NewAttoFILFromFIL(1000), "cancel", pdata)
 
-		result, err := sys.ApplyMessage(msg, 100)
-		require.NoError(t, result.ExecutionError)
-		require.NoError(t, err)
-		require.Equal(t, uint8(0), result.Receipt.ExitCode)
+	result, err := sys.ApplyMessage(msg, 100)
+	require.NoError(t, result.ExecutionError)
+	require.NoError(t, err)
+	require.Equal(t, uint8(0), result.Receipt.ExitCode)
 
-		result, err = sys.ApplyRedeemMessageWithBlockHeight(sys.target, 500, 0, 10000)
-		require.NoError(t, err)
+	result, err = sys.ApplyRedeemMessageWithBlockHeight(sys.target, 500, 0, 10000)
+	require.NoError(t, err)
 
-		paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
-		channel := sys.retrieveChannel(paymentBroker)
+	paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+	channel := sys.retrieveChannel(paymentBroker)
 
-		assert.Equal(t, types.NewBlockHeight(20000), channel.AgreedEol)
-		assert.Equal(t, types.NewBlockHeight(20000), channel.Eol)
-	})
-
-	t.Run("does not reset EOL on failure", func(t *testing.T) {
-		sys := setup(t)
-
-		pdata := core.MustConvertParams(sys.channelID)
-		msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, types.NewAttoFILFromFIL(1000), "cancel", pdata)
-
-		result, err := sys.ApplyMessage(msg, 100)
-		require.NoError(t, result.ExecutionError)
-		require.NoError(t, err)
-		require.Equal(t, uint8(0), result.Receipt.ExitCode)
-
-		result, err = sys.ApplyRedeemMessageWithBlockHeight(sys.target, 500, 0, 10200)
-		require.NoError(t, err)
-
-		paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
-		channel := sys.retrieveChannel(paymentBroker)
-
-		assert.Equal(t, types.NewBlockHeight(20000), channel.AgreedEol)
-		assert.Equal(t, types.NewBlockHeight(10100), channel.Eol)
-	})
+	assert.Equal(t, types.NewBlockHeight(20000), channel.AgreedEol)
+	assert.Equal(t, types.NewBlockHeight(20000), channel.Eol)
 }
 
 func TestPaymentBrokerUpdateErrorsWithIncorrectChannel(t *testing.T) {


### PR DESCRIPTION
# Problem

Payment Channel Cancellation currently has no recourse. If a client cancels an accepted payment channel, the miner has no way to dispute said cancellation when complying with the original agreement.

# Solution

Change Payment Channel Redeem to automatically reset the EOL of a channel to the originally agreed upon EOL as long as the piece inclusion proof for said redemption is valid.

Resolves #2622 