### PR TITLE
Remove homedir

### DIFF
--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -120,9 +120,11 @@ func daemonRun(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment)
 
 func getRepo(req *cmds.Request) (repo.Repo, error) {
 	repoDir, _ := req.Options[OptionRepoDir].(string)
-	repoDir = paths.GetRepoPath(repoDir)
-	r, err := repo.OpenFSRepo(repoDir)
-	return r, err
+	repoDir, err := paths.GetRepoPath(repoDir)
+	if err != nil {
+		return nil, err
+	}
+	return repo.OpenFSRepo(repoDir)
 }
 
 func runAPIAndWait(ctx context.Context, nd *node.Node, config *config.Config, req *cmds.Request) error {

--- a/commands/init.go
+++ b/commands/init.go
@@ -51,7 +51,10 @@ var initCmd = &cmds.Command{
 		if err := re.Emit(fmt.Sprintf("initializing filecoin node at %s\n", repoDir)); err != nil {
 			return err
 		}
-		repoDir = paths.GetRepoPath(repoDir)
+		repoDir, err = paths.GetRepoPath(repoDir)
+		if err != nil {
+			return err
+		}
 		rep, err := repo.CreateRepo(repoDir, newConfig)
 		if err != nil {
 			return err

--- a/commands/main.go
+++ b/commands/main.go
@@ -273,7 +273,10 @@ func getAPIAddress(req *cmds.Request) (string, error) {
 	// we will read the api file if no other option is given.
 	if len(rawAddr) == 0 {
 		repoDir, _ := req.Options[OptionRepoDir].(string)
-		repoDir = paths.GetRepoPath(repoDir)
+		repoDir, err = paths.GetRepoPath(repoDir)
+		if err != nil {
+			return "", err
+		}
 		rawAddr, err = repo.APIAddrFromRepoPath(repoDir)
 		if err != nil {
 			return "", errors.Wrap(err, "can't find API endpoint address in environment, command-line, or local repo (is the daemon running?)")

--- a/node/node.go
+++ b/node/node.go
@@ -938,14 +938,31 @@ func initSectorBuilderForNode(ctx context.Context, node *Node, proofsMode types.
 	// metadata in the staging directory, it should be in its own directory.
 	//
 	// Tracked here: https://github.com/filecoin-project/rust-fil-proofs/issues/402
-	sectorDir := paths.GetSectorPath(node.Repo.Config().SectorBase.RootDir)
+	repoPath, err := node.Repo.Path()
+	if err != nil {
+		return nil, err
+	}
+	sectorDir, err := paths.GetSectorPath(node.Repo.Config().SectorBase.RootDir, repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	stagingDir, err := paths.StagingDir(sectorDir)
+	if err != nil {
+		return nil, err
+	}
+
+	sealedDir, err := paths.SealedDir(sectorDir)
+	if err != nil {
+		return nil, err
+	}
 	cfg := sectorbuilder.RustSectorBuilderConfig{
 		BlockService:     node.blockservice,
 		LastUsedSectorID: lastUsedSectorID,
-		MetadataDir:      paths.StagingDir(sectorDir),
+		MetadataDir:      stagingDir,
 		MinerAddr:        minerAddr,
-		SealedSectorDir:  paths.SealedDir(sectorDir),
-		StagedSectorDir:  paths.StagingDir(sectorDir),
+		SealedSectorDir:  sealedDir,
+		StagedSectorDir:  stagingDir,
 		SectorClass:      sectorClass,
 	}
 

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -3,60 +3,61 @@ package paths
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/mitchellh/go-homedir"
 )
 
 // node repo path defaults
 const filPathVar = "FIL_PATH"
-const defaultHomeDir = "~/.filecoin"
-const defaultRepoDir = "repo"
+const defaultRepoDir = "~/.filecoin"
 
 // node sector storage path defaults
 const filSectorPathVar = "FIL_SECTOR_PATH"
-const defaultSectorDir = "sectors"
+const defaultSectorDir = ".filecoin_sectors"
 const defaultSectorStagingDir = "staging"
 const defaultSectorSealingDir = "sealed"
 
 // GetRepoPath returns the path of the filecoin repo from a potential override
 // string, the FIL_PATH environment variable and a default of ~/.filecoin/repo.
-func GetRepoPath(override string) string {
+func GetRepoPath(override string) (string, error) {
 	// override is first precedence
 	if override != "" {
-		return override
+		return homedir.Expand(override)
 	}
 	// Environment variable is second precedence
 	envRepoDir := os.Getenv(filPathVar)
 	if envRepoDir != "" {
-		return envRepoDir
+		return homedir.Expand(envRepoDir)
 	}
 	// Default is third precedence
-	return filepath.Join(defaultHomeDir, defaultRepoDir)
+	return homedir.Expand(defaultRepoDir)
 }
 
 // GetSectorPath returns the path of the filecoin sector storage from a
 // potential override string, the FIL_SECTOR_PATH environment variable and a
-// default of ~/.filecoin/sectors.
-func GetSectorPath(override string) string {
+// default of repoPath/../.filecoin_sectors.
+func GetSectorPath(override, repoPath string) (string, error) {
 	// override is first precedence
 	if override != "" {
-		return override
+		return homedir.Expand(override)
 	}
 	// Environment variable is second precedence
 	envRepoDir := os.Getenv(filSectorPathVar)
 	if envRepoDir != "" {
-		return envRepoDir
+		return homedir.Expand(envRepoDir)
 	}
-	// Default is third precedence
-	return filepath.Join(defaultHomeDir, defaultSectorDir)
+	// Default is third precedence: repoPath/../defaultSectorDir
+	return homedir.Expand(filepath.Join(repoPath, "../", defaultSectorDir))
 }
 
 // StagingDir returns the path to the sector staging directory given the sector
 // storage directory path.
-func StagingDir(sectorPath string) string {
-	return filepath.Join(sectorPath, defaultSectorStagingDir)
+func StagingDir(sectorPath string) (string, error) {
+	return homedir.Expand(filepath.Join(sectorPath, defaultSectorStagingDir))
 }
 
 // StagingDir returns the path to the sector sealed directory given the sector
 // storage directory path.
-func SealedDir(sectorPath string) string {
-	return filepath.Join(sectorPath, defaultSectorSealingDir)
+func SealedDir(sectorPath string) (string, error) {
+	return homedir.Expand(filepath.Join(sectorPath, defaultSectorSealingDir))
 }

--- a/repo/fsrepo.go
+++ b/repo/fsrepo.go
@@ -49,7 +49,7 @@ func (err NoRepoError) Error() string {
 
 // FSRepo is a repo implementation backed by a filesystem.
 type FSRepo struct {
-	repoPath string
+	path string
 
 	version uint
 
@@ -92,9 +92,9 @@ func OpenFSRepo(repoPath string) (*FSRepo, error) {
 		return nil, &NoRepoError{repoPath}
 	}
 
-	r := &FSRepo{repoPath: repoPath}
+	r := &FSRepo{path: repoPath}
 
-	r.lockfile, err = lockfile.Lock(r.repoPath, lockFile)
+	r.lockfile, err = lockfile.Lock(r.path, lockFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to take repo lock")
 	}
@@ -197,7 +197,7 @@ func (r *FSRepo) ReplaceConfig(cfg *config.Config) error {
 	defer r.lk.Unlock()
 
 	r.cfg = cfg
-	tmp := filepath.Join(r.repoPath, tempConfigFilename)
+	tmp := filepath.Join(r.path, tempConfigFilename)
 	err := os.RemoveAll(tmp)
 	if err != nil {
 		return err
@@ -206,13 +206,13 @@ func (r *FSRepo) ReplaceConfig(cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, filepath.Join(r.repoPath, configFilename))
+	return os.Rename(tmp, filepath.Join(r.path, configFilename))
 }
 
 // SnapshotConfig stores a copy `cfg` in <repo_path>/snapshots/ appending the
 // time of snapshot to the filename.
 func (r *FSRepo) SnapshotConfig(cfg *config.Config) error {
-	snapshotFile := filepath.Join(r.repoPath, snapshotStorePrefix, genSnapshotFileName())
+	snapshotFile := filepath.Join(r.path, snapshotStorePrefix, genSnapshotFileName())
 	if fileExists(snapshotFile) {
 		// this should never happen
 		return fmt.Errorf("file already exists: %s", snapshotFile)
@@ -284,7 +284,7 @@ func (r *FSRepo) removeFile(path string) error {
 }
 
 func (r *FSRepo) removeAPIFile() error {
-	return r.removeFile(filepath.Join(r.repoPath, apiFile))
+	return r.removeFile(filepath.Join(r.path, apiFile))
 }
 
 func isInitialized(p string) (bool, error) {
@@ -302,7 +302,7 @@ func isInitialized(p string) (bool, error) {
 }
 
 func (r *FSRepo) loadConfig() error {
-	configFile := filepath.Join(r.repoPath, configFilename)
+	configFile := filepath.Join(r.path, configFilename)
 
 	cfg, err := config.ReadFile(configFile)
 	if err != nil {
@@ -315,7 +315,7 @@ func (r *FSRepo) loadConfig() error {
 
 func (r *FSRepo) loadVersion() (uint, error) {
 	// TODO: limited file reading, to avoid attack vector
-	file, err := ioutil.ReadFile(filepath.Join(r.repoPath, versionFilename))
+	file, err := ioutil.ReadFile(filepath.Join(r.path, versionFilename))
 	if err != nil {
 		return 0, err
 	}
@@ -331,7 +331,7 @@ func (r *FSRepo) loadVersion() (uint, error) {
 func (r *FSRepo) openDatastore() error {
 	switch r.cfg.Datastore.Type {
 	case "badgerds":
-		ds, err := badgerds.NewDatastore(filepath.Join(r.repoPath, r.cfg.Datastore.Path), badgerOptions())
+		ds, err := badgerds.NewDatastore(filepath.Join(r.path, r.cfg.Datastore.Path), badgerOptions())
 		if err != nil {
 			return err
 		}
@@ -344,7 +344,7 @@ func (r *FSRepo) openDatastore() error {
 }
 
 func (r *FSRepo) openKeystore() error {
-	ksp := filepath.Join(r.repoPath, "keystore")
+	ksp := filepath.Join(r.path, "keystore")
 
 	ks, err := keystore.NewFSKeystore(ksp)
 	if err != nil {
@@ -357,7 +357,7 @@ func (r *FSRepo) openKeystore() error {
 }
 
 func (r *FSRepo) openChainDatastore() error {
-	ds, err := badgerds.NewDatastore(filepath.Join(r.repoPath, chainDatastorePrefix), badgerOptions())
+	ds, err := badgerds.NewDatastore(filepath.Join(r.path, chainDatastorePrefix), badgerOptions())
 	if err != nil {
 		return err
 	}
@@ -369,7 +369,7 @@ func (r *FSRepo) openChainDatastore() error {
 
 func (r *FSRepo) openWalletDatastore() error {
 	// TODO: read wallet datastore info from config, use that to open it up
-	ds, err := badgerds.NewDatastore(filepath.Join(r.repoPath, walletDatastorePrefix), badgerOptions())
+	ds, err := badgerds.NewDatastore(filepath.Join(r.path, walletDatastorePrefix), badgerOptions())
 	if err != nil {
 		return err
 	}
@@ -380,7 +380,7 @@ func (r *FSRepo) openWalletDatastore() error {
 }
 
 func (r *FSRepo) openDealsDatastore() error {
-	ds, err := badgerds.NewDatastore(filepath.Join(r.repoPath, dealsDatastorePrefix), badgerOptions())
+	ds, err := badgerds.NewDatastore(filepath.Join(r.path, dealsDatastorePrefix), badgerOptions())
 	if err != nil {
 		return err
 	}
@@ -442,7 +442,7 @@ func fileExists(file string) bool {
 // SetAPIAddr writes the address to the API file. SetAPIAddr expects parameter
 // `port` to be of the form `:<port>`.
 func (r *FSRepo) SetAPIAddr(maddr string) error {
-	f, err := os.Create(filepath.Join(r.repoPath, apiFile))
+	f, err := os.Create(filepath.Join(r.path, apiFile))
 	if err != nil {
 		return errors.Wrap(err, "could not create API file")
 	}
@@ -463,6 +463,10 @@ func (r *FSRepo) SetAPIAddr(maddr string) error {
 	}
 
 	return nil
+}
+
+func (r *FSRepo) Path() (string, error) {
+	return r.path, nil
 }
 
 func APIAddrFromRepoPath(repoPath string) (string, error) {
@@ -489,7 +493,7 @@ func apiAddrFromFile(apiFilePath string) (string, error) {
 
 // APIAddr reads the FSRepo's api file and returns the api address
 func (r *FSRepo) APIAddr() (string, error) {
-	return apiAddrFromFile(filepath.Join(filepath.Clean(r.repoPath), apiFile))
+	return apiAddrFromFile(filepath.Join(filepath.Clean(r.path), apiFile))
 }
 
 func badgerOptions() *badgerds.Options {

--- a/repo/fsrepo_test.go
+++ b/repo/fsrepo_test.go
@@ -318,13 +318,13 @@ func TestRepoAPIFile(t *testing.T) {
 		withFSRepo(t, func(r *FSRepo) {
 			mustSetAPIAddr(t, r, "/ip4/127.0.0.1/tcp/1234")
 
-			info, err := os.Stat(filepath.Join(r.repoPath, apiFile))
+			info, err := os.Stat(filepath.Join(r.path, apiFile))
 			assert.NoError(t, err)
 			assert.Equal(t, apiFile, info.Name())
 
 			r.Close()
 
-			_, err = os.Stat(filepath.Join(r.repoPath, apiFile))
+			_, err = os.Stat(filepath.Join(r.path, apiFile))
 			assert.Error(t, err)
 		})
 	})
@@ -333,7 +333,7 @@ func TestRepoAPIFile(t *testing.T) {
 		withFSRepo(t, func(r *FSRepo) {
 			mustSetAPIAddr(t, r, "/ip4/127.0.0.1/tcp/1234")
 
-			err := os.Remove(filepath.Join(r.repoPath, apiFile))
+			err := os.Remove(filepath.Join(r.path, apiFile))
 			assert.NoError(t, err)
 
 			assert.NoError(t, r.Close())
@@ -343,7 +343,7 @@ func TestRepoAPIFile(t *testing.T) {
 	t.Run("SetAPI fails if unable to create API file", func(t *testing.T) {
 		withFSRepo(t, func(r *FSRepo) {
 			// create a file with permission bits that prevent us from truncating
-			err := ioutil.WriteFile(filepath.Join(r.repoPath, apiFile), []byte("/ip4/127.0.0.1/tcp/9999"), 0000)
+			err := ioutil.WriteFile(filepath.Join(r.path, apiFile), []byte("/ip4/127.0.0.1/tcp/9999"), 0000)
 			assert.NoError(t, err)
 
 			// try to os.Create to same path - will see a failure

--- a/repo/mem.go
+++ b/repo/mem.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ipfs/go-ipfs-keystore"
 
 	"github.com/filecoin-project/go-filecoin/config"
+	"github.com/filecoin-project/go-filecoin/paths"
 )
 
 // MemRepo is an in-memory implementation of the Repo interface.
@@ -102,4 +103,9 @@ func (mr *MemRepo) SetAPIAddr(addr string) error {
 // APIAddr reads the address of the running API from memory.
 func (mr *MemRepo) APIAddr() (string, error) {
 	return mr.apiAddress, nil
+}
+
+// Path returns the default path.
+func (mr *MemRepo) Path() (string, error) {
+	return paths.GetRepoPath("")
 }

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -43,7 +43,12 @@ type Repo interface {
 	// APIAddr returns the address of the running API.
 	APIAddr() (string, error)
 
+	// Version returns the current repo version.
 	Version() uint
 
+	// Path returns the repo path.
+	Path() (string, error)
+
+	// Close shuts down the repo.
 	Close() error
 }

--- a/tools/iptb-plugins/filecoin/local/localfilecoin.go
+++ b/tools/iptb-plugins/filecoin/local/localfilecoin.go
@@ -38,6 +38,9 @@ var errTimeout = errors.New("timeout")
 // DefaultFilecoinBinary is the name or full path of the binary that will be used
 var DefaultFilecoinBinary = "go-filecoin"
 
+// DefaultSectorsPath is the name of the sector path relative to the repo path
+var DefaultSectorsPath = "sectors"
+
 // DefaultLogLevel is the value that will be used for GO_FILECOIN_LOG_LEVEL
 var DefaultLogLevel = "3"
 
@@ -53,6 +56,9 @@ var (
 
 	// AttrLogJSON is the key used to set the node to output json logs
 	AttrLogJSON = "logJSON"
+
+	// AttrSectorsPath is the key used to set the sectors path
+	AttrSectorsPath = "sectorsPath"
 )
 
 // Localfilecoin represents a filecoin node
@@ -61,9 +67,10 @@ type Localfilecoin struct {
 	peerid  cid.Cid
 	apiaddr multiaddr.Multiaddr
 
-	binPath  string
-	logLevel string
-	logJSON  string
+	binPath     string
+	sectorsPath string
+	logLevel    string
+	logJSON     string
 }
 
 var NewNode testbedi.NewNodeFunc // nolint: golint
@@ -73,9 +80,10 @@ func init() {
 		var (
 			err error
 
-			binPath  = ""
-			logLevel = DefaultLogLevel
-			logJSON  = DefaultLogJSON
+			binPath     = ""
+			sectorsPath = filepath.Join(dir, DefaultSectorsPath)
+			logLevel    = DefaultLogLevel
+			logJSON     = DefaultLogJSON
 		)
 
 		if v, ok := attrs[AttrFilecoinBinary]; ok {
@@ -88,6 +96,10 @@ func init() {
 
 		if v, ok := attrs[AttrLogJSON]; ok {
 			logJSON = v
+		}
+
+		if v, ok := attrs[AttrSectorsPath]; ok {
+			sectorsPath = v
 		}
 
 		if len(binPath) == 0 {
@@ -109,11 +121,16 @@ func init() {
 			return nil, err
 		}
 
+		if err := os.Mkdir(sectorsPath, 0755); err != nil {
+			return nil, err
+		}
+
 		return &Localfilecoin{
-			dir:      dir,
-			binPath:  dst,
-			logLevel: logLevel,
-			logJSON:  logJSON,
+			dir:         dir,
+			binPath:     dst,
+			sectorsPath: sectorsPath,
+			logLevel:    logLevel,
+			logJSON:     logJSON,
 		}, nil
 	}
 }
@@ -141,6 +158,18 @@ func (l *Localfilecoin) Init(ctx context.Context, args ...string) (testbedi.Outp
 
 	if err := lcfg.Set("swarm.address", `"/ip4/127.0.0.1/tcp/0"`); err != nil {
 		return nil, err
+	}
+
+	// only set sectors path to l.sectorsPath if init command does not set
+	isectorsPath, err := lcfg.Get("sectorbase.rootdir")
+	if err != nil {
+		return nil, err
+	}
+	lsectorsPath := isectorsPath.(string)
+	if lsectorsPath == "" {
+		if err := lcfg.Set("sectorbase.rootdir", l.sectorsPath); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := l.WriteConfig(lcfg); err != nil {


### PR DESCRIPTION
#2689 

This also closes out #2680 ( I shut down the already reviewed solution in #2682) in favor of this because these changes remove a gnarly CI-only IPTB cleanup failure during the retrieval test)

This gets rid of the homedir concept while keeping the default sector directory out of the repo as part of compromise 2c laid out here #2687.  

@travisperson I went ahead and defaulted IPTB sector directory storage to be within the repo underneath `sectors` just as it was before I started these changes (we're not migrating these repos so putting sectors inside them is nice and doesn't cause problems).  I don't know my way around the filecoin IPTB plugin well so please alert me if the way I did this is ugly / not the right way.

@shannonwells I don't expect this to get in the way of the other repo migration efforts but please let me know if this unintentionally blocks or frustrates your work.

cc @anorth please take a look too