### PR TITLE
issue-2553 GetTipSetAndState should be split into two methods v0

### DIFF
--- a/chain/default_store.go
+++ b/chain/default_store.go
@@ -399,11 +399,11 @@ func (store *DefaultStore) BlockHeight() (uint64, error) {
 
 // ActorFromLatestState gets the latest state and retrieves an actor from it.
 func (store *DefaultStore) ActorFromLatestState(ctx context.Context, addr address.Address) (*actor.Actor, error) {
-	tssr, err := store.GetTipSetStateRoot(store.GetHead())
+	stateCid, err := store.GetTipSetStateRoot(store.GetHead())
 	if err != nil {
 		return nil, err
 	}
-	st, err := state.LoadStateTree(ctx, store.stateStore, tssr, builtin.Actors)
+	st, err := state.LoadStateTree(ctx, store.stateStore, stateCid, builtin.Actors)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/default_store.go
+++ b/chain/default_store.go
@@ -230,12 +230,16 @@ func (store *DefaultStore) PutTipSetAndState(ctx context.Context, tsas *TipSetAn
 	return nil
 }
 
-// GetTipSetAndState returns the tipset and state of the tipset whose block
+// GetTipSet returns the tipset whose block
 // cids correspond to the input sorted cid set.
-func (store *DefaultStore) GetTipSetAndState(tsKey types.SortedCidSet) (*TipSetAndState, error) {
-	return store.tipIndex.Get(tsKey.String())
+func (store *DefaultStore) GetTipSet(tsKey types.SortedCidSet) (*types.TipSet, error) {
+	return store.tipIndex.GetTipSet(tsKey.String())
 }
-
+// GetTipSetStateRoot returns the state of the tipset whose block
+// cids correspond to the input sorted cid set.
+func (store *DefaultStore) GetTipSetStateRoot(tsKey types.SortedCidSet) (cid.Cid, error) {
+	return store.tipIndex.GetTipSetStateRoot(tsKey.String())
+}
 // HasTipSetAndState returns true iff the default store's tipindex is indexing
 // the tipset referenced in the input key.
 func (store *DefaultStore) HasTipSetAndState(ctx context.Context, tsKey string) bool {
@@ -393,11 +397,11 @@ func (store *DefaultStore) BlockHeight() (uint64, error) {
 
 // ActorFromLatestState gets the latest state and retrieves an actor from it.
 func (store *DefaultStore) ActorFromLatestState(ctx context.Context, addr address.Address) (*actor.Actor, error) {
-	tsas, err := store.GetTipSetAndState(store.GetHead())
+	tssr, err := store.GetTipSetStateRoot(store.GetHead())
 	if err != nil {
 		return nil, err
 	}
-	st, err := state.LoadStateTree(ctx, store.stateStore, tsas.TipSetStateRoot, builtin.Actors)
+	st, err := state.LoadStateTree(ctx, store.stateStore, tssr, builtin.Actors)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/default_store.go
+++ b/chain/default_store.go
@@ -235,11 +235,13 @@ func (store *DefaultStore) PutTipSetAndState(ctx context.Context, tsas *TipSetAn
 func (store *DefaultStore) GetTipSet(tsKey types.SortedCidSet) (*types.TipSet, error) {
 	return store.tipIndex.GetTipSet(tsKey.String())
 }
+
 // GetTipSetStateRoot returns the state of the tipset whose block
 // cids correspond to the input sorted cid set.
 func (store *DefaultStore) GetTipSetStateRoot(tsKey types.SortedCidSet) (cid.Cid, error) {
 	return store.tipIndex.GetTipSetStateRoot(tsKey.String())
 }
+
 // HasTipSetAndState returns true iff the default store's tipindex is indexing
 // the tipset referenced in the input key.
 func (store *DefaultStore) HasTipSetAndState(ctx context.Context, tsKey string) bool {

--- a/chain/default_store_test.go
+++ b/chain/default_store_test.go
@@ -75,9 +75,9 @@ func requireGetTsasByParentAndHeight(t *testing.T, chain chain.Store, pKey strin
 }
 
 func requireHeadTipset(t *testing.T, chain chain.Store) types.TipSet {
-	headTipSetAndState, err := chain.GetTipSetAndState(chain.GetHead())
+	headTipSet, err := chain.GetTipSet(chain.GetHead())
 	require.NoError(t, err)
-	return headTipSetAndState.TipSet
+	return *headTipSet
 }
 
 /* Putting and getting tipsets into and from the store. */

--- a/chain/default_store_test.go
+++ b/chain/default_store_test.go
@@ -107,23 +107,31 @@ func TestGetByKey(t *testing.T) {
 
 	requirePutTestChain(t, chain)
 
-	gotG := requireGetTsas(ctx, t, chain, genTS.ToSortedCidSet())
-	got1 := requireGetTsas(ctx, t, chain, link1.ToSortedCidSet())
-	got2 := requireGetTsas(ctx, t, chain, link2.ToSortedCidSet())
-	got3 := requireGetTsas(ctx, t, chain, link3.ToSortedCidSet())
-	got4 := requireGetTsas(ctx, t, chain, link4.ToSortedCidSet())
+	gotGTS := requireGetTipSet(ctx, t, chain, genTS.ToSortedCidSet())
+	gotGTSSR := requireGetTipSetStateRoot(ctx, t, chain, genTS.ToSortedCidSet())
 
-	assert.Equal(t, genTS, gotG.TipSet)
-	assert.Equal(t, link1, got1.TipSet)
-	assert.Equal(t, link2, got2.TipSet)
-	assert.Equal(t, link3, got3.TipSet)
-	assert.Equal(t, link4, got4.TipSet)
+	got1TS := requireGetTipSet(ctx, t, chain, link1.ToSortedCidSet())
+	got1TSSR := requireGetTipSetStateRoot(ctx, t, chain, link1.ToSortedCidSet())
 
-	assert.Equal(t, genStateRoot, gotG.TipSetStateRoot)
-	assert.Equal(t, link1State, got1.TipSetStateRoot)
-	assert.Equal(t, link2State, got2.TipSetStateRoot)
-	assert.Equal(t, link3State, got3.TipSetStateRoot)
-	assert.Equal(t, link4State, got4.TipSetStateRoot)
+	got2TS := requireGetTipSet(ctx, t, chain, link2.ToSortedCidSet())
+	got2TSSR := requireGetTipSetStateRoot(ctx, t, chain, link2.ToSortedCidSet())
+
+	got3TS := requireGetTipSet(ctx, t, chain, link3.ToSortedCidSet())
+	got3TSSR := requireGetTipSetStateRoot(ctx, t, chain, link3.ToSortedCidSet())
+
+	got4TS := requireGetTipSet(ctx, t, chain, link4.ToSortedCidSet())
+	got4TSSR := requireGetTipSetStateRoot(ctx, t, chain, link4.ToSortedCidSet())
+	assert.Equal(t, genTS, *gotGTS)
+	assert.Equal(t, link1, *got1TS)
+	assert.Equal(t, link2, *got2TS)
+	assert.Equal(t, link3, *got3TS)
+	assert.Equal(t, link4, *got4TS)
+
+	assert.Equal(t, genStateRoot, gotGTSSR)
+	assert.Equal(t, link1State, got1TSSR)
+	assert.Equal(t, link2State, got2TSSR)
+	assert.Equal(t, link3State, got3TSSR)
+	assert.Equal(t, link4State, got4TSSR)
 }
 
 // Tipsets can be retrieved by parent key (all block cids of parents).
@@ -368,8 +376,8 @@ func TestLoadAndReboot(t *testing.T) {
 
 	// Check that chain store has index
 	// Get a tipset and state by key
-	got2 := requireGetTsas(ctx, t, rebootChain, link2.ToSortedCidSet())
-	assert.Equal(t, link2, got2.TipSet)
+	got2 := requireGetTipSet(ctx, t, rebootChain, link2.ToSortedCidSet())
+	assert.Equal(t, link2, *got2)
 
 	// Get another by parent key
 	got4 := requireGetTsasByParentAndHeight(t, rebootChain, link3.String(), uint64(6))

--- a/chain/default_syncer.go
+++ b/chain/default_syncer.go
@@ -270,7 +270,7 @@ func (syncer *DefaultSyncer) syncOne(ctx context.Context, parent, next types.Tip
 		}
 		newChain = append(newChain, next)
 		if IsReorg(*headTipSet, newChain) {
-			logSyncer.Infof("reorg occurring while switching from %s to %s", (*headTipSet).String(), next.String())
+			logSyncer.Infof("reorg occurring while switching from %s to %s", headTipSet.String(), next.String())
 		}
 		if err = syncer.chainStore.SetHead(ctx, next); err != nil {
 			return err

--- a/chain/default_syncer.go
+++ b/chain/default_syncer.go
@@ -243,7 +243,7 @@ func (syncer *DefaultSyncer) syncOne(ctx context.Context, parent, next types.Tip
 	if err != nil {
 		return err
 	}
-	headParentCids, err := (*headTipSet).Parents()
+	headParentCids, err := headTipSet.Parents()
 	if err != nil {
 		return err
 	}

--- a/chain/default_syncer.go
+++ b/chain/default_syncer.go
@@ -168,11 +168,11 @@ func (syncer *DefaultSyncer) tipSetState(ctx context.Context, tsKey types.Sorted
 	if !syncer.chainStore.HasTipSetAndState(ctx, tsKey.String()) {
 		return nil, errors.Wrap(ErrUnexpectedStoreState, "parent tipset must be in the store")
 	}
-	tssr, err := syncer.chainStore.GetTipSetStateRoot(tsKey)
+	stateCid, err := syncer.chainStore.GetTipSetStateRoot(tsKey)
 	if err != nil {
 		return nil, err
 	}
-	st, err := state.LoadStateTree(ctx, syncer.stateStore, tssr, builtin.Actors)
+	st, err := state.LoadStateTree(ctx, syncer.stateStore, stateCid, builtin.Actors)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/default_syncer.go
+++ b/chain/default_syncer.go
@@ -168,11 +168,11 @@ func (syncer *DefaultSyncer) tipSetState(ctx context.Context, tsKey types.Sorted
 	if !syncer.chainStore.HasTipSetAndState(ctx, tsKey.String()) {
 		return nil, errors.Wrap(ErrUnexpectedStoreState, "parent tipset must be in the store")
 	}
-	tsas, err := syncer.chainStore.GetTipSetAndState(tsKey)
+	tssr, err := syncer.chainStore.GetTipSetStateRoot(tsKey)
 	if err != nil {
 		return nil, err
 	}
-	st, err := state.LoadStateTree(ctx, syncer.stateStore, tsas.TipSetStateRoot, builtin.Actors)
+	st, err := state.LoadStateTree(ctx, syncer.stateStore, tssr, builtin.Actors)
 	if err != nil {
 		return nil, err
 	}
@@ -239,11 +239,11 @@ func (syncer *DefaultSyncer) syncOne(ctx context.Context, parent, next types.Tip
 	if err != nil {
 		return err
 	}
-	headTipSetAndState, err := syncer.chainStore.GetTipSetAndState(head)
+	headTipSet, err := syncer.chainStore.GetTipSet(head)
 	if err != nil {
 		return err
 	}
-	headParentCids, err := headTipSetAndState.TipSet.Parents()
+	headParentCids, err := (*headTipSet).Parents()
 	if err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func (syncer *DefaultSyncer) syncOne(ctx context.Context, parent, next types.Tip
 		}
 	}
 
-	heavier, err := syncer.consensus.IsHeavier(ctx, next, headTipSetAndState.TipSet, nextParentSt, headParentSt)
+	heavier, err := syncer.consensus.IsHeavier(ctx, next, *headTipSet, nextParentSt, headParentSt)
 	if err != nil {
 		return err
 	}
@@ -269,8 +269,8 @@ func (syncer *DefaultSyncer) syncOne(ctx context.Context, parent, next types.Tip
 			return err
 		}
 		newChain = append(newChain, next)
-		if IsReorg(headTipSetAndState.TipSet, newChain) {
-			logSyncer.Infof("reorg occurring while switching from %s to %s", headTipSetAndState.TipSet.String(), next.String())
+		if IsReorg(*headTipSet, newChain) {
+			logSyncer.Infof("reorg occurring while switching from %s to %s", (*headTipSet).String(), next.String())
 		}
 		if err = syncer.chainStore.SetHead(ctx, next); err != nil {
 			return err
@@ -362,11 +362,11 @@ func (syncer *DefaultSyncer) HandleNewTipset(ctx context.Context, tipsetCids typ
 	if err != nil {
 		return err
 	}
-	parentTsas, err := syncer.chainStore.GetTipSetAndState(parentCids)
+	parentTs, err := syncer.chainStore.GetTipSet(parentCids)
 	if err != nil {
 		return err
 	}
-	parent := parentTsas.TipSet
+	parent := *parentTs
 
 	// Try adding the tipsets of the chain to the store, checking for new
 	// heaviest tipsets.

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -1067,16 +1067,16 @@ func TestTipSetWeightDeep(t *testing.T) {
 	assert.Equal(t, expectedWeight, measuredWeight)
 }
 
-func requireGetTsas(ctx context.Context, t *testing.T, chainStore chain.Store, key types.SortedCidSet) *chain.TipSetAndState {
+func requireGetTipSet(ctx context.Context, t *testing.T, chainStore chain.Store, key types.SortedCidSet) *types.TipSet {
 	ts, err := chainStore.GetTipSet(key)
 	require.NoError(t, err)
+	return ts
+}
+
+func requireGetTipSetStateRoot(ctx context.Context, t *testing.T, chainStore chain.Store, key types.SortedCidSet) cid.Cid {
 	tssr, err := chainStore.GetTipSetStateRoot(key)
 	require.NoError(t, err)
-	return &chain.TipSetAndState{
-		TipSet:          *ts,
-		TipSetStateRoot: tssr,
-	}
-
+	return tssr
 }
 
 func initGenesis(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -271,9 +271,9 @@ func requireTsAdded(t *testing.T, chain chain.Store, ts types.TipSet) {
 	h, err := ts.Height()
 	require.NoError(t, err)
 	// Tip Index correctly updated
-	gotTsas, err := chain.GetTipSetAndState(ts.ToSortedCidSet())
+	gotTs, err := chain.GetTipSet(ts.ToSortedCidSet())
 	require.NoError(t, err)
-	require.Equal(t, ts, gotTsas.TipSet)
+	require.Equal(t, ts, *gotTs)
 	parent, err := ts.Parents()
 	require.NoError(t, err)
 	childTsasSlice, err := chain.GetTipSetAndStatesByParentsAndHeight(parent.String(), h)
@@ -291,9 +291,9 @@ func assertTsAdded(t *testing.T, chainStore chain.Store, ts types.TipSet) {
 	h, err := ts.Height()
 	assert.NoError(t, err)
 	// Tip Index correctly updated
-	gotTsas, err := chainStore.GetTipSetAndState(ts.ToSortedCidSet())
+	gotTs, err := chainStore.GetTipSet(ts.ToSortedCidSet())
 	assert.NoError(t, err)
-	assert.Equal(t, ts, gotTsas.TipSet)
+	assert.Equal(t, ts, *gotTs)
 	parent, err := ts.Parents()
 	assert.NoError(t, err)
 	childTsasSlice, err := chainStore.GetTipSetAndStatesByParentsAndHeight(parent.String(), h)
@@ -309,7 +309,7 @@ func assertTsAdded(t *testing.T, chainStore chain.Store, ts types.TipSet) {
 func assertNoAdd(t *testing.T, chainStore chain.Store, cids types.SortedCidSet) {
 	ctx := context.Background()
 	// Tip Index correctly updated
-	_, err := chainStore.GetTipSetAndState(cids)
+	_, err := chainStore.GetTipSet(cids)
 	assert.Error(t, err)
 	// Blocks exist in store
 	for _, c := range cids.ToSlice() {
@@ -322,9 +322,9 @@ func requireHead(t *testing.T, chain chain.Store, head types.TipSet) {
 }
 
 func assertHead(t *testing.T, chain chain.Store, head types.TipSet) {
-	headTipSetAndState, err := chain.GetTipSetAndState(chain.GetHead())
+	headTipSet, err := chain.GetTipSet(chain.GetHead())
 	assert.NoError(t, err)
-	assert.Equal(t, head, headTipSetAndState.TipSet)
+	assert.Equal(t, head, *headTipSet)
 }
 
 func requirePutBlocks(t *testing.T, f *th.TestFetcher, blocks ...*types.Block) types.SortedCidSet {
@@ -1067,10 +1067,16 @@ func TestTipSetWeightDeep(t *testing.T) {
 	assert.Equal(t, expectedWeight, measuredWeight)
 }
 
-func requireGetTsas(ctx context.Context, t *testing.T, chain chain.Store, key types.SortedCidSet) *chain.TipSetAndState {
-	tsas, err := chain.GetTipSetAndState(key)
+func requireGetTsas(ctx context.Context, t *testing.T, chainStore chain.Store, key types.SortedCidSet) *chain.TipSetAndState {
+	ts, err := chainStore.GetTipSet(key)
 	require.NoError(t, err)
-	return tsas
+	tssr, err := chainStore.GetTipSetStateRoot(key)
+	require.NoError(t, err)
+	  return &chain.TipSetAndState{
+		TipSet:		*ts,
+		TipSetStateRoot:	tssr,
+	}
+	
 }
 
 func initGenesis(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -1072,11 +1072,11 @@ func requireGetTsas(ctx context.Context, t *testing.T, chainStore chain.Store, k
 	require.NoError(t, err)
 	tssr, err := chainStore.GetTipSetStateRoot(key)
 	require.NoError(t, err)
-	  return &chain.TipSetAndState{
-		TipSet:		*ts,
-		TipSetStateRoot:	tssr,
+	return &chain.TipSetAndState{
+		TipSet:          *ts,
+		TipSetStateRoot: tssr,
 	}
-	
+
 }
 
 func initGenesis(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -1074,9 +1074,9 @@ func requireGetTipSet(ctx context.Context, t *testing.T, chainStore chain.Store,
 }
 
 func requireGetTipSetStateRoot(ctx context.Context, t *testing.T, chainStore chain.Store, key types.SortedCidSet) cid.Cid {
-	tssr, err := chainStore.GetTipSetStateRoot(key)
+	stateCid, err := chainStore.GetTipSetStateRoot(key)
 	require.NoError(t, err)
-	return tssr
+	return stateCid
 }
 
 func initGenesis(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {

--- a/chain/get_ancestors.go
+++ b/chain/get_ancestors.go
@@ -77,11 +77,11 @@ func GetRecentAncestors(ctx context.Context, base types.TipSet, chainReader Read
 	}
 
 	// Step 2 -- gather the lookback tipsets directly preceding provingPeriodAncestors.
-	ts, err := chainReader.GetTipSet(firstExtraRandomnessAncestorsCids)
+	lookBackTS, err := chainReader.GetTipSet(firstExtraRandomnessAncestorsCids)
 	if err != nil {
 		return nil, err
 	}
-	iterator = IterAncestors(ctx, chainReader, *ts)
+	iterator = IterAncestors(ctx, chainReader, *lookBackTS)
 	extraRandomnessAncestors, err := CollectAtMostNTipSets(ctx, iterator, lookback)
 	if err != nil {
 		return nil, err

--- a/chain/get_ancestors.go
+++ b/chain/get_ancestors.go
@@ -16,12 +16,12 @@ import (
 // height `descendantBlockHeight` in the heaviest chain.
 func GetRecentAncestorsOfHeaviestChain(ctx context.Context, chainReader ReadStore, descendantBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
 	head := chainReader.GetHead()
-	headTipSetAndState, err := chainReader.GetTipSetAndState(head)
+	headTipSet, err := chainReader.GetTipSet(head)
 	if err != nil {
 		return nil, err
 	}
 	ancestorHeight := types.NewBlockHeight(consensus.AncestorRoundsNeeded)
-	return GetRecentAncestors(ctx, headTipSetAndState.TipSet, chainReader, descendantBlockHeight, ancestorHeight, sampling.LookbackParameter)
+	return GetRecentAncestors(ctx, *headTipSet, chainReader, descendantBlockHeight, ancestorHeight, sampling.LookbackParameter)
 }
 
 // GetRecentAncestors returns the ancestors of base as a slice of TipSets.
@@ -77,11 +77,11 @@ func GetRecentAncestors(ctx context.Context, base types.TipSet, chainReader Read
 	}
 
 	// Step 2 -- gather the lookback tipsets directly preceding provingPeriodAncestors.
-	tsas, err := chainReader.GetTipSetAndState(firstExtraRandomnessAncestorsCids)
+	ts, err := chainReader.GetTipSet(firstExtraRandomnessAncestorsCids)
 	if err != nil {
 		return nil, err
 	}
-	iterator = IterAncestors(ctx, chainReader, tsas.TipSet)
+	iterator = IterAncestors(ctx, chainReader, *ts)
 	extraRandomnessAncestors, err := CollectAtMostNTipSets(ctx, iterator, lookback)
 	if err != nil {
 		return nil, err

--- a/chain/store.go
+++ b/chain/store.go
@@ -32,7 +32,7 @@ type ReadStore interface {
 	// provided tipset key if in the store and an error if it does not
 	// exist.
 	GetTipSet(tsKey types.SortedCidSet) (*types.TipSet, error)
-	
+
 	// GetTipSet retrieves the state at the
 	// provided tipset key if in the store and an error if it does not
 	// exist.

--- a/chain/store.go
+++ b/chain/store.go
@@ -32,6 +32,7 @@ type ReadStore interface {
 	// provided tipset key if in the store and an error if it does not
 	// exist.
 	GetTipSet(tsKey types.SortedCidSet) (*types.TipSet, error)
+	
 	// GetTipSet retrieves the state at the
 	// provided tipset key if in the store and an error if it does not
 	// exist.

--- a/chain/store.go
+++ b/chain/store.go
@@ -48,6 +48,9 @@ type ReadStore interface {
 	ActorFromLatestState(ctx context.Context, address address.Address) (*actor.Actor, error)
 
 	GenesisCid() cid.Cid
+
+	//returns the chain height of the head tipset
+	BlockHeight() (uint64, error)
 }
 
 // Store wraps the on-disk storage of a valid blockchain.  Callers can get and

--- a/chain/store.go
+++ b/chain/store.go
@@ -28,10 +28,15 @@ type ReadStore interface {
 	// Stop stops all activities and cleans up.
 	Stop()
 
-	// GetTipSet retrieves the tipindex value (tipset, state) at the
+	// GetTipSet retrieves the tipset at the
 	// provided tipset key if in the store and an error if it does not
 	// exist.
-	GetTipSetAndState(tsKey types.SortedCidSet) (*TipSetAndState, error)
+	GetTipSet(tsKey types.SortedCidSet) (*types.TipSet, error)
+	// GetTipSet retrieves the state at the
+	// provided tipset key if in the store and an error if it does not
+	// exist.
+	GetTipSetStateRoot(tsKey types.SortedCidSet) (cid.Cid, error)
+
 	// GetBlock gets a block by cid.
 	GetBlock(ctx context.Context, id cid.Cid) (*types.Block, error)
 

--- a/chain/tip_index.go
+++ b/chain/tip_index.go
@@ -86,6 +86,20 @@ func (ti *TipIndex) Get(tsKey string) (*TipSetAndState, error) {
 	return tsas, nil
 }
 
+func (ti *TipIndex) GetTipSet(tsKey string) (*types.TipSet,error){
+	tsas,err:=ti.Get(tsKey)
+	if err!=nil{
+		return nil,err
+	}
+	return &(tsas.TipSet),nil
+}
+func (ti *TipIndex) GetTipSetStateRoot(tsKey string) (cid.Cid,error){
+	tsas,err:=ti.Get(tsKey)
+	if err!=nil{
+		return cid.Cid{},err
+	}
+	return tsas.TipSetStateRoot,nil
+}
 // Has returns true iff the tipset with the input ID is stored in
 // the TipIndex.
 func (ti *TipIndex) Has(tsKey string) bool {

--- a/chain/tip_index.go
+++ b/chain/tip_index.go
@@ -86,20 +86,21 @@ func (ti *TipIndex) Get(tsKey string) (*TipSetAndState, error) {
 	return tsas, nil
 }
 
-func (ti *TipIndex) GetTipSet(tsKey string) (*types.TipSet,error){
-	tsas,err:=ti.Get(tsKey)
-	if err!=nil{
-		return nil,err
+func (ti *TipIndex) GetTipSet(tsKey string) (*types.TipSet, error) {
+	tsas, err := ti.Get(tsKey)
+	if err != nil {
+		return nil, err
 	}
-	return &(tsas.TipSet),nil
+	return &(tsas.TipSet), nil
 }
-func (ti *TipIndex) GetTipSetStateRoot(tsKey string) (cid.Cid,error){
-	tsas,err:=ti.Get(tsKey)
-	if err!=nil{
-		return cid.Cid{},err
+func (ti *TipIndex) GetTipSetStateRoot(tsKey string) (cid.Cid, error) {
+	tsas, err := ti.Get(tsKey)
+	if err != nil {
+		return cid.Cid{}, err
 	}
-	return tsas.TipSetStateRoot,nil
+	return tsas.TipSetStateRoot, nil
 }
+
 // Has returns true iff the tipset with the input ID is stored in
 // the TipIndex.
 func (ti *TipIndex) Has(tsKey string) bool {

--- a/chain/tip_index.go
+++ b/chain/tip_index.go
@@ -95,7 +95,7 @@ func (ti *TipIndex) GetTipSet(tsKey string) (*types.TipSet, error) {
 	return &(tsas.TipSet), nil
 }
 
-// GetTipSetStateRoot returns the tipsetStateRoot func (ti *TipIndex) Get(tsKey string).
+// GetTipSetStateRoot returns the tipsetStateRoot from func (ti *TipIndex) Get(tsKey string).
 func (ti *TipIndex) GetTipSetStateRoot(tsKey string) (cid.Cid, error) {
 	tsas, err := ti.Get(tsKey)
 	if err != nil {

--- a/chain/tip_index.go
+++ b/chain/tip_index.go
@@ -86,6 +86,7 @@ func (ti *TipIndex) Get(tsKey string) (*TipSetAndState, error) {
 	return tsas, nil
 }
 
+// GetTipSet returns the tipset from func (ti *TipIndex) Get(tsKey string)
 func (ti *TipIndex) GetTipSet(tsKey string) (*types.TipSet, error) {
 	tsas, err := ti.Get(tsKey)
 	if err != nil {
@@ -93,6 +94,8 @@ func (ti *TipIndex) GetTipSet(tsKey string) (*types.TipSet, error) {
 	}
 	return &(tsas.TipSet), nil
 }
+
+// GetTipSetStateRoot returns the tipsetStateRoot func (ti *TipIndex) Get(tsKey string).
 func (ti *TipIndex) GetTipSetStateRoot(tsKey string) (cid.Cid, error) {
 	tsas, err := ti.Get(tsKey)
 	if err != nil {

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -52,9 +52,9 @@ func TestBlockPropsManyNodes(t *testing.T) {
 	connect(t, nodes[2], nodes[3])
 
 	head := minerNode.ChainReader.GetHead()
-	headTipSetAndState, err := minerNode.ChainReader.GetTipSetAndState(head)
+	headTipSet, err := minerNode.ChainReader.GetTipSet(head)
 	require.NoError(t, err)
-	baseTS := headTipSetAndState.TipSet
+	baseTS := *headTipSet
 	require.NotNil(t, baseTS)
 	proof := testhelpers.MakeRandomPoSTProofForTest()
 
@@ -102,9 +102,9 @@ func TestChainSync(t *testing.T) {
 	defer StopNodes(nodes)
 
 	head := nodes[0].ChainReader.GetHead()
-	headTipSetAndState, err := nodes[0].ChainReader.GetTipSetAndState(head)
+	headTipSet, err := nodes[0].ChainReader.GetTipSet(head)
 	require.NoError(t, err)
-	baseTS := headTipSetAndState.TipSet
+	baseTS := *headTipSet
 
 	signer, ki := types.NewMockSignersAndKeyInfo(1)
 	mockSignerPubKey := ki[0].PublicKey()

--- a/node/node.go
+++ b/node/node.go
@@ -1096,11 +1096,11 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (mining.Worker, error)
 
 // getStateFromKey returns the state tree based on tipset fetched with provided key tsKey
 func (node *Node) getStateFromKey(ctx context.Context, tsKey types.SortedCidSet) (state.Tree, error) {
-	tssr, err := node.ChainReader.GetTipSetStateRoot(tsKey)
+	stateCid, err := node.ChainReader.GetTipSetStateRoot(tsKey)
 	if err != nil {
 		return nil, err
 	}
-	return state.LoadStateTree(ctx, node.CborStore(), tssr, builtin.Actors)
+	return state.LoadStateTree(ctx, node.CborStore(), stateCid, builtin.Actors)
 }
 
 // getStateTree is the default GetStateTree function for the mining worker.

--- a/node/node.go
+++ b/node/node.go
@@ -1096,11 +1096,11 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (mining.Worker, error)
 
 // getStateFromKey returns the state tree based on tipset fetched with provided key tsKey
 func (node *Node) getStateFromKey(ctx context.Context, tsKey types.SortedCidSet) (state.Tree, error) {
-	tsas, err := node.ChainReader.GetTipSetAndState(tsKey)
+	tssr, err := node.ChainReader.GetTipSetStateRoot(tsKey)
 	if err != nil {
 		return nil, err
 	}
-	return state.LoadStateTree(ctx, node.CborStore(), tsas.TipSetStateRoot, builtin.Actors)
+	return state.LoadStateTree(ctx, node.CborStore(), tssr, builtin.Actors)
 }
 
 // getStateTree is the default GetStateTree function for the mining worker.

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -212,9 +212,9 @@ func TestUpdateMessagePool(t *testing.T) {
 	// Msg pool: [m0, m3],   Chain: gen -> b[] -> b[m1, m2]
 	assert.NoError(t, chainForTest.Load(ctx)) // load up head to get genesis block
 	head := chainForTest.GetHead()
-	headTipSetAndState, err := chainForTest.GetTipSetAndState(head)
+	headTipSet, err := chainForTest.GetTipSet(head)
 	require.NoError(t, err)
-	genTS := headTipSetAndState.TipSet
+	genTS := *headTipSet
 	m := types.NewSignedMsgs(4, mockSigner)
 	core.MustAdd(node.MsgPool, m[0], m[1])
 

--- a/plumbing/bcf/blockchain_facade.go
+++ b/plumbing/bcf/blockchain_facade.go
@@ -47,20 +47,20 @@ func NewBlockChainFacade(chainReader chain.ReadStore, cst *hamt.CborIpldStore) *
 
 // Head returns the head tipset
 func (chn *BlockChainFacade) Head() (*types.TipSet, error) {
-	ts, err := chn.reader.GetTipSetAndState(chn.reader.GetHead())
+	ts, err := chn.reader.GetTipSet(chn.reader.GetHead())
 	if err != nil {
 		return nil, err
 	}
-	return &ts.TipSet, nil
+	return ts, nil
 }
 
 // Ls returns a channel of tipsets from head to genesis
 func (chn *BlockChainFacade) Ls(ctx context.Context) (*chain.TipsetIterator, error) {
-	tsas, err := chn.reader.GetTipSetAndState(chn.reader.GetHead())
+	ts, err := chn.reader.GetTipSet(chn.reader.GetHead())
 	if err != nil {
 		return nil, err
 	}
-	return chain.IterAncestors(ctx, chn.reader, tsas.TipSet), nil
+	return chain.IterAncestors(ctx, chn.reader, *ts), nil
 }
 
 // GetBlock gets a block by CID
@@ -132,10 +132,10 @@ func (chn *BlockChainFacade) GetActorSignature(ctx context.Context, actorAddr ad
 // getExecutable returns the builtin actor code from the latest state on the chain
 func (chn *BlockChainFacade) getLatestState(ctx context.Context) (state.Tree, error) {
 	head := chn.reader.GetHead()
-	tsas, err := chn.reader.GetTipSetAndState(head)
+	tssr, err := chn.reader.GetTipSetStateRoot(head)
 	if err != nil {
 		return nil, err
 	}
 
-	return state.LoadStateTree(ctx, chn.cst, tsas.TipSetStateRoot, builtin.Actors)
+	return state.LoadStateTree(ctx, chn.cst, tssr, builtin.Actors)
 }

--- a/plumbing/bcf/blockchain_facade.go
+++ b/plumbing/bcf/blockchain_facade.go
@@ -132,10 +132,10 @@ func (chn *BlockChainFacade) GetActorSignature(ctx context.Context, actorAddr ad
 // getExecutable returns the builtin actor code from the latest state on the chain
 func (chn *BlockChainFacade) getLatestState(ctx context.Context) (state.Tree, error) {
 	head := chn.reader.GetHead()
-	tssr, err := chn.reader.GetTipSetStateRoot(head)
+	stateCid, err := chn.reader.GetTipSetStateRoot(head)
 	if err != nil {
 		return nil, err
 	}
 
-	return state.LoadStateTree(ctx, chn.cst, tssr, builtin.Actors)
+	return state.LoadStateTree(ctx, chn.cst, stateCid, builtin.Actors)
 }

--- a/plumbing/msg/previewer.go
+++ b/plumbing/msg/previewer.go
@@ -42,11 +42,11 @@ func (p *Previewer) Preview(ctx context.Context, optFrom, to address.Address, me
 	}
 
 	headTs := p.chainReader.GetHead()
-	tssr, err := p.chainReader.GetTipSetStateRoot(headTs)
+	stateCid, err := p.chainReader.GetTipSetStateRoot(headTs)
 	if err != nil {
 		return types.NewGasUnits(0), errors.Wrap(err, "couldnt get latest state root")
 	}
-	st, err := state.LoadStateTree(ctx, p.cst, tssr, builtin.Actors)
+	st, err := state.LoadStateTree(ctx, p.cst, stateCid, builtin.Actors)
 	if err != nil {
 		return types.NewGasUnits(0), errors.Wrap(err, "could load tree for latest state root")
 	}

--- a/plumbing/msg/previewer.go
+++ b/plumbing/msg/previewer.go
@@ -42,15 +42,19 @@ func (p *Previewer) Preview(ctx context.Context, optFrom, to address.Address, me
 	}
 
 	headTs := p.chainReader.GetHead()
-	tsas, err := p.chainReader.GetTipSetAndState(headTs)
+	tssr, err := p.chainReader.GetTipSetStateRoot(headTs)
 	if err != nil {
 		return types.NewGasUnits(0), errors.Wrap(err, "couldnt get latest state root")
 	}
-	st, err := state.LoadStateTree(ctx, p.cst, tsas.TipSetStateRoot, builtin.Actors)
+	st, err := state.LoadStateTree(ctx, p.cst, tssr, builtin.Actors)
 	if err != nil {
 		return types.NewGasUnits(0), errors.Wrap(err, "could load tree for latest state root")
 	}
-	h, err := tsas.TipSet.Height()
+	ts, err := p.chainReader.GetTipSet(headTs)
+	if err != nil {
+		return types.NewGasUnits(0), errors.Wrap(err, "couldnt get tipset")
+	}
+	h, err := (*ts).Height()
 	if err != nil {
 		return types.NewGasUnits(0), errors.Wrap(err, "couldnt get base tipset height")
 	}

--- a/plumbing/msg/previewer.go
+++ b/plumbing/msg/previewer.go
@@ -50,11 +50,8 @@ func (p *Previewer) Preview(ctx context.Context, optFrom, to address.Address, me
 	if err != nil {
 		return types.NewGasUnits(0), errors.Wrap(err, "could load tree for latest state root")
 	}
-	ts, err := p.chainReader.GetTipSet(headTs)
-	if err != nil {
-		return types.NewGasUnits(0), errors.Wrap(err, "couldnt get tipset")
-	}
-	h, err := (*ts).Height()
+
+	h, err := p.chainReader.BlockHeight()
 	if err != nil {
 		return types.NewGasUnits(0), errors.Wrap(err, "couldnt get base tipset height")
 	}

--- a/plumbing/msg/queryer.go
+++ b/plumbing/msg/queryer.go
@@ -45,11 +45,11 @@ func (q *Queryer) Query(ctx context.Context, optFrom, to address.Address, method
 	}
 
 	headTs := q.chainReader.GetHead()
-	tssr, err := q.chainReader.GetTipSetStateRoot(headTs)
+	stateCid, err := q.chainReader.GetTipSetStateRoot(headTs)
 	if err != nil {
 		return nil, errors.Wrap(err, "couldnt get latest state root")
 	}
-	st, err := state.LoadStateTree(ctx, q.cst, tssr, builtin.Actors)
+	st, err := state.LoadStateTree(ctx, q.cst, stateCid, builtin.Actors)
 	if err != nil {
 		return nil, errors.Wrap(err, "could load tree for latest state root")
 	}

--- a/plumbing/msg/queryer.go
+++ b/plumbing/msg/queryer.go
@@ -45,15 +45,19 @@ func (q *Queryer) Query(ctx context.Context, optFrom, to address.Address, method
 	}
 
 	headTs := q.chainReader.GetHead()
-	tsas, err := q.chainReader.GetTipSetAndState(headTs)
+	tssr, err := q.chainReader.GetTipSetStateRoot(headTs)
 	if err != nil {
 		return nil, errors.Wrap(err, "couldnt get latest state root")
 	}
-	st, err := state.LoadStateTree(ctx, q.cst, tsas.TipSetStateRoot, builtin.Actors)
+	st, err := state.LoadStateTree(ctx, q.cst, tssr, builtin.Actors)
 	if err != nil {
 		return nil, errors.Wrap(err, "could load tree for latest state root")
 	}
-	h, err := tsas.TipSet.Height()
+	ts, err := q.chainReader.GetTipSet(headTs)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldnt get tipset")
+	}
+	h, err := (*ts).Height()
 	if err != nil {
 		return nil, errors.Wrap(err, "couldnt get base tipset height")
 	}

--- a/plumbing/msg/queryer.go
+++ b/plumbing/msg/queryer.go
@@ -53,11 +53,8 @@ func (q *Queryer) Query(ctx context.Context, optFrom, to address.Address, method
 	if err != nil {
 		return nil, errors.Wrap(err, "could load tree for latest state root")
 	}
-	ts, err := q.chainReader.GetTipSet(headTs)
-	if err != nil {
-		return nil, errors.Wrap(err, "couldnt get tipset")
-	}
-	h, err := (*ts).Height()
+
+	h, err := q.chainReader.BlockHeight()
 	if err != nil {
 		return nil, errors.Wrap(err, "couldnt get base tipset height")
 	}

--- a/plumbing/msg/sender.go
+++ b/plumbing/msg/sender.go
@@ -28,7 +28,9 @@ const Topic = "/fil/msgs"
 // Abstracts over a store of blockchain state.
 type chainState interface {
 	GetHead() types.SortedCidSet
-	GetTipSetAndState(tsKey types.SortedCidSet) (*chain.TipSetAndState, error)
+	GetTipSet(tsKey types.SortedCidSet) (*types.TipSet, error)
+	GetTipSetStateRoot(tsKey types.SortedCidSet) (cid.Cid, error)
+
 }
 
 // BlockClock defines a interface to a struct that can give the current block height.
@@ -96,11 +98,11 @@ func (s *Sender) Send(ctx context.Context, from, to address.Address, value *type
 	defer s.l.Unlock()
 
 	headTs := s.chainState.GetHead()
-	tsas, err := s.chainState.GetTipSetAndState(headTs)
+	tssr, err := s.chainState.GetTipSetStateRoot(headTs)
 	if err != nil {
 		return cid.Undef, errors.Wrap(err, "couldnt get latest state root")
 	}
-	st, err := state.LoadStateTree(ctx, s.cst, tsas.TipSetStateRoot, builtin.Actors)
+	st, err := state.LoadStateTree(ctx, s.cst, tssr, builtin.Actors)
 	if err != nil {
 		return cid.Undef, errors.Wrap(err, "failed to load state from chain")
 	}

--- a/plumbing/msg/sender.go
+++ b/plumbing/msg/sender.go
@@ -28,7 +28,6 @@ const Topic = "/fil/msgs"
 // Abstracts over a store of blockchain state.
 type chainState interface {
 	GetHead() types.SortedCidSet
-	GetTipSet(tsKey types.SortedCidSet) (*types.TipSet, error)
 	GetTipSetStateRoot(tsKey types.SortedCidSet) (cid.Cid, error)
 }
 
@@ -97,11 +96,11 @@ func (s *Sender) Send(ctx context.Context, from, to address.Address, value *type
 	defer s.l.Unlock()
 
 	headTs := s.chainState.GetHead()
-	tssr, err := s.chainState.GetTipSetStateRoot(headTs)
+	stateCid, err := s.chainState.GetTipSetStateRoot(headTs)
 	if err != nil {
 		return cid.Undef, errors.Wrap(err, "couldnt get latest state root")
 	}
-	st, err := state.LoadStateTree(ctx, s.cst, tssr, builtin.Actors)
+	st, err := state.LoadStateTree(ctx, s.cst, stateCid, builtin.Actors)
 	if err != nil {
 		return cid.Undef, errors.Wrap(err, "failed to load state from chain")
 	}

--- a/plumbing/msg/sender.go
+++ b/plumbing/msg/sender.go
@@ -30,7 +30,6 @@ type chainState interface {
 	GetHead() types.SortedCidSet
 	GetTipSet(tsKey types.SortedCidSet) (*types.TipSet, error)
 	GetTipSetStateRoot(tsKey types.SortedCidSet) (cid.Cid, error)
-
 }
 
 // BlockClock defines a interface to a struct that can give the current block height.

--- a/plumbing/msg/waiter.go
+++ b/plumbing/msg/waiter.go
@@ -202,6 +202,9 @@ func (w *Waiter) receiptFromTipSet(ctx context.Context, msgCid cid.Cid, ts types
 	tsBlockHeight := types.NewBlockHeight(tsHeight)
 	ancestorHeight := types.NewBlockHeight(consensus.AncestorRoundsNeeded)
 	parentTs, err := w.chainReader.GetTipSet(ids)
+	if err != nil {
+		return nil, err
+	}
 	ancestors, err := chain.GetRecentAncestors(ctx, *parentTs, w.chainReader, tsBlockHeight, ancestorHeight, sampling.LookbackParameter)
 	if err != nil {
 		return nil, err

--- a/plumbing/msg/waiter.go
+++ b/plumbing/msg/waiter.go
@@ -46,11 +46,11 @@ func NewWaiter(chainStore chain.ReadStore, bs bstore.Blockstore, cst *hamt.CborI
 
 // Find searches the blockchain history for a message (but doesn't wait).
 func (w *Waiter) Find(ctx context.Context, msgCid cid.Cid) (*ChainMessage, bool, error) {
-	headTipSetAndState, err := w.chainReader.GetTipSetAndState(w.chainReader.GetHead())
+	headTipSet, err := w.chainReader.GetTipSet(w.chainReader.GetHead())
 	if err != nil {
 		return nil, false, err
 	}
-	return w.findMessage(ctx, &headTipSetAndState.TipSet, msgCid)
+	return w.findMessage(ctx, headTipSet, msgCid)
 }
 
 // Wait invokes the callback when a message with the given cid appears on chain.
@@ -186,11 +186,11 @@ func (w *Waiter) receiptFromTipSet(ctx context.Context, msgCid cid.Cid, ts types
 	if err != nil {
 		return nil, err
 	}
-	tsas, err := w.chainReader.GetTipSetAndState(ids)
+	tssr, err := w.chainReader.GetTipSetStateRoot(ids)
 	if err != nil {
 		return nil, err
 	}
-	st, err := state.LoadStateTree(ctx, w.cst, tsas.TipSetStateRoot, builtin.Actors)
+	st, err := state.LoadStateTree(ctx, w.cst, tssr, builtin.Actors)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,8 @@ func (w *Waiter) receiptFromTipSet(ctx context.Context, msgCid cid.Cid, ts types
 	}
 	tsBlockHeight := types.NewBlockHeight(tsHeight)
 	ancestorHeight := types.NewBlockHeight(consensus.AncestorRoundsNeeded)
-	ancestors, err := chain.GetRecentAncestors(ctx, tsas.TipSet, w.chainReader, tsBlockHeight, ancestorHeight, sampling.LookbackParameter)
+	parentTs, err := w.chainReader.GetTipSet(ids)
+	ancestors, err := chain.GetRecentAncestors(ctx, *parentTs, w.chainReader, tsBlockHeight, ancestorHeight, sampling.LookbackParameter)
 	if err != nil {
 		return nil, err
 	}

--- a/plumbing/msg/waiter.go
+++ b/plumbing/msg/waiter.go
@@ -186,11 +186,11 @@ func (w *Waiter) receiptFromTipSet(ctx context.Context, msgCid cid.Cid, ts types
 	if err != nil {
 		return nil, err
 	}
-	tssr, err := w.chainReader.GetTipSetStateRoot(ids)
+	stateCid, err := w.chainReader.GetTipSetStateRoot(ids)
 	if err != nil {
 		return nil, err
 	}
-	st, err := state.LoadStateTree(ctx, w.cst, tssr, builtin.Actors)
+	st, err := state.LoadStateTree(ctx, w.cst, stateCid, builtin.Actors)
 	if err != nil {
 		return nil, err
 	}

--- a/plumbing/msg/waiter_test.go
+++ b/plumbing/msg/waiter_test.go
@@ -67,9 +67,9 @@ func TestWait(t *testing.T) {
 func testWaitExisting(ctx context.Context, t *testing.T, cst *hamt.CborIpldStore, chainStore *chain.DefaultStore, waiter *Waiter) {
 	m1, m2 := newSignedMessage(), newSignedMessage()
 	head := chainStore.GetHead()
-	headTipSetAndState, err := chainStore.GetTipSetAndState(head)
+	headTipSet, err := chainStore.GetTipSet(head)
 	require.NoError(t, err)
-	chainWithMsgs := core.NewChainWithMessages(cst, headTipSetAndState.TipSet, smsgsSet{smsgs{m1, m2}})
+	chainWithMsgs := core.NewChainWithMessages(cst, *headTipSet, smsgsSet{smsgs{m1, m2}})
 	ts := chainWithMsgs[len(chainWithMsgs)-1]
 	require.Equal(t, 1, len(ts))
 	th.RequirePutTsas(ctx, t, chainStore, &chain.TipSetAndState{
@@ -88,9 +88,9 @@ func testWaitNew(ctx context.Context, t *testing.T, cst *hamt.CborIpldStore, cha
 	_, _ = newSignedMessage(), newSignedMessage() // flush out so we get distinct messages from testWaitExisting
 	m3, m4 := newSignedMessage(), newSignedMessage()
 	head := chainStore.GetHead()
-	headTipSetAndState, err := chainStore.GetTipSetAndState(head)
+	headTipSet, err := chainStore.GetTipSet(head)
 	require.NoError(t, err)
-	chainWithMsgs := core.NewChainWithMessages(cst, headTipSetAndState.TipSet, smsgsSet{smsgs{m3, m4}})
+	chainWithMsgs := core.NewChainWithMessages(cst, *headTipSet, smsgsSet{smsgs{m3, m4}})
 
 	wg.Add(2)
 	go testWaitHelp(&wg, t, waiter, m3, false, nil)
@@ -120,9 +120,9 @@ func TestWaitError(t *testing.T) {
 func testWaitError(ctx context.Context, t *testing.T, cst *hamt.CborIpldStore, chainStore *chain.DefaultStore, waiter *Waiter) {
 	m1, m2, m3, m4 := newSignedMessage(), newSignedMessage(), newSignedMessage(), newSignedMessage()
 	head := chainStore.GetHead()
-	headTipSetAndState, err := chainStore.GetTipSetAndState(head)
+	headTipSet, err := chainStore.GetTipSet(head)
 	require.NoError(t, err)
-	chain := core.NewChainWithMessages(cst, headTipSetAndState.TipSet, smsgsSet{smsgs{m1, m2}}, smsgsSet{smsgs{m3, m4}})
+	chain := core.NewChainWithMessages(cst, *headTipSet, smsgsSet{smsgs{m1, m2}}, smsgsSet{smsgs{m3, m4}})
 	// set the head without putting the ancestor block in the chainStore.
 	err = chainStore.SetHead(ctx, chain[len(chain)-1])
 	assert.Nil(t, err)
@@ -158,9 +158,9 @@ func TestWaitConflicting(t *testing.T) {
 	require.NoError(t, err)
 
 	head := chainStore.GetHead()
-	headTipSetAndState, err := chainStore.GetTipSetAndState(head)
+	headTipSet, err := chainStore.GetTipSet(head)
 	require.NoError(t, err)
-	baseTS := headTipSetAndState.TipSet
+	baseTS := *headTipSet
 	require.Equal(t, 1, len(baseTS))
 	baseBlock := baseTS.ToSlice()[0]
 

--- a/protocol/block/mining_api.go
+++ b/protocol/block/mining_api.go
@@ -40,18 +40,17 @@ func New(
 
 // MiningOnce mines a single block in the given context, and returns the new block.
 func (a *MiningAPI) MiningOnce(ctx context.Context) (*types.Block, error) {
-	tsas, err := a.chainReader.GetTipSetAndState(a.chainReader.GetHead())
+	ts, err := a.chainReader.GetTipSet(a.chainReader.GetHead())
 	if err != nil {
 		return nil, err
 	}
-	ts := tsas.TipSet
 
 	miningWorker, err := a.createWorkerFunc(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := mining.MineOnce(ctx, miningWorker, a.mineDelay, ts)
+	res, err := mining.MineOnce(ctx, miningWorker, a.mineDelay, *ts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
My first try for this issue.
I think that there are some question remain:
1. How to name abbreviate tipsetstateroot?
I see that most of tipset in code is named ts, so I name tipsetstateroot tssr, but it seems weird. So maybe something like tsStateRoot?
2.At [here](https://github.com/jscode017/go-filecoin/blob/34c19cb529fb27c26aad974f3897ee4462f77f80/chain/tip_index.go#L79) What I did in chain/tip_index.go is that the Get() function remains and write to new methods to access Get() function then access TipSet and TipSetStateRoot respectively, I'm not sure is this appropriate? 