### PR TITLE
Feat/paych cancel fails with valid conditions 2678

### DIFF
--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -40,6 +40,8 @@ const (
 	ErrTooEarly = 43
 	//ErrConditionInvalid indicates that the condition attached to a voucher did not execute successfully
 	ErrConditionInvalid = 44
+	//ErrConditionValid indicates that the condition attached to a voucher did execute successfully and therefore can't be cancelled
+	ErrConditionValid = 45
 )
 
 // CancelDelayBlockTime is the number of rounds given to the target to respond after the channel
@@ -416,14 +418,14 @@ func (pb *Actor) Cancel(vmctx exec.VMContext, chid *types.ChannelID) (uint8, err
 
 		if channel.Redeemed {
 			if channel.Condition == nil {
-				return errors.NewFaultError("Channel cannot be cancelled due to successful redeem")
+				return errors.NewCodedRevertError(ErrConditionValid, "channel cannot be cancelled due to successful redeem")
 			} else {
 				err := checkCondition(vmctx, channel, channel.Condition, []interface{}{})
-				if err != nil && !errors.IsFault(err) {
-					return err
-				}
 				if err == nil {
-					return errors.NewFaultError("Channel cannot be cancelled due to successful redeem")
+					return errors.NewCodedRevertError(ErrConditionValid, "channel cannot be cancelled due to successful redeem")
+				}
+				if !errors.ShouldRevert(err) {
+					return err
 				}
 			}
 		}

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -416,14 +416,21 @@ func (pb *Actor) Cancel(vmctx exec.VMContext, chid *types.ChannelID) (uint8, err
 			return errors.NewFaultError("Expected PaymentChannel from channels lookup")
 		}
 
+		// If the payment channel has been successfully redeemed, check if it's
+		// valid and fail to prevent abuse
 		if channel.Redeemed {
+			// If it doesn't have a condition, it's valid, so throw an error
 			if channel.Condition == nil {
 				return errors.NewCodedRevertError(ErrConditionValid, "channel cannot be cancelled due to successful redeem")
 			} else {
+				// Otherwise, check the condition on the payment channel
 				err := checkCondition(vmctx, channel)
+				// If we receive no error, the condition is valid, so we fail
 				if err == nil {
 					return errors.NewCodedRevertError(ErrConditionValid, "channel cannot be cancelled due to successful redeem")
 				}
+				// If there's a non-revert error, we have bigger problem, so raise the
+				// error
 				if !errors.ShouldRevert(err) {
 					return err
 				}

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -424,18 +424,17 @@ func (pb *Actor) Cancel(vmctx exec.VMContext, chid *types.ChannelID) (uint8, err
 			// If it doesn't have a condition, it's valid, so throw an error
 			if channel.Condition == nil {
 				return errors.NewCodedRevertError(ErrInvalidCancel, "channel cannot be cancelled due to successful redeem")
-			} else {
-				// Otherwise, check the condition on the payment channel
-				err := checkCondition(vmctx, channel)
-				// If we receive no error, the condition is valid, so we fail
-				if err == nil {
-					return errors.NewCodedRevertError(ErrInvalidCancel, "channel cannot be cancelled due to successful redeem")
-				}
-				// If there's a non-revert error, we have bigger problem, so raise the
-				// error
-				if !errors.ShouldRevert(err) {
-					return err
-				}
+			}
+			// Otherwise, check the condition on the payment channel
+			err := checkCondition(vmctx, channel)
+			// If we receive no error, the condition is valid, so we fail
+			if err == nil {
+				return errors.NewCodedRevertError(ErrInvalidCancel, "channel cannot be cancelled due to successful redeem")
+			}
+			// If there's a non-revert error, we have bigger problem, so raise the
+			// error
+			if !errors.ShouldRevert(err) {
+				return err
 			}
 		}
 

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -40,8 +40,8 @@ const (
 	ErrTooEarly = 43
 	//ErrConditionInvalid indicates that the condition attached to a voucher did not execute successfully
 	ErrConditionInvalid = 44
-	//ErrConditionValid indicates that the condition attached to a voucher did execute successfully and therefore can't be cancelled
-	ErrConditionValid = 45
+	//ErrInvalidCancel indicates that the condition attached to a voucher did execute successfully and therefore can't be cancelled
+	ErrInvalidCancel = 45
 )
 
 // CancelDelayBlockTime is the number of rounds given to the target to respond after the channel
@@ -421,13 +421,13 @@ func (pb *Actor) Cancel(vmctx exec.VMContext, chid *types.ChannelID) (uint8, err
 		if channel.Redeemed {
 			// If it doesn't have a condition, it's valid, so throw an error
 			if channel.Condition == nil {
-				return errors.NewCodedRevertError(ErrConditionValid, "channel cannot be cancelled due to successful redeem")
+				return errors.NewCodedRevertError(ErrInvalidCancel, "channel cannot be cancelled due to successful redeem")
 			} else {
 				// Otherwise, check the condition on the payment channel
 				err := checkCondition(vmctx, channel)
 				// If we receive no error, the condition is valid, so we fail
 				if err == nil {
-					return errors.NewCodedRevertError(ErrConditionValid, "channel cannot be cancelled due to successful redeem")
+					return errors.NewCodedRevertError(ErrInvalidCancel, "channel cannot be cancelled due to successful redeem")
 				}
 				// If there's a non-revert error, we have bigger problem, so raise the
 				// error

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -838,7 +838,7 @@ func TestPaymentBrokerCancelFailsAfterSuccessfulRedeem(t *testing.T) {
 	redeemerParams := []interface{}{blockHeightParam}
 
 	sys := setup(t)
-	require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+	require.NoError(t, sys.st.SetActor(context.Background(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
 
 	// Successfully redeem the payment channel with params
 	condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
@@ -863,7 +863,7 @@ func TestPaymentBrokerCancelSucceedsAfterSuccessfulRedeemButFailedConditions(t *
 	payerParams := []interface{}{toAddress, sectorIdParam}
 
 	sys := setup(t)
-	require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+	require.NoError(t, sys.st.SetActor(context.Background(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
 
 	// Redeem the payment channel with bad params and expect invalid condition error
 	condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -854,6 +854,28 @@ func TestPaymentBrokerCancelFailsAfterSuccessfulRedeem(t *testing.T) {
 	assert.Error(t, result.ExecutionError)
 }
 
+func TestPaymentBrokerCancelFailsAfterSuccessfulRedeemWithNilCondtion(t *testing.T) {
+	tf.UnitTest(t)
+
+	addrGetter := address.NewForTestGetter()
+	toAddress := addrGetter()
+
+	sys := setup(t)
+	require.NoError(t, sys.st.SetActor(context.Background(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
+	// Successfully redeem the payment channel with params
+	result, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, nil)
+	require.NoError(t, err)
+	require.NoError(t, result.ExecutionError)
+
+	// Attempts to Cancel and expects failure
+	pdata := core.MustConvertParams(sys.channelID)
+	msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, types.NewAttoFILFromFIL(1000), "cancel", pdata)
+	result, err = sys.ApplyMessage(msg, 100)
+	assert.NoError(t, err)
+	assert.Error(t, result.ExecutionError)
+}
+
 func TestPaymentBrokerCancelSucceedsAfterSuccessfulRedeemButFailedConditions(t *testing.T) {
 	tf.UnitTest(t)
 

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -870,7 +870,7 @@ func TestPaymentBrokerCancelSucceedsAfterSuccessfulRedeemButFailedConditions(t *
 	result, err := sys.applySignatureMessage(sys.target, 200, types.NewBlockHeight(0), 0, "redeem", 0, condition)
 	require.NoError(t, err)
 	require.Error(t, result.ExecutionError)
-	require.EqualValues(t, errors.CodeError(result.ExecutionError), ErrConditionInvalid)
+	require.EqualValues(t, ErrConditionInvalid, errors.CodeError(result.ExecutionError))
 
 	// Attempt to Cancel and expects success
 	pdata := core.MustConvertParams(sys.channelID)

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -849,8 +849,9 @@ func TestPaymentBrokerCancelFailsAfterSuccessfulRedeem(t *testing.T) {
 	// Attempts to Cancel and expects failure
 	pdata := core.MustConvertParams(sys.channelID)
 	msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, types.NewAttoFILFromFIL(1000), "cancel", pdata)
-	_, err = sys.ApplyMessage(msg, 100)
-	assert.Error(t, err)
+	result, err = sys.ApplyMessage(msg, 100)
+	assert.NoError(t, err)
+	assert.Error(t, result.ExecutionError)
 }
 
 func TestPaymentBrokerCancelSucceedsAfterSuccessfulRedeemButFailedConditions(t *testing.T) {

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -852,6 +852,7 @@ func TestPaymentBrokerCancelFailsAfterSuccessfulRedeem(t *testing.T) {
 	result, err = sys.ApplyMessage(msg, 100)
 	assert.NoError(t, err)
 	assert.Error(t, result.ExecutionError)
+	assert.EqualValues(t, ErrConditionValid, errors.CodeError(result.ExecutionError))
 }
 
 func TestPaymentBrokerCancelFailsAfterSuccessfulRedeemWithNilCondtion(t *testing.T) {
@@ -874,6 +875,7 @@ func TestPaymentBrokerCancelFailsAfterSuccessfulRedeemWithNilCondtion(t *testing
 	result, err = sys.ApplyMessage(msg, 100)
 	assert.NoError(t, err)
 	assert.Error(t, result.ExecutionError)
+	assert.EqualValues(t, ErrConditionValid, errors.CodeError(result.ExecutionError))
 }
 
 func TestPaymentBrokerCancelSucceedsAfterSuccessfulRedeemButFailedConditions(t *testing.T) {

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -852,7 +852,7 @@ func TestPaymentBrokerCancelFailsAfterSuccessfulRedeem(t *testing.T) {
 	result, err = sys.ApplyMessage(msg, 100)
 	assert.NoError(t, err)
 	assert.Error(t, result.ExecutionError)
-	assert.EqualValues(t, ErrConditionValid, errors.CodeError(result.ExecutionError))
+	assert.EqualValues(t, ErrInvalidCancel, errors.CodeError(result.ExecutionError))
 }
 
 func TestPaymentBrokerCancelFailsAfterSuccessfulRedeemWithNilCondtion(t *testing.T) {
@@ -875,7 +875,7 @@ func TestPaymentBrokerCancelFailsAfterSuccessfulRedeemWithNilCondtion(t *testing
 	result, err = sys.ApplyMessage(msg, 100)
 	assert.NoError(t, err)
 	assert.Error(t, result.ExecutionError)
-	assert.EqualValues(t, ErrConditionValid, errors.CodeError(result.ExecutionError))
+	assert.EqualValues(t, ErrInvalidCancel, errors.CodeError(result.ExecutionError))
 }
 
 func TestPaymentBrokerCancelSucceedsAfterSuccessfulRedeemButFailedConditions(t *testing.T) {


### PR DESCRIPTION
# Problem

The current implementation of payment channel cancel allows payers to harass payees by repeatedly cancelling channels and forcing payees to reopen them by redeeming.

# Solution

Only allow payers to cancel payment channels when the channel either hasn't been redeemed yet or the last redeem included invalid conditions.

Resolves #2678 