### PR TITLE
pin a miner to a sector size when creating

### DIFF
--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -138,6 +138,10 @@ type State struct {
 	LastPoSt           *types.BlockHeight
 
 	Power *big.Int
+
+	// SectorSize is the amount of space in each sector committed to the network
+	// by this miner.
+	SectorSize *types.BytesAmount
 }
 
 // NewActor returns a new miner actor
@@ -146,7 +150,7 @@ func NewActor() *actor.Actor {
 }
 
 // NewState creates a miner state struct
-func NewState(owner address.Address, key []byte, pledge *big.Int, pid peer.ID, collateral *types.AttoFIL) *State {
+func NewState(owner address.Address, key []byte, pledge *big.Int, pid peer.ID, collateral *types.AttoFIL, sectorSize *types.BytesAmount) *State {
 	return &State{
 		Owner:             owner,
 		PeerID:            pid,
@@ -156,6 +160,7 @@ func NewState(owner address.Address, key []byte, pledge *big.Int, pid peer.ID, c
 		SectorCommitments: make(map[string]types.Commitments),
 		Power:             big.NewInt(0),
 		NextAskID:         big.NewInt(0),
+		SectorSize:        sectorSize,
 	}
 }
 
@@ -251,6 +256,10 @@ var minerExports = exec.Exports{
 	"isBootstrapMiner": &exec.FunctionSignature{
 		Params: nil,
 		Return: []abi.Type{abi.Boolean},
+	},
+	"getSectorSize": &exec.FunctionSignature{
+		Params: nil,
+		Return: []abi.Type{abi.BytesAmount},
 	},
 }
 
@@ -449,6 +458,29 @@ func (ma *Actor) GetSectorCommitments(ctx exec.VMContext) (map[string]types.Comm
 	return a, 0, nil
 }
 
+// GetSectorSize returns the size of the sectors committed to the network by
+// this miner.
+func (ma *Actor) GetSectorSize(ctx exec.VMContext) (*types.BytesAmount, uint8, error) {
+	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
+		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
+	var state State
+	out, err := actor.WithState(ctx, &state, func() (interface{}, error) {
+		return state.SectorSize, nil
+	})
+	if err != nil {
+		return nil, errors.CodeError(err), err
+	}
+
+	amt, ok := out.(*types.BytesAmount)
+	if !ok {
+		return nil, 1, errors.NewFaultErrorf("expected a *types.BytesAmount, but got %T instead", out)
+	}
+
+	return amt, 0, nil
+}
+
 // CommitSector adds a commitment to the specified sector. The sector must not
 // already be committed.
 func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR, commRStar []byte, proof types.PoRepProof) (uint8, error) {
@@ -465,58 +497,39 @@ func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR,
 		return 1, errors.NewRevertError("invalid sized commRStar")
 	}
 
-	// As with submitPoSt messages, bootstrap miner actors don't verify
-	// the commitSector messages that they are sent.
-	//
-	// This switching will be removed when issue #2270 is completed.
-	if !ma.Bootstrap {
-		// This unfortunate environment variable-checking needs to happen because
-		// the PoRep verification operation needs to know some things (e.g. size)
-		// about the sector for which the proof was generated in order to verify.
-		//
-		// It is undefined behavior for a miner using "LiveProofsMode" to verify
-		// a proof created by a miner in "TestProofsMode"(and vice-versa).
-		//
-		proofsMode, err := GetProofsMode(ctx)
-		if err != nil {
-			return ErrGetProofsModeFailed, Errors[ErrGetProofsModeFailed]
-		}
-
-		var sectorSize types.SectorSize
-		if proofsMode == types.TestProofsMode {
-			sectorSize = types.OneKiBSectorSize
-		} else {
-			sectorSize = types.TwoHundredFiftySixMiBSectorSize
-		}
-
-		req := proofs.VerifySealRequest{}
-		copy(req.CommD[:], commD)
-		copy(req.CommR[:], commR)
-		copy(req.CommRStar[:], commRStar)
-		req.Proof = proof
-		req.ProverID = sectorbuilder.AddressToProverID(ctx.Message().To)
-		req.SectorID = sectorbuilder.SectorIDToBytes(sectorID)
-		req.SectorSize = sectorSize
-
-		res, err := (&proofs.RustVerifier{}).VerifySeal(req)
-		if err != nil {
-			return 1, errors.RevertErrorWrap(err, "failed to verify seal proof")
-		}
-		if !res.IsValid {
-			return ErrInvalidSealProof, Errors[ErrInvalidSealProof]
-		}
-	}
-
-	// TODO: use uint64 instead of this abomination, once refmt is fixed
-	// https://github.com/polydawn/refmt/issues/35
-	sectorIDstr := strconv.FormatUint(sectorID, 10)
-
 	var state State
 	_, err := actor.WithState(ctx, &state, func() (interface{}, error) {
+		// As with submitPoSt messages, bootstrap miner actors don't verify
+		// the commitSector messages that they are sent.
+		//
+		// This switching will be removed when issue #2270 is completed.
+		if !ma.Bootstrap {
+			req := proofs.VerifySealRequest{}
+			copy(req.CommD[:], commD)
+			copy(req.CommR[:], commR)
+			copy(req.CommRStar[:], commRStar)
+			req.Proof = proof
+			req.ProverID = sectorbuilder.AddressToProverID(ctx.Message().To)
+			req.SectorID = sectorbuilder.SectorIDToBytes(sectorID)
+			req.SectorSize = state.SectorSize
+
+			res, err := (&proofs.RustVerifier{}).VerifySeal(req)
+			if err != nil {
+				return nil, errors.RevertErrorWrap(err, "failed to verify seal proof")
+			}
+			if !res.IsValid {
+				return nil, Errors[ErrInvalidSealProof]
+			}
+		}
+
 		// verify that the caller is authorized to perform update
 		if ctx.Message().From != state.Owner {
 			return nil, Errors[ErrCallerUnauthorized]
 		}
+
+		// TODO: use uint64 instead of this abomination, once refmt is fixed
+		// https://github.com/polydawn/refmt/issues/35
+		sectorIDstr := strconv.FormatUint(sectorID, 10)
 
 		_, ok := state.SectorCommitments[sectorIDstr]
 		if ok {
@@ -736,24 +749,6 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, poStProofs []types.PoStProof) (u
 		//
 		// This switching will be removed when issue #2270 is completed.
 		if !ma.Bootstrap {
-			// See comment above, in CommitSector.
-			//
-			// It is undefined behavior for a miner using "LiveProofsMode" to
-			// verify a proof created by a miner using "TestProofsMode" (and
-			// vice-versa).
-			//
-			proofsMode, err := GetProofsMode(ctx)
-			if err != nil {
-				return ErrGetProofsModeFailed, Errors[ErrGetProofsModeFailed]
-			}
-
-			var sectorSize types.SectorSize
-			if proofsMode == types.TestProofsMode {
-				sectorSize = types.OneKiBSectorSize
-			} else {
-				sectorSize = types.TwoHundredFiftySixMiBSectorSize
-			}
-
 			seed, err := currentProvingPeriodPoStChallengeSeed(ctx, state)
 			if err != nil {
 				return nil, errors.RevertErrorWrap(err, "failed to sample chain for challenge seed")
@@ -766,12 +761,12 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, poStProofs []types.PoStProof) (u
 
 			sortedCommRs := proofs.NewSortedCommRs(commRs...)
 
-			req := proofs.VerifyPoSTRequest{
+			req := proofs.VerifyPoStRequest{
 				ChallengeSeed: seed,
 				SortedCommRs:  sortedCommRs,
 				Faults:        []uint64{},
 				Proofs:        poStProofs,
-				SectorSize:    sectorSize,
+				SectorSize:    state.SectorSize,
 			}
 
 			res, err := (&proofs.RustVerifier{}).VerifyPoST(req)

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -40,7 +40,7 @@ func createTestMinerWith(pledge int64,
 	msg := types.NewMessage(minerOwnerAddr, address.StorageMarketAddress, nonce, types.NewAttoFILFromFIL(collateral), "createMiner", pdata)
 
 	result, err := th.ApplyTestMessage(stateTree, vms, msg, types.NewBlockHeight(0))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	addr, err := address.NewFromBytes(result.Receipt.Return[0])
 	assert.NoError(t, err)
@@ -136,7 +136,7 @@ func TestGetKey(t *testing.T) {
 func TestCBOREncodeState(t *testing.T) {
 	tf.UnitTest(t)
 
-	state := NewState(address.TestAddress, []byte{}, big.NewInt(1), th.RequireRandomPeerID(t), types.NewZeroAttoFIL())
+	state := NewState(address.TestAddress, []byte{}, big.NewInt(1), th.RequireRandomPeerID(t), types.NewZeroAttoFIL(), types.OneKiBSectorSize)
 
 	state.SectorCommitments["1"] = types.Commitments{
 		CommD:     types.CommD{},

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -1075,6 +1075,6 @@ func requireGetTsas(ctx context.Context, t *testing.T, chain chain.Store, key ty
 
 func initGenesis(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
 	return consensus.MakeGenesisFunc(
-		consensus.MinerActor(minerAddress, minerOwnerAddress, []byte{}, 1000, minerPeerID, types.ZeroAttoFIL),
+		consensus.MinerActor(minerAddress, minerOwnerAddress, []byte{}, 1000, minerPeerID, types.ZeroAttoFIL, types.OneKiBSectorSize),
 	)(cst, bs)
 }

--- a/commands/protocol.go
+++ b/commands/protocol.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"io"
 
-	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
-	cmds "github.com/ipfs/go-ipfs-cmds"
-
 	"github.com/filecoin-project/go-filecoin/porcelain"
+	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/ipfs/go-ipfs-cmdkit"
+	"github.com/ipfs/go-ipfs-cmds"
 )
 
 var protocolCmd = &cmds.Command{
@@ -35,7 +35,9 @@ var protocolCmd = &cmds.Command{
 				sectorSize = types.TwoHundredFiftySixMiBSectorSize
 			}
 
-			_, err = fmt.Fprintf(w, "\t%d bytes\n", sectorSize.Uint64())
+			maxUserBytes := proofs.GetMaxUserBytesPerStagedSector(sectorSize)
+
+			_, err = fmt.Fprintf(w, "\t%s (%s writeable)\n", readableBytesAmount(float64(sectorSize.Uint64())), readableBytesAmount(float64(maxUserBytes.Uint64())))
 			if err != nil {
 				return err
 			}
@@ -43,4 +45,16 @@ var protocolCmd = &cmds.Command{
 			return nil
 		}),
 	},
+}
+
+func readableBytesAmount(amt float64) string {
+	unit := 0
+	units := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
+
+	for amt >= 1024 {
+		amt /= 1024
+		unit++
+	}
+
+	return fmt.Sprintf("%.2f %s", amt, units[unit])
 }

--- a/commands/protocol.go
+++ b/commands/protocol.go
@@ -8,6 +8,7 @@ import (
 	cmds "github.com/ipfs/go-ipfs-cmds"
 
 	"github.com/filecoin-project/go-filecoin/porcelain"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 var protocolCmd = &cmds.Command{
@@ -28,12 +29,17 @@ var protocolCmd = &cmds.Command{
 			if err != nil {
 				return err
 			}
-			for _, sectorSize := range pp.SectorSizes {
-				_, err := fmt.Fprintf(w, "\t%d bytes\n", sectorSize)
-				if err != nil {
-					return err
-				}
+
+			sectorSize := types.OneKiBSectorSize
+			if pp.ProofsMode == types.LiveProofsMode {
+				sectorSize = types.TwoHundredFiftySixMiBSectorSize
 			}
+
+			_, err = fmt.Fprintf(w, "\t%d bytes\n", sectorSize.Uint64())
+			if err != nil {
+				return err
+			}
+
 			return nil
 		}),
 	},

--- a/commands/protocol.go
+++ b/commands/protocol.go
@@ -51,7 +51,7 @@ func readableBytesAmount(amt float64) string {
 	unit := 0
 	units := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
 
-	for amt >= 1024 {
+	for amt >= 1024 && unit < len(units)-1 {
 		amt /= 1024
 		unit++
 	}

--- a/consensus/genesis.go
+++ b/consensus/genesis.go
@@ -56,9 +56,9 @@ func ActorAccount(addr address.Address, amt *types.AttoFIL) GenOption {
 }
 
 // MinerActor returns a config option that sets up an miner actor account.
-func MinerActor(addr address.Address, owner address.Address, key []byte, pledge uint64, pid peer.ID, coll *types.AttoFIL) GenOption {
+func MinerActor(addr address.Address, owner address.Address, key []byte, pledge uint64, pid peer.ID, coll *types.AttoFIL, sectorSize *types.BytesAmount) GenOption {
 	return func(gc *Config) error {
-		gc.miners[addr] = miner.NewState(owner, key, big.NewInt(int64(pledge)), pid, coll)
+		gc.miners[addr] = miner.NewState(owner, key, big.NewInt(int64(pledge)), pid, coll, sectorSize)
 		return nil
 	}
 }

--- a/functional-tests/lib/helpers.bash
+++ b/functional-tests/lib/helpers.bash
@@ -44,6 +44,9 @@ function finish {
   rm -rf "${CL_REPO_DIR}"
   rm -rf "${BOOTSTRAP_MN_REPO_DIR}"
   rm -rf "${STORAGE_MN_REPO_DIR}"
+  rm -rf "${CL_SECTOR_DIR}"
+  rm -rf "${BOOTSTRAP_MN_SECTOR_DIR}"
+  rm -rf "${STORAGE_MN_SECTOR_DIR}"
 }
 
 function free_port {
@@ -59,8 +62,9 @@ function init_local_daemon {
   ./go-filecoin init \
     --auto-seal-interval-seconds="${AUTO_SEAL_INTERVAL_SECONDS}" \
     --repodir="$1" \
-    --cmdapiaddr=/ip4/127.0.0.1/tcp/"$2" \
-    --genesisfile="$3"
+    --sectordir="$2" \
+    --cmdapiaddr=/ip4/127.0.0.1/tcp/"$3" \
+    --genesisfile="$4"
 }
 
 function init_devnet_daemon {

--- a/functional-tests/retrieval
+++ b/functional-tests/retrieval
@@ -32,6 +32,9 @@ CL_PID=""
 STORAGE_MN_REPO_DIR=""
 BOOTSTRAP_MN_REPO_DIR=""
 CL_REPO_DIR=""
+STORAGE_MN_SECTOR_DIR=""
+BOOTSTRAP_MN_SECTOR_DIR=""
+CL_SECTOR_DIR=""
 PIECE_1_PATH=$(mktemp)
 PIECE_2_PATH=$(mktemp)
 UNSEAL_PATH=$(mktemp)
@@ -52,14 +55,17 @@ fi
 trap finish EXIT
 
 STORAGE_MN_REPO_DIR=$(mktemp -d $(mktemp -d /tmp/XXXXXX)/XXXXXX)
+STORAGE_MN_SECTOR_DIR=$(mktemp -d $(mktemp -d /tmp/XXXXXX)/XXXXXX)
 STORAGE_MN_CMDAPI_PORT=$(free_port)
 STORAGE_MN_SWARM_PORT=$(free_port)
 
 BOOTSTRAP_MN_REPO_DIR=$(mktemp -d $(mktemp -d /tmp/XXXXXX)/XXXXXX)
+BOOTSTRAP_MN_SECTOR_DIR=$(mktemp -d $(mktemp -d /tmp/XXXXXX)/XXXXXX)
 BOOTSTRAP_MN_CMDAPI_PORT=$(free_port)
 BOOTSTRAP_MN_SWARM_PORT=$(free_port)
 
 CL_REPO_DIR=$(mktemp -d $(mktemp -d /tmp/XXXXXX)/XXXXXX)
+CL_SECTOR_DIR=$(mktemp -d $(mktemp -d /tmp/XXXXXX)/XXXXXX)
 CL_CMDAPI_PORT=$(free_port)
 CL_SWARM_PORT=$(free_port)
 
@@ -69,9 +75,9 @@ BOOTSTRAP_MN_MINER_FIL_ADDR=$(jq -r '.Miners[] | select(.Owner == 0).Address' < 
 
 echo ""
 echo "initializing daemons..."
-init_local_daemon "${BOOTSTRAP_MN_REPO_DIR}" "${BOOTSTRAP_MN_CMDAPI_PORT}" "${FIXTURES_PATH}/genesis.car"
-init_local_daemon "${STORAGE_MN_REPO_DIR}" "${STORAGE_MN_CMDAPI_PORT}" "${FIXTURES_PATH}/genesis.car"
-init_local_daemon "${CL_REPO_DIR}" "${CL_CMDAPI_PORT}" "${FIXTURES_PATH}/genesis.car"
+init_local_daemon "${BOOTSTRAP_MN_REPO_DIR}" "${BOOTSTRAP_MN_SECTOR_DIR}" "${BOOTSTRAP_MN_CMDAPI_PORT}" "${FIXTURES_PATH}/genesis.car"
+init_local_daemon "${STORAGE_MN_REPO_DIR}" "${STORAGE_MN_SECTOR_DIR}" "${STORAGE_MN_CMDAPI_PORT}" "${FIXTURES_PATH}/genesis.car"
+init_local_daemon "${CL_REPO_DIR}" "${CL_SECTOR_DIR}" "${CL_CMDAPI_PORT}" "${FIXTURES_PATH}/genesis.car"
 
 echo ""
 echo "start daemons..."

--- a/plumbing/msg/waiter_test.go
+++ b/plumbing/msg/waiter_test.go
@@ -144,7 +144,7 @@ func TestWaitConflicting(t *testing.T) {
 		consensus.ActorAccount(addr1, types.NewAttoFILFromFIL(10000)),
 		consensus.ActorAccount(addr2, types.NewAttoFILFromFIL(0)),
 		consensus.ActorAccount(addr3, types.NewAttoFILFromFIL(0)),
-		consensus.MinerActor(minerAddr, addr3, []byte{}, 1000, th.RequireRandomPeerID(t), types.ZeroAttoFIL),
+		consensus.MinerActor(minerAddr, addr3, []byte{}, 1000, th.RequireRandomPeerID(t), types.ZeroAttoFIL, types.OneKiBSectorSize),
 	)
 	cst, chainStore, waiter := setupTestWithGif(t, testGen)
 

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -124,6 +124,16 @@ func (a *API) MinerGetOwnerAddress(ctx context.Context, minerAddr address.Addres
 	return MinerGetOwnerAddress(ctx, a, minerAddr)
 }
 
+// MinerGetSectorSize queries for the sector size of the given miner.
+func (a *API) MinerGetSectorSize(ctx context.Context, minerAddr address.Address) (*types.BytesAmount, error) {
+	return MinerGetSectorSize(ctx, a, minerAddr)
+}
+
+// MinerGetSectorSize queries for the sector size of the given miner.
+func (a *API) MinerGetLastCommittedSectorID(ctx context.Context, minerAddr address.Address) (uint64, error) {
+	return MinerGetLastCommittedSectorID(ctx, a, minerAddr)
+}
+
 // MinerGetKey queries for the public key of the given miner
 func (a *API) MinerGetKey(ctx context.Context, minerAddr address.Address) ([]byte, error) {
 	return MinerGetKey(ctx, a, minerAddr)

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -129,7 +129,7 @@ func (a *API) MinerGetSectorSize(ctx context.Context, minerAddr address.Address)
 	return MinerGetSectorSize(ctx, a, minerAddr)
 }
 
-// MinerGetSectorSize queries for the sector size of the given miner.
+// MinerGetLastCommittedSectorID queries for the sector size of the given miner.
 func (a *API) MinerGetLastCommittedSectorID(ctx context.Context, minerAddr address.Address) (uint64, error) {
 	return MinerGetLastCommittedSectorID(ctx, a, minerAddr)
 }

--- a/porcelain/miner_test.go
+++ b/porcelain/miner_test.go
@@ -3,6 +3,7 @@ package porcelain_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -10,8 +11,10 @@ import (
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/libp2p/go-libp2p-peer"
 
+	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/plumbing/cfg"
 	. "github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/repo"
@@ -422,6 +425,17 @@ type minerGetOwnerPlumbing struct{}
 
 func (mgop *minerGetOwnerPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error) {
 	return [][]byte{address.TestAddress.Bytes()}, nil
+}
+
+func (mgop *minerGetOwnerPlumbing) ActorGetSignature(ctx context.Context, actorAddr address.Address, method string) (*exec.FunctionSignature, error) {
+	if method == "getSectorSize" {
+		return &exec.FunctionSignature{
+			Params: nil,
+			Return: []abi.Type{abi.BytesAmount},
+		}, nil
+	}
+
+	return nil, fmt.Errorf("unsupported method: %s", method)
 }
 
 func TestMinerGetOwnerAddress(t *testing.T) {

--- a/porcelain/miner_test.go
+++ b/porcelain/miner_test.go
@@ -7,10 +7,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ipfs/go-cid"
-	cbor "github.com/ipfs/go-ipld-cbor"
-	"github.com/libp2p/go-libp2p-peer"
-
 	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
@@ -20,6 +16,10 @@ import (
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/wallet"
+	"github.com/filecoin-project/go-leb128"
+	"github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+	"github.com/libp2p/go-libp2p-peer"
 
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/stretchr/testify/assert"
@@ -496,4 +496,46 @@ func requirePeerID() peer.ID {
 		panic("Could not create peer id")
 	}
 	return id
+}
+
+type minerGetSectorSizePlumbing struct{}
+
+func (minerGetSectorSizePlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error) {
+	return [][]byte{types.NewBytesAmount(1234).Bytes()}, nil
+}
+func (minerGetSectorSizePlumbing) ActorGetSignature(ctx context.Context, actorAddr address.Address, method string) (*exec.FunctionSignature, error) {
+	return &exec.FunctionSignature{
+		Params: nil,
+		Return: []abi.Type{abi.BytesAmount},
+	}, nil
+}
+
+func TestMinerGetSectorSize(t *testing.T) {
+	tf.UnitTest(t)
+
+	sectorSize, err := MinerGetSectorSize(context.Background(), &minerGetSectorSizePlumbing{}, address.TestAddress2)
+	require.NoError(t, err)
+
+	assert.Equal(t, int(sectorSize.Uint64()), 1234)
+}
+
+type minerGetLastCommittedSectorIDPlumbing struct{}
+
+func (minerGetLastCommittedSectorIDPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error) {
+	return [][]byte{leb128.FromUInt64(5432)}, nil
+}
+func (minerGetLastCommittedSectorIDPlumbing) ActorGetSignature(ctx context.Context, actorAddr address.Address, method string) (*exec.FunctionSignature, error) {
+	return &exec.FunctionSignature{
+		Params: nil,
+		Return: []abi.Type{abi.SectorID},
+	}, nil
+}
+
+func TestMinerGetLastCommittedSectorID(t *testing.T) {
+	tf.UnitTest(t)
+
+	lastCommittedSectorId, err := MinerGetLastCommittedSectorID(context.Background(), &minerGetLastCommittedSectorIDPlumbing{}, address.TestAddress2)
+	require.NoError(t, err)
+
+	assert.Equal(t, int(lastCommittedSectorId), 5432)
 }

--- a/porcelain/miner_test.go
+++ b/porcelain/miner_test.go
@@ -534,8 +534,8 @@ func (minerGetLastCommittedSectorIDPlumbing) ActorGetSignature(ctx context.Conte
 func TestMinerGetLastCommittedSectorID(t *testing.T) {
 	tf.UnitTest(t)
 
-	lastCommittedSectorId, err := MinerGetLastCommittedSectorID(context.Background(), &minerGetLastCommittedSectorIDPlumbing{}, address.TestAddress2)
+	lastCommittedSectorID, err := MinerGetLastCommittedSectorID(context.Background(), &minerGetLastCommittedSectorIDPlumbing{}, address.TestAddress2)
 	require.NoError(t, err)
 
-	assert.Equal(t, int(lastCommittedSectorId), 5432)
+	assert.Equal(t, int(lastCommittedSectorID), 5432)
 }

--- a/porcelain/protocol_test.go
+++ b/porcelain/protocol_test.go
@@ -39,7 +39,7 @@ func TestProtocolParams(t *testing.T) {
 
 		expected := &porcelain.ProtocolParams{
 			AutoSealInterval: 120,
-			SectorSizes:      []uint64{1016},
+			ProofsMode:       types.TestProofsMode,
 		}
 
 		out, err := porcelain.ProtocolParameters(context.TODO(), plumbing)

--- a/proofs/interface.go
+++ b/proofs/interface.go
@@ -12,16 +12,16 @@ type VerifySealRequest struct {
 	Proof      types.PoRepProof // returned from seal
 	ProverID   [31]byte         // uniquely identifies miner
 	SectorID   [31]byte         // uniquely identifies sector
-	SectorSize types.SectorSize
+	SectorSize *types.BytesAmount
 }
 
-// VerifyPoSTRequest represents a request to generate verify a proof-of-spacetime.
-type VerifyPoSTRequest struct {
+// VerifyPoStRequest represents a request to generate verify a proof-of-spacetime.
+type VerifyPoStRequest struct {
 	ChallengeSeed types.PoStChallengeSeed
 	SortedCommRs  SortedCommRs
 	Faults        []uint64
 	Proofs        []types.PoStProof
-	SectorSize    types.SectorSize
+	SectorSize    *types.BytesAmount
 }
 
 // VerifyPoSTResponse communicates the validity of a provided proof-of-spacetime.
@@ -36,6 +36,6 @@ type VerifySealResponse struct {
 
 // Verifier provides an interface to the proving subsystem.
 type Verifier interface {
-	VerifyPoST(VerifyPoSTRequest) (VerifyPoSTResponse, error)
+	VerifyPoST(VerifyPoStRequest) (VerifyPoSTResponse, error)
 	VerifySeal(VerifySealRequest) (VerifySealResponse, error)
 }

--- a/proofs/rustverifier.go
+++ b/proofs/rustverifier.go
@@ -75,7 +75,7 @@ func (rp *RustVerifier) VerifySeal(req VerifySealRequest) (VerifySealResponse, e
 }
 
 // VerifyPoST verifies that a proof-of-spacetime is valid.
-func (rp *RustVerifier) VerifyPoST(req VerifyPoSTRequest) (VerifyPoSTResponse, error) {
+func (rp *RustVerifier) VerifyPoST(req VerifyPoStRequest) (VerifyPoSTResponse, error) {
 	defer elapsed("VerifyPoST")()
 
 	// validate verification request
@@ -132,8 +132,7 @@ func (rp *RustVerifier) VerifyPoST(req VerifyPoSTRequest) (VerifyPoSTResponse, e
 
 // GetMaxUserBytesPerStagedSector returns the number of user bytes that will fit
 // into a staged sector. Due to bit-padding, the number of user bytes that will
-// fit into the staged sector will be less than number of bytes reported in
-// types.SectorSize.
-func GetMaxUserBytesPerStagedSector(size types.SectorSize) (uint64, error) {
-	return uint64(C.get_max_user_bytes_per_staged_sector(C.uint64_t(size.Uint64()))), nil
+// fit into the staged sector will be less than number of bytes in sectorSize.
+func GetMaxUserBytesPerStagedSector(sectorSize *types.BytesAmount) *types.BytesAmount {
+	return types.NewBytesAmount(uint64(C.get_max_user_bytes_per_staged_sector(C.uint64_t(sectorSize.Uint64()))))
 }

--- a/proofs/sectorbuilder/testing/builder.go
+++ b/proofs/sectorbuilder/testing/builder.go
@@ -75,7 +75,7 @@ func (b *Builder) Build() Harness {
 		panic(err)
 	}
 
-	class := types.NewTestSectorClass()
+	class := types.NewSectorClass(types.OneKiBSectorSize)
 
 	sb, err := sectorbuilder.NewRustSectorBuilder(sectorbuilder.RustSectorBuilderConfig{
 		BlockService:     blockService,
@@ -88,7 +88,7 @@ func (b *Builder) Build() Harness {
 	})
 	require.NoError(b.t, err)
 
-	max, err := proofs.GetMaxUserBytesPerStagedSector(class.SectorSize())
+	max := proofs.GetMaxUserBytesPerStagedSector(class.SectorSize())
 	require.NoError(b.t, err)
 
 	return Harness{

--- a/proofs/sectorbuilder/testing/harness.go
+++ b/proofs/sectorbuilder/testing/harness.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"github.com/filecoin-project/go-filecoin/types"
 	"io"
 	"strings"
 	"testing"
@@ -16,6 +15,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/address"
 	sb "github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
 	"github.com/filecoin-project/go-filecoin/repo"
+	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/stretchr/testify/require"
 )
 

--- a/proofs/sectorbuilder/testing/harness.go
+++ b/proofs/sectorbuilder/testing/harness.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"github.com/filecoin-project/go-filecoin/types"
 	"io"
 	"strings"
 	"testing"
@@ -21,7 +22,7 @@ import (
 // Harness is a struct used to make SectorBuilder testing easier
 type Harness struct {
 	blockService      bserv.BlockService
-	MaxBytesPerSector uint64
+	MaxBytesPerSector *types.BytesAmount
 	MinerAddr         address.Address
 	repo              repo.Repo
 	SectorBuilder     sb.SectorBuilder

--- a/proofs/sectorbuilder/testing/interface_test.go
+++ b/proofs/sectorbuilder/testing/interface_test.go
@@ -68,7 +68,7 @@ func TestSectorBuilder(t *testing.T) {
 		piecesToSeal := 10
 		for i := 0; i < piecesToSeal; i++ {
 			go func() {
-				_, pieceCid, err := h.AddPiece(context.Background(), RequireRandomBytes(t, h.MaxBytesPerSector/3))
+				_, pieceCid, err := h.AddPiece(context.Background(), RequireRandomBytes(t, h.MaxBytesPerSector.Uint64()/3))
 				if err != nil {
 					errs <- err
 				} else {
@@ -150,7 +150,7 @@ func TestSectorBuilder(t *testing.T) {
 		piecesToSeal := 5
 		for i := 0; i < piecesToSeal; i++ {
 			go func() {
-				_, pieceCid, err := h.AddPiece(context.Background(), RequireRandomBytes(t, h.MaxBytesPerSector))
+				_, pieceCid, err := h.AddPiece(context.Background(), RequireRandomBytes(t, h.MaxBytesPerSector.Uint64()))
 				if err != nil {
 					errs <- err
 				} else {
@@ -187,7 +187,7 @@ func TestSectorBuilder(t *testing.T) {
 		h := NewBuilder(t).Build()
 		defer h.Close()
 
-		inputBytes := RequireRandomBytes(t, h.MaxBytesPerSector)
+		inputBytes := RequireRandomBytes(t, h.MaxBytesPerSector.Uint64())
 		ref, size, reader, err := h.CreateAddPieceArgs(inputBytes)
 		require.NoError(t, err)
 
@@ -244,7 +244,7 @@ func TestSectorBuilder(t *testing.T) {
 		sectorIDSet := sync.Map{}
 
 		// SectorBuilder begins polling for SectorIDA seal-status
-		sectorIDA, _, errA := hA.AddPiece(context.Background(), RequireRandomBytes(t, hA.MaxBytesPerSector-10))
+		sectorIDA, _, errA := hA.AddPiece(context.Background(), RequireRandomBytes(t, hA.MaxBytesPerSector.Uint64()-10))
 		require.NoError(t, errA)
 		sectorIDSet.Store(sectorIDA, true)
 
@@ -260,7 +260,7 @@ func TestSectorBuilder(t *testing.T) {
 
 		// second SectorBuilder begins polling for SectorIDB seal-status in
 		// addition to SectorIDA
-		sectorIDB, _, errB := hB.AddPiece(context.Background(), RequireRandomBytes(t, hB.MaxBytesPerSector-50))
+		sectorIDB, _, errB := hB.AddPiece(context.Background(), RequireRandomBytes(t, hB.MaxBytesPerSector.Uint64()-50))
 		require.NoError(t, errB)
 		sectorIDSet.Store(sectorIDB, true)
 
@@ -301,7 +301,7 @@ func TestSectorBuilder(t *testing.T) {
 		h := NewBuilder(t).Build()
 		defer h.Close()
 
-		inputBytes := RequireRandomBytes(t, h.MaxBytesPerSector)
+		inputBytes := RequireRandomBytes(t, h.MaxBytesPerSector.Uint64())
 		ref, size, reader, err := h.CreateAddPieceArgs(inputBytes)
 		require.NoError(t, err)
 
@@ -341,7 +341,7 @@ func TestSectorBuilder(t *testing.T) {
 			require.NoError(t, gerr)
 
 			// verify the proof-of-spacetime
-			vres, verr := (&proofs.RustVerifier{}).VerifyPoST(proofs.VerifyPoSTRequest{
+			vres, verr := (&proofs.RustVerifier{}).VerifyPoST(proofs.VerifyPoStRequest{
 				ChallengeSeed: challengeSeed,
 				SortedCommRs:  sortedCommRs,
 				Faults:        gres.Faults,

--- a/proofs/testing.go
+++ b/proofs/testing.go
@@ -13,7 +13,7 @@ func NewFakeVerifier(isValid bool, err error) FakeVerifier {
 
 // VerifyPoST returns the valid of verifyPostValid and verifyPostError.
 // It fulfils a requirement for the Verifier interface
-func (fp FakeVerifier) VerifyPoST(VerifyPoSTRequest) (VerifyPoSTResponse, error) {
+func (fp FakeVerifier) VerifyPoST(VerifyPoStRequest) (VerifyPoSTResponse, error) {
 	return VerifyPoSTResponse{IsValid: fp.verifyPostValid}, fp.verifyPostError
 }
 

--- a/protocol/storage/client_test.go
+++ b/protocol/storage/client_test.go
@@ -180,6 +180,10 @@ func (ctp *clientTestAPI) MinerGetOwnerAddress(ctx context.Context, minerAddr ad
 	return address.TestAddress, nil
 }
 
+func (ctp *clientTestAPI) MinerGetSectorSize(ctx context.Context, minerAddr address.Address) (*types.BytesAmount, error) {
+	return types.OneKiBSectorSize, nil
+}
+
 func (ctp *clientTestAPI) MinerGetPeerID(ctx context.Context, minerAddr address.Address) (peer.ID, error) {
 	id, err := peer.IDB58Decode("QmWbMozPyW6Ecagtxq7SXBXXLY5BNdP1GwHB2WoZCKMvcb")
 	require.NoError(ctp.testing, err, "Could not create peer id")

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -408,6 +408,10 @@ type minerTestPorcelain struct {
 	testing *testing.T
 }
 
+func (mtp *minerTestPorcelain) MinerGetSectorSize(ctx context.Context, minerAddr address.Address) (*types.BytesAmount, error) {
+	return types.OneKiBSectorSize, nil
+}
+
 func (mtp *minerTestPorcelain) ChainSampleRandomness(ctx context.Context, sampleHeight *types.BlockHeight) ([]byte, error) {
 	bytes := make([]byte, 42)
 	if _, err := rand.Read(bytes); err != nil {

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -59,7 +59,7 @@ func RequireNewAccountActor(t *testing.T, value *types.AttoFIL) *actor.Actor {
 func RequireNewMinerActor(t *testing.T, vms vm.StorageMap, addr address.Address, owner address.Address, key []byte, pledge uint64, pid peer.ID, coll *types.AttoFIL) *actor.Actor {
 	act := actor.NewActor(types.MinerActorCodeCid, types.NewZeroAttoFIL())
 	storage := vms.NewStorage(addr, act)
-	initializerData := miner.NewState(owner, key, big.NewInt(int64(pledge)), pid, coll)
+	initializerData := miner.NewState(owner, key, big.NewInt(int64(pledge)), pid, coll, types.OneKiBSectorSize)
 	err := (&miner.Actor{}).InitializeState(storage, initializerData)
 	require.NoError(t, err)
 	require.NoError(t, storage.Flush())

--- a/testhelpers/mining.go
+++ b/testhelpers/mining.go
@@ -2,40 +2,15 @@ package testhelpers
 
 import (
 	"crypto/rand"
-	"math/big"
 	"strconv"
 	"testing"
 	"time"
 
-	"github.com/libp2p/go-libp2p-peer"
-
-	"github.com/filecoin-project/go-filecoin/abi"
-	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
 // BlockTimeTest is the block time used by workers during testing
 const BlockTimeTest = time.Second
-
-// CreateMinerMessage creates a message to create a miner.
-func CreateMinerMessage(from address.Address, nonce uint64, pledge uint64, pid peer.ID, collateral *types.AttoFIL) (*types.Message, error) {
-	params, err := abi.ToEncodedValues(big.NewInt(int64(pledge)), []byte{}, pid)
-	if err != nil {
-		return nil, err
-	}
-
-	return types.NewMessage(from, address.StorageMarketAddress, nonce, collateral, "createMiner", params), nil
-}
-
-// CommitSectorMessage creates a message to commit a sector.
-func CommitSectorMessage(miner, from address.Address, nonce, sectorID uint64, commD, commR, commRStar, proof []byte) (*types.Message, error) {
-	params, err := abi.ToEncodedValues(sectorID, commD, commR, commRStar, proof)
-	if err != nil {
-		return nil, err
-	}
-
-	return types.NewMessage(from, miner, nonce, types.NewZeroAttoFIL(), "commitSector", params), nil
-}
 
 // MakeCommitment creates a random commitment.
 func MakeCommitment() []byte {

--- a/tools/fast/bin/localnet/main.go
+++ b/tools/fast/bin/localnet/main.go
@@ -280,14 +280,8 @@ func main() {
 			return
 		}
 
-		max, err := getMaxUserBytesPerStagedSector()
-		if err != nil {
-			exitcode = handleError(err, "failed to get max user bytes per staged sector;")
-			return
-		}
-
 		var data bytes.Buffer
-		dataReader := io.LimitReader(rand.Reader, int64(max))
+		dataReader := io.LimitReader(rand.Reader, int64(getMaxUserBytesPerStagedSector()))
 		dataReader = io.TeeReader(dataReader, &data)
 		_, deal, err := series.ImportAndStore(ctx, genesis, ask, files.NewReaderFile(dataReader))
 		if err != nil {
@@ -356,16 +350,8 @@ func main() {
 	<-exit
 }
 
-func getMaxUserBytesPerStagedSector() (uint64, error) {
-	proofsMode := getProofsMode(smallSectors)
-	var sectorClass types.SectorClass
-	if proofsMode == types.TestProofsMode {
-		sectorClass = types.NewTestSectorClass()
-	} else {
-		sectorClass = types.NewLiveSectorClass()
-	}
-
-	return proofs.GetMaxUserBytesPerStagedSector(sectorClass.SectorSize())
+func getMaxUserBytesPerStagedSector() uint64 {
+	return proofs.GetMaxUserBytesPerStagedSector(types.OneKiBSectorSize).Uint64()
 }
 
 func handleError(err error, msg ...string) int {

--- a/types/sector_class.go
+++ b/types/sector_class.go
@@ -5,25 +5,19 @@ package types
 type SectorClass struct {
 	poStProofPartitions  PoStProofPartitions
 	poRepProofPartitions PoRepProofPartitions
-	sectorSize           SectorSize
+	sectorSize           *BytesAmount
 }
 
-// NewTestSectorClass returns a SectorClass suitable for testing.
-func NewTestSectorClass() SectorClass {
+// NewSectorClass returns a sector class configured with the provided sector
+// size. Note that there must exist a published Groth parameter and verifying
+// key in order for the sector size to be usable. A miner configured to use a
+// sector size for which we have not published Groth parameters will fail to
+// prove their storage.
+func NewSectorClass(sectorSize *BytesAmount) SectorClass {
 	return SectorClass{
 		poRepProofPartitions: TwoPoRepProofPartitions,
 		poStProofPartitions:  OnePoStProofPartition,
-		sectorSize:           OneKiBSectorSize,
-	}
-}
-
-// NewLiveSectorClass returns a SectorClass suitable for normal operation of a
-// go-filecoin node.
-func NewLiveSectorClass() SectorClass {
-	return SectorClass{
-		poRepProofPartitions: TwoPoRepProofPartitions,
-		poStProofPartitions:  OnePoStProofPartition,
-		sectorSize:           TwoHundredFiftySixMiBSectorSize,
+		sectorSize:           sectorSize,
 	}
 }
 
@@ -40,6 +34,6 @@ func (sc *SectorClass) PoStProofPartitions() PoStProofPartitions {
 // SectorSize returns the size of this sector class's sectors after bit-padding
 // has been added. Note that the amount of user bytes that will fit into a
 // sector is less than SectorSize due to bit-padding.
-func (sc *SectorClass) SectorSize() SectorSize {
+func (sc *SectorClass) SectorSize() *BytesAmount {
 	return sc.sectorSize
 }

--- a/types/sector_size.go
+++ b/types/sector_size.go
@@ -1,32 +1,5 @@
 package types
 
-import "fmt"
+var OneKiBSectorSize = NewBytesAmount(1024)
 
-// SectorSize is the amount of bytes in a sector. This amount will be slightly
-// greater than the number of user bytes which can be written to a sector due to
-// bit-padding.
-type SectorSize int
-
-const (
-	// UnknownSectorSize sector size
-	UnknownSectorSize = SectorSize(iota)
-
-	// OneKiBSectorSize indicates a sector which, after sealing, contains 1024 bytes.
-	OneKiBSectorSize = SectorSize(iota)
-
-	// TwoHundredFiftySixMiBSectorSize indicates a sector which, after sealing, contains 256MiB.
-	TwoHundredFiftySixMiBSectorSize
-)
-
-// Uint64 produces the number of bytes which the miner will get power for when
-// committing a sector of this size to the network.
-func (s SectorSize) Uint64() uint64 {
-	switch s {
-	case OneKiBSectorSize:
-		return 1024
-	case TwoHundredFiftySixMiBSectorSize:
-		return 1 << 28
-	default:
-		panic(fmt.Sprintf("unexpected value %v", s))
-	}
-}
+var TwoHundredFiftySixMiBSectorSize = NewBytesAmount(1 << 28)

--- a/types/sector_size.go
+++ b/types/sector_size.go
@@ -1,5 +1,9 @@
 package types
 
+// OneKiBSectorSize contain 1024 bytes after sealing. These sectors are used
+// when the network is in TestProofsMode.
 var OneKiBSectorSize = NewBytesAmount(1024)
 
+// TwoHundredFiftySixMiBSectorSize contain 256MiB after sealing. These sectors
+// are used when the network is in LiveProofsMode.
 var TwoHundredFiftySixMiBSectorSize = NewBytesAmount(1 << 28)


### PR DESCRIPTION
Makes incremental progress on #2530 

## Why does this PR exist?

A storage miner operator needs to be able to select a sector size when pledging. This sector size becomes an immutable property of their storage miner actor. This PR makes incremental progress to that end by creating a miner with a sector size (derived from the proofs mode) and persisting that choice to the miner's storage.

## What's in this PR?

- remove notion of test sector class
- replace SectorSize enum with BytesAmount to [conform to spec](https://github.com/filecoin-project/specs/blob/master/actors.md#createstorageminer)
- modify the `protocol` command such that it reports writeable (pre bit-padding) and non-writable ("sector size") in its output
- modify storage market actor `CreateMiner` command to select a sector size for miner based on proofs mode

## Next steps

The `miner create` command needs to be updated to accept a sector size (in bytes), and that value should be plumbed to the storage market actor's `CreateMiner` method.

Note: Before loosening the restriction that live proofs mode must always use the 256MiB sectors, I need to complete #2601.
