### PR TITLE
Use a struct over global vars in default_syncer_test

### DIFF
--- a/chain/default_store_test.go
+++ b/chain/default_store_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/repo"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -86,6 +87,7 @@ func requireHeadTipset(t *testing.T, chain chain.Store) types.TipSet {
 
 // Adding tipsets to the store doesn't error.
 func TestPutTipSet(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx := context.Background()
@@ -101,6 +103,7 @@ func TestPutTipSet(t *testing.T) {
 
 // Tipsets can be retrieved by key (all block cids).
 func TestGetByKey(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx := context.Background()
@@ -137,6 +140,7 @@ func TestGetByKey(t *testing.T) {
 
 // Tipsets can be retrieved by parent key (all block cids of parents).
 func TestGetByParent(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx := context.Background()
@@ -170,6 +174,7 @@ func TestGetByParent(t *testing.T) {
 }
 
 func TestGetMultipleByParent(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx := context.Background()
@@ -213,6 +218,7 @@ func TestGetMultipleByParent(t *testing.T) {
 
 // All blocks of a tipset can be retrieved after putting their wrapping tipset.
 func TestGetBlocks(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx := context.Background()
@@ -241,6 +247,7 @@ func TestGetBlocks(t *testing.T) {
 
 // chain.Store correctly indicates that is has all blocks in put tipsets
 func TestHasAllBlocks(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx := context.Background()
@@ -266,6 +273,7 @@ func TestHasAllBlocks(t *testing.T) {
 
 // The constructor call sets the dstP.genesis block for the chain store.
 func TestSetGenesis(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx := context.Background()
@@ -283,6 +291,7 @@ func assertSetHead(t *testing.T, chainStore chain.Store, ts types.TipSet) {
 
 // Set and Get Head.
 func TestHead(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx := context.Background()
@@ -316,6 +325,7 @@ func assertEmptyCh(t *testing.T, ch <-chan interface{}) {
 
 // Head events are propagated on HeadEvents.
 func TestHeadEvents(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx := context.Background()
@@ -356,6 +366,7 @@ func TestHeadEvents(t *testing.T) {
 // Load does not error and gives the chain store access to all blocks and
 // tipset indexes along the heaviest chain.
 func TestLoadAndReboot(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx := context.Background()

--- a/chain/default_store_test.go
+++ b/chain/default_store_test.go
@@ -21,45 +21,48 @@ import (
 )
 
 // Note: many of these tests use the test chain defined in the init function of default_syncer_test.
-func initStoreTest(ctx context.Context, t *testing.T) {
+func initStoreTest(ctx context.Context, t *testing.T, dstP *DefaultSyncerTestParams) {
 	powerTable := &th.TestView{}
 	r := repo.NewInMemoryRepo()
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := hamt.NewCborStore()
-	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), powerTable, genCid, proofs.NewFakeVerifier(true, nil))
-	initSyncTest(t, con, initGenesis, cst, bs, r)
-	requireSetTestChain(t, con, true)
+	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), powerTable, dstP.genCid, proofs.NewFakeVerifier(true, nil))
+	initGenesisWrapper := func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
+		return initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs)
+	}
+	initSyncTest(t, con, initGenesisWrapper, cst, bs, r, dstP)
+	requireSetTestChain(t, con, true, dstP)
 }
 
-func newChainStore() chain.Store {
+func newChainStore(dstP *DefaultSyncerTestParams) chain.Store {
 	r := repo.NewInMemoryRepo()
 	ds := r.Datastore()
-	return chain.NewDefaultStore(ds, genCid)
+	return chain.NewDefaultStore(ds, dstP.genCid)
 }
 
 // requirePutTestChain adds all test chain tipsets to the passed in chain store.
-func requirePutTestChain(t *testing.T, chainStore chain.Store) {
+func requirePutTestChain(t *testing.T, chainStore chain.Store, dstP *DefaultSyncerTestParams) {
 	ctx := context.Background()
 	genTsas := &chain.TipSetAndState{
-		TipSet:          genTS,
-		TipSetStateRoot: genStateRoot,
+		TipSet:          dstP.genTS,
+		TipSetStateRoot: dstP.genStateRoot,
 	}
 	link1Tsas := &chain.TipSetAndState{
-		TipSet:          link1,
-		TipSetStateRoot: link1State,
+		TipSet:          dstP.link1,
+		TipSetStateRoot: dstP.link1State,
 	}
 	link2Tsas := &chain.TipSetAndState{
-		TipSet:          link2,
-		TipSetStateRoot: link2State,
+		TipSet:          dstP.link2,
+		TipSetStateRoot: dstP.link2State,
 	}
 	link3Tsas := &chain.TipSetAndState{
-		TipSet:          link3,
-		TipSetStateRoot: link3State,
+		TipSet:          dstP.link3,
+		TipSetStateRoot: dstP.link3State,
 	}
 
 	link4Tsas := &chain.TipSetAndState{
-		TipSet:          link4,
-		TipSetStateRoot: link4State,
+		TipSet:          dstP.link4,
+		TipSetStateRoot: dstP.link4State,
 	}
 	th.RequirePutTsas(ctx, t, chainStore, genTsas)
 	th.RequirePutTsas(ctx, t, chainStore, link1Tsas)
@@ -84,14 +87,15 @@ func requireHeadTipset(t *testing.T, chain chain.Store) types.TipSet {
 
 // Adding tipsets to the store doesn't error.
 func TestPutTipSet(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
-	initStoreTest(ctx, t)
-	cs := newChainStore()
+	initStoreTest(ctx, t, dstP)
+	cs := newChainStore(dstP)
 	genTsas := &chain.TipSetAndState{
-		TipSet:          genTS,
-		TipSetStateRoot: genStateRoot,
+		TipSet:          dstP.genTS,
+		TipSetStateRoot: dstP.genStateRoot,
 	}
 	err := cs.PutTipSetAndState(ctx, genTsas)
 	assert.NoError(t, err)
@@ -136,18 +140,19 @@ func TestGetByKey(t *testing.T) {
 
 // Tipsets can be retrieved by parent key (all block cids of parents).
 func TestGetByParent(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
-	initStoreTest(ctx, t)
-	chain := newChainStore()
+	initStoreTest(ctx, t, dstP)
+	chain := newChainStore(dstP)
 
-	requirePutTestChain(t, chain)
-	pkg := types.SortedCidSet{}.String() // empty cid set is genesis pIDs
-	pk1 := genTS.String()
-	pk2 := link1.String()
-	pk3 := link2.String()
-	pk4 := link3.String()
+	requirePutTestChain(t, chain, dstP)
+	pkg := types.SortedCidSet{}.String() // empty cid set is dstP.genesis pIDs
+	pk1 := dstP.genTS.String()
+	pk2 := dstP.link1.String()
+	pk3 := dstP.link2.String()
+	pk4 := dstP.link3.String()
 
 	gotG := requireGetTsasByParentAndHeight(t, chain, pkg, uint64(0))
 	got1 := requireGetTsasByParentAndHeight(t, chain, pk1, uint64(1))
@@ -155,45 +160,46 @@ func TestGetByParent(t *testing.T) {
 	got3 := requireGetTsasByParentAndHeight(t, chain, pk3, uint64(3))
 	got4 := requireGetTsasByParentAndHeight(t, chain, pk4, uint64(6)) // two null blocks in between 3 and 4!
 
-	assert.Equal(t, genTS, gotG[0].TipSet)
-	assert.Equal(t, link1, got1[0].TipSet)
-	assert.Equal(t, link2, got2[0].TipSet)
-	assert.Equal(t, link3, got3[0].TipSet)
-	assert.Equal(t, link4, got4[0].TipSet)
+	assert.Equal(t, dstP.genTS, gotG[0].TipSet)
+	assert.Equal(t, dstP.link1, got1[0].TipSet)
+	assert.Equal(t, dstP.link2, got2[0].TipSet)
+	assert.Equal(t, dstP.link3, got3[0].TipSet)
+	assert.Equal(t, dstP.link4, got4[0].TipSet)
 
-	assert.Equal(t, genStateRoot, gotG[0].TipSetStateRoot)
-	assert.Equal(t, link1State, got1[0].TipSetStateRoot)
-	assert.Equal(t, link2State, got2[0].TipSetStateRoot)
-	assert.Equal(t, link3State, got3[0].TipSetStateRoot)
-	assert.Equal(t, link4State, got4[0].TipSetStateRoot)
+	assert.Equal(t, dstP.genStateRoot, gotG[0].TipSetStateRoot)
+	assert.Equal(t, dstP.link1State, got1[0].TipSetStateRoot)
+	assert.Equal(t, dstP.link2State, got2[0].TipSetStateRoot)
+	assert.Equal(t, dstP.link3State, got3[0].TipSetStateRoot)
+	assert.Equal(t, dstP.link4State, got4[0].TipSetStateRoot)
 }
 
 func TestGetMultipleByParent(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
-	initStoreTest(ctx, t)
-	chainStore := newChainStore()
+	initStoreTest(ctx, t, dstP)
+	chainStore := newChainStore(dstP)
 
 	mockSigner, ki := types.NewMockSignersAndKeyInfo(2)
 	mockSignerPubKey := ki[0].PublicKey()
 
 	fakeChildParams := th.FakeChildParams{
-		Parent:      genTS,
-		GenesisCid:  genCid,
-		StateRoot:   genStateRoot,
-		MinerAddr:   minerAddress,
+		Parent:      dstP.genTS,
+		GenesisCid:  dstP.genCid,
+		StateRoot:   dstP.genStateRoot,
+		MinerAddr:   dstP.minerAddress,
 		Nonce:       uint64(5),
 		Signer:      mockSigner,
 		MinerPubKey: mockSignerPubKey,
 	}
 
-	requirePutTestChain(t, chainStore)
-	pk1 := genTS.String()
+	requirePutTestChain(t, chainStore, dstP)
+	pk1 := dstP.genTS.String()
 	// give one parent multiple children and then query
 	newBlk := th.RequireMkFakeChild(t, fakeChildParams)
 	newChild := th.RequireNewTipSet(t, newBlk)
-	newRoot := cidGetter()
+	newRoot := dstP.cidGetter()
 	newChildTsas := &chain.TipSetAndState{
 		TipSet:          newChild,
 		TipSetStateRoot: newRoot,
@@ -205,25 +211,26 @@ func TestGetMultipleByParent(t *testing.T) {
 		if len(tsas.TipSet) == 1 {
 			assert.Equal(t, newRoot, tsas.TipSetStateRoot)
 		} else {
-			assert.Equal(t, link1State, tsas.TipSetStateRoot)
+			assert.Equal(t, dstP.link1State, tsas.TipSetStateRoot)
 		}
 	}
 }
 
 // All blocks of a tipset can be retrieved after putting their wrapping tipset.
 func TestGetBlocks(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
-	initStoreTest(ctx, t)
-	chain := newChainStore()
+	initStoreTest(ctx, t, dstP)
+	chain := newChainStore(dstP)
 
-	blks := []*types.Block{genesis, link1blk1, link1blk2, link2blk1,
-		link2blk2, link2blk3, link3blk1, link4blk1, link4blk2}
-	_, err := chain.GetBlock(ctx, genCid)
+	blks := []*types.Block{dstP.genesis, dstP.link1blk1, dstP.link1blk2, dstP.link2blk1,
+		dstP.link2blk2, dstP.link2blk3, dstP.link3blk1, dstP.link4blk1, dstP.link4blk2}
+	_, err := chain.GetBlock(ctx, dstP.genCid)
 	assert.Error(t, err) // Get errors before put
 
-	requirePutTestChain(t, chain)
+	requirePutTestChain(t, chain, dstP)
 
 	var cids types.SortedCidSet
 	for _, blk := range blks {
@@ -240,17 +247,18 @@ func TestGetBlocks(t *testing.T) {
 
 // chain.Store correctly indicates that is has all blocks in put tipsets
 func TestHasAllBlocks(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
-	initStoreTest(ctx, t)
-	chain := newChainStore()
+	initStoreTest(ctx, t, dstP)
+	chain := newChainStore(dstP)
 
-	blks := []*types.Block{genesis, link1blk1, link1blk2, link2blk1,
-		link2blk2, link2blk3, link3blk1, link4blk1, link4blk2}
-	assert.False(t, chain.HasBlock(ctx, genCid)) // Has returns false before put
+	blks := []*types.Block{dstP.genesis, dstP.link1blk1, dstP.link1blk2, dstP.link2blk1,
+		dstP.link2blk2, dstP.link2blk3, dstP.link3blk1, dstP.link4blk1, dstP.link4blk2}
+	assert.False(t, chain.HasBlock(ctx, dstP.genCid)) // Has returns false before put
 
-	requirePutTestChain(t, chain)
+	requirePutTestChain(t, chain, dstP)
 
 	var cids []cid.Cid
 	for _, blk := range blks {
@@ -263,15 +271,16 @@ func TestHasAllBlocks(t *testing.T) {
 
 /* Head and its State is set and notified properly. */
 
-// The constructor call sets the genesis block for the chain store.
+// The constructor call sets the dstP.genesis block for the chain store.
 func TestSetGenesis(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
-	initStoreTest(ctx, t)
-	chain := newChainStore()
-	requirePutTestChain(t, chain)
-	require.Equal(t, genCid, chain.GenesisCid())
+	initStoreTest(ctx, t, dstP)
+	chain := newChainStore(dstP)
+	requirePutTestChain(t, chain, dstP)
+	require.Equal(t, dstP.genCid, chain.GenesisCid())
 }
 
 func assertSetHead(t *testing.T, chainStore chain.Store, ts types.TipSet) {
@@ -282,27 +291,28 @@ func assertSetHead(t *testing.T, chainStore chain.Store, ts types.TipSet) {
 
 // Set and Get Head.
 func TestHead(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
-	initStoreTest(ctx, t)
-	chain := newChainStore()
-	requirePutTestChain(t, chain)
+	initStoreTest(ctx, t, dstP)
+	chain := newChainStore(dstP)
+	requirePutTestChain(t, chain, dstP)
 
 	// Head starts as an empty cid set
 	assert.Equal(t, types.SortedCidSet{}, chain.GetHead())
 
 	// Set Head
-	assertSetHead(t, chain, genTS)
-	assert.Equal(t, genTS.ToSortedCidSet(), chain.GetHead())
+	assertSetHead(t, chain, dstP.genTS)
+	assert.Equal(t, dstP.genTS.ToSortedCidSet(), chain.GetHead())
 
 	// Move head forward
-	assertSetHead(t, chain, link4)
-	assert.Equal(t, link4.ToSortedCidSet(), chain.GetHead())
+	assertSetHead(t, chain, dstP.link4)
+	assert.Equal(t, dstP.link4.ToSortedCidSet(), chain.GetHead())
 
 	// Move head back
-	assertSetHead(t, chain, genTS)
-	assert.Equal(t, genTS.ToSortedCidSet(), chain.GetHead())
+	assertSetHead(t, chain, dstP.genTS)
+	assert.Equal(t, dstP.genTS.ToSortedCidSet(), chain.GetHead())
 }
 
 func assertEmptyCh(t *testing.T, ch <-chan interface{}) {
@@ -315,28 +325,29 @@ func assertEmptyCh(t *testing.T, ch <-chan interface{}) {
 
 // Head events are propagated on HeadEvents.
 func TestHeadEvents(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
-	initStoreTest(ctx, t)
-	chainStore := newChainStore()
-	requirePutTestChain(t, chainStore)
+	initStoreTest(ctx, t, dstP)
+	chainStore := newChainStore(dstP)
+	requirePutTestChain(t, chainStore, dstP)
 
 	ps := chainStore.HeadEvents()
 	chA := ps.Sub(chain.NewHeadTopic)
 	chB := ps.Sub(chain.NewHeadTopic)
 
-	assertSetHead(t, chainStore, genTS)
-	assertSetHead(t, chainStore, link1)
-	assertSetHead(t, chainStore, link2)
-	assertSetHead(t, chainStore, link3)
-	assertSetHead(t, chainStore, link4)
-	assertSetHead(t, chainStore, link3)
-	assertSetHead(t, chainStore, link2)
-	assertSetHead(t, chainStore, link1)
-	assertSetHead(t, chainStore, genTS)
-	heads := []types.TipSet{genTS, link1, link2, link3, link4, link3,
-		link2, link1, genTS}
+	assertSetHead(t, chainStore, dstP.genTS)
+	assertSetHead(t, chainStore, dstP.link1)
+	assertSetHead(t, chainStore, dstP.link2)
+	assertSetHead(t, chainStore, dstP.link3)
+	assertSetHead(t, chainStore, dstP.link4)
+	assertSetHead(t, chainStore, dstP.link3)
+	assertSetHead(t, chainStore, dstP.link2)
+	assertSetHead(t, chainStore, dstP.link1)
+	assertSetHead(t, chainStore, dstP.genTS)
+	heads := []types.TipSet{dstP.genTS, dstP.link1, dstP.link2, dstP.link3, dstP.link4, dstP.link3,
+		dstP.link2, dstP.link1, dstP.genTS}
 
 	// Heads arrive in the expected order
 	for i := 0; i < 9; i++ {

--- a/chain/default_store_test.go
+++ b/chain/default_store_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/repo"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
-	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -88,7 +87,6 @@ func requireHeadTipset(t *testing.T, chain chain.Store) types.TipSet {
 // Adding tipsets to the store doesn't error.
 func TestPutTipSet(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
 	initStoreTest(ctx, t, dstP)
@@ -103,45 +101,43 @@ func TestPutTipSet(t *testing.T) {
 
 // Tipsets can be retrieved by key (all block cids).
 func TestGetByKey(t *testing.T) {
-	tf.BadUnitTestWithSideEffects(t)
+	dstP := initDSTParams()
 
 	ctx := context.Background()
-	initStoreTest(ctx, t)
-	chain := newChainStore()
+	initStoreTest(ctx, t, dstP)
+	chain := newChainStore(dstP)
+	requirePutTestChain(t, chain, dstP)
 
-	requirePutTestChain(t, chain)
+	gotGTS := requireGetTipSet(ctx, t, chain, dstP.genTS.ToSortedCidSet())
+	gotGTSSR := requireGetTipSetStateRoot(ctx, t, chain, dstP.genTS.ToSortedCidSet())
 
-	gotGTS := requireGetTipSet(ctx, t, chain, genTS.ToSortedCidSet())
-	gotGTSSR := requireGetTipSetStateRoot(ctx, t, chain, genTS.ToSortedCidSet())
+	got1TS := requireGetTipSet(ctx, t, chain, dstP.link1.ToSortedCidSet())
+	got1TSSR := requireGetTipSetStateRoot(ctx, t, chain, dstP.link1.ToSortedCidSet())
 
-	got1TS := requireGetTipSet(ctx, t, chain, link1.ToSortedCidSet())
-	got1TSSR := requireGetTipSetStateRoot(ctx, t, chain, link1.ToSortedCidSet())
+	got2TS := requireGetTipSet(ctx, t, chain, dstP.link2.ToSortedCidSet())
+	got2TSSR := requireGetTipSetStateRoot(ctx, t, chain, dstP.link2.ToSortedCidSet())
 
-	got2TS := requireGetTipSet(ctx, t, chain, link2.ToSortedCidSet())
-	got2TSSR := requireGetTipSetStateRoot(ctx, t, chain, link2.ToSortedCidSet())
+	got3TS := requireGetTipSet(ctx, t, chain, dstP.link3.ToSortedCidSet())
+	got3TSSR := requireGetTipSetStateRoot(ctx, t, chain, dstP.link3.ToSortedCidSet())
 
-	got3TS := requireGetTipSet(ctx, t, chain, link3.ToSortedCidSet())
-	got3TSSR := requireGetTipSetStateRoot(ctx, t, chain, link3.ToSortedCidSet())
+	got4TS := requireGetTipSet(ctx, t, chain, dstP.link4.ToSortedCidSet())
+	got4TSSR := requireGetTipSetStateRoot(ctx, t, chain, dstP.link4.ToSortedCidSet())
+	assert.Equal(t, dstP.genTS, *gotGTS)
+	assert.Equal(t, dstP.link1, *got1TS)
+	assert.Equal(t, dstP.link2, *got2TS)
+	assert.Equal(t, dstP.link3, *got3TS)
+	assert.Equal(t, dstP.link4, *got4TS)
 
-	got4TS := requireGetTipSet(ctx, t, chain, link4.ToSortedCidSet())
-	got4TSSR := requireGetTipSetStateRoot(ctx, t, chain, link4.ToSortedCidSet())
-	assert.Equal(t, genTS, *gotGTS)
-	assert.Equal(t, link1, *got1TS)
-	assert.Equal(t, link2, *got2TS)
-	assert.Equal(t, link3, *got3TS)
-	assert.Equal(t, link4, *got4TS)
-
-	assert.Equal(t, genStateRoot, gotGTSSR)
-	assert.Equal(t, link1State, got1TSSR)
-	assert.Equal(t, link2State, got2TSSR)
-	assert.Equal(t, link3State, got3TSSR)
-	assert.Equal(t, link4State, got4TSSR)
+	assert.Equal(t, dstP.genStateRoot, gotGTSSR)
+	assert.Equal(t, dstP.link1State, got1TSSR)
+	assert.Equal(t, dstP.link2State, got2TSSR)
+	assert.Equal(t, dstP.link3State, got3TSSR)
+	assert.Equal(t, dstP.link4State, got4TSSR)
 }
 
 // Tipsets can be retrieved by parent key (all block cids of parents).
 func TestGetByParent(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
 	initStoreTest(ctx, t, dstP)
@@ -175,7 +171,6 @@ func TestGetByParent(t *testing.T) {
 
 func TestGetMultipleByParent(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
 	initStoreTest(ctx, t, dstP)
@@ -219,7 +214,6 @@ func TestGetMultipleByParent(t *testing.T) {
 // All blocks of a tipset can be retrieved after putting their wrapping tipset.
 func TestGetBlocks(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
 	initStoreTest(ctx, t, dstP)
@@ -248,7 +242,6 @@ func TestGetBlocks(t *testing.T) {
 // chain.Store correctly indicates that is has all blocks in put tipsets
 func TestHasAllBlocks(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
 	initStoreTest(ctx, t, dstP)
@@ -274,7 +267,6 @@ func TestHasAllBlocks(t *testing.T) {
 // The constructor call sets the dstP.genesis block for the chain store.
 func TestSetGenesis(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
 	initStoreTest(ctx, t, dstP)
@@ -292,7 +284,6 @@ func assertSetHead(t *testing.T, chainStore chain.Store, ts types.TipSet) {
 // Set and Get Head.
 func TestHead(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
 	initStoreTest(ctx, t, dstP)
@@ -326,7 +317,6 @@ func assertEmptyCh(t *testing.T, ch <-chan interface{}) {
 // Head events are propagated on HeadEvents.
 func TestHeadEvents(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
 	initStoreTest(ctx, t, dstP)
@@ -366,37 +356,37 @@ func TestHeadEvents(t *testing.T) {
 // Load does not error and gives the chain store access to all blocks and
 // tipset indexes along the heaviest chain.
 func TestLoadAndReboot(t *testing.T) {
-	tf.BadUnitTestWithSideEffects(t)
+	dstP := initDSTParams()
 
 	ctx := context.Background()
-	initStoreTest(ctx, t)
+	initStoreTest(ctx, t, dstP)
 
 	r := repo.NewInMemoryRepo()
 	ds := r.Datastore()
-	chainStore := chain.NewDefaultStore(ds, genCid)
-	requirePutTestChain(t, chainStore)
-	assertSetHead(t, chainStore, genTS) // set the genesis block
+	chainStore := chain.NewDefaultStore(ds, dstP.genCid)
+	requirePutTestChain(t, chainStore, dstP)
+	assertSetHead(t, chainStore, dstP.genTS) // set the genesis block
 
-	assertSetHead(t, chainStore, link4)
+	assertSetHead(t, chainStore, dstP.link4)
 	chainStore.Stop()
 
 	// rebuild chain with same datastore
-	rebootChain := chain.NewDefaultStore(ds, genCid)
+	rebootChain := chain.NewDefaultStore(ds, dstP.genCid)
 	err := rebootChain.Load(ctx)
 	assert.NoError(t, err)
 
 	// Check that chain store has index
 	// Get a tipset and state by key
-	got2 := requireGetTipSet(ctx, t, rebootChain, link2.ToSortedCidSet())
-	assert.Equal(t, link2, *got2)
+	got2 := requireGetTipSet(ctx, t, rebootChain, dstP.link2.ToSortedCidSet())
+	assert.Equal(t, dstP.link2, *got2)
 
 	// Get another by parent key
-	got4 := requireGetTsasByParentAndHeight(t, rebootChain, link3.String(), uint64(6))
+	got4 := requireGetTsasByParentAndHeight(t, rebootChain, dstP.link3.String(), uint64(6))
 	assert.Equal(t, 1, len(got4))
-	assert.Equal(t, link4, got4[0].TipSet)
+	assert.Equal(t, dstP.link4, got4[0].TipSet)
 
 	// Check that chainStore store has blocks
-	assert.True(t, rebootChain.HasBlock(ctx, link3blk1.Cid()))
-	assert.True(t, rebootChain.HasBlock(ctx, link2blk3.Cid()))
-	assert.True(t, rebootChain.HasBlock(ctx, genesis.Cid()))
+	assert.True(t, rebootChain.HasBlock(ctx, dstP.link3blk1.Cid()))
+	assert.True(t, rebootChain.HasBlock(ctx, dstP.link2blk3.Cid()))
+	assert.True(t, rebootChain.HasBlock(ctx, dstP.genesis.Cid()))
 }

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -20,7 +20,6 @@ import (
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
 
-	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -359,7 +358,6 @@ func requirePutBlocks(t *testing.T, f *th.TestFetcher, blocks ...*types.Block) t
 // Syncer syncs a single block
 func TestSyncOneBlock(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
@@ -376,7 +374,6 @@ func TestSyncOneBlock(t *testing.T) {
 // Syncer syncs a single tipset.
 func TestSyncOneTipSet(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
@@ -392,7 +389,6 @@ func TestSyncOneTipSet(t *testing.T) {
 // Syncer syncs one tipset, block by block.
 func TestSyncTipSetBlockByBlock(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	pt := th.NewTestPowerTableView(1, 1)
 	syncer, chainStore, _, blockSource := initSyncTestWithPowerTable(t, pt, dstP)
@@ -416,7 +412,6 @@ func TestSyncTipSetBlockByBlock(t *testing.T) {
 // Syncer syncs a chain, tipset by tipset.
 func TestSyncChainTipSetByTipSet(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
@@ -450,7 +445,6 @@ func TestSyncChainTipSetByTipSet(t *testing.T) {
 // Syncer syncs a whole chain given only the head cids.
 func TestSyncChainHead(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
@@ -472,7 +466,6 @@ func TestSyncChainHead(t *testing.T) {
 // Syncer determines the heavier fork.
 func TestSyncIgnoreLightFork(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
@@ -514,7 +507,6 @@ func TestSyncIgnoreLightFork(t *testing.T) {
 // Correctly sync a heavier fork
 func TestHeavierFork(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
@@ -587,7 +579,6 @@ func TestHeavierFork(t *testing.T) {
 // Syncer errors if blocks don't form a tipset
 func TestBlocksNotATipSet(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
@@ -605,7 +596,6 @@ func TestBlocksNotATipSet(t *testing.T) {
 // Syncer is capable of recovering from a fork reorg after Load.
 func TestLoadFork(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	syncer, chainStore, r, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
@@ -704,7 +694,6 @@ func TestLoadFork(t *testing.T) {
 // kept in the store because syncing C1 requires retrieving parent state.
 func TestSubsetParent(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	syncer, _, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
@@ -757,7 +746,6 @@ func TestSubsetParent(t *testing.T) {
 // Check that the syncer correctly adds widened chain ancestors to the store.
 func TestWidenChainAncestor(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
@@ -841,7 +829,6 @@ func (pt *powerTableForWidenTest) HasPower(ctx context.Context, st state.Tree, b
 // Therefore the syncer should set the head of the store to the union of the links..
 func TestHeaviestIsWidenedAncestor(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	pt := &powerTableForWidenTest{}
 	syncer, chainStore, con, blockSource := initSyncTestWithPowerTable(t, pt, dstP)
@@ -921,7 +908,6 @@ func TestHeaviestIsWidenedAncestor(t *testing.T) {
 // and I can't figure out why because we pass in the correct blockstore to createminerwithpower.
 
 func TestTipSetWeightDeep(t *testing.T) {
-	tf.BadUnitTestWithSideEffects(t)
 
 	r := repo.NewInMemoryRepo()
 	bs := bstore.NewBlockstore(r.Datastore())

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
+type DefaultSyncerTestParams struct {
 	// Chain diagram below.  Note that blocks in the same tipset are in parentheses.
 	//
 	// genesis -> (link1blk1, link1blk2) -> (link2blk1, link2blk2, link2blk3) -> link3blk1 -> (link4blk1, link4blk2)
@@ -49,19 +49,19 @@ var (
 	minerAddress      address.Address
 	minerOwnerAddress address.Address
 	minerPeerID       peer.ID
-)
+}
 
-func init() {
+func initDSTParams() *DefaultSyncerTestParams {
 	var err error
-	minerAddress, err = address.NewActorAddress([]byte("miner"))
+	minerAddress, err := address.NewActorAddress([]byte("miner"))
 	if err != nil {
 		panic(err)
 	}
-	minerOwnerAddress, err = address.NewActorAddress([]byte("minerOwner"))
+	minerOwnerAddress, err := address.NewActorAddress([]byte("minerOwner"))
 	if err != nil {
 		panic(err)
 	}
-	minerPeerID, err = th.RandPeerID()
+	minerPeerID, err := th.RandPeerID()
 	if err != nil {
 		panic(err)
 	}
@@ -69,23 +69,34 @@ func init() {
 	// Set up the test chain
 	bs := bstore.NewBlockstore(repo.NewInMemoryRepo().Datastore())
 	cst := hamt.NewCborStore()
-	genesis, err = initGenesis(cst, bs)
+	genesis, err := initGenesis(minerAddress, minerOwnerAddress, minerPeerID, cst, bs)
 	if err != nil {
 		panic(err)
 	}
-	genCid = genesis.Cid()
-	genTS = th.MustNewTipSet(genesis)
+	genCid := genesis.Cid()
+	genTS := th.MustNewTipSet(genesis)
 
 	// mock state root cids
-	cidGetter = types.NewCidForTestGetter()
+	cidGetter := types.NewCidForTestGetter()
 
-	genStateRoot = genesis.StateRoot
+	genStateRoot := genesis.StateRoot
+
+	return &DefaultSyncerTestParams{
+		minerAddress:      minerAddress,
+		minerOwnerAddress: minerOwnerAddress,
+		minerPeerID:       minerPeerID,
+		genesis:           genesis,
+		genCid:            genCid,
+		genTS:             genTS,
+		cidGetter:         cidGetter,
+		genStateRoot:      genStateRoot,
+	}
 }
 
 // This function sets global variables according to the tests needs.  The
 // test chain's basic structure is always the same, but some tests want
 // mocked stateRoots or parent weight calculations from different consensus protocols.
-func requireSetTestChain(t *testing.T, con consensus.Protocol, mockStateRoots bool) {
+func requireSetTestChain(t *testing.T, con consensus.Protocol, mockStateRoots bool, dstP *DefaultSyncerTestParams) {
 
 	var err error
 	// see powerTableForWidenTest
@@ -95,100 +106,100 @@ func requireSetTestChain(t *testing.T, con consensus.Protocol, mockStateRoots bo
 	mockSignerPubKey := mockSigner.PubKeys[0]
 
 	fakeChildParams := th.FakeChildParams{
-		Parent:      genTS,
-		GenesisCid:  genCid,
-		StateRoot:   genStateRoot,
+		Parent:      dstP.genTS,
+		GenesisCid:  dstP.genCid,
+		StateRoot:   dstP.genStateRoot,
 		Consensus:   con,
-		MinerAddr:   minerAddress,
+		MinerAddr:   dstP.minerAddress,
 		MinerPubKey: mockSignerPubKey,
 		Signer:      mockSigner,
 	}
 
-	link1blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	link1blk1.Proof, link1blk1.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
+	dstP.link1blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link1blk1.Proof, dstP.link1blk1.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
 	require.NoError(t, err)
 
-	link1blk2 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	link1blk2.Proof, link1blk2.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
+	dstP.link1blk2 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link1blk2.Proof, dstP.link1blk2.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
 	require.NoError(t, err)
 
-	link1 = th.RequireNewTipSet(t, link1blk1, link1blk2)
+	dstP.link1 = th.RequireNewTipSet(t, dstP.link1blk1, dstP.link1blk2)
 
 	if mockStateRoots {
-		link1State = cidGetter()
+		dstP.link1State = dstP.cidGetter()
 	} else {
-		link1State = genStateRoot
+		dstP.link1State = dstP.genStateRoot
 	}
 
-	fakeChildParams.Parent = link1
-	fakeChildParams.StateRoot = link1State
-	link2blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	link2blk1.Proof, link2blk1.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
+	fakeChildParams.Parent = dstP.link1
+	fakeChildParams.StateRoot = dstP.link1State
+	dstP.link2blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link2blk1.Proof, dstP.link2blk1.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
 	require.NoError(t, err)
 
-	link2blk2 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	link2blk2.Proof, link2blk2.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
+	dstP.link2blk2 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link2blk2.Proof, dstP.link2blk2.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
 	require.NoError(t, err)
 
 	fakeChildParams.Nonce = uint64(1)
-	link2blk3 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	link2blk3.Proof, link2blk3.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
+	dstP.link2blk3 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link2blk3.Proof, dstP.link2blk3.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
 	require.NoError(t, err)
 
-	link2 = th.RequireNewTipSet(t, link2blk1, link2blk2, link2blk3)
+	dstP.link2 = th.RequireNewTipSet(t, dstP.link2blk1, dstP.link2blk2, dstP.link2blk3)
 
 	if mockStateRoots {
-		link2State = cidGetter()
+		dstP.link2State = dstP.cidGetter()
 	} else {
-		link2State = genStateRoot
+		dstP.link2State = dstP.genStateRoot
 	}
 
-	fakeChildParams.Parent = link2
-	fakeChildParams.StateRoot = link2State
-	link3blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	link3blk1.Proof, link3blk1.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
+	fakeChildParams.Parent = dstP.link2
+	fakeChildParams.StateRoot = dstP.link2State
+	dstP.link3blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link3blk1.Proof, dstP.link3blk1.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
 	require.NoError(t, err)
 
-	link3 = th.RequireNewTipSet(t, link3blk1)
+	dstP.link3 = th.RequireNewTipSet(t, dstP.link3blk1)
 
 	if mockStateRoots {
-		link3State = cidGetter()
+		dstP.link3State = dstP.cidGetter()
 	} else {
-		link3State = genStateRoot
+		dstP.link3State = dstP.genStateRoot
 	}
 
-	fakeChildParams.Parent = link3
-	fakeChildParams.StateRoot = link3State
+	fakeChildParams.Parent = dstP.link3
+	fakeChildParams.StateRoot = dstP.link3State
 	fakeChildParams.NullBlockCount = uint64(2)
-	link4blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	link4blk1.Proof, link4blk1.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
+	dstP.link4blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link4blk1.Proof, dstP.link4blk1.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
 	require.NoError(t, err)
 
 	fakeChildParams.Nonce = uint64(1)
-	link4blk2 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	link4blk2.Proof, link4blk2.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
+	dstP.link4blk2 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link4blk2.Proof, dstP.link4blk2.Ticket, err = th.MakeProofAndWinningTicket(mockSignerPubKey, minerPower, totalPower, mockSigner)
 	require.NoError(t, err)
 
-	link4 = th.RequireNewTipSet(t, link4blk1, link4blk2)
+	dstP.link4 = th.RequireNewTipSet(t, dstP.link4blk1, dstP.link4blk2)
 
 	if mockStateRoots {
-		link4State = cidGetter()
+		dstP.link4State = dstP.cidGetter()
 	} else {
-		link4State = genStateRoot
+		dstP.link4State = dstP.genStateRoot
 	}
 }
 
 // loadSyncerFromRepo creates a store and syncer from an existing repo.
-func loadSyncerFromRepo(t *testing.T, r repo.Repo) (*chain.DefaultSyncer, *th.TestFetcher) {
+func loadSyncerFromRepo(t *testing.T, r repo.Repo, dstP *DefaultSyncerTestParams) (*chain.DefaultSyncer, *th.TestFetcher) {
 	powerTable := &th.TestView{}
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := hamt.NewCborStore()
 	verifier := proofs.NewFakeVerifier(true, nil)
-	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), powerTable, genCid, verifier)
+	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), powerTable, dstP.genCid, verifier)
 
-	calcGenBlk, err := initGenesis(cst, bs) // flushes state
+	calcGenBlk, err := initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs) // flushes state
 	require.NoError(t, err)
-	calcGenBlk.StateRoot = genStateRoot
+	calcGenBlk.StateRoot = dstP.genStateRoot
 	chainDS := r.ChainDatastore()
 	chainStore := chain.NewDefaultStore(chainDS, calcGenBlk.Cid())
 
@@ -203,53 +214,59 @@ func loadSyncerFromRepo(t *testing.T, r repo.Repo) (*chain.DefaultSyncer, *th.Te
 
 // initSyncTestDefault creates and returns the datastructures (chain store, syncer, etc)
 // needed to run tests.  It also sets the global test variables appropriately.
-func initSyncTestDefault(t *testing.T) (*chain.DefaultSyncer, chain.Store, repo.Repo, *th.TestFetcher) {
+func initSyncTestDefault(t *testing.T, dstP *DefaultSyncerTestParams) (*chain.DefaultSyncer, chain.Store, repo.Repo, *th.TestFetcher) {
 	processor := th.NewTestProcessor()
 	powerTable := &th.TestView{}
 	r := repo.NewInMemoryRepo()
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := hamt.NewCborStore()
 	verifier := proofs.NewFakeVerifier(true, nil)
-	con := consensus.NewExpected(cst, bs, processor, powerTable, genCid, verifier)
-	requireSetTestChain(t, con, false)
-	return initSyncTest(t, con, initGenesis, cst, bs, r)
+	con := consensus.NewExpected(cst, bs, processor, powerTable, dstP.genCid, verifier)
+	requireSetTestChain(t, con, false, dstP)
+	initGenesisWrapper := func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
+		return initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs)
+	}
+	return initSyncTest(t, con, initGenesisWrapper, cst, bs, r, dstP)
 }
 
 // initSyncTestWithPowerTable creates and returns the datastructures (chain store, syncer, etc)
 // needed to run tests.  It also sets the global test variables appropriately.
-func initSyncTestWithPowerTable(t *testing.T, powerTable consensus.PowerTableView) (*chain.DefaultSyncer, chain.Store, consensus.Protocol, *th.TestFetcher) {
+func initSyncTestWithPowerTable(t *testing.T, powerTable consensus.PowerTableView, dstP *DefaultSyncerTestParams) (*chain.DefaultSyncer, chain.Store, consensus.Protocol, *th.TestFetcher) {
 	processor := th.NewTestProcessor()
 	r := repo.NewInMemoryRepo()
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := hamt.NewCborStore()
 	verifier := proofs.NewFakeVerifier(true, nil)
-	con := consensus.NewExpected(cst, bs, processor, powerTable, genCid, verifier)
-	requireSetTestChain(t, con, false)
-	sync, testchain, _, fetcher := initSyncTest(t, con, initGenesis, cst, bs, r)
+	con := consensus.NewExpected(cst, bs, processor, powerTable, dstP.genCid, verifier)
+	requireSetTestChain(t, con, false, dstP)
+	initGenesisWrapper := func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
+		return initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs)
+	}
+	sync, testchain, _, fetcher := initSyncTest(t, con, initGenesisWrapper, cst, bs, r, dstP)
 	return sync, testchain, con, fetcher
 }
 
-func initSyncTest(t *testing.T, con consensus.Protocol, genFunc func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error), cst *hamt.CborIpldStore, bs bstore.Blockstore, r repo.Repo) (*chain.DefaultSyncer, chain.Store, repo.Repo, *th.TestFetcher) {
+func initSyncTest(t *testing.T, con consensus.Protocol, genFunc func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error), cst *hamt.CborIpldStore, bs bstore.Blockstore, r repo.Repo, dstP *DefaultSyncerTestParams) (*chain.DefaultSyncer, chain.Store, repo.Repo, *th.TestFetcher) {
 	ctx := context.Background()
 
 	calcGenBlk, err := genFunc(cst, bs) // flushes state
 	require.NoError(t, err)
-	calcGenBlk.StateRoot = genStateRoot
+	calcGenBlk.StateRoot = dstP.genStateRoot
 	chainDS := r.ChainDatastore()
 	chainStore := chain.NewDefaultStore(chainDS, calcGenBlk.Cid())
 
 	fetcher := th.NewTestFetcher()
 	syncer := chain.NewDefaultSyncer(cst, con, chainStore, fetcher) // note we use same cst for on and offline for tests
 
-	// Initialize stores to contain genesis block and state
+	// Initialize stores to contain dstP.genesis block and state
 	calcGenTS := th.RequireNewTipSet(t, calcGenBlk)
 
 	genTsas := &chain.TipSetAndState{
 		TipSet:          calcGenTS,
-		TipSetStateRoot: genStateRoot,
+		TipSetStateRoot: dstP.genStateRoot,
 	}
 	th.RequirePutTsas(ctx, t, chainStore, genTsas)
-	err = chainStore.SetHead(ctx, calcGenTS) // Initialize chainStore store with correct genesis
+	err = chainStore.SetHead(ctx, calcGenTS) // Initialize chainStore store with correct dstP.genesis
 	require.NoError(t, err)
 	requireHead(t, chainStore, calcGenTS)
 	requireTsAdded(t, chainStore, calcGenTS)
@@ -341,13 +358,14 @@ func requirePutBlocks(t *testing.T, f *th.TestFetcher, blocks ...*types.Block) t
 
 // Syncer syncs a single block
 func TestSyncOneBlock(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t)
+	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
-	expectedTs := th.RequireNewTipSet(t, link1blk1)
+	expectedTs := th.RequireNewTipSet(t, dstP.link1blk1)
 
-	cids := requirePutBlocks(t, blockSource, link1blk1)
+	cids := requirePutBlocks(t, blockSource, dstP.link1blk1)
 	err := syncer.HandleNewTipset(ctx, cids)
 	assert.NoError(t, err)
 
@@ -357,153 +375,159 @@ func TestSyncOneBlock(t *testing.T) {
 
 // Syncer syncs a single tipset.
 func TestSyncOneTipSet(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t)
+	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
 
-	cids := requirePutBlocks(t, blockSource, link1blk1, link1blk2)
+	cids := requirePutBlocks(t, blockSource, dstP.link1blk1, dstP.link1blk2)
 	err := syncer.HandleNewTipset(ctx, cids)
 	assert.NoError(t, err)
 
-	assertTsAdded(t, chainStore, link1)
-	assertHead(t, chainStore, link1)
+	assertTsAdded(t, chainStore, dstP.link1)
+	assertHead(t, chainStore, dstP.link1)
 }
 
 // Syncer syncs one tipset, block by block.
 func TestSyncTipSetBlockByBlock(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
 	pt := th.NewTestPowerTableView(1, 1)
-	syncer, chainStore, _, blockSource := initSyncTestWithPowerTable(t, pt)
+	syncer, chainStore, _, blockSource := initSyncTestWithPowerTable(t, pt, dstP)
 	ctx := context.Background()
-	expTs1 := th.RequireNewTipSet(t, link1blk1)
+	expTs1 := th.RequireNewTipSet(t, dstP.link1blk1)
 
-	_ = requirePutBlocks(t, blockSource, link1blk1, link1blk2)
-	err := syncer.HandleNewTipset(ctx, types.NewSortedCidSet(link1blk1.Cid()))
+	_ = requirePutBlocks(t, blockSource, dstP.link1blk1, dstP.link1blk2)
+	err := syncer.HandleNewTipset(ctx, types.NewSortedCidSet(dstP.link1blk1.Cid()))
 	assert.NoError(t, err)
 
 	assertTsAdded(t, chainStore, expTs1)
 	assertHead(t, chainStore, expTs1)
 
-	err = syncer.HandleNewTipset(ctx, types.NewSortedCidSet(link1blk2.Cid()))
+	err = syncer.HandleNewTipset(ctx, types.NewSortedCidSet(dstP.link1blk2.Cid()))
 	assert.NoError(t, err)
 
-	assertTsAdded(t, chainStore, link1)
-	assertHead(t, chainStore, link1)
+	assertTsAdded(t, chainStore, dstP.link1)
+	assertHead(t, chainStore, dstP.link1)
 }
 
 // Syncer syncs a chain, tipset by tipset.
 func TestSyncChainTipSetByTipSet(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t)
+	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
 
-	cids1 := requirePutBlocks(t, blockSource, link1.ToSlice()...)
-	cids2 := requirePutBlocks(t, blockSource, link2.ToSlice()...)
-	cids3 := requirePutBlocks(t, blockSource, link3.ToSlice()...)
-	cids4 := requirePutBlocks(t, blockSource, link4.ToSlice()...)
+	cids1 := requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
+	cids2 := requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
+	cids3 := requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
+	cids4 := requirePutBlocks(t, blockSource, dstP.link4.ToSlice()...)
 
 	err := syncer.HandleNewTipset(ctx, cids1)
 	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, link1)
-	assertHead(t, chainStore, link1)
+	assertTsAdded(t, chainStore, dstP.link1)
+	assertHead(t, chainStore, dstP.link1)
 
 	err = syncer.HandleNewTipset(ctx, cids2)
 	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, link2)
-	assertHead(t, chainStore, link2)
+	assertTsAdded(t, chainStore, dstP.link2)
+	assertHead(t, chainStore, dstP.link2)
 
 	err = syncer.HandleNewTipset(ctx, cids3)
 	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, link3)
-	assertHead(t, chainStore, link3)
+	assertTsAdded(t, chainStore, dstP.link3)
+	assertHead(t, chainStore, dstP.link3)
 
 	err = syncer.HandleNewTipset(ctx, cids4)
 	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, link4)
-	assertHead(t, chainStore, link4)
+	assertTsAdded(t, chainStore, dstP.link4)
+	assertHead(t, chainStore, dstP.link4)
 }
 
 // Syncer syncs a whole chain given only the head cids.
 func TestSyncChainHead(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t)
+	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
 
-	_ = requirePutBlocks(t, blockSource, link1.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, link2.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, link3.ToSlice()...)
-	cids4 := requirePutBlocks(t, blockSource, link4.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
+	cids4 := requirePutBlocks(t, blockSource, dstP.link4.ToSlice()...)
 
 	err := syncer.HandleNewTipset(ctx, cids4)
 	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, link4)
-	assertTsAdded(t, chainStore, link3)
-	assertTsAdded(t, chainStore, link2)
-	assertTsAdded(t, chainStore, link1)
-	assertHead(t, chainStore, link4)
+	assertTsAdded(t, chainStore, dstP.link4)
+	assertTsAdded(t, chainStore, dstP.link3)
+	assertTsAdded(t, chainStore, dstP.link2)
+	assertTsAdded(t, chainStore, dstP.link1)
+	assertHead(t, chainStore, dstP.link4)
 }
 
 // Syncer determines the heavier fork.
 func TestSyncIgnoreLightFork(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t)
+	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
 
-	forkbase := th.RequireNewTipSet(t, link2blk1)
+	forkbase := th.RequireNewTipSet(t, dstP.link2blk1)
 	signer, ki := types.NewMockSignersAndKeyInfo(1)
 	signerPubKey := ki[0].PublicKey()
 
 	forkblk1 := th.RequireMkFakeChild(t,
 		th.FakeChildParams{
-			MinerAddr:   minerAddress,
+			MinerAddr:   dstP.minerAddress,
 			Signer:      signer,
 			MinerPubKey: signerPubKey,
 			Parent:      forkbase,
-			GenesisCid:  genCid,
-			StateRoot:   genStateRoot,
+			GenesisCid:  dstP.genCid,
+			StateRoot:   dstP.genStateRoot,
 		})
 	forklink1 := th.RequireNewTipSet(t, forkblk1)
 
-	_ = requirePutBlocks(t, blockSource, link1.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, link2.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, link3.ToSlice()...)
-	cids4 := requirePutBlocks(t, blockSource, link4.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
+	cids4 := requirePutBlocks(t, blockSource, dstP.link4.ToSlice()...)
 
 	forkCids1 := requirePutBlocks(t, blockSource, forklink1.ToSlice()...)
 
 	// Sync heaviest branch first.
 	err := syncer.HandleNewTipset(ctx, cids4)
 	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, link4)
-	assertHead(t, chainStore, link4)
+	assertTsAdded(t, chainStore, dstP.link4)
+	assertHead(t, chainStore, dstP.link4)
 
 	// lighter fork should be processed but not change head.
 	assert.NoError(t, syncer.HandleNewTipset(ctx, forkCids1))
 	assertTsAdded(t, chainStore, forklink1)
-	assertHead(t, chainStore, link4)
+	assertHead(t, chainStore, dstP.link4)
 }
 
 // Correctly sync a heavier fork
 func TestHeavierFork(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t)
+	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
 
 	signer, ki := types.NewMockSignersAndKeyInfo(2)
 	mockSignerPubKey := ki[0].PublicKey()
 
-	forkbase := th.RequireNewTipSet(t, link2blk1)
+	forkbase := th.RequireNewTipSet(t, dstP.link2blk1)
 	fakeChildParams := th.FakeChildParams{
 		Parent:      forkbase,
-		GenesisCid:  genCid,
-		StateRoot:   genStateRoot,
-		MinerAddr:   minerAddress,
+		GenesisCid:  dstP.genCid,
+		StateRoot:   dstP.genStateRoot,
+		MinerAddr:   dstP.minerAddress,
 		Signer:      signer,
 		MinerPubKey: mockSignerPubKey,
 		Nonce:       uint64(1),
@@ -538,18 +562,18 @@ func TestHeavierFork(t *testing.T) {
 	forklink3blk2 := th.RequireMkFakeChild(t, fakeChildParams)
 	forklink3 := th.RequireNewTipSet(t, forklink3blk1, forklink3blk2)
 
-	_ = requirePutBlocks(t, blockSource, link1.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, link2.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, link3.ToSlice()...)
-	cids4 := requirePutBlocks(t, blockSource, link4.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
+	cids4 := requirePutBlocks(t, blockSource, dstP.link4.ToSlice()...)
 	_ = requirePutBlocks(t, blockSource, forklink1.ToSlice()...)
 	_ = requirePutBlocks(t, blockSource, forklink2.ToSlice()...)
 	forkHead := requirePutBlocks(t, blockSource, forklink3.ToSlice()...)
 
 	err := syncer.HandleNewTipset(ctx, cids4)
 	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, link4)
-	assertHead(t, chainStore, link4)
+	assertTsAdded(t, chainStore, dstP.link4)
+	assertHead(t, chainStore, dstP.link4)
 
 	// heavier fork updates head
 	err = syncer.HandleNewTipset(ctx, forkHead)
@@ -562,14 +586,15 @@ func TestHeavierFork(t *testing.T) {
 
 // Syncer errors if blocks don't form a tipset
 func TestBlocksNotATipSet(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t)
+	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
 
-	_ = requirePutBlocks(t, blockSource, link1.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, link2.ToSlice()...)
-	badCids := types.NewSortedCidSet(link1blk1.Cid(), link2blk1.Cid())
+	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
+	badCids := types.NewSortedCidSet(dstP.link1blk1.Cid(), dstP.link2blk1.Cid())
 	err := syncer.HandleNewTipset(ctx, badCids)
 	assert.Error(t, err)
 	assertNoAdd(t, chainStore, badCids)
@@ -579,29 +604,30 @@ func TestBlocksNotATipSet(t *testing.T) {
 
 // Syncer is capable of recovering from a fork reorg after Load.
 func TestLoadFork(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	syncer, chainStore, r, blockSource := initSyncTestDefault(t)
+	syncer, chainStore, r, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
 
-	// Set up chain store to have standard chain up to link2
-	_ = requirePutBlocks(t, blockSource, link1.ToSlice()...)
-	cids2 := requirePutBlocks(t, blockSource, link2.ToSlice()...)
+	// Set up chain store to have standard chain up to dstP.link2
+	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
+	cids2 := requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
 	err := syncer.HandleNewTipset(ctx, cids2)
 	require.NoError(t, err)
 
-	// Now sync the store with a heavier fork, forking off link1.
-	forkbase := th.RequireNewTipSet(t, link2blk1)
+	// Now sync the store with a heavier fork, forking off dstP.link1.
+	forkbase := th.RequireNewTipSet(t, dstP.link2blk1)
 
 	signer, ki := types.NewMockSignersAndKeyInfo(2)
 	mockSignerPubKey := ki[0].PublicKey()
 
 	fakeChildParams := th.FakeChildParams{
 		Parent:      forkbase,
-		GenesisCid:  genCid,
-		MinerAddr:   minerAddress,
+		GenesisCid:  dstP.genCid,
+		MinerAddr:   dstP.minerAddress,
 		Nonce:       uint64(1),
-		StateRoot:   genStateRoot,
+		StateRoot:   dstP.genStateRoot,
 		Signer:      signer,
 		MinerPubKey: mockSignerPubKey,
 	}
@@ -613,7 +639,7 @@ func TestLoadFork(t *testing.T) {
 
 	fakeChildParams.Nonce = uint64(2)
 	forklink1blk3 := th.RequireMkFakeChild(t, fakeChildParams)
-	//th.FakeChildParams{Parent: forkbase, GenesisCid: genCid, StateRoot: genStateRoot, Nonce: uint64(2)})
+	//th.FakeChildParams{Parent: forkbase, dstP.GenesisCid: dstP.genCid, StateRoot: dstP.genStateRoot, Nonce: uint64(2)})
 	forklink1 := th.RequireNewTipSet(t, forklink1blk1, forklink1blk2, forklink1blk3)
 
 	fakeChildParams.Parent = forklink1
@@ -643,12 +669,12 @@ func TestLoadFork(t *testing.T) {
 	requireHead(t, chainStore, forklink3)
 
 	// Shut down store, reload and wire to syncer.
-	loadSyncer, blockSource := loadSyncerFromRepo(t, r)
+	loadSyncer, blockSource := loadSyncerFromRepo(t, r, dstP)
 
 	// Test that the syncer can't sync a block on the old chain
 	// without getting old blocks from network. i.e. the repo is trimmed
 	// of non-heaviest chain blocks
-	cids3 := requirePutBlocks(t, blockSource, link3.ToSlice()...)
+	cids3 := requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
 	err = loadSyncer.HandleNewTipset(ctx, cids3)
 	assert.Error(t, err)
 
@@ -677,29 +703,30 @@ func TestLoadFork(t *testing.T) {
 // The last operation will fail if the state of subset {B1, B2} is not
 // kept in the store because syncing C1 requires retrieving parent state.
 func TestSubsetParent(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	syncer, _, _, blockSource := initSyncTestDefault(t)
+	syncer, _, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
 
-	// Set up store to have standard chain up to link2
-	_ = requirePutBlocks(t, blockSource, link1.ToSlice()...)
-	cids2 := requirePutBlocks(t, blockSource, link2.ToSlice()...)
+	// Set up store to have standard chain up to dstP.link2
+	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
+	cids2 := requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
 	err := syncer.HandleNewTipset(ctx, cids2)
 	require.NoError(t, err)
 
 	// Sync one tipset with a parent equal to a subset of an existing
 	// tipset in the store.
-	forkbase := th.RequireNewTipSet(t, link2blk1, link2blk2)
+	forkbase := th.RequireNewTipSet(t, dstP.link2blk1, dstP.link2blk2)
 
 	signer, ki := types.NewMockSignersAndKeyInfo(2)
 	mockSignerPubKey := ki[0].PublicKey()
 
 	fakeChildParams := th.FakeChildParams{
 		Parent:      forkbase,
-		GenesisCid:  genCid,
-		MinerAddr:   minerAddress,
-		StateRoot:   genStateRoot,
+		GenesisCid:  dstP.genCid,
+		MinerAddr:   dstP.minerAddress,
+		StateRoot:   dstP.genStateRoot,
 		Signer:      signer,
 		MinerPubKey: mockSignerPubKey,
 	}
@@ -729,19 +756,20 @@ func TestSubsetParent(t *testing.T) {
 
 // Check that the syncer correctly adds widened chain ancestors to the store.
 func TestWidenChainAncestor(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t)
+	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
 
 	signer, ki := types.NewMockSignersAndKeyInfo(2)
 	mockSignerPubKey := ki[0].PublicKey()
 
 	fakeChildParams := th.FakeChildParams{
-		MinerAddr:   minerAddress,
-		Parent:      link1,
-		GenesisCid:  genCid,
-		StateRoot:   genStateRoot,
+		MinerAddr:   dstP.minerAddress,
+		Parent:      dstP.link1,
+		GenesisCid:  dstP.genCid,
+		StateRoot:   dstP.genStateRoot,
 		Signer:      signer,
 		MinerPubKey: mockSignerPubKey,
 		Nonce:       uint64(27),
@@ -749,29 +777,29 @@ func TestWidenChainAncestor(t *testing.T) {
 
 	link2blkother := th.RequireMkFakeChild(t, fakeChildParams)
 
-	link2intersect := th.RequireNewTipSet(t, link2blk1, link2blkother)
+	link2intersect := th.RequireNewTipSet(t, dstP.link2blk1, link2blkother)
 
-	_ = requirePutBlocks(t, blockSource, link1.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, link2.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, link3.ToSlice()...)
-	cids4 := requirePutBlocks(t, blockSource, link4.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
+	cids4 := requirePutBlocks(t, blockSource, dstP.link4.ToSlice()...)
 
 	intersectCids := requirePutBlocks(t, blockSource, link2intersect.ToSlice()...)
 
-	// Sync the subset of link2 first
+	// Sync the subset of dstP.link2 first
 	err := syncer.HandleNewTipset(ctx, intersectCids)
 	assert.NoError(t, err)
 	assertTsAdded(t, chainStore, link2intersect)
 	assertHead(t, chainStore, link2intersect)
 
-	// Sync chain with head at link4
+	// Sync chain with head at dstP.link4
 	err = syncer.HandleNewTipset(ctx, cids4)
 	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, link4)
-	assertHead(t, chainStore, link4)
+	assertTsAdded(t, chainStore, dstP.link4)
+	assertHead(t, chainStore, dstP.link4)
 
-	// Check that the widened tipset (link2intersect U link2) is tracked
-	link2Union := th.RequireNewTipSet(t, link2blk1, link2blk2, link2blk3, link2blkother)
+	// Check that the widened tipset (link2intersect U dstP.link2) is tracked
+	link2Union := th.RequireNewTipSet(t, dstP.link2blk1, dstP.link2blk2, dstP.link2blk3, link2blkother)
 	assertTsAdded(t, chainStore, link2Union)
 }
 
@@ -797,25 +825,26 @@ func (pt *powerTableForWidenTest) HasPower(ctx context.Context, st state.Tree, b
 // should correctly set this tipset as the head.
 //
 // From above we have the test-chain:
-// genesis -> (link1blk1, link1blk2) -> (link2blk1, link2blk2, link2blk3) -> link3blk1 -> (link4blk1, link4blk2)
+// dstP.genesis -> (link1blk1, dstP.link1blk2) -> (link2blk1, dstP.link2blk2, dstP.link2blk3) -> dstP.link3blk1 -> (link4blk1, dstP.link4blk2)
 //
-// Now we introduce a disjoint fork on top of link1
-// genesis -> (link1blk1, link1blk2) -> (forklink2blk1, forklink2blk2, forklink2blk3, forklink3blk4) -> forklink3blk1
+// Now we introduce a disjoint fork on top of dstP.link1
+// dstP.genesis -> (link1blk1, dstP.link1blk2) -> (forklink2blk1, forklink2blk2, forklink2blk3, forklink3blk4) -> forklink3blk1
 //
 // Using the provided powertable all new tipsets contribute to the weight: + 35*(num of blocks in tipset).
 // So, the weight of the  head of the test chain =
 //   W(link1) + 105 + 35 + 70 = W(link1) + 210 = 280
 // and the weight of the head of the fork chain =
 //   W(link1) + 140 + 35 = W(link1) + 175 = 245
-// and the weight of the union of link2 of both branches (a valid tipset) is
+// and the weight of the union of dstP.link2 of both branches (a valid tipset) is
 //   W(link1) + 245 = 315
 //
 // Therefore the syncer should set the head of the store to the union of the links..
 func TestHeaviestIsWidenedAncestor(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
 	pt := &powerTableForWidenTest{}
-	syncer, chainStore, con, blockSource := initSyncTestWithPowerTable(t, pt)
+	syncer, chainStore, con, blockSource := initSyncTestWithPowerTable(t, pt, dstP)
 	ctx := context.Background()
 
 	minerPower := uint64(25)
@@ -824,11 +853,11 @@ func TestHeaviestIsWidenedAncestor(t *testing.T) {
 	mockSignerPubKey := ki[0].PublicKey()
 
 	fakeChildParams := th.FakeChildParams{
-		Parent:     link1,
+		Parent:     dstP.link1,
 		Consensus:  con,
-		GenesisCid: genCid,
-		StateRoot:  genStateRoot,
-		MinerAddr:  minerAddress,
+		GenesisCid: dstP.genCid,
+		StateRoot:  dstP.genStateRoot,
+		MinerAddr:  dstP.minerAddress,
 		Signer:     signer,
 		Nonce:      uint64(1),
 	}
@@ -863,10 +892,10 @@ func TestHeaviestIsWidenedAncestor(t *testing.T) {
 
 	forklink3 := th.RequireNewTipSet(t, forklink3blk1)
 
-	_ = requirePutBlocks(t, blockSource, link1.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, link2.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, link3.ToSlice()...)
-	testhead := requirePutBlocks(t, blockSource, link4.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
+	testhead := requirePutBlocks(t, blockSource, dstP.link4.ToSlice()...)
 
 	_ = requirePutBlocks(t, blockSource, forklink2.ToSlice()...)
 	forkhead := requirePutBlocks(t, blockSource, forklink3.ToSlice()...)
@@ -880,7 +909,7 @@ func TestHeaviestIsWidenedAncestor(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Assert that widened chain is the new head
-	wideTs := th.RequireNewTipSet(t, link2blk1, link2blk2, link2blk3, forklink2blk1, forklink2blk2, forklink2blk3, forklink2blk4)
+	wideTs := th.RequireNewTipSet(t, dstP.link2blk1, dstP.link2blk2, dstP.link2blk3, forklink2blk1, forklink2blk2, forklink2blk3, forklink2blk4)
 	assertTsAdded(t, chainStore, wideTs)
 	assertHead(t, chainStore, wideTs)
 }
@@ -904,7 +933,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 	signerPubKey1 := ki[0].PublicKey()
 	signerPubKey2 := ki[1].PublicKey()
 
-	// set up genesis block with power
+	// set up dstP.genesis block with power
 	genCfg := &gengen.GenesisCfg{
 		Keys: 4,
 		Miners: []gengen.Miner{
@@ -934,14 +963,14 @@ func TestTipSetWeightDeep(t *testing.T) {
 	verifier := proofs.NewFakeVerifier(true, nil)
 	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), &th.TestView{}, calcGenBlk.Cid(), verifier)
 
-	// Initialize stores to contain genesis block and state
+	// Initialize stores to contain dstP.genesis block and state
 	calcGenTS := th.RequireNewTipSet(t, &calcGenBlk)
 	genTsas := &chain.TipSetAndState{
 		TipSet:          calcGenTS,
 		TipSetStateRoot: calcGenBlk.StateRoot,
 	}
 	th.RequirePutTsas(ctx, t, chainStore, genTsas)
-	err = chainStore.SetHead(ctx, calcGenTS) // Initialize chainStore with correct genesis
+	err = chainStore.SetHead(ctx, calcGenTS) // Initialize chainStore with correct dstP.genesis
 	require.NoError(t, err)
 	requireHead(t, chainStore, calcGenTS)
 	requireTsAdded(t, chainStore, calcGenTS)
@@ -1079,7 +1108,7 @@ func requireGetTipSetStateRoot(ctx context.Context, t *testing.T, chainStore cha
 	return stateCid
 }
 
-func initGenesis(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
+func initGenesis(minerAddress address.Address, minerOwnerAddress address.Address, minerPeerID peer.ID, cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
 	return consensus.MakeGenesisFunc(
 		consensus.MinerActor(minerAddress, minerOwnerAddress, []byte{}, 1000, minerPeerID, types.ZeroAttoFIL, types.OneKiBSectorSize),
 	)(cst, bs)

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/state"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
 
 	"github.com/stretchr/testify/assert"
@@ -357,6 +358,7 @@ func requirePutBlocks(t *testing.T, f *th.TestFetcher, blocks ...*types.Block) t
 
 // Syncer syncs a single block
 func TestSyncOneBlock(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
@@ -373,6 +375,7 @@ func TestSyncOneBlock(t *testing.T) {
 
 // Syncer syncs a single tipset.
 func TestSyncOneTipSet(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
@@ -388,6 +391,7 @@ func TestSyncOneTipSet(t *testing.T) {
 
 // Syncer syncs one tipset, block by block.
 func TestSyncTipSetBlockByBlock(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	pt := th.NewTestPowerTableView(1, 1)
@@ -411,6 +415,7 @@ func TestSyncTipSetBlockByBlock(t *testing.T) {
 
 // Syncer syncs a chain, tipset by tipset.
 func TestSyncChainTipSetByTipSet(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
@@ -444,6 +449,7 @@ func TestSyncChainTipSetByTipSet(t *testing.T) {
 
 // Syncer syncs a whole chain given only the head cids.
 func TestSyncChainHead(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
@@ -465,6 +471,7 @@ func TestSyncChainHead(t *testing.T) {
 
 // Syncer determines the heavier fork.
 func TestSyncIgnoreLightFork(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
@@ -506,6 +513,7 @@ func TestSyncIgnoreLightFork(t *testing.T) {
 
 // Correctly sync a heavier fork
 func TestHeavierFork(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
@@ -578,6 +586,7 @@ func TestHeavierFork(t *testing.T) {
 
 // Syncer errors if blocks don't form a tipset
 func TestBlocksNotATipSet(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
@@ -595,6 +604,7 @@ func TestBlocksNotATipSet(t *testing.T) {
 
 // Syncer is capable of recovering from a fork reorg after Load.
 func TestLoadFork(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	syncer, chainStore, r, blockSource := initSyncTestDefault(t, dstP)
@@ -629,7 +639,6 @@ func TestLoadFork(t *testing.T) {
 
 	fakeChildParams.Nonce = uint64(2)
 	forklink1blk3 := th.RequireMkFakeChild(t, fakeChildParams)
-	//th.FakeChildParams{Parent: forkbase, dstP.GenesisCid: dstP.genCid, StateRoot: dstP.genStateRoot, Nonce: uint64(2)})
 	forklink1 := th.RequireNewTipSet(t, forklink1blk1, forklink1blk2, forklink1blk3)
 
 	fakeChildParams.Parent = forklink1
@@ -693,6 +702,7 @@ func TestLoadFork(t *testing.T) {
 // The last operation will fail if the state of subset {B1, B2} is not
 // kept in the store because syncing C1 requires retrieving parent state.
 func TestSubsetParent(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	syncer, _, _, blockSource := initSyncTestDefault(t, dstP)
@@ -745,6 +755,7 @@ func TestSubsetParent(t *testing.T) {
 
 // Check that the syncer correctly adds widened chain ancestors to the store.
 func TestWidenChainAncestor(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
@@ -828,6 +839,7 @@ func (pt *powerTableForWidenTest) HasPower(ctx context.Context, st state.Tree, b
 //
 // Therefore the syncer should set the head of the store to the union of the links..
 func TestHeaviestIsWidenedAncestor(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	pt := &powerTableForWidenTest{}
@@ -908,6 +920,7 @@ func TestHeaviestIsWidenedAncestor(t *testing.T) {
 // and I can't figure out why because we pass in the correct blockstore to createminerwithpower.
 
 func TestTipSetWeightDeep(t *testing.T) {
+	tf.UnitTest(t)
 
 	r := repo.NewInMemoryRepo()
 	bs := bstore.NewBlockstore(r.Datastore())

--- a/chain/get_ancestors_test.go
+++ b/chain/get_ancestors_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/chain"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -49,6 +50,7 @@ func requireGrowChain(ctx context.Context, t *testing.T, blockSource *th.TestFet
 
 // Happy path
 func TestCollectTipSetsOfHeightAtLeast(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
@@ -69,6 +71,7 @@ func TestCollectTipSetsOfHeightAtLeast(t *testing.T) {
 
 // Height at least 0.
 func TestCollectTipSetsOfHeightAtLeastZero(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
@@ -89,6 +92,7 @@ func TestCollectTipSetsOfHeightAtLeastZero(t *testing.T) {
 
 // The starting epoch is a null block.
 func TestCollectTipSetsOfHeightAtLeastStartingEpochIsNull(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
@@ -141,6 +145,7 @@ func TestCollectTipSetsOfHeightAtLeastStartingEpochIsNull(t *testing.T) {
 }
 
 func TestCollectAtMostNTipSets(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
@@ -167,6 +172,7 @@ func TestCollectAtMostNTipSets(t *testing.T) {
 // DependentAncestor epochs = 100
 // Lookback = 20
 func TestGetRecentAncestors(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
@@ -190,6 +196,7 @@ func TestGetRecentAncestors(t *testing.T) {
 
 // Test case where parameters specify a chain past genesis.
 func TestGetRecentAncestorsTruncates(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
@@ -217,6 +224,7 @@ func TestGetRecentAncestorsTruncates(t *testing.T) {
 
 // Test case where no block has the start height in the chain due to null blocks.
 func TestGetRecentAncestorsStartingEpochIsNull(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
@@ -269,6 +277,7 @@ func TestGetRecentAncestorsStartingEpochIsNull(t *testing.T) {
 }
 
 func TestFindCommonAncestorSameChain(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	// Add 30 tipsets to the head of the chainStore.
@@ -283,6 +292,7 @@ func TestFindCommonAncestorSameChain(t *testing.T) {
 }
 
 func TestFindCommonAncestorFork(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	// Add 3 tipsets to the head of the chainStore.
@@ -333,6 +343,7 @@ func TestFindCommonAncestorFork(t *testing.T) {
 }
 
 func TestFindCommonAncestorNoFork(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	// Add 30 tipsets to the head of the chainStore.
@@ -353,6 +364,7 @@ func TestFindCommonAncestorNoFork(t *testing.T) {
 // This test exercises an edge case fork that our previous common ancestor
 // utility handled incorrectly.
 func TestFindCommonAncestorNullBlockFork(t *testing.T) {
+	tf.UnitTest(t)
 	dstP := initDSTParams()
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	// Add 10 tipsets to the head of the chainStore.

--- a/chain/get_ancestors_test.go
+++ b/chain/get_ancestors_test.go
@@ -14,14 +14,14 @@ import (
 )
 
 // setupGetAncestorTests initializes genesis and chain store for tests.
-func setupGetAncestorTests(t *testing.T) (context.Context, *th.TestFetcher, chain.Store) {
-	_, chainStore, _, blockSource := initSyncTestDefault(t)
+func setupGetAncestorTests(t *testing.T, dstP *DefaultSyncerTestParams) (context.Context, *th.TestFetcher, chain.Store) {
+	_, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	return context.Background(), blockSource, chainStore
 }
 
 // requireGrowChain grows the given store numBlocks single block tipsets from
 // its head.
-func requireGrowChain(ctx context.Context, t *testing.T, blockSource *th.TestFetcher, chainStore chain.Store, numBlocks int) {
+func requireGrowChain(ctx context.Context, t *testing.T, blockSource *th.TestFetcher, chainStore chain.Store, numBlocks int, dstP *DefaultSyncerTestParams) {
 	link := requireHeadTipset(t, chainStore)
 
 	signer, ki := types.NewMockSignersAndKeyInfo(1)
@@ -30,17 +30,17 @@ func requireGrowChain(ctx context.Context, t *testing.T, blockSource *th.TestFet
 	for i := 0; i < numBlocks; i++ {
 		fakeChildParams := th.FakeChildParams{
 			Parent:      link,
-			GenesisCid:  genCid,
+			GenesisCid:  dstP.genCid,
 			Signer:      signer,
 			MinerPubKey: mockSignerPubKey,
-			StateRoot:   genStateRoot,
+			StateRoot:   dstP.genStateRoot,
 		}
 		linkBlock := th.RequireMkFakeChild(t, fakeChildParams)
 		requirePutBlocks(t, blockSource, linkBlock)
 		link = th.RequireNewTipSet(t, linkBlock)
 		linkTsas := &chain.TipSetAndState{
 			TipSet:          link,
-			TipSetStateRoot: genStateRoot,
+			TipSetStateRoot: dstP.genStateRoot,
 		}
 		th.RequirePutTsas(ctx, t, chainStore, linkTsas)
 	}
@@ -50,11 +50,12 @@ func requireGrowChain(ctx context.Context, t *testing.T, blockSource *th.TestFet
 
 // Happy path
 func TestCollectTipSetsOfHeightAtLeast(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	ctx, blockSource, chainStore := setupGetAncestorTests(t)
+	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	chainLen := 15
-	requireGrowChain(ctx, t, blockSource, chainStore, chainLen-1)
+	requireGrowChain(ctx, t, blockSource, chainStore, chainLen-1, dstP)
 	stopHeight := types.NewBlockHeight(uint64(4))
 	iterator := chain.IterAncestors(ctx, chainStore, requireHeadTipset(t, chainStore))
 	tipsets, err := chain.CollectTipSetsOfHeightAtLeast(ctx, iterator, stopHeight)
@@ -70,11 +71,12 @@ func TestCollectTipSetsOfHeightAtLeast(t *testing.T) {
 
 // Height at least 0.
 func TestCollectTipSetsOfHeightAtLeastZero(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	ctx, blockSource, chainStore := setupGetAncestorTests(t)
+	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	chainLen := 25
-	requireGrowChain(ctx, t, blockSource, chainStore, chainLen-1)
+	requireGrowChain(ctx, t, blockSource, chainStore, chainLen-1, dstP)
 	stopHeight := types.NewBlockHeight(uint64(0))
 	iterator := chain.IterAncestors(ctx, chainStore, requireHeadTipset(t, chainStore))
 	tipsets, err := chain.CollectTipSetsOfHeightAtLeast(ctx, iterator, stopHeight)
@@ -90,12 +92,13 @@ func TestCollectTipSetsOfHeightAtLeastZero(t *testing.T) {
 
 // The starting epoch is a null block.
 func TestCollectTipSetsOfHeightAtLeastStartingEpochIsNull(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	ctx, blockSource, chainStore := setupGetAncestorTests(t)
+	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	// Add 30 tipsets to the head of the chainStore.
 	len1 := 30
-	requireGrowChain(ctx, t, blockSource, chainStore, len1)
+	requireGrowChain(ctx, t, blockSource, chainStore, len1, dstP)
 
 	// Now add 10 null blocks and 1 tipset.
 
@@ -106,11 +109,11 @@ func TestCollectTipSetsOfHeightAtLeastStartingEpochIsNull(t *testing.T) {
 
 	fakeChildParams := th.FakeChildParams{
 		Parent:         requireHeadTipset(t, chainStore),
-		GenesisCid:     genCid,
+		GenesisCid:     dstP.genCid,
 		NullBlockCount: nullBlocks,
 		Signer:         signer,
 		MinerPubKey:    mockSignerPubKey,
-		StateRoot:      genStateRoot,
+		StateRoot:      dstP.genStateRoot,
 	}
 
 	afterNullBlock := th.RequireMkFakeChild(t, fakeChildParams)
@@ -118,7 +121,7 @@ func TestCollectTipSetsOfHeightAtLeastStartingEpochIsNull(t *testing.T) {
 	afterNull := th.RequireNewTipSet(t, afterNullBlock)
 	afterNullTsas := &chain.TipSetAndState{
 		TipSet:          afterNull,
-		TipSetStateRoot: genStateRoot,
+		TipSetStateRoot: dstP.genStateRoot,
 	}
 	th.RequirePutTsas(ctx, t, chainStore, afterNullTsas)
 	err := chainStore.SetHead(ctx, afterNull)
@@ -126,7 +129,7 @@ func TestCollectTipSetsOfHeightAtLeastStartingEpochIsNull(t *testing.T) {
 
 	// Now add 19 more tipsets.
 	len2 := 19
-	requireGrowChain(ctx, t, blockSource, chainStore, len2)
+	requireGrowChain(ctx, t, blockSource, chainStore, len2, dstP)
 
 	stopHeight := types.NewBlockHeight(uint64(35))
 	iterator := chain.IterAncestors(ctx, chainStore, requireHeadTipset(t, chainStore))
@@ -142,11 +145,12 @@ func TestCollectTipSetsOfHeightAtLeastStartingEpochIsNull(t *testing.T) {
 }
 
 func TestCollectAtMostNTipSets(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	ctx, blockSource, chainStore := setupGetAncestorTests(t)
+	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	chainLen := 25
-	requireGrowChain(ctx, t, blockSource, chainStore, chainLen-1)
+	requireGrowChain(ctx, t, blockSource, chainStore, chainLen-1, dstP)
 	t.Run("happy path", func(t *testing.T) {
 		number := uint(10)
 		iterator := chain.IterAncestors(ctx, chainStore, requireHeadTipset(t, chainStore))
@@ -168,11 +172,12 @@ func TestCollectAtMostNTipSets(t *testing.T) {
 // DependentAncestor epochs = 100
 // Lookback = 20
 func TestGetRecentAncestors(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	ctx, blockSource, chainStore := setupGetAncestorTests(t)
+	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	chainLen := 200
-	requireGrowChain(ctx, t, blockSource, chainStore, chainLen-1)
+	requireGrowChain(ctx, t, blockSource, chainStore, chainLen-1, dstP)
 	head := requireHeadTipset(t, chainStore)
 	h, err := head.Height()
 	require.NoError(t, err)
@@ -191,11 +196,12 @@ func TestGetRecentAncestors(t *testing.T) {
 
 // Test case where parameters specify a chain past genesis.
 func TestGetRecentAncestorsTruncates(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	ctx, blockSource, chainStore := setupGetAncestorTests(t)
+	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	chainLen := 100
-	requireGrowChain(ctx, t, blockSource, chainStore, chainLen-1)
+	requireGrowChain(ctx, t, blockSource, chainStore, chainLen-1, dstP)
 	h, err := requireHeadTipset(t, chainStore).Height()
 	require.NoError(t, err)
 	epochs := uint64(200)
@@ -218,12 +224,13 @@ func TestGetRecentAncestorsTruncates(t *testing.T) {
 
 // Test case where no block has the start height in the chain due to null blocks.
 func TestGetRecentAncestorsStartingEpochIsNull(t *testing.T) {
+	dstP := initDSTParams()
 	tf.BadUnitTestWithSideEffects(t)
 
-	ctx, blockSource, chainStore := setupGetAncestorTests(t)
+	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	// Add 30 tipsets to the head of the chainStore.
 	len1 := 30
-	requireGrowChain(ctx, t, blockSource, chainStore, len1)
+	requireGrowChain(ctx, t, blockSource, chainStore, len1, dstP)
 
 	// Now add 10 null blocks and 1 tipset.
 	signer, ki := types.NewMockSignersAndKeyInfo(1)
@@ -233,8 +240,8 @@ func TestGetRecentAncestorsStartingEpochIsNull(t *testing.T) {
 
 	fakeChildParams := th.FakeChildParams{
 		Parent:         requireHeadTipset(t, chainStore),
-		GenesisCid:     genCid,
-		StateRoot:      genStateRoot,
+		GenesisCid:     dstP.genCid,
+		StateRoot:      dstP.genStateRoot,
 		NullBlockCount: nullBlocks,
 		Signer:         signer,
 		MinerPubKey:    mockSignerPubKey,
@@ -244,7 +251,7 @@ func TestGetRecentAncestorsStartingEpochIsNull(t *testing.T) {
 	afterNull := th.RequireNewTipSet(t, afterNullBlock)
 	afterNullTsas := &chain.TipSetAndState{
 		TipSet:          afterNull,
-		TipSetStateRoot: genStateRoot,
+		TipSetStateRoot: dstP.genStateRoot,
 	}
 	th.RequirePutTsas(ctx, t, chainStore, afterNullTsas)
 	err := chainStore.SetHead(ctx, afterNull)
@@ -252,7 +259,7 @@ func TestGetRecentAncestorsStartingEpochIsNull(t *testing.T) {
 
 	// Now add 19 more tipsets.
 	len2 := 19
-	requireGrowChain(ctx, t, blockSource, chainStore, len2)
+	requireGrowChain(ctx, t, blockSource, chainStore, len2, dstP)
 
 	epochs := uint64(28)
 	lookback := uint(6)

--- a/chain/get_ancestors_test.go
+++ b/chain/get_ancestors_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/chain"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
-	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -51,7 +50,6 @@ func requireGrowChain(ctx context.Context, t *testing.T, blockSource *th.TestFet
 // Happy path
 func TestCollectTipSetsOfHeightAtLeast(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	chainLen := 15
@@ -72,7 +70,6 @@ func TestCollectTipSetsOfHeightAtLeast(t *testing.T) {
 // Height at least 0.
 func TestCollectTipSetsOfHeightAtLeastZero(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	chainLen := 25
@@ -93,7 +90,6 @@ func TestCollectTipSetsOfHeightAtLeastZero(t *testing.T) {
 // The starting epoch is a null block.
 func TestCollectTipSetsOfHeightAtLeastStartingEpochIsNull(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	// Add 30 tipsets to the head of the chainStore.
@@ -146,7 +142,6 @@ func TestCollectTipSetsOfHeightAtLeastStartingEpochIsNull(t *testing.T) {
 
 func TestCollectAtMostNTipSets(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	chainLen := 25
@@ -173,7 +168,6 @@ func TestCollectAtMostNTipSets(t *testing.T) {
 // Lookback = 20
 func TestGetRecentAncestors(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	chainLen := 200
@@ -197,7 +191,6 @@ func TestGetRecentAncestors(t *testing.T) {
 // Test case where parameters specify a chain past genesis.
 func TestGetRecentAncestorsTruncates(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	chainLen := 100
@@ -225,7 +218,6 @@ func TestGetRecentAncestorsTruncates(t *testing.T) {
 // Test case where no block has the start height in the chain due to null blocks.
 func TestGetRecentAncestorsStartingEpochIsNull(t *testing.T) {
 	dstP := initDSTParams()
-	tf.BadUnitTestWithSideEffects(t)
 
 	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	// Add 30 tipsets to the head of the chainStore.
@@ -277,11 +269,11 @@ func TestGetRecentAncestorsStartingEpochIsNull(t *testing.T) {
 }
 
 func TestFindCommonAncestorSameChain(t *testing.T) {
-	tf.BadUnitTestWithSideEffects(t)
-	ctx, blockSource, chainStore := setupGetAncestorTests(t)
+	dstP := initDSTParams()
+	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	// Add 30 tipsets to the head of the chainStore.
 	len1 := 30
-	requireGrowChain(ctx, t, blockSource, chainStore, len1)
+	requireGrowChain(ctx, t, blockSource, chainStore, len1, dstP)
 	headTipSet := requireHeadTipset(t, chainStore)
 	headIterOne := chain.IterAncestors(ctx, chainStore, headTipSet)
 	headIterTwo := chain.IterAncestors(ctx, chainStore, headTipSet)
@@ -291,12 +283,11 @@ func TestFindCommonAncestorSameChain(t *testing.T) {
 }
 
 func TestFindCommonAncestorFork(t *testing.T) {
-
-	tf.BadUnitTestWithSideEffects(t)
-	ctx, blockSource, chainStore := setupGetAncestorTests(t)
+	dstP := initDSTParams()
+	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	// Add 3 tipsets to the head of the chainStore.
 	len1 := 3
-	requireGrowChain(ctx, t, blockSource, chainStore, len1)
+	requireGrowChain(ctx, t, blockSource, chainStore, len1, dstP)
 	headTipSetCA := requireHeadTipset(t, chainStore)
 
 	// make the first fork tipset
@@ -304,10 +295,10 @@ func TestFindCommonAncestorFork(t *testing.T) {
 	mockSignerPubKey := ki[0].PublicKey()
 	fakeChildParams := th.FakeChildParams{
 		Parent:      headTipSetCA,
-		GenesisCid:  genCid,
+		GenesisCid:  dstP.genCid,
 		Signer:      signer,
 		MinerPubKey: mockSignerPubKey,
-		StateRoot:   genStateRoot,
+		StateRoot:   dstP.genStateRoot,
 		Nonce:       uint64(4),
 	}
 
@@ -316,7 +307,7 @@ func TestFindCommonAncestorFork(t *testing.T) {
 	firstForkTS := th.RequireNewTipSet(t, firstForkBlock)
 	firstForkTsas := &chain.TipSetAndState{
 		TipSet:          firstForkTS,
-		TipSetStateRoot: genStateRoot,
+		TipSetStateRoot: dstP.genStateRoot,
 	}
 	th.RequirePutTsas(ctx, t, chainStore, firstForkTsas)
 	err := chainStore.SetHead(ctx, firstForkTS)
@@ -324,7 +315,7 @@ func TestFindCommonAncestorFork(t *testing.T) {
 
 	// grow the fork by 10 blocks
 	lenFork := 10
-	requireGrowChain(ctx, t, blockSource, chainStore, lenFork)
+	requireGrowChain(ctx, t, blockSource, chainStore, lenFork, dstP)
 	headTipSetFork := requireHeadTipset(t, chainStore)
 	headIterFork := chain.IterAncestors(ctx, chainStore, headTipSetFork)
 
@@ -332,7 +323,7 @@ func TestFindCommonAncestorFork(t *testing.T) {
 	err = chainStore.SetHead(ctx, headTipSetCA)
 	require.NoError(t, err)
 	lenMainChain := 14
-	requireGrowChain(ctx, t, blockSource, chainStore, lenMainChain)
+	requireGrowChain(ctx, t, blockSource, chainStore, lenMainChain, dstP)
 	headTipSetMainChain := requireHeadTipset(t, chainStore)
 	headIterMainChain := chain.IterAncestors(ctx, chainStore, headTipSetMainChain)
 
@@ -342,16 +333,16 @@ func TestFindCommonAncestorFork(t *testing.T) {
 }
 
 func TestFindCommonAncestorNoFork(t *testing.T) {
-	tf.BadUnitTestWithSideEffects(t)
-	ctx, blockSource, chainStore := setupGetAncestorTests(t)
+	dstP := initDSTParams()
+	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	// Add 30 tipsets to the head of the chainStore.
 	len1 := 30
-	requireGrowChain(ctx, t, blockSource, chainStore, len1)
+	requireGrowChain(ctx, t, blockSource, chainStore, len1, dstP)
 	headTipSet1 := requireHeadTipset(t, chainStore)
 	headIterOne := chain.IterAncestors(ctx, chainStore, headTipSet1)
 	// Now add 19 more tipsets.
 	len2 := 19
-	requireGrowChain(ctx, t, blockSource, chainStore, len2)
+	requireGrowChain(ctx, t, blockSource, chainStore, len2, dstP)
 	headTipSet2 := requireHeadTipset(t, chainStore)
 	headIterTwo := chain.IterAncestors(ctx, chainStore, headTipSet2)
 	commonAncestor, err := chain.FindCommonAncestor(headIterOne, headIterTwo)
@@ -362,11 +353,11 @@ func TestFindCommonAncestorNoFork(t *testing.T) {
 // This test exercises an edge case fork that our previous common ancestor
 // utility handled incorrectly.
 func TestFindCommonAncestorNullBlockFork(t *testing.T) {
-	tf.BadUnitTestWithSideEffects(t)
-	ctx, blockSource, chainStore := setupGetAncestorTests(t)
+	dstP := initDSTParams()
+	ctx, blockSource, chainStore := setupGetAncestorTests(t, dstP)
 	// Add 10 tipsets to the head of the chainStore.
 	len1 := 10
-	requireGrowChain(ctx, t, blockSource, chainStore, len1)
+	requireGrowChain(ctx, t, blockSource, chainStore, len1, dstP)
 	expectedCA := requireHeadTipset(t, chainStore)
 
 	// add a null block and another block to the head
@@ -374,10 +365,10 @@ func TestFindCommonAncestorNullBlockFork(t *testing.T) {
 	mockSignerPubKey := ki[0].PublicKey()
 	fakeChildParams := th.FakeChildParams{
 		Parent:         expectedCA,
-		GenesisCid:     genCid,
+		GenesisCid:     dstP.genCid,
 		Signer:         signer,
 		MinerPubKey:    mockSignerPubKey,
-		StateRoot:      genStateRoot,
+		StateRoot:      dstP.genStateRoot,
 		NullBlockCount: uint64(1),
 	}
 
@@ -386,14 +377,14 @@ func TestFindCommonAncestorNullBlockFork(t *testing.T) {
 	afterNullTS := th.RequireNewTipSet(t, afterNullBlock)
 	afterNullTsas := &chain.TipSetAndState{
 		TipSet:          afterNullTS,
-		TipSetStateRoot: genStateRoot,
+		TipSetStateRoot: dstP.genStateRoot,
 	}
 	th.RequirePutTsas(ctx, t, chainStore, afterNullTsas)
 	afterNullIter := chain.IterAncestors(ctx, chainStore, afterNullTS)
 
 	// grow the fork by 1 block on the other fork
 	len2 := 1
-	requireGrowChain(ctx, t, blockSource, chainStore, len2)
+	requireGrowChain(ctx, t, blockSource, chainStore, len2, dstP)
 	mainChainTS := requireHeadTipset(t, chainStore)
 	mainChainIter := chain.IterAncestors(ctx, chainStore, mainChainTS)
 


### PR DESCRIPTION
Closes #2116. All `*Test` methods initialize a struct that contains the syncer params, which is in turn passed to all the other initialization/`require*` methods. Let me know if there's an alternative approach you'd like me to implement.