### PR TITLE
add piece inclusion proofs to deals

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -838,7 +838,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 					val := result.SealingResult
 					// This call can fail due to, e.g. nonce collisions. Our miners existence depends on this.
 					// We should deal with this, but MessageSendWithRetry is problematic.
-					_, err := node.PorcelainAPI.MessageSend(
+					msgCid, err := node.PorcelainAPI.MessageSend(
 						node.miningCtx,
 						minerOwnerAddr,
 						minerAddr,
@@ -857,7 +857,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 						continue
 					}
 
-					node.StorageMiner.OnCommitmentAddedToChain(val, nil)
+					node.StorageMiner.OnCommitmentSent(val, msgCid, nil)
 				}
 			case <-node.miningCtx.Done():
 				return

--- a/proofs/sectorbuilder/interface.go
+++ b/proofs/sectorbuilder/interface.go
@@ -68,8 +68,9 @@ type SectorSealResult struct {
 
 // PieceInfo is information about a filecoin piece
 type PieceInfo struct {
-	Ref  cid.Cid `json:"ref"`
-	Size uint64  `json:"size"` // TODO: use BytesAmount
+	Ref            cid.Cid `json:"ref"`
+	Size           uint64  `json:"size"` // TODO: use BytesAmount
+	InclusionProof []byte  `json:"inclusionProof"`
 }
 
 // SealedSectorMetadata is a sector that has been sealed by the PoRep setup process

--- a/proofs/sectorbuilder/rustsectorbuilder.go
+++ b/proofs/sectorbuilder/rustsectorbuilder.go
@@ -285,6 +285,17 @@ func (sb *RustSectorBuilder) findSealedSectorMetadata(sectorID uint64) (*SealedS
 			return nil, errors.Wrap(err, "failed to marshal from string to cid")
 		}
 
+		// TODO: These piece inclusion proofs are fake, remove this when proofs are available
+		// The fake proof uses the piece cid as a fake CommP and concatenates CommP with CommD
+		// see https://github.com/filecoin-project/go-filecoin/issues/2629
+		for _, pieceInfo := range ps {
+			var commP types.CommP
+			copy(commP[:], pieceInfo.Ref.Bytes())
+			pieceInfo.InclusionProof = []byte{}
+			pieceInfo.InclusionProof = append(pieceInfo.InclusionProof, commP[:]...)
+			pieceInfo.InclusionProof = append(pieceInfo.InclusionProof, commD[:]...)
+		}
+
 		return &SealedSectorMetadata{
 			CommD:     commD,
 			CommR:     commR,

--- a/protocol/storage/storagedeal/types.go
+++ b/protocol/storage/storagedeal/types.go
@@ -124,11 +124,15 @@ type Deal struct {
 }
 
 // ProofInfo contains the details about a seal proof, that the client needs to know to verify that his deal was posted on chain.
-// TODO: finalize parameters
 type ProofInfo struct {
+	// Sector id allows us to find the committed sector metadata on chain
 	SectorID uint64
-	CommR    []byte
-	CommD    []byte
+
+	// CommitmentMessage is the cid of the message that committed the sector. It's used to track when the sector goes on chain.
+	CommitmentMessage *cid.Cid
+
+	// PieceInclusionProof is a proof that a the piece is included within a sector
+	PieceInclusionProof []byte
 }
 
 // QueryRequest is used for making protocol api requests for deals


### PR DESCRIPTION
Closes #2571

### Problem

There is currently no mechanism for miners to send piece inclusion proofs back to clients. As a convenience, we would also like storage miners to communicate the message cid of the `commitSector` message used to commit the sector containing the client's piece, so that the client can more easily track when the commitment lands on their own chain.

### Solution

This PR adds the inclusion proof and the commit message cid to the ProofInfo in the deal response sent back to the client. The piece inclusion proof is currently faked pending the availability real proofs from rust proofs (#2629).