### PR TITLE
init takes --sectordir flag

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -34,6 +34,7 @@ var initCmd = &cmds.Command{
 		cmdkit.StringOption(GenesisFile, "path of file or HTTP(S) URL containing archive of genesis block DAG data"),
 		cmdkit.StringOption(PeerKeyFile, "path of file containing key to use for new node's libp2p identity"),
 		cmdkit.StringOption(WithMiner, "when set, creates a custom genesis block with a pre generated miner account, requires running the daemon using dev mode (--dev)"),
+		cmdkit.StringOption(OptionSectorDir, "path of directory into which staged and sealed sectors will be written"),
 		cmdkit.StringOption(DefaultAddress, "when set, sets the daemons's default address to the provided address"),
 		cmdkit.UintOption(AutoSealIntervalSeconds, "when set to a number > 0, configures the daemon to check for and seal any staged sectors on an interval.").WithDefault(uint(120)),
 		cmdkit.BoolOption(DevnetTest, "when set, populates config bootstrap addrs with the dns multiaddrs of the test devnet and other test devnet specific bootstrap parameters."),

--- a/commands/init.go
+++ b/commands/init.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 
 	"github.com/ipfs/go-car"
 	hamt "github.com/ipfs/go-hamt-ipld"
@@ -80,6 +81,10 @@ var initCmd = &cmds.Command{
 
 func getConfigFromOptions(options cmdkit.OptMap) (*config.Config, error) {
 	newConfig := config.NewDefaultConfig()
+
+	if dir, ok := options[OptionRepoDir].(string); ok {
+		newConfig.SectorBase.RootDir = filepath.Join(dir, "sectors")
+	}
 
 	if m, ok := options[WithMiner].(string); ok {
 		var err error

--- a/commands/init.go
+++ b/commands/init.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 
 	"github.com/ipfs/go-car"
 	hamt "github.com/ipfs/go-hamt-ipld"
@@ -82,8 +81,8 @@ var initCmd = &cmds.Command{
 func getConfigFromOptions(options cmdkit.OptMap) (*config.Config, error) {
 	newConfig := config.NewDefaultConfig()
 
-	if dir, ok := options[OptionRepoDir].(string); ok {
-		newConfig.SectorBase.RootDir = filepath.Join(dir, "sectors")
+	if dir, ok := options[OptionSectorDir].(string); ok {
+		newConfig.SectorBase.RootDir = dir
 	}
 
 	if m, ok := options[WithMiner].(string); ok {

--- a/commands/main.go
+++ b/commands/main.go
@@ -28,6 +28,9 @@ const (
 	// OptionRepoDir is the name of the option for specifying the directory of the repo.
 	OptionRepoDir = "repodir"
 
+	// OptionSectorDir is the name of the option for specifying the directory into which staged and sealed sectors will be written.
+	OptionSectorDir = "sectordir"
+
 	// APIPrefix is the prefix for the http version of the api.
 	APIPrefix = "/api"
 

--- a/node/testing.go
+++ b/node/testing.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"testing"
 
@@ -242,6 +243,14 @@ var TestGenCfg = &gengen.GenesisCfg{
 // GenNode allows you to completely configure a node for testing.
 func GenNode(t *testing.T, tno *TestNodeOptions) *Node {
 	r := repo.NewInMemoryRepo()
+
+	sectorDir, err := ioutil.TempDir("", "go-fil-test-sectors")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r.Config().SectorBase.RootDir = sectorDir
+
 	r.Config().Swarm.Address = "/ip4/0.0.0.0/tcp/0"
 	if !tno.OfflineMode {
 		r.Config().Swarm.Address = "/ip4/127.0.0.1/tcp/0"

--- a/testhelpers/commands.go
+++ b/testhelpers/commands.go
@@ -98,6 +98,7 @@ type TestDaemon struct {
 	cmdAddr          string
 	swarmAddr        string
 	repoDir          string
+	sectorsDir       string
 	genesisFile      string
 	keyFiles         []string
 	withMiner        string
@@ -755,14 +756,20 @@ func NewDaemon(t *testing.T, options ...func(*TestDaemon)) *TestDaemon {
 	// Ensure we have the actual binary
 	filecoinBin := MustGetFilecoinBinary()
 
-	dir, err := ioutil.TempDir("", "go-fil-test")
+	repoDir, err := ioutil.TempDir("", "go-fil-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sectorsDir, err := ioutil.TempDir("", "go-fil-test-sectors")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	td := &TestDaemon{
 		test:        t,
-		repoDir:     dir,
+		repoDir:     repoDir,
+		sectorsDir:  sectorsDir,
 		init:        true, // we want to init unless told otherwise
 		firstRun:    true,
 		cmdTimeout:  DefaultDaemonCmdTimeout,
@@ -776,8 +783,10 @@ func NewDaemon(t *testing.T, options ...func(*TestDaemon)) *TestDaemon {
 
 	repoDirFlag := fmt.Sprintf("--repodir=%s", td.repoDir)
 
+	sectorsDirFlag := fmt.Sprintf("--sectordir=%s", td.sectorsDir)
+
 	// build command options
-	initopts := []string{repoDirFlag}
+	initopts := []string{repoDirFlag, sectorsDirFlag}
 
 	if td.genesisFile != "" {
 		initopts = append(initopts, fmt.Sprintf("--genesisfile=%s", td.genesisFile))

--- a/testhelpers/commands.go
+++ b/testhelpers/commands.go
@@ -98,7 +98,7 @@ type TestDaemon struct {
 	cmdAddr          string
 	swarmAddr        string
 	repoDir          string
-	sectorsDir       string
+	sectorDir        string
 	genesisFile      string
 	keyFiles         []string
 	withMiner        string
@@ -761,7 +761,7 @@ func NewDaemon(t *testing.T, options ...func(*TestDaemon)) *TestDaemon {
 		t.Fatal(err)
 	}
 
-	sectorsDir, err := ioutil.TempDir("", "go-fil-test-sectors")
+	sectorDir, err := ioutil.TempDir("", "go-fil-test-sectors")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -769,7 +769,7 @@ func NewDaemon(t *testing.T, options ...func(*TestDaemon)) *TestDaemon {
 	td := &TestDaemon{
 		test:        t,
 		repoDir:     repoDir,
-		sectorsDir:  sectorsDir,
+		sectorDir:   sectorDir,
 		init:        true, // we want to init unless told otherwise
 		firstRun:    true,
 		cmdTimeout:  DefaultDaemonCmdTimeout,
@@ -783,10 +783,10 @@ func NewDaemon(t *testing.T, options ...func(*TestDaemon)) *TestDaemon {
 
 	repoDirFlag := fmt.Sprintf("--repodir=%s", td.repoDir)
 
-	sectorsDirFlag := fmt.Sprintf("--sectordir=%s", td.sectorsDir)
+	sectorDirFlag := fmt.Sprintf("--sectordir=%s", td.sectorDir)
 
 	// build command options
-	initopts := []string{repoDirFlag, sectorsDirFlag}
+	initopts := []string{repoDirFlag, sectorDirFlag}
 
 	if td.genesisFile != "" {
 		initopts = append(initopts, fmt.Sprintf("--genesisfile=%s", td.genesisFile))


### PR DESCRIPTION
## Why does this PR exist?

Our tests are all writing sector and sector metadata to `~/.filecoin/sectors` in spite of the fact that the test daemons are being initialized with unique repo directories. 

This bug prevents me from updating the rust-fil-proofs submodule. The new head of rust-fil-proofs contains commits which replace the JSON/filesystem sector builder metadata store with a RocksDB metadata store. The RocksDB metadata store writes a `LOCK` to the directory into which it was initialized, and since all go-filecoin test daemons were using the same directory, most go-filecoin tests fail after the update.

## What's in this PR?

Allow callers of `init` to pass `--sectordir` flag which specifies the directory into which sealed and staged sector data will be written (and sector builder metadata, too).

## Future work

This changeset is deliberately small - just enough to unblock me from integrating rust-fil-proofs. Further work is required to ensure that the `"sectors"` string isn't duplicated across the `paths` and `commands` packages.