### PR TITLE
Feat/store condition in paych 2677

### DIFF
--- a/abi/encode.go
+++ b/abi/encode.go
@@ -31,6 +31,10 @@ func EncodeValues(vals []*Value) ([]byte, error) {
 // DecodeValues decodes an array of abi values from the given buffer, using the
 // provided type information.
 func DecodeValues(data []byte, types []Type) ([]*Value, error) {
+	if len(types) > 0 && len(data) == 0 {
+		return nil, fmt.Errorf("expected %d parameters, but got 0", len(types))
+	}
+
 	if len(data) == 0 {
 		return nil, nil
 	}

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -84,7 +84,7 @@ type PaymentChannel struct {
 
 	// Conditions are the set of conditions for redeeming or closing the payment
 	// channel
-	Conditions *types.Predicate
+	Conditions *types.Predicate `json:"conditions"`
 
 	// Eol is the actual expiration for the payment channel which can differ from
 	// AgreedEol when the payment channel is in dispute
@@ -93,7 +93,7 @@ type PaymentChannel struct {
 	// Redeemed is a flag indicating whether or not Redeem has been called on the
 	// payment channel yet. This is necessary because AmountRedeemed can still be
 	// zero in the event of a zero-value voucher
-	Redeemed boolean
+	Redeemed bool `json:"redeemed"`
 }
 
 // Actor provides a mechanism for off chain payments.
@@ -263,6 +263,9 @@ func (pb *Actor) Redeem(vmctx exec.VMContext, payer address.Address, chid *types
 		// Reset the EOL to the originally agreed upon EOL in the event that the
 		// channel has been cancelled.
 		channel.Eol = channel.AgreedEol
+
+		// Mark the payment channel as redeemed
+		channel.Redeemed = true
 
 		return byChannelID.Set(ctx, chid.KeyString(), channel)
 	})

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -266,7 +266,9 @@ func (pb *Actor) Redeem(vmctx exec.VMContext, payer address.Address, chid *types
 
 		// Mark the payment channel as redeemed and set the conditions
 		channel.Redeemed = true
-		if condition != nil {
+		if condition == nil {
+			channel.Conditions = nil
+		} else {
 			newConditions := *condition
 			newConditions.Params = append(newConditions.Params, redeemerConditionParams...)
 			channel.Conditions = &newConditions
@@ -793,7 +795,9 @@ func checkCondition(vmctx exec.VMContext, chid *types.ChannelID, payerAddress ad
 				return errors.NewFaultError("Expected PaymentChannel from channels lookup")
 			}
 
-			cachedCondition = channel.Conditions
+			if channel.Redeemed {
+				cachedCondition = channel.Conditions
+			}
 			return nil
 		})
 		if err != nil {

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -82,9 +82,18 @@ type PaymentChannel struct {
 	// payer and payee upon initialization or extension
 	AgreedEol *types.BlockHeight `json:"agreed_eol"`
 
+	// Conditions are the set of conditions for redeeming or closing the payment
+	// channel
+	Conditions *types.Predicate
+
 	// Eol is the actual expiration for the payment channel which can differ from
 	// AgreedEol when the payment channel is in dispute
 	Eol *types.BlockHeight `json:"eol"`
+
+	// Redeemed is a flag indicating whether or not Redeem has been called on the
+	// payment channel yet. This is necessary because AmountRedeemed can still be
+	// zero in the event of a zero-value voucher
+	Redeemed boolean
 }
 
 // Actor provides a mechanism for off chain payments.

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -264,8 +264,13 @@ func (pb *Actor) Redeem(vmctx exec.VMContext, payer address.Address, chid *types
 		// channel has been cancelled.
 		channel.Eol = channel.AgreedEol
 
-		// Mark the payment channel as redeemed
+		// Mark the payment channel as redeemed and set the conditions
 		channel.Redeemed = true
+		if condition != nil {
+			newConditions := *condition
+			newConditions.Params = append(newConditions.Params, redeemerConditionParams...)
+			channel.Conditions = &newConditions
+		}
 
 		return byChannelID.Set(ctx, chid.KeyString(), channel)
 	})

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -766,6 +766,8 @@ func checkCondition(vmctx exec.VMContext, channel *PaymentChannel, condition *ty
 		return nil
 	}
 
+	// If new params have been provided or we don't yet have a cached condition,
+	// cache the provided params and condition on the payment channel.
 	if !channel.Redeemed || channel.Condition == nil || len(redeemerSuppliedParams) > 0 {
 		newParams := condition.Params
 		newParams = append(newParams, redeemerSuppliedParams...)

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -782,7 +782,7 @@ func checkCondition(vmctx exec.VMContext, channel *PaymentChannel, condition *ty
 		if errors.IsFault(err) {
 			return err
 		}
-		return errors.RevertErrorWrap(err, "failed to validate voucher condition")
+		return errors.NewCodedRevertErrorf(ErrConditionInvalid, "failed to validate voucher condition: %s", err)
 	}
 	return nil
 }

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -231,15 +231,20 @@ func (pb *Actor) Redeem(vmctx exec.VMContext, payer address.Address, chid *types
 		return errors.CodeError(Errors[ErrInvalidSignature]), Errors[ErrInvalidSignature]
 	}
 
-	if errCode, err := checkCondition(vmctx, chid, payer, condition, redeemerConditionParams); err != nil {
-		return errCode, err
-	}
-
 	ctx := context.Background()
 	storage := vmctx.Storage()
 
 	err := withPayerChannels(ctx, storage, payer, func(byChannelID exec.Lookup) error {
 		var channel *PaymentChannel
+
+		// If we already have params to check the condition with, check them before
+		// fetching the channel so we return more helpful errors in the event of
+		// undefined address
+		if len(redeemerConditionParams) > 0 {
+			if err := checkCondition(vmctx, condition, redeemerConditionParams); err != nil {
+				return err
+			}
+		}
 
 		chInt, err := byChannelID.Find(ctx, chid.KeyString())
 		if err != nil {
@@ -252,6 +257,14 @@ func (pb *Actor) Redeem(vmctx exec.VMContext, payer address.Address, chid *types
 		channel, ok := chInt.(*PaymentChannel)
 		if !ok {
 			return errors.NewFaultError("Expected PaymentChannel from channels lookup")
+		}
+
+		// If we didn't have any condition params earlier, check for a cached
+		// condition and check condition with it
+		if channel.Redeemed && channel.Condition != nil && len(redeemerConditionParams) == 0 {
+			if err := checkCondition(vmctx, condition, channel.Condition.Params); err != nil {
+				return err
+			}
 		}
 
 		// validate the amount can be sent to the target and send payment to that address.
@@ -306,14 +319,19 @@ func (pb *Actor) Close(vmctx exec.VMContext, payer address.Address, chid *types.
 		return errors.CodeError(Errors[ErrInvalidSignature]), Errors[ErrInvalidSignature]
 	}
 
-	if errCode, err := checkCondition(vmctx, chid, payer, condition, redeemerConditionParams); err != nil {
-		return errCode, err
-	}
-
 	ctx := context.Background()
 	storage := vmctx.Storage()
 
 	err := withPayerChannels(ctx, storage, payer, func(byChannelID exec.Lookup) error {
+		// If we already have params to check the condition with, check them before
+		// fetching the channel so we return more helpful errors in the event of
+		// undefined address
+		if len(redeemerConditionParams) > 0 {
+			if err := checkCondition(vmctx, condition, redeemerConditionParams); err != nil {
+				return err
+			}
+		}
+
 		chInt, err := byChannelID.Find(ctx, chid.KeyString())
 		if err != nil {
 			if err == hamt.ErrNotFound {
@@ -325,6 +343,14 @@ func (pb *Actor) Close(vmctx exec.VMContext, payer address.Address, chid *types.
 		channel, ok := chInt.(*PaymentChannel)
 		if !ok {
 			return errors.NewFaultError("Expected PaymentChannel from channels lookup")
+		}
+
+		// If we didn't have any condition params earlier, check for a cached
+		// condition and check condition with it
+		if channel.Redeemed && channel.Condition != nil && len(redeemerConditionParams) == 0 {
+			if err := checkCondition(vmctx, condition, channel.Condition.Params); err != nil {
+				return err
+			}
 		}
 
 		// validate the amount can be sent to the target and send payment to that address.
@@ -769,43 +795,9 @@ func findByChannelLookup(ctx context.Context, storage exec.Storage, byPayer exec
 
 // checkCondition combines params in the condition with the redeemerSuppliedParams, sends a message
 // to the actor and method specified in the condition, and returns an error if one exists.
-func checkCondition(vmctx exec.VMContext, chid *types.ChannelID, payerAddress address.Address, condition *types.Predicate, redeemerSuppliedParams []interface{}) (uint8, error) {
+func checkCondition(vmctx exec.VMContext, condition *types.Predicate, redeemerSuppliedParams []interface{}) error {
 	if condition == nil {
-		return 0, nil
-	}
-
-	if len(redeemerSuppliedParams) == 0 {
-		ctx := context.Background()
-		storage := vmctx.Storage()
-
-		var cachedCondition *types.Predicate
-		err := withPayerChannelsForReading(ctx, storage, payerAddress, func(byChannelID exec.Lookup) error {
-			var channel *PaymentChannel
-
-			chInt, err := byChannelID.Find(ctx, chid.KeyString())
-			if err != nil {
-				if err == hamt.ErrNotFound {
-					return Errors[ErrUnknownChannel]
-				}
-				return errors.FaultErrorWrapf(err, "Could not retrieve payment channel with ID: %s", chid)
-			}
-
-			channel, ok := chInt.(*PaymentChannel)
-			if !ok {
-				return errors.NewFaultError("Expected PaymentChannel from channels lookup")
-			}
-
-			if channel.Redeemed {
-				cachedCondition = channel.Condition
-			}
-			return nil
-		})
-		if err != nil {
-			return ErrConditionInvalid, errors.RevertErrorWrap(err, "failed to load cached condition")
-		}
-		if cachedCondition != nil {
-			redeemerSuppliedParams = cachedCondition.Params
-		}
+		return nil
 	}
 
 	params := append(condition.Params[:0:0], condition.Params...)
@@ -813,9 +805,9 @@ func checkCondition(vmctx exec.VMContext, chid *types.ChannelID, payerAddress ad
 	_, _, err := vmctx.Send(condition.To, condition.Method, types.NewZeroAttoFIL(), params)
 	if err != nil {
 		if errors.IsFault(err) {
-			return errors.CodeError(err), err
+			return err
 		}
-		return ErrConditionInvalid, errors.RevertErrorWrap(err, "failed to validate voucher condition")
+		return errors.RevertErrorWrap(err, "failed to validate voucher condition")
 	}
-	return 0, nil
+	return nil
 }

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -762,9 +762,7 @@ func findByChannelLookup(ctx context.Context, storage exec.Storage, byPayer exec
 // to the actor and method specified in the condition, and returns an error if one exists.
 func checkCondition(vmctx exec.VMContext, channel *PaymentChannel, condition *types.Predicate, redeemerSuppliedParams []interface{}) error {
 	if condition == nil {
-		if channel != nil {
-			channel.Condition = nil
-		}
+		channel.Condition = nil
 		return nil
 	}
 

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -82,9 +82,9 @@ type PaymentChannel struct {
 	// payer and payee upon initialization or extension
 	AgreedEol *types.BlockHeight `json:"agreed_eol"`
 
-	// Conditions are the set of conditions for redeeming or closing the payment
+	// Condition are the set of conditions for redeeming or closing the payment
 	// channel
-	Conditions *types.Predicate `json:"conditions"`
+	Condition *types.Predicate `json:"condition"`
 
 	// Eol is the actual expiration for the payment channel which can differ from
 	// AgreedEol when the payment channel is in dispute
@@ -264,14 +264,14 @@ func (pb *Actor) Redeem(vmctx exec.VMContext, payer address.Address, chid *types
 		// channel has been cancelled.
 		channel.Eol = channel.AgreedEol
 
-		// Mark the payment channel as redeemed and set the conditions
+		// Mark the payment channel as redeemed and set the condition
 		channel.Redeemed = true
 		if condition == nil {
-			channel.Conditions = nil
+			channel.Condition = nil
 		} else {
-			newConditions := *condition
-			newConditions.Params = append(newConditions.Params, redeemerConditionParams...)
-			channel.Conditions = &newConditions
+			newCondition := *condition
+			newCondition.Params = append(newCondition.Params, redeemerConditionParams...)
+			channel.Condition = &newCondition
 		}
 
 		return byChannelID.Set(ctx, chid.KeyString(), channel)
@@ -796,12 +796,12 @@ func checkCondition(vmctx exec.VMContext, chid *types.ChannelID, payerAddress ad
 			}
 
 			if channel.Redeemed {
-				cachedCondition = channel.Conditions
+				cachedCondition = channel.Condition
 			}
 			return nil
 		})
 		if err != nil {
-			return ErrConditionInvalid, errors.RevertErrorWrap(err, "failed to load cached conditions")
+			return ErrConditionInvalid, errors.RevertErrorWrap(err, "failed to load cached condition")
 		}
 		if cachedCondition != nil {
 			redeemerSuppliedParams = cachedCondition.Params

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -235,17 +235,6 @@ func (pb *Actor) Redeem(vmctx exec.VMContext, payer address.Address, chid *types
 	storage := vmctx.Storage()
 
 	err := withPayerChannels(ctx, storage, payer, func(byChannelID exec.Lookup) error {
-		var channel *PaymentChannel
-
-		// If we already have params to check the condition with, check them before
-		// fetching the channel so we return more helpful errors in the event of
-		// undefined address
-		if len(redeemerConditionParams) > 0 {
-			if err := checkCondition(vmctx, nil, condition, redeemerConditionParams); err != nil {
-				return err
-			}
-		}
-
 		chInt, err := byChannelID.Find(ctx, chid.KeyString())
 		if err != nil {
 			if err == hamt.ErrNotFound {
@@ -259,15 +248,11 @@ func (pb *Actor) Redeem(vmctx exec.VMContext, payer address.Address, chid *types
 			return errors.NewFaultError("Expected PaymentChannel from channels lookup")
 		}
 
-		// If we didn't have any condition params earlier, check for a cached
-		// condition and check condition with it
 		if channel.Redeemed && channel.Condition != nil && len(redeemerConditionParams) == 0 {
 			if err := checkCondition(vmctx, channel, condition, channel.Condition.Params); err != nil {
 				return err
 			}
 		} else {
-			// Otherwise, check condition again with the provided condition params to
-			// cache the new condition params on the payment channel
 			if err := checkCondition(vmctx, channel, condition, redeemerConditionParams); err != nil {
 				return err
 			}
@@ -322,15 +307,6 @@ func (pb *Actor) Close(vmctx exec.VMContext, payer address.Address, chid *types.
 	storage := vmctx.Storage()
 
 	err := withPayerChannels(ctx, storage, payer, func(byChannelID exec.Lookup) error {
-		// If we already have params to check the condition with, check them before
-		// fetching the channel so we return more helpful errors in the event of
-		// undefined address
-		if len(redeemerConditionParams) > 0 {
-			if err := checkCondition(vmctx, nil, condition, redeemerConditionParams); err != nil {
-				return err
-			}
-		}
-
 		chInt, err := byChannelID.Find(ctx, chid.KeyString())
 		if err != nil {
 			if err == hamt.ErrNotFound {
@@ -344,15 +320,11 @@ func (pb *Actor) Close(vmctx exec.VMContext, payer address.Address, chid *types.
 			return errors.NewFaultError("Expected PaymentChannel from channels lookup")
 		}
 
-		// If we didn't have any condition params earlier, check for a cached
-		// condition and check condition with it
 		if channel.Redeemed && channel.Condition != nil && len(redeemerConditionParams) == 0 {
 			if err := checkCondition(vmctx, channel, condition, channel.Condition.Params); err != nil {
 				return err
 			}
 		} else {
-			// Otherwise, check condition again with the provided condition params to
-			// cache the new condition params on the payment channel
 			if err := checkCondition(vmctx, channel, condition, redeemerConditionParams); err != nil {
 				return err
 			}

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -243,10 +243,15 @@ func TestPaymentBrokerRedeemSetsConditionsAndRedeemed(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, appResult.ExecutionError)
 
-		// Expect that the conditions are now set
+		// Expect that the conditions are now set and correct
 		paymentBroker = state.MustGetActor(sys.st, address.PaymentBrokerAddress)
 		channel = sys.retrieveChannel(paymentBroker)
 		assert.NotNil(t, channel.Conditions)
+		assert.Equal(t, toAddress, channel.Conditions.To)
+		assert.Equal(t, method, channel.Conditions.Method)
+		assert.Contains(t, channel.Conditions.Params, addrParam.Bytes())
+		assert.Contains(t, channel.Conditions.Params, sectorIdParam)
+		assert.Contains(t, channel.Conditions.Params, blockHeightParam.Bytes())
 	})
 }
 

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -539,10 +539,10 @@ func TestPaymentBrokerCloseWithCondition(t *testing.T) {
 	addrGetter := address.NewForTestGetter()
 	toAddress := addrGetter()
 
-	sys := setup(t)
-	require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
-
 	t.Run("Close should succeed if condition is met", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		condition := &types.Predicate{To: toAddress, Method: "paramsNotZero", Params: []interface{}{addrGetter(), uint64(6)}}
 
 		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "close", 0, condition, types.NewBlockHeight(43))
@@ -551,6 +551,9 @@ func TestPaymentBrokerCloseWithCondition(t *testing.T) {
 	})
 
 	t.Run("Close should fail if condition is _NOT_ met", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		condition := &types.Predicate{To: toAddress, Method: "paramsNotZero", Params: []interface{}{address.Undef, uint64(6)}}
 
 		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "close", 0, condition, types.NewBlockHeight(43))

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -289,17 +289,23 @@ func TestPaymentBrokerRedeemSetsConditionAndRedeemed(t *testing.T) {
 		sys := setup(t)
 		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
 
+		// Redeem without params and expect a panic
+		condition := &types.Predicate{To: toAddress, Method: method}
+		require.Panics(t, func() {
+			sys.applySignatureMessage(sys.target, 200, types.NewBlockHeight(0), 0, "redeem", 0, condition)
+		})
+
 		// Successfully redeem the payment channel with params
-		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
+		condition = &types.Predicate{To: toAddress, Method: method, Params: payerParams}
 		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
 		require.NoError(t, err)
 		require.NoError(t, appResult.ExecutionError)
 
-		// Redeem again without params
+		// Redeem again without params and expect no error
 		condition = &types.Predicate{To: toAddress, Method: method}
 		appResult, err = sys.applySignatureMessage(sys.target, 200, types.NewBlockHeight(0), 0, "redeem", 0, condition)
-		require.NoError(t, err)
-		require.NoError(t, appResult.ExecutionError)
+		assert.NoError(t, err)
+		assert.NoError(t, appResult.ExecutionError)
 	})
 }
 

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -659,10 +659,11 @@ func TestPaymentBrokerCloseChecksCachedConditions(t *testing.T) {
 	require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
 
 	// Close without params and expect a panic
-	condition := &types.Predicate{To: toAddress, Method: method}
+	condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
 	result, err := sys.applySignatureMessage(sys.target, 100, sys.defaultValidAt, 0, "close", 0, condition)
 	require.NoError(t, err)
 	require.Error(t, result.ExecutionError)
+	require.EqualValues(t, errors.CodeError(result.ExecutionError), ErrConditionInvalid)
 
 	// Successfully redeem the payment channel with params
 	condition = &types.Predicate{To: toAddress, Method: method, Params: payerParams}
@@ -671,7 +672,7 @@ func TestPaymentBrokerCloseChecksCachedConditions(t *testing.T) {
 	require.NoError(t, result.ExecutionError)
 
 	// Close again without params and expect no error
-	result, err = sys.ApplyCloseMessage(sys.target, 200, 0)
+	result, err = sys.applySignatureMessage(sys.target, 200, sys.defaultValidAt, 0, "close", 0, condition)
 	require.NoError(t, err)
 	require.NoError(t, result.ExecutionError)
 }

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -195,7 +195,7 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 	})
 }
 
-func TestPaymentBrokerRedeemSetsConditionsAndRedeemed(t *testing.T) {
+func TestPaymentBrokerRedeemSetsConditionAndRedeemed(t *testing.T) {
 	tf.UnitTest(t)
 
 	addrGetter := address.NewForTestGetter()
@@ -228,14 +228,14 @@ func TestPaymentBrokerRedeemSetsConditionsAndRedeemed(t *testing.T) {
 		assert.Equal(t, true, channel.Redeemed)
 	})
 
-	t.Run("Redeem should set cached conditions on success", func(t *testing.T) {
+	t.Run("Redeem should set cached condition on success", func(t *testing.T) {
 		sys := setup(t)
 		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
 
-		// Expect that the conditions are nil on init
+		// Expect that the condition is nil on init
 		paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
 		channel := sys.retrieveChannel(paymentBroker)
-		assert.Nil(t, channel.Conditions)
+		assert.Nil(t, channel.Condition)
 
 		// Successfully redeem the payment channel
 		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
@@ -243,49 +243,49 @@ func TestPaymentBrokerRedeemSetsConditionsAndRedeemed(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, appResult.ExecutionError)
 
-		// Expect that the conditions are now set and correct
+		// Expect that the condition is now set and correct
 		paymentBroker = state.MustGetActor(sys.st, address.PaymentBrokerAddress)
 		channel = sys.retrieveChannel(paymentBroker)
-		assert.NotNil(t, channel.Conditions)
-		assert.Equal(t, toAddress, channel.Conditions.To)
-		assert.Equal(t, method, channel.Conditions.Method)
-		assert.Contains(t, channel.Conditions.Params, addrParam.Bytes())
-		assert.Contains(t, channel.Conditions.Params, sectorIdParam)
-		assert.Contains(t, channel.Conditions.Params, blockHeightParam.Bytes())
+		assert.NotNil(t, channel.Condition)
+		assert.Equal(t, toAddress, channel.Condition.To)
+		assert.Equal(t, method, channel.Condition.Method)
+		assert.Contains(t, channel.Condition.Params, addrParam.Bytes())
+		assert.Contains(t, channel.Condition.Params, sectorIdParam)
+		assert.Contains(t, channel.Condition.Params, blockHeightParam.Bytes())
 	})
 
-	t.Run("Redeem should set cached conditions back to nil when no condition is provided", func(t *testing.T) {
+	t.Run("Redeem should set cached condition back to nil when no condition is provided", func(t *testing.T) {
 		sys := setup(t)
 		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
 
-		// Successfully redeem the payment channel with conditions
+		// Successfully redeem the payment channel with condition
 		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
 		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
 		require.NoError(t, err)
 		require.NoError(t, appResult.ExecutionError)
 
-		// Expect that the conditions are set and correct
+		// Expect that the condition is set and correct
 		paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
 		channel := sys.retrieveChannel(paymentBroker)
-		assert.NotNil(t, channel.Conditions)
-		assert.Equal(t, toAddress, channel.Conditions.To)
-		assert.Equal(t, method, channel.Conditions.Method)
-		assert.Contains(t, channel.Conditions.Params, addrParam.Bytes())
-		assert.Contains(t, channel.Conditions.Params, sectorIdParam)
-		assert.Contains(t, channel.Conditions.Params, blockHeightParam.Bytes())
+		assert.NotNil(t, channel.Condition)
+		assert.Equal(t, toAddress, channel.Condition.To)
+		assert.Equal(t, method, channel.Condition.Method)
+		assert.Contains(t, channel.Condition.Params, addrParam.Bytes())
+		assert.Contains(t, channel.Condition.Params, sectorIdParam)
+		assert.Contains(t, channel.Condition.Params, blockHeightParam.Bytes())
 
-		// Successfully redeem the payment channel again without conditions
+		// Successfully redeem the payment channel again without condition
 		appResult, err = sys.applySignatureMessage(sys.target, 200, types.NewBlockHeight(0), 0, "redeem", 0, nil, redeemerParams...)
 		require.NoError(t, err)
 		require.NoError(t, appResult.ExecutionError)
 
-		// Expect that the conditions are now nil
+		// Expect that the condition is now nil
 		paymentBroker = state.MustGetActor(sys.st, address.PaymentBrokerAddress)
 		channel = sys.retrieveChannel(paymentBroker)
-		assert.Nil(t, channel.Conditions)
+		assert.Nil(t, channel.Condition)
 	})
 
-	t.Run("Redeem uses cached conditions in subsequent calls", func(t *testing.T) {
+	t.Run("Redeem uses cached condition in subsequent calls", func(t *testing.T) {
 		sys := setup(t)
 		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
 

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -293,6 +293,41 @@ func TestPaymentBrokerRedeemSetsConditionAndRedeemed(t *testing.T) {
 		assert.Nil(t, channel.Condition)
 	})
 
+	t.Run("Redeem should update the cached condition with new params when provided", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
+
+		// Successfully redeem the payment channel with condition
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
+		require.NoError(t, err)
+		require.NoError(t, appResult.ExecutionError)
+
+		// Expect that the condition is set and correct
+		paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+		channel := sys.retrieveChannel(paymentBroker)
+		assert.NotNil(t, channel.Condition)
+		assert.Equal(t, toAddress, channel.Condition.To)
+		assert.Equal(t, method, channel.Condition.Method)
+
+		// Successfully redeem the payment channel again without condition
+		newBlockHeightParam := types.NewBlockHeight(52)
+		newRedeemerParams := []interface{}{newBlockHeightParam}
+		appResult, err = sys.applySignatureMessage(sys.target, 200, types.NewBlockHeight(0), 0, "redeem", 0, condition, newRedeemerParams...)
+		require.NoError(t, err)
+		require.NoError(t, appResult.ExecutionError)
+
+		// Expect that the condition is updated with the new redeemer params
+		paymentBroker = state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+		channel = sys.retrieveChannel(paymentBroker)
+		assert.NotNil(t, channel.Condition)
+		assert.Equal(t, toAddress, channel.Condition.To)
+		assert.Equal(t, method, channel.Condition.Method)
+		assert.Contains(t, channel.Condition.Params, addrParam.Bytes())
+		assert.Contains(t, channel.Condition.Params, sectorIdParam)
+		assert.Contains(t, channel.Condition.Params, newBlockHeightParam.Bytes())
+	})
+
 	t.Run("Redeem uses cached condition in subsequent calls", func(t *testing.T) {
 		sys := setup(t)
 		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -146,7 +146,8 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
-		require.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: got undefined address")
+		assert.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: got undefined address")
+		assert.EqualValues(t, errors.CodeError(appResult.ExecutionError), ErrConditionInvalid)
 	})
 
 	t.Run("Redeem should fail if condition goes to non-existent actor", func(t *testing.T) {
@@ -160,7 +161,8 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
-		require.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: actor code not found")
+		assert.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: actor code not found")
+		assert.EqualValues(t, errors.CodeError(appResult.ExecutionError), ErrConditionInvalid)
 	})
 
 	t.Run("Redeem should fail if condition goes to non-existent method", func(t *testing.T) {
@@ -174,7 +176,8 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
-		require.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: actor does not export method")
+		assert.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: actor does not export method")
+		assert.EqualValues(t, errors.CodeError(appResult.ExecutionError), ErrConditionInvalid)
 	})
 
 	t.Run("Redeem should fail if condition has the wrong number of condition parameters", func(t *testing.T) {
@@ -188,7 +191,8 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
-		require.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: invalid params")
+		assert.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: invalid params")
+		assert.EqualValues(t, errors.CodeError(appResult.ExecutionError), ErrConditionInvalid)
 	})
 
 	t.Run("Redeem should fail if condition has the wrong number of supplied parameters", func(t *testing.T) {
@@ -202,7 +206,8 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
-		require.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: invalid params")
+		assert.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: invalid params")
+		assert.EqualValues(t, errors.CodeError(appResult.ExecutionError), ErrConditionInvalid)
 	})
 }
 

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -117,13 +117,6 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 	blockHeightParam := types.NewBlockHeight(43)
 	redeemerParams := []interface{}{blockHeightParam}
 
-	sys := setup(t)
-	require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
-
-	callRedeem := func(condition *types.Predicate, params []interface{}) (*consensus.ApplicationResult, error) {
-		return sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, params...)
-	}
-
 	// All the following tests attempt to call PBTestActor.ParamsNotZero with a condition.
 	// PBTestActor.ParamsNotZero takes 3 parameter: an Address, a uint64 sector id, and a BlockHeight
 	// If any of these are zero values the method throws an error indicating the condition is false.
@@ -131,19 +124,25 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 	// height will be added as a redeemer supplied parameter to redeem.
 
 	t.Run("Redeem should succeed if condition is met", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
-		appResult, err := callRedeem(condition, redeemerParams)
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
 
 		require.NoError(t, err)
 		require.NoError(t, appResult.ExecutionError)
 	})
 
 	t.Run("Redeem should fail if condition is _NOT_ met", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		badAddressParam := address.Undef
 		badParams := []interface{}{badAddressParam, sectorIdParam}
 
 		condition := &types.Predicate{To: toAddress, Method: method, Params: badParams}
-		appResult, err := callRedeem(condition, redeemerParams)
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
@@ -151,10 +150,13 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 	})
 
 	t.Run("Redeem should fail if condition goes to non-existent actor", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		badToAddress := addrGetter()
 
 		condition := &types.Predicate{To: badToAddress, Method: method, Params: payerParams}
-		appResult, err := callRedeem(condition, redeemerParams)
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
@@ -162,10 +164,13 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 	})
 
 	t.Run("Redeem should fail if condition goes to non-existent method", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		badMethod := "nonexistentMethod"
 
 		condition := &types.Predicate{To: toAddress, Method: badMethod, Params: payerParams}
-		appResult, err := callRedeem(condition, redeemerParams)
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
@@ -173,10 +178,13 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 	})
 
 	t.Run("Redeem should fail if condition has the wrong number of condition parameters", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		badParams := []interface{}{}
 
 		condition := &types.Predicate{To: toAddress, Method: method, Params: badParams}
-		appResult, err := callRedeem(condition, redeemerParams)
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
@@ -184,10 +192,13 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 	})
 
 	t.Run("Redeem should fail if condition has the wrong number of supplied parameters", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		badRedeemerParams := []interface{}{}
 
 		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
-		appResult, err := callRedeem(condition, badRedeemerParams)
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, badRedeemerParams...)
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -291,13 +291,13 @@ func TestPaymentBrokerRedeemSetsConditionAndRedeemed(t *testing.T) {
 
 		// Redeem without params and expect a panic
 		condition := &types.Predicate{To: toAddress, Method: method}
-		require.Panics(t, func() {
-			sys.applySignatureMessage(sys.target, 200, types.NewBlockHeight(0), 0, "redeem", 0, condition)
-		})
+		appResult, err := sys.applySignatureMessage(sys.target, 200, types.NewBlockHeight(0), 0, "redeem", 0, condition)
+		require.NoError(t, err)
+		require.Error(t, appResult.ExecutionError)
 
 		// Successfully redeem the payment channel with params
 		condition = &types.Predicate{To: toAddress, Method: method, Params: payerParams}
-		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
+		appResult, err = sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
 		require.NoError(t, err)
 		require.NoError(t, appResult.ExecutionError)
 
@@ -580,13 +580,13 @@ func TestPaymentBrokerCloseChecksCachedConditions(t *testing.T) {
 
 	// Close without params and expect a panic
 	condition := &types.Predicate{To: toAddress, Method: method}
-	require.Panics(t, func() {
-		sys.applySignatureMessage(sys.target, 100, sys.defaultValidAt, 0, "close", 0, condition)
-	})
+	result, err := sys.applySignatureMessage(sys.target, 100, sys.defaultValidAt, 0, "close", 0, condition)
+	require.NoError(t, err)
+	require.Error(t, result.ExecutionError)
 
 	// Successfully redeem the payment channel with params
 	condition = &types.Predicate{To: toAddress, Method: method, Params: payerParams}
-	result, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
+	result, err = sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
 	require.NoError(t, err)
 	require.NoError(t, result.ExecutionError)
 

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -368,11 +368,12 @@ func TestPaymentBrokerRedeemSetsConditionAndRedeemed(t *testing.T) {
 		sys := setup(t)
 		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
 
-		// Redeem without params and expect a panic
+		// Redeem without params expects an invalid condition error
 		condition := &types.Predicate{To: toAddress, Method: method}
 		appResult, err := sys.applySignatureMessage(sys.target, 200, types.NewBlockHeight(0), 0, "redeem", 0, condition)
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
+		require.EqualValues(t, errors.CodeError(appResult.ExecutionError), ErrConditionInvalid)
 
 		// Successfully redeem the payment channel with params
 		condition = &types.Predicate{To: toAddress, Method: method, Params: payerParams}

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -281,9 +281,6 @@ func TestPaymentBrokerRedeemSetsConditionAndRedeemed(t *testing.T) {
 		assert.NotNil(t, channel.Condition)
 		assert.Equal(t, toAddress, channel.Condition.To)
 		assert.Equal(t, method, channel.Condition.Method)
-		assert.Contains(t, channel.Condition.Params, addrParam.Bytes())
-		assert.Contains(t, channel.Condition.Params, sectorIdParam)
-		assert.Contains(t, channel.Condition.Params, blockHeightParam.Bytes())
 
 		// Successfully redeem the payment channel again without condition
 		appResult, err = sys.applySignatureMessage(sys.target, 200, types.NewBlockHeight(0), 0, "redeem", 0, nil, redeemerParams...)


### PR DESCRIPTION
# Problem

The conditions params provided to redeem a payment channel can sometimes be very large and identical from one call to another.

# Solution

Cache them on the payment channel, so they only need to be sent once.

Resolves #2677 