### PR TITLE
expand homedir in paths

### DIFF
--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -120,9 +120,11 @@ func daemonRun(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment)
 
 func getRepo(req *cmds.Request) (repo.Repo, error) {
 	repoDir, _ := req.Options[OptionRepoDir].(string)
-	repoDir = paths.GetRepoPath(repoDir)
-	r, err := repo.OpenFSRepo(repoDir)
-	return r, err
+	repoDir, err := paths.GetRepoPath(repoDir)
+	if err != nil {
+		return nil, err
+	}
+	return repo.OpenFSRepo(repoDir)
 }
 
 func runAPIAndWait(ctx context.Context, nd *node.Node, config *config.Config, req *cmds.Request) error {

--- a/commands/init.go
+++ b/commands/init.go
@@ -51,7 +51,10 @@ var initCmd = &cmds.Command{
 		if err := re.Emit(fmt.Sprintf("initializing filecoin node at %s\n", repoDir)); err != nil {
 			return err
 		}
-		repoDir = paths.GetRepoPath(repoDir)
+		repoDir, err = paths.GetRepoPath(repoDir)
+		if err != nil {
+			return err
+		}
 		rep, err := repo.CreateRepo(repoDir, newConfig)
 		if err != nil {
 			return err

--- a/commands/main.go
+++ b/commands/main.go
@@ -273,7 +273,10 @@ func getAPIAddress(req *cmds.Request) (string, error) {
 	// we will read the api file if no other option is given.
 	if len(rawAddr) == 0 {
 		repoDir, _ := req.Options[OptionRepoDir].(string)
-		repoDir = paths.GetRepoPath(repoDir)
+		repoDir, err = paths.GetRepoPath(repoDir)
+		if err != nil {
+			return "", err
+		}
 		rawAddr, err = repo.APIAddrFromRepoPath(repoDir)
 		if err != nil {
 			return "", errors.Wrap(err, "can't find API endpoint address in environment, command-line, or local repo (is the daemon running?)")

--- a/node/node.go
+++ b/node/node.go
@@ -938,14 +938,28 @@ func initSectorBuilderForNode(ctx context.Context, node *Node, proofsMode types.
 	// metadata in the staging directory, it should be in its own directory.
 	//
 	// Tracked here: https://github.com/filecoin-project/rust-fil-proofs/issues/402
-	sectorDir := paths.GetSectorPath(node.Repo.Config().SectorBase.RootDir)
+	sectorDir, err := paths.GetSectorPath(node.Repo.Config().SectorBase.RootDir)
+	if err != nil {
+		return nil, err
+	}
+
+	stagingDir, err := paths.StagingDir(sectorDir)
+	if err != nil {
+		return nil, err
+	}
+
+	sealedDir, err := paths.SealedDir(sectorDir)
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := sectorbuilder.RustSectorBuilderConfig{
 		BlockService:     node.blockservice,
 		LastUsedSectorID: lastUsedSectorID,
-		MetadataDir:      paths.StagingDir(sectorDir),
+		MetadataDir:      stagingDir,
 		MinerAddr:        minerAddr,
-		SealedSectorDir:  paths.SealedDir(sectorDir),
-		StagedSectorDir:  paths.StagingDir(sectorDir),
+		SealedSectorDir:  sealedDir,
+		StagedSectorDir:  stagingDir,
 		SectorClass:      sectorClass,
 	}
 

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -3,6 +3,8 @@ package paths
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/mitchellh/go-homedir"
 )
 
 // node repo path defaults
@@ -18,45 +20,45 @@ const defaultSectorSealingDir = "sealed"
 
 // GetRepoPath returns the path of the filecoin repo from a potential override
 // string, the FIL_PATH environment variable and a default of ~/.filecoin/repo.
-func GetRepoPath(override string) string {
+func GetRepoPath(override string) (string, error) {
 	// override is first precedence
 	if override != "" {
-		return override
+		return homedir.Expand(override)
 	}
 	// Environment variable is second precedence
 	envRepoDir := os.Getenv(filPathVar)
 	if envRepoDir != "" {
-		return envRepoDir
+		return homedir.Expand(envRepoDir)
 	}
 	// Default is third precedence
-	return filepath.Join(defaultHomeDir, defaultRepoDir)
+	return homedir.Expand(filepath.Join(defaultHomeDir, defaultRepoDir))
 }
 
 // GetSectorPath returns the path of the filecoin sector storage from a
 // potential override string, the FIL_SECTOR_PATH environment variable and a
 // default of ~/.filecoin/sectors.
-func GetSectorPath(override string) string {
+func GetSectorPath(override string) (string, error) {
 	// override is first precedence
 	if override != "" {
-		return override
+		return homedir.Expand(override)
 	}
 	// Environment variable is second precedence
 	envRepoDir := os.Getenv(filSectorPathVar)
 	if envRepoDir != "" {
-		return envRepoDir
+		return homedir.Expand(envRepoDir)
 	}
 	// Default is third precedence
-	return filepath.Join(defaultHomeDir, defaultSectorDir)
+	return homedir.Expand(filepath.Join(defaultHomeDir, defaultSectorDir))
 }
 
 // StagingDir returns the path to the sector staging directory given the sector
 // storage directory path.
-func StagingDir(sectorPath string) string {
-	return filepath.Join(sectorPath, defaultSectorStagingDir)
+func StagingDir(sectorPath string) (string, error) {
+	return homedir.Expand(filepath.Join(sectorPath, defaultSectorStagingDir))
 }
 
 // StagingDir returns the path to the sector sealed directory given the sector
 // storage directory path.
-func SealedDir(sectorPath string) string {
-	return filepath.Join(sectorPath, defaultSectorSealingDir)
+func SealedDir(sectorPath string) (string, error) {
+	return homedir.Expand(filepath.Join(sectorPath, defaultSectorSealingDir))
 }

--- a/tools/fast/process_options.go
+++ b/tools/fast/process_options.go
@@ -45,6 +45,13 @@ func PODevnetNightly() ProcessInitOption {
 	}
 }
 
+// POSectorDir provides the `--sectordir=<path>` to process when starting.
+func POSectorDir(sd string) ProcessInitOption {
+	return func() []string {
+		return []string{"--sectordir", sd}
+	}
+}
+
 // ProcessDaemonOption are options passed to process when starting.
 type ProcessDaemonOption func() []string
 


### PR DESCRIPTION
Should I go ahead and implement a `--homedir` flag right now and move everything (iptb, fast, daemon test, wiki) to specify both repo and sectors base with this flag?

Alternatively I could implement and move callers to specify a sectors dir with `--sectordir`.

We should probably do this sooner rather than later because I'm realizing that lots of different testing daemons are using the same sealed and staged dirs and this is probably not great.

cc @anorth @shannonwells @travisperson 