### PR TITLE
Docker faucet and genesis server binary coping

### DIFF
--- a/Dockerfile.ci.faucet
+++ b/Dockerfile.ci.faucet
@@ -2,7 +2,7 @@ FROM busybox:1-glibc
 MAINTAINER Filecoin Dev Team
 
 # Get the binary, entrypoint script, and TLS CAs from the build container.
-COPY tools/faucet /usr/local/bin/faucet
+COPY tools/faucet/faucet /usr/local/bin/faucet
 COPY --from=filecoin:all /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=filecoin:all /tmp/tini /sbin/tini
 COPY --from=filecoin:all /etc/ssl/certs /etc/ssl/certs

--- a/Dockerfile.ci.genesis
+++ b/Dockerfile.ci.genesis
@@ -2,7 +2,7 @@ FROM busybox:1-glibc
 MAINTAINER Filecoin Dev Team
 
 # Get the binary, entrypoint script, and TLS CAs from the build container.
-COPY tools/genesis-file-server /usr/local/bin/genesis-file-server
+COPY tools/genesis-file-server/genesis-file-server /usr/local/bin/genesis-file-server
 COPY fixtures/* /data/
 COPY --from=filecoin:all /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=filecoin:all /tmp/tini /sbin/tini


### PR DESCRIPTION
Ran into permission issues with these docker files, turns out we were coping a directory instead of the binary.