### PR TITLE
Change localfilecoin IPTB plugin to nest the repo and sector dirs inside the IPTB dir.

### DIFF
--- a/tools/iptb-plugins/filecoin/local/filecoinutil.go
+++ b/tools/iptb-plugins/filecoin/local/filecoinutil.go
@@ -41,7 +41,7 @@ func (l *Localfilecoin) isAlive() (bool, error) {
 }
 
 func (l *Localfilecoin) getPID() (int, error) {
-	b, err := ioutil.ReadFile(filepath.Join(l.dir, "daemon.pid"))
+	b, err := ioutil.ReadFile(filepath.Join(l.iptbPath, "daemon.pid"))
 	if err != nil {
 		return -1, err
 	}
@@ -56,7 +56,7 @@ func (l *Localfilecoin) env() ([]string, error) {
 	pathList := filepath.SplitList(currPath)
 	pathList = append([]string{filepath.Dir(l.binPath)}, pathList...)
 	newPath := strings.Join(pathList, string(filepath.ListSeparator))
-	envs = filecoin.UpdateOrAppendEnv(envs, "FIL_PATH", l.dir)
+	envs = filecoin.UpdateOrAppendEnv(envs, "FIL_PATH", l.repoPath)
 	envs = filecoin.UpdateOrAppendEnv(envs, "GO_FILECOIN_LOG_LEVEL", l.logLevel)
 	envs = filecoin.UpdateOrAppendEnv(envs, "GO_FILECOIN_LOG_JSON", l.logJSON)
 	envs = filecoin.UpdateOrAppendEnv(envs, "PATH", newPath)
@@ -71,7 +71,7 @@ func (l *Localfilecoin) env() ([]string, error) {
 func (l *Localfilecoin) signalAndWait(p *os.Process, waitch <-chan struct{}, signal os.Signal, t time.Duration) error {
 	err := p.Signal(signal)
 	if err != nil {
-		return fmt.Errorf("error killing daemon %s: %s", l.dir, err)
+		return fmt.Errorf("error killing daemon %s: %s", l.iptbPath, err)
 	}
 
 	select {
@@ -83,7 +83,7 @@ func (l *Localfilecoin) signalAndWait(p *os.Process, waitch <-chan struct{}, sig
 }
 
 func (l *Localfilecoin) readerFor(file string) (io.ReadCloser, error) {
-	return os.OpenFile(filepath.Join(l.dir, file), os.O_RDONLY, 0)
+	return os.OpenFile(filepath.Join(l.iptbPath, file), os.O_RDONLY, 0)
 }
 
 // GetPeerID returns the nodes peerID by running its `id` command.

--- a/tools/iptb-plugins/filecoin/local/localfilecoin.go
+++ b/tools/iptb-plugins/filecoin/local/localfilecoin.go
@@ -31,21 +31,24 @@ var PluginName = "localfilecoin"
 
 var log = logging.Logger(PluginName)
 
-// ErrIsAlive will be returned by Start if the node is already running
-var ErrIsAlive = errors.New("node is already running")
+// errIsAlive will be returned by Start if the node is already running
+var errIsAlive = errors.New("node is already running")
 var errTimeout = errors.New("timeout")
 
-// DefaultFilecoinBinary is the name or full path of the binary that will be used
-var DefaultFilecoinBinary = "go-filecoin"
+// defaultFilecoinBinary is the name or full path of the binary that will be used
+const defaultFilecoinBinary = "go-filecoin"
 
-// DefaultSectorsPath is the name of the sector path relative to the repo path
-var DefaultSectorsPath = "sectors"
+// defaultRepoPath is the name of the repo path relative to the plugin root directory
+const defaultRepoPath = "repo"
 
-// DefaultLogLevel is the value that will be used for GO_FILECOIN_LOG_LEVEL
-var DefaultLogLevel = "3"
+// defaultSectorsPath is the name of the sector path relative to the plugin root directory
+const defaultSectorsPath = "sectors"
 
-// DefaultLogJSON is the value that will be used for GO_FILECOIN_LOG_JSON
-var DefaultLogJSON = "false"
+// defaultLogLevel is the value that will be used for GO_FILECOIN_LOG_LEVEL
+const defaultLogLevel = "3"
+
+// defaultLogJSON is the value that will be used for GO_FILECOIN_LOG_JSON
+const defaultLogJSON = "false"
 
 var (
 	// AttrFilecoinBinary is the key used to set which binary to use in the plugin through NewNode attrs
@@ -63,12 +66,13 @@ var (
 
 // Localfilecoin represents a filecoin node
 type Localfilecoin struct {
-	dir     string
-	peerid  cid.Cid
-	apiaddr multiaddr.Multiaddr
+	iptbPath string // Absolute path for all process data
+	peerid   cid.Cid
+	apiaddr  multiaddr.Multiaddr
 
-	binPath     string
-	sectorsPath string
+	binPath     string // Absolute path to binary
+	repoPath    string // Absolute path to repo
+	sectorsPath string // Absolute path to sectors
 	logLevel    string
 	logJSON     string
 }
@@ -77,13 +81,16 @@ var NewNode testbedi.NewNodeFunc // nolint: golint
 
 func init() {
 	NewNode = func(dir string, attrs map[string]string) (testbedi.Core, error) {
+		dir, err := filepath.Abs(dir)
+		if err != nil {
+			return nil, err
+		}
 		var (
-			err error
-
 			binPath     = ""
-			sectorsPath = filepath.Join(dir, DefaultSectorsPath)
-			logLevel    = DefaultLogLevel
-			logJSON     = DefaultLogJSON
+			repoPath    = filepath.Join(dir, defaultRepoPath)
+			sectorsPath = filepath.Join(dir, defaultSectorsPath)
+			logLevel    = defaultLogLevel
+			logJSON     = defaultLogJSON
 		)
 
 		if v, ok := attrs[AttrFilecoinBinary]; ok {
@@ -103,7 +110,7 @@ func init() {
 		}
 
 		if len(binPath) == 0 {
-			if binPath, err = exec.LookPath(DefaultFilecoinBinary); err != nil {
+			if binPath, err = exec.LookPath(defaultFilecoinBinary); err != nil {
 				return nil, err
 			}
 		}
@@ -121,13 +128,18 @@ func init() {
 			return nil, err
 		}
 
+		if err := os.Mkdir(repoPath, 0755); err != nil {
+			return nil, err
+		}
+
 		if err := os.Mkdir(sectorsPath, 0755); err != nil {
 			return nil, err
 		}
 
 		return &Localfilecoin{
-			dir:         dir,
+			iptbPath:    dir,
 			binPath:     dst,
+			repoPath:    repoPath,
 			sectorsPath: sectorsPath,
 			logLevel:    logLevel,
 			logJSON:     logJSON,
@@ -139,6 +151,7 @@ func init() {
 
 // Init runs the node init process.
 func (l *Localfilecoin) Init(ctx context.Context, args ...string) (testbedi.Output, error) {
+	// The repo path is provided by the environment
 	args = append([]string{l.binPath, "init"}, args...)
 	output, oerr := l.RunCmd(ctx, nil, args...)
 	if oerr != nil {
@@ -187,14 +200,13 @@ func (l *Localfilecoin) Start(ctx context.Context, wait bool, args ...string) (t
 	}
 
 	if alive {
-		return nil, ErrIsAlive
+		return nil, errIsAlive
 	}
 
-	dir := l.dir
-	repoFlag := fmt.Sprintf("--repodir=%s", l.dir)
+	repoFlag := fmt.Sprintf("--repodir=%s", l.repoPath) // Not provided by environment here
 	dargs := append([]string{"daemon", repoFlag}, args...)
 	cmd := exec.CommandContext(ctx, l.binPath, dargs...)
-	cmd.Dir = dir
+	cmd.Dir = l.iptbPath
 
 	cmd.Env, err = l.env()
 	if err != nil {
@@ -203,12 +215,12 @@ func (l *Localfilecoin) Start(ctx context.Context, wait bool, args ...string) (t
 
 	iptbutil.SetupOpt(cmd)
 
-	stdout, err := os.Create(filepath.Join(dir, "daemon.stdout"))
+	stdout, err := os.Create(filepath.Join(l.iptbPath, "daemon.stdout"))
 	if err != nil {
 		return nil, err
 	}
 
-	stderr, err := os.Create(filepath.Join(dir, "daemon.stderr"))
+	stderr, err := os.Create(filepath.Join(l.iptbPath, "daemon.stderr"))
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +240,7 @@ func (l *Localfilecoin) Start(ctx context.Context, wait bool, args ...string) (t
 
 	l.Infof("Started daemon: %s, pid: %d", l, pid)
 
-	if err := ioutil.WriteFile(filepath.Join(dir, "daemon.pid"), []byte(fmt.Sprint(pid)), 0666); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(l.iptbPath, "daemon.pid"), []byte(fmt.Sprint(pid)), 0666); err != nil {
 		return nil, err
 	}
 	if wait {
@@ -243,12 +255,12 @@ func (l *Localfilecoin) Start(ctx context.Context, wait bool, args ...string) (t
 func (l *Localfilecoin) Stop(ctx context.Context) error {
 	pid, err := l.getPID()
 	if err != nil {
-		return fmt.Errorf("error killing daemon %s: %s", l.dir, err)
+		return fmt.Errorf("error killing daemon %s: %s", l.iptbPath, err)
 	}
 
 	p, err := os.FindProcess(pid)
 	if err != nil {
-		return fmt.Errorf("error killing daemon %s: %s", l.dir, err)
+		return fmt.Errorf("error killing daemon %s: %s", l.iptbPath, err)
 	}
 
 	waitch := make(chan struct{}, 1)
@@ -259,13 +271,13 @@ func (l *Localfilecoin) Stop(ctx context.Context) error {
 	}()
 
 	defer func() {
-		err := os.Remove(filepath.Join(l.dir, "daemon.pid"))
+		err := os.Remove(filepath.Join(l.iptbPath, "daemon.pid"))
 		if err != nil && !os.IsNotExist(err) {
-			panic(fmt.Errorf("error removing pid file for daemon at %s: %s", l.dir, err))
+			panic(fmt.Errorf("error removing pid file for daemon at %s: %s", l.iptbPath, err))
 		}
-		err = os.Remove(filepath.Join(l.dir, "api"))
+		err = os.Remove(filepath.Join(l.repoPath, "api"))
 		if err != nil && !os.IsNotExist(err) {
-			panic(fmt.Errorf("error removing pid file for daemon at %s: %s", l.dir, err))
+			panic(fmt.Errorf("error removing API file for daemon at %s: %s", l.repoPath, err))
 		}
 	}()
 
@@ -480,9 +492,9 @@ func (l *Localfilecoin) Errorf(format string, args ...interface{}) {
 	log.Errorf("Node: %s %s", l, fmt.Sprintf(format, args...))
 }
 
-// Dir returns the repo directory the node is using.
+// Dir returns the IPTB directory the node is using.
 func (l *Localfilecoin) Dir() string {
-	return l.dir
+	return l.iptbPath
 }
 
 // Type returns the type of the node.
@@ -492,7 +504,7 @@ func (l *Localfilecoin) Type() string {
 
 // String implements the stringr interface.
 func (l *Localfilecoin) String() string {
-	return l.dir
+	return l.iptbPath
 }
 
 /** Libp2p Interface **/
@@ -523,7 +535,7 @@ func (l *Localfilecoin) APIAddr() (string, error) {
 	*/
 
 	var err error
-	l.apiaddr, err = filecoin.GetAPIAddrFromRepo(l.dir)
+	l.apiaddr, err = filecoin.GetAPIAddrFromRepo(l.repoPath)
 	if err != nil {
 		return "", err
 	}
@@ -551,11 +563,11 @@ func (l *Localfilecoin) SwarmAddrs() ([]string, error) {
 
 // Config returns the nodes config.
 func (l *Localfilecoin) Config() (interface{}, error) {
-	return config.ReadFile(filepath.Join(l.dir, "config.json"))
+	return config.ReadFile(filepath.Join(l.repoPath, "config.json"))
 }
 
 // WriteConfig writes a nodes config file.
 func (l *Localfilecoin) WriteConfig(cfg interface{}) error {
 	lcfg := cfg.(*config.Config)
-	return lcfg.WriteFile(filepath.Join(l.dir, "config.json"))
+	return lcfg.WriteFile(filepath.Join(l.repoPath, "config.json"))
 }


### PR DESCRIPTION
This removes the possibility of collision between files in the repo and anything else placed
in the IPTB directory (log files, pidfiles etc). This is a prefactor for #2701, which tightens
the go-filecoin init checks to require the prospective repo directory to be absent or empty.