### PR TITLE
Mfc/first migration (rebase feat/repo-mig-version on master before looking)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,9 @@ linters:
     - structcheck
     - deadcode
 
+issues:
+  exclude-use-default: false
+
 linters-settings:
   goconst:
     min-occurrences: 6

--- a/CODEWALK.md
+++ b/CODEWALK.md
@@ -39,7 +39,7 @@ It is complemented by specs (link forthcoming) that describe the key concepts im
 - [Sector builder & proofs](#sector-builder--proofs)
   - [Building and distribution.](#building-and-distribution)
   - [Groth parameters](#groth-parameters)
-  - [Sector size configuration](#sector-size-configuration)
+  - [Proof mode configuration](#proof-mode-configuration)
 - [Networking](#networking)
 - [Filesystem storage](#filesystem-storage)
   - [JSON Config](#json-config)
@@ -50,10 +50,14 @@ It is complemented by specs (link forthcoming) that describe the key concepts im
       - [Unit Tests (`-unit`)](#unit-tests--unit)
       - [Integration Tests (`-integration`)](#integration-tests--integration)
       - [Functional Tests (`-functional`)](#functional-tests--functional)
+      - [Sector Builder Tests (`-sectorbuilder`)](#sector-builder-tests--sectorbuilder)
 - [Dependencies](#dependencies)
 - [Patterns](#patterns)
   - [Plumbing and porcelain](#plumbing-and-porcelain)
   - [Consumer-defined interfaces](#consumer-defined-interfaces)
+  - [Observability](#observability)
+    - [Metrics](#metrics)
+    - [Tracing](#tracing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -636,3 +640,20 @@ Our implementation of [plumbing and porcelain](#plumbing-and-porcelain) embraces
 
 This idiom is unfortunately hidden away in a [wiki page about code review](https://github.com/golang/go/wiki/CodeReviewComments#interfaces).
 See also Dave Cheney on [SOLID Go Design](https://dave.cheney.net/2016/08/20/solid-go-design).
+
+### Observability
+
+go-filecoin uses [Opencensus-go](https://github.com/census-instrumentation/opencensus-go) for stats collection and distributed tracing instrumentation.
+Stats are exported for consumption via [Prometheus](https://prometheus.io/) and traces are exported for consumption via [Jaeger](https://www.jaegertracing.io/docs/1.11/).
+
+#### Metrics
+
+go-filecoin can be configured to collect and export metrics to Prometheus via the `MetricsConfig`.
+The details of this can be found inside the [`config/`](https://godoc.org/github.com/filecoin-project/go-filecoin/config#ObservabilityConfig) package.
+To view metrics from your filecoin node using the default configuration options set the `prometheusEnabled` value to `true`, start the filecoin daemon, then visit `localhost:9400/metrics` in your web-browser. 
+
+#### Tracing
+
+go-filecoin can be configured to collect and export traces to Jaeger via the `TraceConfig`.
+The details of this can be found inside the [`config/`](https://godoc.org/github.com/filecoin-project/go-filecoin/config#ObservabilityConfig) package.
+To collect traces from your filecoin node using the default configuration options set the `jaegerTracingEnabled` value to `true`, start the filecoin daemon, then follow the [Jaeger Getting](https://www.jaegertracing.io/docs/1.11/getting-started/#all-in-one) started guide.

--- a/Dockerfile.ci.faucet
+++ b/Dockerfile.ci.faucet
@@ -2,7 +2,7 @@ FROM busybox:1-glibc
 MAINTAINER Filecoin Dev Team
 
 # Get the binary, entrypoint script, and TLS CAs from the build container.
-COPY tools/faucet /usr/local/bin/faucet
+COPY tools/faucet/faucet /usr/local/bin/faucet
 COPY --from=filecoin:all /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=filecoin:all /tmp/tini /sbin/tini
 COPY --from=filecoin:all /etc/ssl/certs /etc/ssl/certs

--- a/Dockerfile.ci.genesis
+++ b/Dockerfile.ci.genesis
@@ -2,7 +2,7 @@ FROM busybox:1-glibc
 MAINTAINER Filecoin Dev Team
 
 # Get the binary, entrypoint script, and TLS CAs from the build container.
-COPY tools/genesis-file-server /usr/local/bin/genesis-file-server
+COPY tools/genesis-file-server/genesis-file-server /usr/local/bin/genesis-file-server
 COPY fixtures/* /data/
 COPY --from=filecoin:all /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=filecoin:all /tmp/tini /sbin/tini

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The build process for go-filecoin requires:
 
 - [Go](https://golang.org/doc/install) >= v1.12.1
   - Installing Go for the first time? We recommend [this tutorial](https://www.ardanlabs.com/blog/2016/05/installing-go-and-your-workspace.html) which includes environment setup.
-- [Rust](https://www.rust-lang.org/) >= v1.31.0 and `cargo`
+- [Rust](https://www.rust-lang.org/) >= v1.36.0 and `cargo`
 - `pkg-config` - used by go-filecoin to handle generating linker flags
   - Mac OS devs can install through brew `brew install pkg-config`
 

--- a/abi/encode.go
+++ b/abi/encode.go
@@ -31,6 +31,10 @@ func EncodeValues(vals []*Value) ([]byte, error) {
 // DecodeValues decodes an array of abi values from the given buffer, using the
 // provided type information.
 func DecodeValues(data []byte, types []Type) ([]*Value, error) {
+	if len(types) > 0 && len(data) == 0 {
+		return nil, fmt.Errorf("expected %d parameters, but got 0", len(types))
+	}
+
 	if len(data) == 0 {
 		return nil, nil
 	}

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -117,13 +117,6 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 	blockHeightParam := types.NewBlockHeight(43)
 	redeemerParams := []interface{}{blockHeightParam}
 
-	sys := setup(t)
-	require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
-
-	callRedeem := func(condition *types.Predicate, params []interface{}) (*consensus.ApplicationResult, error) {
-		return sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, params...)
-	}
-
 	// All the following tests attempt to call PBTestActor.ParamsNotZero with a condition.
 	// PBTestActor.ParamsNotZero takes 3 parameter: an Address, a uint64 sector id, and a BlockHeight
 	// If any of these are zero values the method throws an error indicating the condition is false.
@@ -131,67 +124,268 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 	// height will be added as a redeemer supplied parameter to redeem.
 
 	t.Run("Redeem should succeed if condition is met", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
-		appResult, err := callRedeem(condition, redeemerParams)
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
 
 		require.NoError(t, err)
 		require.NoError(t, appResult.ExecutionError)
 	})
 
 	t.Run("Redeem should fail if condition is _NOT_ met", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		badAddressParam := address.Undef
 		badParams := []interface{}{badAddressParam, sectorIdParam}
 
 		condition := &types.Predicate{To: toAddress, Method: method, Params: badParams}
-		appResult, err := callRedeem(condition, redeemerParams)
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
-		require.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: got undefined address")
+		assert.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: got undefined address")
+		assert.EqualValues(t, errors.CodeError(appResult.ExecutionError), ErrConditionInvalid)
 	})
 
 	t.Run("Redeem should fail if condition goes to non-existent actor", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		badToAddress := addrGetter()
 
 		condition := &types.Predicate{To: badToAddress, Method: method, Params: payerParams}
-		appResult, err := callRedeem(condition, redeemerParams)
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
-		require.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: actor code not found")
+		assert.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: actor code not found")
+		assert.EqualValues(t, errors.CodeError(appResult.ExecutionError), ErrConditionInvalid)
 	})
 
 	t.Run("Redeem should fail if condition goes to non-existent method", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		badMethod := "nonexistentMethod"
 
 		condition := &types.Predicate{To: toAddress, Method: badMethod, Params: payerParams}
-		appResult, err := callRedeem(condition, redeemerParams)
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
-		require.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: actor does not export method")
+		assert.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: actor does not export method")
+		assert.EqualValues(t, errors.CodeError(appResult.ExecutionError), ErrConditionInvalid)
 	})
 
 	t.Run("Redeem should fail if condition has the wrong number of condition parameters", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		badParams := []interface{}{}
 
 		condition := &types.Predicate{To: toAddress, Method: method, Params: badParams}
-		appResult, err := callRedeem(condition, redeemerParams)
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
-		require.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: invalid params")
+		assert.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: invalid params")
+		assert.EqualValues(t, errors.CodeError(appResult.ExecutionError), ErrConditionInvalid)
 	})
 
 	t.Run("Redeem should fail if condition has the wrong number of supplied parameters", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		badRedeemerParams := []interface{}{}
 
 		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
-		appResult, err := callRedeem(condition, badRedeemerParams)
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, badRedeemerParams...)
 
 		require.NoError(t, err)
 		require.Error(t, appResult.ExecutionError)
-		require.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: invalid params")
+		assert.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: invalid params")
+		assert.EqualValues(t, errors.CodeError(appResult.ExecutionError), ErrConditionInvalid)
+	})
+}
+
+func TestPaymentBrokerRedeemSetsConditionAndRedeemed(t *testing.T) {
+	tf.UnitTest(t)
+
+	addrGetter := address.NewForTestGetter()
+	toAddress := addrGetter()
+	method := "paramsNotZero"
+	addrParam := addrGetter()
+	sectorIdParam := uint64(6)
+	payerParams := []interface{}{addrParam, sectorIdParam}
+	blockHeightParam := types.NewBlockHeight(43)
+	redeemerParams := []interface{}{blockHeightParam}
+
+	t.Run("Redeem should set the redeemed flag to true on success", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
+		// Expect that the redeemed flag is false on init
+		paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+		channel := sys.retrieveChannel(paymentBroker)
+		assert.Equal(t, false, channel.Redeemed)
+
+		// Successfully redeem the payment channel
+		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
+		require.NoError(t, err)
+		require.NoError(t, appResult.ExecutionError)
+
+		// Expect that the redeemed flag is now true
+		paymentBroker = state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+		channel = sys.retrieveChannel(paymentBroker)
+		assert.Equal(t, true, channel.Redeemed)
+	})
+
+	t.Run("Redeem should set cached condition on success", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
+		// Expect that the condition is nil on init
+		paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+		channel := sys.retrieveChannel(paymentBroker)
+		assert.Nil(t, channel.Condition)
+
+		// Successfully redeem the payment channel
+		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
+		require.NoError(t, err)
+		require.NoError(t, appResult.ExecutionError)
+
+		// Expect that the condition is now set and correct
+		paymentBroker = state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+		channel = sys.retrieveChannel(paymentBroker)
+		assert.NotNil(t, channel.Condition)
+		assert.Equal(t, toAddress, channel.Condition.To)
+		assert.Equal(t, method, channel.Condition.Method)
+		assert.Contains(t, channel.Condition.Params, addrParam.Bytes())
+		assert.Contains(t, channel.Condition.Params, sectorIdParam)
+		assert.Contains(t, channel.Condition.Params, blockHeightParam.Bytes())
+	})
+
+	t.Run("Redeem should set cached condition back to nil when no condition is provided", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
+		// Successfully redeem the payment channel with condition
+		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
+		require.NoError(t, err)
+		require.NoError(t, appResult.ExecutionError)
+
+		// Expect that the condition is set and correct
+		paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+		channel := sys.retrieveChannel(paymentBroker)
+		assert.NotNil(t, channel.Condition)
+		assert.Equal(t, toAddress, channel.Condition.To)
+		assert.Equal(t, method, channel.Condition.Method)
+
+		// Successfully redeem the payment channel again without condition
+		appResult, err = sys.applySignatureMessage(sys.target, 200, types.NewBlockHeight(0), 0, "redeem", 0, nil, redeemerParams...)
+		require.NoError(t, err)
+		require.NoError(t, appResult.ExecutionError)
+
+		// Expect that the condition is now nil
+		paymentBroker = state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+		channel = sys.retrieveChannel(paymentBroker)
+		assert.Nil(t, channel.Condition)
+	})
+
+	t.Run("Redeem should update the cached condition with new params when initial redeem condition is nil", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
+
+		// Successfully redeem the payment channel with no condition
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, nil, redeemerParams...)
+		require.NoError(t, err)
+		require.NoError(t, appResult.ExecutionError)
+
+		// Expect that the condition is nil
+		paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+		channel := sys.retrieveChannel(paymentBroker)
+		assert.Nil(t, channel.Condition)
+
+		// Successfully redeem the payment channel again with a condition
+		appResult, err = sys.applySignatureMessage(sys.target, 200, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
+		require.NoError(t, err)
+		require.NoError(t, appResult.ExecutionError)
+
+		// Expect that the condition is updated with the new redeemer params
+		paymentBroker = state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+		channel = sys.retrieveChannel(paymentBroker)
+		assert.NotNil(t, channel.Condition)
+		assert.Equal(t, toAddress, channel.Condition.To)
+		assert.Equal(t, method, channel.Condition.Method)
+		assert.Contains(t, channel.Condition.Params, addrParam.Bytes())
+		assert.Contains(t, channel.Condition.Params, sectorIdParam)
+		assert.Contains(t, channel.Condition.Params, blockHeightParam.Bytes())
+	})
+
+	t.Run("Redeem should update the cached condition with new params when provided", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
+
+		// Successfully redeem the payment channel with condition
+		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
+		require.NoError(t, err)
+		require.NoError(t, appResult.ExecutionError)
+
+		// Expect that the condition is set and correct
+		paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+		channel := sys.retrieveChannel(paymentBroker)
+		assert.NotNil(t, channel.Condition)
+		assert.Equal(t, toAddress, channel.Condition.To)
+		assert.Equal(t, method, channel.Condition.Method)
+
+		// Successfully redeem the payment channel again with new redeemer params
+		newBlockHeightParam := types.NewBlockHeight(52)
+		newRedeemerParams := []interface{}{newBlockHeightParam}
+		appResult, err = sys.applySignatureMessage(sys.target, 200, types.NewBlockHeight(0), 0, "redeem", 0, condition, newRedeemerParams...)
+		require.NoError(t, err)
+		require.NoError(t, appResult.ExecutionError)
+
+		// Expect that the condition is updated with the new redeemer params
+		paymentBroker = state.MustGetActor(sys.st, address.PaymentBrokerAddress)
+		channel = sys.retrieveChannel(paymentBroker)
+		assert.NotNil(t, channel.Condition)
+		assert.Equal(t, toAddress, channel.Condition.To)
+		assert.Equal(t, method, channel.Condition.Method)
+		assert.Contains(t, channel.Condition.Params, addrParam.Bytes())
+		assert.Contains(t, channel.Condition.Params, sectorIdParam)
+		assert.Contains(t, channel.Condition.Params, newBlockHeightParam.Bytes())
+	})
+
+	t.Run("Redeem uses cached condition in subsequent calls", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
+		// Redeem without params expects an invalid condition error
+		condition := &types.Predicate{To: toAddress, Method: method}
+		appResult, err := sys.applySignatureMessage(sys.target, 200, types.NewBlockHeight(0), 0, "redeem", 0, condition)
+		require.NoError(t, err)
+		require.Error(t, appResult.ExecutionError)
+		require.EqualValues(t, errors.CodeError(appResult.ExecutionError), ErrConditionInvalid)
+
+		// Successfully redeem the payment channel with params
+		condition = &types.Predicate{To: toAddress, Method: method, Params: payerParams}
+		appResult, err = sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
+		require.NoError(t, err)
+		require.NoError(t, appResult.ExecutionError)
+
+		// Redeem again without params and expect no error
+		condition = &types.Predicate{To: toAddress, Method: method}
+		appResult, err = sys.applySignatureMessage(sys.target, 200, types.NewBlockHeight(0), 0, "redeem", 0, condition)
+		assert.NoError(t, err)
+		assert.NoError(t, appResult.ExecutionError)
 	})
 }
 
@@ -425,10 +619,10 @@ func TestPaymentBrokerCloseWithCondition(t *testing.T) {
 	addrGetter := address.NewForTestGetter()
 	toAddress := addrGetter()
 
-	sys := setup(t)
-	require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
-
 	t.Run("Close should succeed if condition is met", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		condition := &types.Predicate{To: toAddress, Method: "paramsNotZero", Params: []interface{}{addrGetter(), uint64(6)}}
 
 		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "close", 0, condition, types.NewBlockHeight(43))
@@ -437,6 +631,9 @@ func TestPaymentBrokerCloseWithCondition(t *testing.T) {
 	})
 
 	t.Run("Close should fail if condition is _NOT_ met", func(t *testing.T) {
+		sys := setup(t)
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
 		condition := &types.Predicate{To: toAddress, Method: "paramsNotZero", Params: []interface{}{address.Undef, uint64(6)}}
 
 		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "close", 0, condition, types.NewBlockHeight(43))
@@ -444,6 +641,40 @@ func TestPaymentBrokerCloseWithCondition(t *testing.T) {
 		require.Error(t, appResult.ExecutionError)
 		require.Contains(t, appResult.ExecutionError.Error(), "failed to validate voucher condition: got undefined address")
 	})
+}
+
+func TestPaymentBrokerCloseChecksCachedConditions(t *testing.T) {
+	tf.UnitTest(t)
+
+	addrGetter := address.NewForTestGetter()
+	toAddress := addrGetter()
+	method := "paramsNotZero"
+	addrParam := addrGetter()
+	sectorIdParam := uint64(6)
+	payerParams := []interface{}{addrParam, sectorIdParam}
+	blockHeightParam := types.NewBlockHeight(43)
+	redeemerParams := []interface{}{blockHeightParam}
+
+	sys := setup(t)
+	require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+
+	// Close without params and expect a panic
+	condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
+	result, err := sys.applySignatureMessage(sys.target, 100, sys.defaultValidAt, 0, "close", 0, condition)
+	require.NoError(t, err)
+	require.Error(t, result.ExecutionError)
+	require.EqualValues(t, errors.CodeError(result.ExecutionError), ErrConditionInvalid)
+
+	// Successfully redeem the payment channel with params
+	condition = &types.Predicate{To: toAddress, Method: method, Params: payerParams}
+	result, err = sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
+	require.NoError(t, err)
+	require.NoError(t, result.ExecutionError)
+
+	// Close again without params and expect no error
+	result, err = sys.applySignatureMessage(sys.target, 200, sys.defaultValidAt, 0, "close", 0, condition)
+	require.NoError(t, err)
+	require.NoError(t, result.ExecutionError)
 }
 
 func TestPaymentBrokerRedeemInvalidSig(t *testing.T) {

--- a/build/main.go
+++ b/build/main.go
@@ -21,7 +21,10 @@ func init() {
 		lineBreak = "\r\n"
 	}
 	// We build with go modules.
-	os.Setenv("GO111MODULE", "on")
+	if err := os.Setenv("GO111MODULE", "on"); err != nil {
+		fmt.Println("Failed to set GO111MODULE env")
+		os.Exit(1)
+	}
 }
 
 // command is a structure representing a shell command to be run in the

--- a/chain/default_store.go
+++ b/chain/default_store.go
@@ -13,10 +13,12 @@ import (
 	bstore "github.com/ipfs/go-ipfs-blockstore"
 	logging "github.com/ipfs/go-log"
 	"github.com/pkg/errors"
+	"go.opencensus.io/trace"
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/metrics/tracing"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
@@ -94,7 +96,10 @@ func NewDefaultStore(ds repo.Datastore, stateStore *hamt.CborIpldStore, genesisC
 // head does not link back to the expected genesis block, or the Store's
 // datastore does not store a link in the chain.  In case of error the caller
 // should not consider the chain useable and propagate the error.
-func (store *DefaultStore) Load(ctx context.Context) error {
+func (store *DefaultStore) Load(ctx context.Context) (err error) {
+	ctx, span := trace.StartSpan(ctx, "DefaultStore.Load")
+	defer tracing.AddErrorEndSpan(ctx, span, &err)
+
 	tipCids, err := store.loadHead()
 	if err != nil {
 		return err
@@ -251,7 +256,11 @@ func (store *DefaultStore) HasTipSetAndStatesWithParentsAndHeight(pTsKey string,
 }
 
 // GetBlocks retrieves the blocks referenced in the input cid set.
-func (store *DefaultStore) GetBlocks(ctx context.Context, cids types.SortedCidSet) ([]*types.Block, error) {
+func (store *DefaultStore) GetBlocks(ctx context.Context, cids types.SortedCidSet) (blks []*types.Block, err error) {
+	ctx, span := trace.StartSpan(ctx, "DefaultStore.GetBlocks")
+	span.AddAttributes(trace.StringAttribute("tipset", cids.String()))
+	defer tracing.AddErrorEndSpan(ctx, span, &err)
+
 	var blocks []*types.Block
 	for it := cids.Iter(); !it.Complete(); it.Next() {
 		id := it.Value()

--- a/commands/address_daemon_test.go
+++ b/commands/address_daemon_test.go
@@ -134,7 +134,9 @@ func TestWalletExportImportRoundTrip(t *testing.T) {
 
 	wf, err := os.Create("walletFileTest")
 	require.NoError(t, err)
-	defer os.Remove("walletFileTest")
+	defer func() {
+		require.NoError(t, os.Remove("walletFileTest"))
+	}()
 	_, err = wf.WriteString(ki)
 	require.NoError(t, err)
 	require.NoError(t, wf.Close())

--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -137,6 +137,7 @@ func runAPIAndWait(ctx context.Context, nd *node.Node, config *config.Config, re
 		// TODO: should this be the passed in context?  Issue 2641
 		blockMiningAPI: nd.BlockMiningAPI,
 		ctx:            context.Background(),
+		inspectorAPI:   NewInspectorAPI(nd.Repo),
 		porcelainAPI:   nd.PorcelainAPI,
 		retrievalAPI:   nd.RetrievalAPI,
 		storageAPI:     nd.StorageAPI,

--- a/commands/env.go
+++ b/commands/env.go
@@ -18,6 +18,7 @@ type Env struct {
 	porcelainAPI   *porcelain.API
 	retrievalAPI   *retrieval.API
 	storageAPI     *storage.API
+	inspectorAPI   *Inspector
 }
 
 var _ cmds.Environment = (*Env)(nil)
@@ -33,20 +34,26 @@ func GetPorcelainAPI(env cmds.Environment) *porcelain.API {
 	return ce.porcelainAPI
 }
 
-// GetBlockAPI returns the block protocol api from the given environment
+// GetBlockAPI returns the block protocol api from the given environment.
 func GetBlockAPI(env cmds.Environment) *block.MiningAPI {
 	ce := env.(*Env)
 	return ce.blockMiningAPI
 }
 
-// GetRetrievalAPI returns the retrieval protocol api from the given environment
+// GetRetrievalAPI returns the retrieval protocol api from the given environment.
 func GetRetrievalAPI(env cmds.Environment) *retrieval.API {
 	ce := env.(*Env)
 	return ce.retrievalAPI
 }
 
-// GetStorageAPI returns the storage protocol api from the given environment
+// GetStorageAPI returns the storage protocol api from the given environment.
 func GetStorageAPI(env cmds.Environment) *storage.API {
 	ce := env.(*Env)
 	return ce.storageAPI
+}
+
+// GetInspectorAPI returns the inspector api from the given environment.
+func GetInspectorAPI(env cmds.Environment) *Inspector {
+	ce := env.(*Env)
+	return ce.inspectorAPI
 }

--- a/commands/inspector.go
+++ b/commands/inspector.go
@@ -1,0 +1,247 @@
+package commands
+
+import (
+	"os"
+	"runtime"
+
+	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
+	cmds "github.com/ipfs/go-ipfs-cmds"
+	sysi "github.com/whyrusleeping/go-sysinfo"
+
+	"github.com/filecoin-project/go-filecoin/config"
+	"github.com/filecoin-project/go-filecoin/repo"
+)
+
+var inspectCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Show info about the filecoin node",
+	},
+	Subcommands: map[string]*cmds.Command{
+		"all":         allInspectCmd,
+		"runtime":     runtimeInspectCmd,
+		"disk":        diskInspectCmd,
+		"memory":      memoryInspectCmd,
+		"config":      configInspectCmd,
+		"environment": envInspectCmd,
+	},
+}
+var allInspectCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Print all diagnostic information.",
+		ShortDescription: `
+Prints out information about filecoin process and its environment.
+`,
+	},
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		var allInfo AllInspectorInfo
+		allInfo.Runtime = GetInspectorAPI(env).Runtime()
+
+		dsk, err := GetInspectorAPI(env).Disk()
+		if err != nil {
+			return err
+		}
+		allInfo.Disk = dsk
+
+		mem, err := GetInspectorAPI(env).Memory()
+		if err != nil {
+			return err
+		}
+		allInfo.Memory = mem
+		allInfo.Config = GetInspectorAPI(env).Config()
+		allInfo.Environment = GetInspectorAPI(env).Environment()
+		return cmds.EmitOnce(res, allInfo)
+	},
+}
+
+var runtimeInspectCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Print runtime diagnostic information.",
+		ShortDescription: `
+Prints out information about the golang runtime.
+`,
+	},
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		out := GetInspectorAPI(env).Runtime()
+		return cmds.EmitOnce(res, out)
+	},
+}
+
+var diskInspectCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Print filesystem usage information.",
+		ShortDescription: `
+Prints out information about the filesystem.
+`,
+	},
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		out, err := GetInspectorAPI(env).Disk()
+		if err != nil {
+			return err
+		}
+		return cmds.EmitOnce(res, out)
+	},
+}
+
+var memoryInspectCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Print memory usage information.",
+		ShortDescription: `
+Prints out information about memory usage.
+`,
+	},
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		out, err := GetInspectorAPI(env).Memory()
+		if err != nil {
+			return err
+		}
+		return cmds.EmitOnce(res, out)
+	},
+}
+
+var configInspectCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Print in-memory config information.",
+		ShortDescription: `
+Prints out information about your filecoin nodes config.
+`,
+	},
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		out := GetInspectorAPI(env).Config()
+		return cmds.EmitOnce(res, out)
+	},
+}
+
+var envInspectCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Print filecoin environment information.",
+		ShortDescription: `
+Prints out information about your filecoin nodes environment.
+`,
+	},
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		out := GetInspectorAPI(env).Environment()
+		return cmds.EmitOnce(res, out)
+	},
+}
+
+// NewInspectorAPI returns a `Inspector` used to inspect the go-filecoin node.
+func NewInspectorAPI(r repo.Repo) *Inspector {
+	return &Inspector{
+		repo: r,
+	}
+}
+
+// Inspector contains information used to inspect the go-filecoin node.
+type Inspector struct {
+	repo repo.Repo
+}
+
+// AllInspectorInfo contains all information the inspector can gather.
+type AllInspectorInfo struct {
+	Config      *config.Config
+	Runtime     *RuntimeInfo
+	Environment *EnvironmentInfo
+	Disk        *DiskInfo
+	Memory      *MemoryInfo
+}
+
+// RuntimeInfo contains information about the golang runtime.
+type RuntimeInfo struct {
+	OS            string
+	Arch          string
+	Version       string
+	Compiler      string
+	NumProc       int
+	GoMaxProcs    int
+	NumGoRoutines int
+	NumCGoCalls   int64
+}
+
+// EnvironmentInfo contains information about the environment filecoin is running in.
+type EnvironmentInfo struct {
+	FilAPI  string `json:"FIL_API"`
+	FilPath string `json:"FIL_PATH"`
+	GoPath  string `json:"GOPATH"`
+}
+
+// DiskInfo contains information about disk usage and type.
+type DiskInfo struct {
+	Free   uint64
+	Total  uint64
+	FSType string
+}
+
+// MemoryInfo contains information about memory usage.
+type MemoryInfo struct {
+	Swap    uint64
+	Virtual uint64
+}
+
+// Runtime returns infrormation about the golang runtime.
+func (g *Inspector) Runtime() *RuntimeInfo {
+	return &RuntimeInfo{
+		OS:            runtime.GOOS,
+		Arch:          runtime.GOARCH,
+		Version:       runtime.Version(),
+		Compiler:      runtime.Compiler,
+		NumProc:       runtime.NumCPU(),
+		GoMaxProcs:    runtime.GOMAXPROCS(0),
+		NumGoRoutines: runtime.NumGoroutine(),
+		NumCGoCalls:   runtime.NumCgoCall(),
+	}
+}
+
+// Environment returns information about the environment filecoin is running in.
+func (g *Inspector) Environment() *EnvironmentInfo {
+	return &EnvironmentInfo{
+		FilAPI:  os.Getenv("FIL_API"),
+		FilPath: os.Getenv("FIL_PATH"),
+		GoPath:  os.Getenv("GOPATH"),
+	}
+}
+
+// Disk return information about filesystem the filecoin nodes repo is on.
+func (g *Inspector) Disk() (*DiskInfo, error) {
+	fsr, ok := g.repo.(*repo.FSRepo)
+	if !ok {
+		// we are using a in memory repo
+		return &DiskInfo{
+			Free:   0,
+			Total:  0,
+			FSType: "0",
+		}, nil
+	}
+
+	p, err := fsr.Path()
+	if err != nil {
+		return nil, err
+	}
+
+	dinfo, err := sysi.DiskUsage(p)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DiskInfo{
+		Free:   dinfo.Free,
+		Total:  dinfo.Total,
+		FSType: dinfo.FsType,
+	}, nil
+}
+
+// Memory return information about system meory usage.
+func (g *Inspector) Memory() (*MemoryInfo, error) {
+	meminfo, err := sysi.MemoryInfo()
+	if err != nil {
+		return nil, err
+	}
+	return &MemoryInfo{
+		Swap:    meminfo.Swap,
+		Virtual: meminfo.Used,
+	}, nil
+}
+
+// Config return the current config values of the filecoin node.
+func (g *Inspector) Config() *config.Config {
+	return g.repo.Config()
+}

--- a/commands/inspector_daemon_test.go
+++ b/commands/inspector_daemon_test.go
@@ -1,0 +1,52 @@
+package commands_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/tools/fast/fastesting"
+)
+
+func TestInspectConfig(t *testing.T) {
+	tf.IntegrationTest(t)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
+	defer cancel()
+
+	// Get basic testing environment
+	ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.EnvironmentOpts{})
+
+	// Teardown after test ends
+	defer func() {
+		err := env.Teardown(ctx)
+		require.NoError(t, err)
+	}()
+
+	nd := env.RequireNewNodeStarted()
+
+	icfg, err := nd.InspectConfig(ctx)
+	require.NoError(t, err)
+
+	rcfg, err := nd.Config()
+	require.NoError(t, err)
+
+	// API is not the same since the FAST plugin reads the config file from disk,
+	// this is a limitation of FAST.
+	// FAST sets API.Address to /ip4/0.0.0.0/0 in the config file to avoid port collisions.
+	// The Inspector returns an in memory representation of the config that has
+	// received a port assignment from the kernel, meaning it is no longer /ip4/0.0.0.0/0
+	assert.Equal(t, rcfg.Bootstrap, icfg.Bootstrap)
+	assert.Equal(t, rcfg.Datastore, icfg.Datastore)
+	assert.Equal(t, rcfg.Swarm, icfg.Swarm)
+	assert.Equal(t, rcfg.Mining, icfg.Mining)
+	assert.Equal(t, rcfg.Wallet, icfg.Wallet)
+	assert.Equal(t, rcfg.Heartbeat, icfg.Heartbeat)
+	assert.Equal(t, rcfg.Net, icfg.Net)
+	assert.Equal(t, rcfg.Mpool, icfg.Mpool)
+}

--- a/commands/inspector_test.go
+++ b/commands/inspector_test.go
@@ -1,0 +1,61 @@
+package commands_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/go-filecoin/commands"
+	"github.com/filecoin-project/go-filecoin/config"
+	"github.com/filecoin-project/go-filecoin/repo"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+)
+
+func TestRuntime(t *testing.T) {
+	tf.UnitTest(t)
+
+	mr := repo.NewInMemoryRepo()
+	g := commands.NewInspectorAPI(mr)
+	rt := g.Runtime()
+
+	assert.Equal(t, runtime.GOOS, rt.OS)
+	assert.Equal(t, runtime.GOARCH, rt.Arch)
+	assert.Equal(t, runtime.Version(), rt.Version)
+	assert.Equal(t, runtime.Compiler, rt.Compiler)
+	assert.Equal(t, runtime.NumCPU(), rt.NumProc)
+	assert.Equal(t, runtime.GOMAXPROCS(0), rt.GoMaxProcs)
+	assert.Equal(t, runtime.NumCgoCall(), rt.NumCGoCalls)
+}
+
+func TestDisk(t *testing.T) {
+	tf.UnitTest(t)
+
+	mr := repo.NewInMemoryRepo()
+	g := commands.NewInspectorAPI(mr)
+	d, err := g.Disk()
+
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), d.Free)
+	assert.Equal(t, uint64(0), d.Total)
+	assert.Equal(t, "0", d.FSType)
+}
+
+func TestMemory(t *testing.T) {
+	tf.UnitTest(t)
+
+	mr := repo.NewInMemoryRepo()
+	g := commands.NewInspectorAPI(mr)
+
+	_, err := g.Memory()
+	assert.NoError(t, err)
+}
+
+func TestConfig(t *testing.T) {
+	tf.UnitTest(t)
+
+	mr := repo.NewInMemoryRepo()
+	g := commands.NewInspectorAPI(mr)
+	c := g.Config()
+	assert.Equal(t, config.NewDefaultConfig(), c)
+}

--- a/commands/main.go
+++ b/commands/main.go
@@ -126,6 +126,7 @@ MESSAGE COMMANDS
   go-filecoin mpool                  - Manage the message pool
 
 TOOL COMMANDS
+  go-filecoin inspect                - Show info about the go-filecoin node
   go-filecoin log                    - Interact with the daemon event log output
   go-filecoin protocol               - Show protocol parameter details
   go-filecoin version                - Show go-filecoin version information
@@ -165,6 +166,7 @@ var rootSubcmdsDaemon = map[string]*cmds.Command{
 	"dag":              dagCmd,
 	"dht":              dhtCmd,
 	"id":               idCmd,
+	"inspect":          inspectCmd,
 	"log":              logCmd,
 	"message":          msgCmd,
 	"miner":            minerCmd,

--- a/config/config.go
+++ b/config/config.go
@@ -17,17 +17,17 @@ import (
 
 // Config is an in memory representation of the filecoin configuration file
 type Config struct {
-	API        *APIConfig         `json:"api"`
-	Bootstrap  *BootstrapConfig   `json:"bootstrap"`
-	Datastore  *DatastoreConfig   `json:"datastore"`
-	Swarm      *SwarmConfig       `json:"swarm"`
-	Mining     *MiningConfig      `json:"mining"`
-	Wallet     *WalletConfig      `json:"wallet"`
-	Heartbeat  *HeartbeatConfig   `json:"heartbeat"`
-	Net        string             `json:"net"`
-	Metrics    *MetricsConfig     `json:"metrics"`
-	Mpool      *MessagePoolConfig `json:"mpool"`
-	SectorBase *SectorBaseConfig  `json:"sectorbase"`
+	API           *APIConfig           `json:"api"`
+	Bootstrap     *BootstrapConfig     `json:"bootstrap"`
+	Datastore     *DatastoreConfig     `json:"datastore"`
+	Heartbeat     *HeartbeatConfig     `json:"heartbeat"`
+	Mining        *MiningConfig        `json:"mining"`
+	Mpool         *MessagePoolConfig   `json:"mpool"`
+	Net           string               `json:"net"`
+	Observability *ObservabilityConfig `json:"observability"`
+	SectorBase    *SectorBaseConfig    `json:"sectorbase"`
+	Swarm         *SwarmConfig         `json:"swarm"`
+	Wallet        *WalletConfig        `json:"wallet"`
 }
 
 // APIConfig holds all configuration options related to the api.
@@ -151,6 +151,19 @@ func newDefaultHeartbeatConfig() *HeartbeatConfig {
 	}
 }
 
+// ObservabilityConfig is a container for configuration related to observables.
+type ObservabilityConfig struct {
+	Metrics *MetricsConfig `json:"metrics"`
+	Tracing *TraceConfig   `json:"tracing"`
+}
+
+func newDefaultObservabilityConfig() *ObservabilityConfig {
+	return &ObservabilityConfig{
+		Metrics: newDefaultMetricsConfig(),
+		Tracing: newDefaultTraceConfig(),
+	}
+}
+
 // MetricsConfig holds all configuration options related to node metrics.
 type MetricsConfig struct {
 	// Enabled will enable prometheus metrics when true.
@@ -166,6 +179,25 @@ func newDefaultMetricsConfig() *MetricsConfig {
 		PrometheusEnabled:  false,
 		ReportInterval:     "5s",
 		PrometheusEndpoint: "/ip4/0.0.0.0/tcp/9400",
+	}
+}
+
+// TraceConfig holds all configuration options related to enabling and exporting
+// filecoin node traces.
+type TraceConfig struct {
+	// JaegerTracingEnabled will enable exporting traces to jaeger when true.
+	JaegerTracingEnabled bool `json:"jaegerTracingEnabled"`
+	// ProbabilitySampler will sample fraction of traces, 1.0 will sample all traces.
+	ProbabilitySampler float64 `json:"probabilitySampler"`
+	// JaegerEndpoint is the URL traces are collected on.
+	JaegerEndpoint string `json:"jaegerEndpoint"`
+}
+
+func newDefaultTraceConfig() *TraceConfig {
+	return &TraceConfig{
+		JaegerEndpoint:       "http://localhost:14268/api/traces",
+		JaegerTracingEnabled: false,
+		ProbabilitySampler:   1.0,
 	}
 }
 
@@ -202,17 +234,17 @@ func newDefaultSectorbaseConfig() *SectorBaseConfig {
 // their default values
 func NewDefaultConfig() *Config {
 	return &Config{
-		API:        newDefaultAPIConfig(),
-		Bootstrap:  newDefaultBootstrapConfig(),
-		Datastore:  newDefaultDatastoreConfig(),
-		Swarm:      newDefaultSwarmConfig(),
-		Mining:     newDefaultMiningConfig(),
-		Wallet:     newDefaultWalletConfig(),
-		Heartbeat:  newDefaultHeartbeatConfig(),
-		Net:        "",
-		Metrics:    newDefaultMetricsConfig(),
-		Mpool:      newDefaultMessagePoolConfig(),
-		SectorBase: newDefaultSectorbaseConfig(),
+		API:           newDefaultAPIConfig(),
+		Bootstrap:     newDefaultBootstrapConfig(),
+		Datastore:     newDefaultDatastoreConfig(),
+		Swarm:         newDefaultSwarmConfig(),
+		Mining:        newDefaultMiningConfig(),
+		Wallet:        newDefaultWalletConfig(),
+		Heartbeat:     newDefaultHeartbeatConfig(),
+		Net:           "",
+		Mpool:         newDefaultMessagePoolConfig(),
+		SectorBase:    newDefaultSectorbaseConfig(),
+		Observability: newDefaultObservabilityConfig(),
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -169,7 +169,7 @@ func newDefaultMetricsConfig() *MetricsConfig {
 	}
 }
 
-// MetricsConfig holds all configuration options related to nodes message pool (mpool).
+// MessagePoolConfig holds all configuration options related to nodes message pool (mpool).
 type MessagePoolConfig struct {
 	// MaxPoolSize is the maximum number of pending messages will will allow in the message pool at any time
 	MaxPoolSize int `json:"maxPoolSize"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/address"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
@@ -29,7 +30,9 @@ func TestWriteFile(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "config")
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	cfg := NewDefaultConfig()
 
@@ -119,7 +122,9 @@ func TestConfigRoundtrip(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "config")
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	cfg := NewDefaultConfig()
 
@@ -147,7 +152,9 @@ func TestConfigReadFileDefaults(t *testing.T) {
 			}
 		}`)
 		assert.NoError(t, err)
-		defer cleaner()
+		defer func() {
+			require.NoError(t, cleaner())
+		}()
 		cfg, err := ReadFile(cfgpath)
 		assert.NoError(t, err)
 
@@ -164,7 +171,9 @@ func TestConfigReadFileDefaults(t *testing.T) {
 			}
 		}`)
 		assert.NoError(t, err)
-		defer cleaner()
+		defer func() {
+			require.NoError(t, cleaner())
+		}()
 		cfg, err := ReadFile(cfgpath)
 		assert.NoError(t, err)
 
@@ -175,7 +184,9 @@ func TestConfigReadFileDefaults(t *testing.T) {
 	t.Run("empty file", func(t *testing.T) {
 		cfgpath, cleaner, err := createConfigFile("")
 		assert.NoError(t, err)
-		defer cleaner()
+		defer func() {
+			require.NoError(t, cleaner())
+		}()
 		cfg, err := ReadFile(cfgpath)
 		assert.NoError(t, err)
 
@@ -272,7 +283,9 @@ func TestConfigSet(t *testing.T) {
 
 		cfg1path, cleaner, err := createConfigFile(fmt.Sprintf(`{"datastore": %s}`, jsonBlob))
 		assert.NoError(t, err)
-		defer cleaner()
+		defer func() {
+			require.NoError(t, cleaner())
+		}()
 
 		cfg1, err := ReadFile(cfg1path)
 		assert.NoError(t, err)
@@ -332,7 +345,7 @@ path = "mushroom-mushroom"}`
 	})
 }
 
-func createConfigFile(content string) (string, func(), error) {
+func createConfigFile(content string) (string, func() error, error) {
 	dir, err := ioutil.TempDir("", "config")
 	if err != nil {
 		return "", nil, err
@@ -343,5 +356,7 @@ func createConfigFile(content string) (string, func(), error) {
 		return "", nil, err
 	}
 
-	return cfgpath, func() { os.RemoveAll(dir) }, nil
+	return cfgpath, func() error {
+		return os.RemoveAll(dir)
+	}, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -66,35 +66,42 @@ func TestWriteFile(t *testing.T) {
 		"type": "badgerds",
 		"path": "badger"
 	},
-	"swarm": {
-		"address": "/ip4/0.0.0.0/tcp/6000"
-	},
-	"mining": {
-		"minerAddress": "empty",
-		"autoSealIntervalSeconds": 120,
-		"storagePrice": "0"
-	},
-	"wallet": {
-		"defaultAddress": "empty"
-	},
 	"heartbeat": {
 		"beatTarget": "",
 		"beatPeriod": "3s",
 		"reconnectPeriod": "10s",
 		"nickname": ""
 	},
-	"net": "",
-	"metrics": {
-		"prometheusEnabled": false,
-		"reportInterval": "5s",
-		"prometheusEndpoint": "/ip4/0.0.0.0/tcp/9400"
+	"mining": {
+		"minerAddress": "empty",
+		"autoSealIntervalSeconds": 120,
+		"storagePrice": "0"
 	},
 	"mpool": {
 		"maxPoolSize": 10000,
 		"maxNonceGap": "100"
 	},
+	"net": "",
+	"observability": {
+		"metrics": {
+			"prometheusEnabled": false,
+			"reportInterval": "5s",
+			"prometheusEndpoint": "/ip4/0.0.0.0/tcp/9400"
+		},
+		"tracing": {
+			"jaegerTracingEnabled": false,
+			"probabilitySampler": 1,
+			"jaegerEndpoint": "http://localhost:14268/api/traces"
+		}
+	},
 	"sectorbase": {
 		"rootdir": ""
+	},
+	"swarm": {
+		"address": "/ip4/0.0.0.0/tcp/6000"
+	},
+	"wallet": {
+		"defaultAddress": "empty"
 	}
 }`,
 		string(content),

--- a/consensus/processor.go
+++ b/consensus/processor.go
@@ -104,10 +104,7 @@ func (p *DefaultProcessor) ProcessBlock(ctx context.Context, st state.Tree, vms 
 	var emptyResults []*ApplicationResult
 
 	pbsw := pbTimer.Start(ctx)
-	defer func() {
-		dur := pbsw.Stop(ctx)
-		log.Infof("[TIMER] DefaultProcessor.ProcessBlock BlkCID: %s - elapsed time: %s", blk.Cid(), dur)
-	}()
+	defer pbsw.Stop(ctx)
 
 	// find miner's owner address
 	minerOwnerAddr, err := minerOwnerAddress(ctx, st, vms, blk.Miner)
@@ -269,18 +266,8 @@ func (p *DefaultProcessor) ProcessTipSet(ctx context.Context, st state.Tree, vms
 //   - everything else: successfully applied (include, keep changes)
 //
 func (p *DefaultProcessor) ApplyMessage(ctx context.Context, st state.Tree, vms vm.StorageMap, msg *types.SignedMessage, minerOwnerAddr address.Address, bh *types.BlockHeight, gasTracker *vm.GasTracker, ancestors []types.TipSet) (*ApplicationResult, error) {
-
-	// used for log timer call below
-	msgCid, err := msg.Cid()
-	if err != nil {
-		return nil, errors.FaultErrorWrap(err, "could not get message cid")
-	}
-
 	amsw := amTimer.Start(ctx)
-	defer func() {
-		dur := amsw.Stop(ctx)
-		log.Infof("[TIMER] DefaultProcessor.ApplyMessage CID: %s - elapsed time: %s", msgCid.String(), dur)
-	}()
+	defer amsw.Stop(ctx)
 
 	cachedStateTree := state.NewCachedStateTree(st)
 

--- a/consensus/processor.go
+++ b/consensus/processor.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"math/big"
 
+	"go.opencensus.io/trace"
+
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/metrics"
+	"github.com/filecoin-project/go-filecoin/metrics/tracing"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
@@ -100,11 +103,15 @@ func NewConfiguredProcessor(validator SignedMessageValidator, rewarder BlockRewa
 // will in many cases be successfully applied even though an
 // error was thrown causing any state changes to be rolled back.
 // See comments on ApplyMessage for specific intent.
-func (p *DefaultProcessor) ProcessBlock(ctx context.Context, st state.Tree, vms vm.StorageMap, blk *types.Block, ancestors []types.TipSet) ([]*ApplicationResult, error) {
-	var emptyResults []*ApplicationResult
+func (p *DefaultProcessor) ProcessBlock(ctx context.Context, st state.Tree, vms vm.StorageMap, blk *types.Block, ancestors []types.TipSet) (results []*ApplicationResult, err error) {
+	ctx, span := trace.StartSpan(ctx, "DefaultProcessor.ProcessBlock")
+	span.AddAttributes(trace.StringAttribute("block", blk.Cid().String()))
+	defer tracing.AddErrorEndSpan(ctx, span, &err)
 
 	pbsw := pbTimer.Start(ctx)
 	defer pbsw.Stop(ctx)
+
+	var emptyResults []*ApplicationResult
 
 	// find miner's owner address
 	minerOwnerAddr, err := minerOwnerAddress(ctx, st, vms, blk.Miner)
@@ -135,7 +142,11 @@ func (p *DefaultProcessor) ProcessBlock(ctx context.Context, st state.Tree, vms 
 // coming from calls to ApplyMessage can be traced to different blocks in the
 // TipSet containing conflicting messages and are ignored.  Blocks are applied
 // in the sorted order of their tickets.
-func (p *DefaultProcessor) ProcessTipSet(ctx context.Context, st state.Tree, vms vm.StorageMap, ts types.TipSet, ancestors []types.TipSet) (*ProcessTipSetResponse, error) {
+func (p *DefaultProcessor) ProcessTipSet(ctx context.Context, st state.Tree, vms vm.StorageMap, ts types.TipSet, ancestors []types.TipSet) (response *ProcessTipSetResponse, err error) {
+	ctx, span := trace.StartSpan(ctx, "DefaultProcessor.ProcessTipSet")
+	span.AddAttributes(trace.StringAttribute("tipset", ts.String()))
+	defer tracing.AddErrorEndSpan(ctx, span, &err)
+
 	var res ProcessTipSetResponse
 	var emptyRes ProcessTipSetResponse
 	h, err := ts.Height()
@@ -265,7 +276,17 @@ func (p *DefaultProcessor) ProcessTipSet(ctx context.Context, st state.Tree, vms
 //       revert errors.
 //   - everything else: successfully applied (include, keep changes)
 //
-func (p *DefaultProcessor) ApplyMessage(ctx context.Context, st state.Tree, vms vm.StorageMap, msg *types.SignedMessage, minerOwnerAddr address.Address, bh *types.BlockHeight, gasTracker *vm.GasTracker, ancestors []types.TipSet) (*ApplicationResult, error) {
+func (p *DefaultProcessor) ApplyMessage(ctx context.Context, st state.Tree, vms vm.StorageMap, msg *types.SignedMessage, minerOwnerAddr address.Address, bh *types.BlockHeight, gasTracker *vm.GasTracker, ancestors []types.TipSet) (result *ApplicationResult, err error) {
+	msgCid, err := msg.Cid()
+	if err != nil {
+		return nil, errors.FaultErrorWrap(err, "could not get message cid")
+	}
+
+	ctx, span := trace.StartSpan(ctx, "DefaultProcessor.ApplyMessage")
+	span.AddAttributes(trace.StringAttribute("message", msgCid.String()))
+	defer tracing.AddErrorEndSpan(ctx, span, &err)
+
+	// used for log timer call below
 	amsw := amTimer.Start(ctx)
 	defer amsw.Stop(ctx)
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/golang/mock v1.2.0 // indirect
 	github.com/golangci/golangci-lint v1.15.0
 	github.com/gorilla/mux v1.7.0 // indirect
+	github.com/ipfs/fs-repo-migrations v0.0.0-20190319005701-46ecb9d16dbc
 	github.com/ipfs/go-bitswap v0.0.2
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.0.2

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/golang/mock v1.2.0 // indirect
 	github.com/golangci/golangci-lint v1.15.0
 	github.com/gorilla/mux v1.7.0 // indirect
-	github.com/ipfs/fs-repo-migrations v0.0.0-20190319005701-46ecb9d16dbc
 	github.com/ipfs/go-bitswap v0.0.2
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.0.2

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/stretchr/testify v1.3.0
 	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc
+	github.com/whyrusleeping/go-sysinfo v0.0.0-20190219211824-4a357d4b90b1
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.1.0
-	go.opencensus.io v0.19.2
+	go.opencensus.io v0.20.2
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.1 h1:s7KkiBPfxCeDVo47KySjK0ACPc5GJRUxFpdyWEuDjhw=
 github.com/ipfs/bbloom v0.0.1/go.mod h1:oqo8CVWsJFMOZqTglBG4wydCE4IQA/G2/SEofB0rjUI=
+github.com/ipfs/fs-repo-migrations v0.0.0-20190319005701-46ecb9d16dbc h1:i+th9i3B0AwjsxUOtZoIQoc/+szlv0zrII4b4ZXzkaY=
+github.com/ipfs/fs-repo-migrations v0.0.0-20190319005701-46ecb9d16dbc/go.mod h1:IFlYMvj9IpEw7kcDGS71WsDt5UAyekoQTm3tMGTWv+4=
 github.com/ipfs/go-bitswap v0.0.1 h1:Xx1ma7TWy9ISOx5zFq5YVQyrTHzUP4GkRPMsZokHxAg=
 github.com/ipfs/go-bitswap v0.0.1/go.mod h1:z+tP3h+HTJ810n1R5yMy2ccKFffJ2F6Vqm/5Bf7vs2c=
 github.com/ipfs/go-bitswap v0.0.2 h1:zlYqGWXAGuroihkjc7eAKqepwlJOcGm3ZwmFWnPUKks=

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,7 @@ github.com/Stebalien/go-bitfield v0.0.0-20180330043415-076a62f9ce6e/go.mod h1:3o
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/apache/thrift v0.12.0 h1:pODnxUFNcjP9UTLZGTdeh+j16A8lJbRvD3rOtrk/7bs=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -596,6 +597,9 @@ github.com/xeipuuv/gojsonschema v1.1.0/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4m
 go.opencensus.io v0.19.1/go.mod h1:gug0GbSHa8Pafr0d2urOSgoXHZ6x/RUlaiT0d9pqb4A=
 go.opencensus.io v0.19.2 h1:ZZpq6xI6kv/LuE/5s5UQvBU5vMjvRnPb8PvJrIntAnc=
 go.opencensus.io v0.19.2/go.mod h1:NO/8qkisMZLZ1FCsKNqtJPwc8/TaclWyY0B6wcYNg9M=
+go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
+go.opencensus.io v0.20.2 h1:NAfh7zF0/3/HqtMvJNZ/RFrSlCE6ZTlHmKfhL/Dm1Jk=
+go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go4.org v0.0.0-20190218023631-ce4c26f7be8e h1:m9LfARr2VIOW0vsV19kEKp/sWQvZnGobA8JHui/XJoY=
 go4.org v0.0.0-20190218023631-ce4c26f7be8e/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -671,7 +675,10 @@ golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/xerrors v0.0.0-20190212162355-a5947ffaace3 h1:P6iTFmrTQqWrqLZPX1VMzCUbCRCAUXSUsSpkEOvWzJ0=
 golang.org/x/xerrors v0.0.0-20190212162355-a5947ffaace3/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.0.0-20181220000619-583d854617af/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
+google.golang.org/api v0.2.0 h1:B5VXkdjt7K2Gm6fGBC9C9a1OAKJDT95cTqwet+2zib0=
 google.golang.org/api v0.2.0/go.mod h1:IfRCZScioGtypHNTlz3gFk67J8uePVW7uDTBzXuIkhU=
+google.golang.org/api v0.3.1 h1:oJra/lMfmtm13/rgY/8i3MzjFWYXvQIAKjQ3HqofMk8=
+google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/go.sum
+++ b/go.sum
@@ -576,6 +576,8 @@ github.com/whyrusleeping/go-smux-multistream v2.0.2+incompatible/go.mod h1:dRWHH
 github.com/whyrusleeping/go-smux-yamux v2.0.8+incompatible/go.mod h1:6qHUzBXUbB9MXmw3AUdB52L8sEb/hScCqOdW2kj/wuI=
 github.com/whyrusleeping/go-smux-yamux v2.0.9+incompatible h1:nVkExQ7pYlN9e45LcqTCOiDD0904fjtm0flnHZGbXkw=
 github.com/whyrusleeping/go-smux-yamux v2.0.9+incompatible/go.mod h1:6qHUzBXUbB9MXmw3AUdB52L8sEb/hScCqOdW2kj/wuI=
+github.com/whyrusleeping/go-sysinfo v0.0.0-20190219211824-4a357d4b90b1 h1:ctS9Anw/KozviCCtK6VWMz5kPL9nbQzbQY4yfqlIV4M=
+github.com/whyrusleeping/go-sysinfo v0.0.0-20190219211824-4a357d4b90b1/go.mod h1:tKH72zYNt/exx6/5IQO6L9LoQ0rEjd5SbbWaDTs9Zso=
 github.com/whyrusleeping/mafmt v1.2.8 h1:TCghSl5kkwEE0j+sU/gudyhVMRlpBin8fMBBHg59EbA=
 github.com/whyrusleeping/mafmt v1.2.8/go.mod h1:faQJFPbLSxzD9xpA02ttW/tS9vZykNvXwGvqIpk20FA=
 github.com/whyrusleeping/mdns v0.0.0-20180901202407-ef14215e6b30/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,6 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.1 h1:s7KkiBPfxCeDVo47KySjK0ACPc5GJRUxFpdyWEuDjhw=
 github.com/ipfs/bbloom v0.0.1/go.mod h1:oqo8CVWsJFMOZqTglBG4wydCE4IQA/G2/SEofB0rjUI=
-github.com/ipfs/fs-repo-migrations v0.0.0-20190319005701-46ecb9d16dbc h1:i+th9i3B0AwjsxUOtZoIQoc/+szlv0zrII4b4ZXzkaY=
-github.com/ipfs/fs-repo-migrations v0.0.0-20190319005701-46ecb9d16dbc/go.mod h1:IFlYMvj9IpEw7kcDGS71WsDt5UAyekoQTm3tMGTWv+4=
 github.com/ipfs/go-bitswap v0.0.1 h1:Xx1ma7TWy9ISOx5zFq5YVQyrTHzUP4GkRPMsZokHxAg=
 github.com/ipfs/go-bitswap v0.0.1/go.mod h1:z+tP3h+HTJ810n1R5yMy2ccKFffJ2F6Vqm/5Bf7vs2c=
 github.com/ipfs/go-bitswap v0.0.2 h1:zlYqGWXAGuroihkjc7eAKqepwlJOcGm3ZwmFWnPUKks=

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.1 h1:s7KkiBPfxCeDVo47KySjK0ACPc5GJRUxFpdyWEuDjhw=
 github.com/ipfs/bbloom v0.0.1/go.mod h1:oqo8CVWsJFMOZqTglBG4wydCE4IQA/G2/SEofB0rjUI=
+github.com/ipfs/fs-repo-migrations v0.0.0-20190319005701-46ecb9d16dbc h1:i+th9i3B0AwjsxUOtZoIQoc/+szlv0zrII4b4ZXzkaY=
+github.com/ipfs/fs-repo-migrations v0.0.0-20190319005701-46ecb9d16dbc/go.mod h1:IFlYMvj9IpEw7kcDGS71WsDt5UAyekoQTm3tMGTWv+4=
 github.com/ipfs/go-bitswap v0.0.1 h1:Xx1ma7TWy9ISOx5zFq5YVQyrTHzUP4GkRPMsZokHxAg=
 github.com/ipfs/go-bitswap v0.0.1/go.mod h1:z+tP3h+HTJ810n1R5yMy2ccKFffJ2F6Vqm/5Bf7vs2c=
 github.com/ipfs/go-bitswap v0.0.2 h1:zlYqGWXAGuroihkjc7eAKqepwlJOcGm3ZwmFWnPUKks=

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ github.com/fatih/color v1.6.0 h1:66qjqZk8kalYAvDRtM1AdAJQI0tj4Wrue3Eq3B3pmFU=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fd/go-nat v1.0.0 h1:DPyQ97sxA9ThrWYRPcWUz/z9TnpTIGRYODIQc/dy64M=
 github.com/fd/go-nat v1.0.0/go.mod h1:BTBu/CKvMmOMUPkKVef1pngt2WFH/lg7E6yQnulfp6E=
+github.com/filecoin-project/go-filecoin/tools/migration v0.0.1 h1:4IfIxT2UIxVhVFTkc7arH29gaZQ2FJ1YIRJ3yOetZZs=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543 h1:aMJGfgqe1QDhAVwxRg5fjCRF533xHidiKsugk7Vvzug=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543/go.mod h1:mjrHv1cDGJWDlGmC0eDc1E5VJr8DmL9XMUcaFwiuKg8=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/metrics/export.go
+++ b/metrics/export.go
@@ -7,8 +7,10 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr-net"
 	prom "github.com/prometheus/client_golang/prometheus"
+	"go.opencensus.io/exporter/jaeger"
 	"go.opencensus.io/exporter/prometheus"
 	"go.opencensus.io/stats/view"
+	"go.opencensus.io/trace"
 
 	"github.com/filecoin-project/go-filecoin/config"
 )
@@ -56,6 +58,28 @@ func RegisterPrometheusEndpoint(cfg *config.MetricsConfig) error {
 			log.Errorf("failed to serve /metrics endpoint on %v", err)
 		}
 	}()
+
+	return nil
+}
+
+// RegisterJaeger registers the jaeger endpoint with opencensus and names the
+// tracer `name`.
+func RegisterJaeger(name string, cfg *config.TraceConfig) error {
+	if !cfg.JaegerTracingEnabled {
+		return nil
+	}
+	je, err := jaeger.NewExporter(jaeger.Options{
+		CollectorEndpoint: cfg.JaegerEndpoint,
+		Process: jaeger.Process{
+			ServiceName: name,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	trace.RegisterExporter(je)
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.ProbabilitySampler(cfg.ProbabilitySampler)})
 
 	return nil
 }

--- a/metrics/heartbeat_test.go
+++ b/metrics/heartbeat_test.go
@@ -143,7 +143,9 @@ func TestHeartbeatRunSuccess(t *testing.T) {
 
 	// The handle method will run the assertions for the test
 	aggregator.Host.SetStreamHandler(HeartbeatProtocol, func(s net.Stream) {
-		defer s.Close()
+		defer func() {
+			require.NoError(t, s.Close())
+		}()
 
 		dec := json.NewDecoder(s)
 		var hb Heartbeat

--- a/metrics/tracing/util.go
+++ b/metrics/tracing/util.go
@@ -1,0 +1,16 @@
+package tracing
+
+import (
+	"context"
+
+	"go.opencensus.io/trace"
+)
+
+// AddErrorEndSpan will end `span` and adds `err` to `span` iff err is not nil.
+// This is a helper method to cut down on boiler plate.
+func AddErrorEndSpan(ctx context.Context, span *trace.Span, err *error) {
+	if *err != nil {
+		span.AddAttributes(trace.StringAttribute("error", (*err).Error()))
+	}
+	span.End()
+}

--- a/net/pinger.go
+++ b/net/pinger.go
@@ -13,7 +13,7 @@ import (
 // ErrPingSelf is returned if the pinger is instructed to ping itself.
 var ErrPingSelf = errors.New("cannot ping self")
 
-// This struct wraps a libp2p ping service.  It exists to serve more helpful
+// Pinger wraps a libp2p ping service.  It exists to serve more helpful
 // error messages in the case a node is pinging itself.
 type Pinger struct {
 	*ping.PingService

--- a/node/node.go
+++ b/node/node.go
@@ -483,8 +483,12 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 
 // Start boots up the node.
 func (node *Node) Start(ctx context.Context) error {
-	if err := metrics.RegisterPrometheusEndpoint(node.Repo.Config().Metrics); err != nil {
+	if err := metrics.RegisterPrometheusEndpoint(node.Repo.Config().Observability.Metrics); err != nil {
 		return errors.Wrap(err, "failed to setup metrics")
+	}
+
+	if err := metrics.RegisterJaeger(node.host.ID().Pretty(), node.Repo.Config().Observability.Tracing); err != nil {
+		return errors.Wrap(err, "failed to setup tracing")
 	}
 
 	var err error

--- a/node/node.go
+++ b/node/node.go
@@ -838,7 +838,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 					val := result.SealingResult
 					// This call can fail due to, e.g. nonce collisions. Our miners existence depends on this.
 					// We should deal with this, but MessageSendWithRetry is problematic.
-					_, err := node.PorcelainAPI.MessageSend(
+					msgCid, err := node.PorcelainAPI.MessageSend(
 						node.miningCtx,
 						minerOwnerAddr,
 						minerAddr,
@@ -857,7 +857,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 						continue
 					}
 
-					node.StorageMiner.OnCommitmentAddedToChain(val, nil)
+					node.StorageMiner.OnCommitmentSent(val, msgCid, nil)
 				}
 			case <-node.miningCtx.Done():
 				return

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -56,7 +56,7 @@ func StagingDir(sectorPath string) (string, error) {
 	return homedir.Expand(filepath.Join(sectorPath, defaultSectorStagingDir))
 }
 
-// StagingDir returns the path to the sector sealed directory given the sector
+// SealedDir returns the path to the sector sealed directory given the sector
 // storage directory path.
 func SealedDir(sectorPath string) (string, error) {
 	return homedir.Expand(filepath.Join(sectorPath, defaultSectorSealingDir))

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -339,6 +339,7 @@ func (api *API) DAGImportData(ctx context.Context, data io.Reader) (ipld.Node, e
 	return api.dag.ImportData(ctx, data)
 }
 
+// BitswapGetStats returns bitswaps stats.
 func (api *API) BitswapGetStats(ctx context.Context) (*bitswap.Stat, error) {
 	return api.bitswap.(*bitswap.Bitswap).Stat()
 }

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -151,7 +151,7 @@ func (a *API) MinerPreviewSetPrice(
 	return MinerPreviewSetPrice(ctx, a, from, miner, price, expiry)
 }
 
-// ProtocolParams fetches the current protocol configuration parameters.
+// ProtocolParameters fetches the current protocol configuration parameters.
 func (a *API) ProtocolParameters(ctx context.Context) (*ProtocolParams, error) {
 	return ProtocolParameters(ctx, a)
 }

--- a/porcelain/protocol.go
+++ b/porcelain/protocol.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
+// ProtocolParams TODO(rosa)
 type ProtocolParams struct {
 	AutoSealInterval uint
 	SectorSizes      []uint64
@@ -21,6 +22,7 @@ type protocolParamsPlumbing interface {
 	MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error)
 }
 
+// ProtocolParameters TODO(rosa)
 func ProtocolParameters(ctx context.Context, plumbing protocolParamsPlumbing) (*ProtocolParams, error) {
 	autoSealIntervalInterface, err := plumbing.ConfigGet("mining.autoSealIntervalSeconds")
 	if err != nil {

--- a/proofs/sectorbuilder/bytesink/fifo.go
+++ b/proofs/sectorbuilder/bytesink/fifo.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Not safe for concurrent access, as writes to underlying pipe are atomic only
+// FifoByteSink is not safe for concurrent access, as writes to underlying pipe are atomic only
 // if len(buf) is less than the OS-specific PIPE_BUF value.
 type FifoByteSink struct {
 	file *os.File
@@ -62,7 +62,7 @@ func (s *FifoByteSink) Close() (retErr error) {
 	return
 }
 
-// Id produces a string-identifier for this byte sink. For now, this is just the
+// ID produces a string-identifier for this byte sink. For now, this is just the
 // path of the FIFO file. This string may get more structured in the future.
 func (s *FifoByteSink) ID() string {
 	return s.path

--- a/proofs/sectorbuilder/interface.go
+++ b/proofs/sectorbuilder/interface.go
@@ -68,8 +68,9 @@ type SectorSealResult struct {
 
 // PieceInfo is information about a filecoin piece
 type PieceInfo struct {
-	Ref  cid.Cid `json:"ref"`
-	Size uint64  `json:"size"` // TODO: use BytesAmount
+	Ref            cid.Cid `json:"ref"`
+	Size           uint64  `json:"size"` // TODO: use BytesAmount
+	InclusionProof []byte  `json:"inclusionProof"`
 }
 
 // SealedSectorMetadata is a sector that has been sealed by the PoRep setup process

--- a/proofs/sectorbuilder/rustsectorbuilder.go
+++ b/proofs/sectorbuilder/rustsectorbuilder.go
@@ -285,6 +285,17 @@ func (sb *RustSectorBuilder) findSealedSectorMetadata(sectorID uint64) (*SealedS
 			return nil, errors.Wrap(err, "failed to marshal from string to cid")
 		}
 
+		// TODO: These piece inclusion proofs are fake, remove this when proofs are available
+		// The fake proof uses the piece cid as a fake CommP and concatenates CommP with CommD
+		// see https://github.com/filecoin-project/go-filecoin/issues/2629
+		for _, pieceInfo := range ps {
+			var commP types.CommP
+			copy(commP[:], pieceInfo.Ref.Bytes())
+			pieceInfo.InclusionProof = []byte{}
+			pieceInfo.InclusionProof = append(pieceInfo.InclusionProof, commP[:]...)
+			pieceInfo.InclusionProof = append(pieceInfo.InclusionProof, commD[:]...)
+		}
+
 		return &SealedSectorMetadata{
 			CommD:     commD,
 			CommR:     commR,

--- a/protocol/storage/storagedeal/types.go
+++ b/protocol/storage/storagedeal/types.go
@@ -124,11 +124,15 @@ type Deal struct {
 }
 
 // ProofInfo contains the details about a seal proof, that the client needs to know to verify that his deal was posted on chain.
-// TODO: finalize parameters
 type ProofInfo struct {
+	// Sector id allows us to find the committed sector metadata on chain
 	SectorID uint64
-	CommR    []byte
-	CommD    []byte
+
+	// CommitmentMessage is the cid of the message that committed the sector. It's used to track when the sector goes on chain.
+	CommitmentMessage *cid.Cid
+
+	// PieceInclusionProof is a proof that a the piece is included within a sector
+	PieceInclusionProof []byte
 }
 
 // QueryRequest is used for making protocol api requests for deals

--- a/repo/fsrepo.go
+++ b/repo/fsrepo.go
@@ -33,7 +33,9 @@ const (
 	dealsDatastorePrefix   = "deals"
 	snapshotStorePrefix    = "snapshots"
 	snapshotFilenamePrefix = "snapshot"
-	DefaultRepoDir         = "repo"
+
+	// DefaultRepoDir is the default directory of the filecoin repo
+	DefaultRepoDir = "repo"
 )
 
 // NoRepoError is returned when trying to open a repo where one does not exist
@@ -465,10 +467,12 @@ func (r *FSRepo) SetAPIAddr(maddr string) error {
 	return nil
 }
 
+// Path returns the path the fsrepo is at
 func (r *FSRepo) Path() (string, error) {
 	return r.path, nil
 }
 
+// APIAddrFromRepoPath returns the api addr from the filecoin repo
 func APIAddrFromRepoPath(repoPath string) (string, error) {
 	repoPath, err := homedir.Expand(repoPath)
 	if err != nil {

--- a/repo/fsrepo_test.go
+++ b/repo/fsrepo_test.go
@@ -80,8 +80,9 @@ func TestFSRepoInit(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
-
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	t.Log("init FSRepo")
 	assert.NoError(t, InitFSRepo(dir, config.NewDefaultConfig()))
@@ -125,7 +126,9 @@ func TestFSRepoOpen(t *testing.T) {
 	t.Run("[fail] repo version newer than binary", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "")
 		assert.NoError(t, err)
-		defer os.RemoveAll(dir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(dir))
+		}()
 
 		assert.NoError(t, InitFSRepo(dir, config.NewDefaultConfig()))
 		// set wrong version
@@ -137,7 +140,9 @@ func TestFSRepoOpen(t *testing.T) {
 	t.Run("[fail] binary version newer than repo", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "")
 		assert.NoError(t, err)
-		defer os.RemoveAll(dir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(dir))
+		}()
 
 		assert.NoError(t, InitFSRepo(dir, config.NewDefaultConfig()))
 		// set wrong version
@@ -149,8 +154,10 @@ func TestFSRepoOpen(t *testing.T) {
 	t.Run("[fail] version corrupt", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "")
 		assert.NoError(t, err)
+		defer func() {
+			require.NoError(t, os.RemoveAll(dir))
+		}()
 
-		defer os.RemoveAll(dir)
 		assert.NoError(t, InitFSRepo(dir, config.NewDefaultConfig()))
 		// set wrong version
 		assert.NoError(t, ioutil.WriteFile(filepath.Join(dir, versionFilename), []byte("v.8"), 0644))
@@ -165,7 +172,9 @@ func TestFSRepoRoundtrip(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	cfg := config.NewDefaultConfig()
 	cfg.API.Address = "foo" // testing that what we get back isnt just the default
@@ -194,7 +203,9 @@ func TestFSRepoReplaceAndSnapshotConfig(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	cfg := config.NewDefaultConfig()
 	cfg.API.Address = "foo"
@@ -233,7 +244,9 @@ func TestRepoLock(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	cfg := config.NewDefaultConfig()
 	assert.NoError(t, err, InitFSRepo(dir, cfg))
@@ -255,7 +268,9 @@ func TestRepoLockFail(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	cfg := config.NewDefaultConfig()
 	assert.NoError(t, err, InitFSRepo(dir, cfg))
@@ -322,7 +337,7 @@ func TestRepoAPIFile(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, apiFile, info.Name())
 
-			r.Close()
+			require.NoError(t, r.Close())
 
 			_, err = os.Stat(filepath.Join(r.path, apiFile))
 			assert.Error(t, err)
@@ -360,9 +375,10 @@ func TestCreateRepo(t *testing.T) {
 
 	t.Run("successfully creates when directory exists", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "init")
-
 		assert.NoError(t, err)
-		defer os.RemoveAll(dir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(dir))
+		}()
 
 		_, err = CreateRepo(dir, cfg)
 		assert.NoError(t, err)
@@ -372,7 +388,9 @@ func TestCreateRepo(t *testing.T) {
 	t.Run("successfully creates when directory does not exist", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "init")
 		assert.NoError(t, err)
-		defer os.RemoveAll(dir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(dir))
+		}()
 
 		dir = filepath.Join(dir, "nested")
 
@@ -385,7 +403,9 @@ func TestCreateRepo(t *testing.T) {
 	t.Run("fails with error if directory is not writeable", func(t *testing.T) {
 		parentDir, err := ioutil.TempDir("", "init")
 		assert.NoError(t, err)
-		defer os.RemoveAll(parentDir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(parentDir))
+		}()
 
 		// make read only dir
 		dir := filepath.Join(parentDir, "readonly")
@@ -399,13 +419,10 @@ func TestCreateRepo(t *testing.T) {
 
 	t.Run("fails with error if config file already exists", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "init")
-
 		assert.NoError(t, err)
-		defer os.RemoveAll(dir)
-
-		err = ioutil.WriteFile(filepath.Join(dir, "config.json"), []byte("hello"), 0644)
-		assert.NoError(t, err)
-		defer os.RemoveAll(dir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(dir))
+		}()
 
 		err = ioutil.WriteFile(filepath.Join(dir, "config.json"), []byte("hello"), 0644)
 		require.NoError(t, err)
@@ -419,7 +436,9 @@ func TestCreateRepo(t *testing.T) {
 func withFSRepo(t *testing.T, f func(*FSRepo)) {
 	dir, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
 	cfg := config.NewDefaultConfig()
 	require.NoError(t, err, InitFSRepo(dir, cfg))

--- a/repo/fsrepo_test.go
+++ b/repo/fsrepo_test.go
@@ -42,35 +42,42 @@ const (
 		"type": "badgerds",
 		"path": "badger"
 	},
-	"swarm": {
-		"address": "/ip4/0.0.0.0/tcp/6000"
-	},
-	"mining": {
-		"minerAddress": "empty",
-		"autoSealIntervalSeconds": 120,
-		"storagePrice": "0"
-	},
-	"wallet": {
-		"defaultAddress": "empty"
-	},
 	"heartbeat": {
 		"beatTarget": "",
 		"beatPeriod": "3s",
 		"reconnectPeriod": "10s",
 		"nickname": ""
 	},
-	"net": "",
-	"metrics": {
-		"prometheusEnabled": false,
-		"reportInterval": "5s",
-		"prometheusEndpoint": "/ip4/0.0.0.0/tcp/9400"
+	"mining": {
+		"minerAddress": "empty",
+		"autoSealIntervalSeconds": 120,
+		"storagePrice": "0"
 	},
 	"mpool": {
 		"maxPoolSize": 10000,
 		"maxNonceGap": "100"
 	},
+	"net": "",
+	"observability": {
+		"metrics": {
+			"prometheusEnabled": false,
+			"reportInterval": "5s",
+			"prometheusEndpoint": "/ip4/0.0.0.0/tcp/9400"
+		},
+		"tracing": {
+			"jaegerTracingEnabled": false,
+			"probabilitySampler": 1,
+			"jaegerEndpoint": "http://localhost:14268/api/traces"
+		}
+	},
 	"sectorbase": {
 		"rootdir": ""
+	},
+	"swarm": {
+		"address": "/ip4/0.0.0.0/tcp/6000"
+	},
+	"wallet": {
+		"defaultAddress": "empty"
 	}
 }`
 )

--- a/state/tree_test.go
+++ b/state/tree_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-hamt-ipld"
 	mh "github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/address"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestStatePutGet(t *testing.T) {
@@ -126,9 +127,9 @@ func TestGetAllActors(t *testing.T) {
 
 	actor := actor.Actor{Code: types.AccountActorCodeCid, Nonce: 1234, Balance: types.NewAttoFILFromFIL(123)}
 	err := tree.SetActor(ctx, addr, &actor)
-	tree.Flush(ctx)
-
 	assert.NoError(t, err)
+	_, err = tree.Flush(ctx)
+	require.NoError(t, err)
 
 	results := GetAllActors(ctx, tree)
 

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -100,14 +100,17 @@ func NewTestMessagePoolAPI(h uint64) *TestMessagePoolAPI {
 	return &TestMessagePoolAPI{Height: h}
 }
 
+// MockMessagePoolValidator is a mock validator
 type MockMessagePoolValidator struct {
 	Valid bool
 }
 
+// NewMockMessagePoolValidator creates a MockMessagePoolValidator
 func NewMockMessagePoolValidator() *MockMessagePoolValidator {
 	return &MockMessagePoolValidator{Valid: true}
 }
 
+// Validate returns true if the mock validator is set to validate the message
 func (v *MockMessagePoolValidator) Validate(ctx context.Context, msg *types.SignedMessage) error {
 	if v.Valid {
 		return nil

--- a/tools/fast/action_inspector.go
+++ b/tools/fast/action_inspector.go
@@ -1,0 +1,93 @@
+package fast
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-filecoin/commands"
+	"github.com/filecoin-project/go-filecoin/config"
+)
+
+// InspectAll runs the `inspect all` command against the filecoin process
+func (f *Filecoin) InspectAll(ctx context.Context, options ...ActionOption) (*commands.AllInspectorInfo, error) {
+	var out commands.AllInspectorInfo
+
+	args := []string{"go-filecoin", "inspect", "all"}
+
+	for _, option := range options {
+		args = append(args, option()...)
+	}
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+// InspectRuntime runs the `inspect runtime` command against the filecoin process
+func (f *Filecoin) InspectRuntime(ctx context.Context, options ...ActionOption) (*commands.RuntimeInfo, error) {
+	var out commands.RuntimeInfo
+
+	args := []string{"go-filecoin", "inspect", "runtime"}
+
+	for _, option := range options {
+		args = append(args, option()...)
+	}
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+// InspectDisk runs the `inspect disk` command against the filecoin process
+func (f *Filecoin) InspectDisk(ctx context.Context, options ...ActionOption) (*commands.DiskInfo, error) {
+	var out commands.DiskInfo
+
+	args := []string{"go-filecoin", "inspect", "disk"}
+
+	for _, option := range options {
+		args = append(args, option()...)
+	}
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+// InspectMemory runs the `inspect memory` command against the filecoin process
+func (f *Filecoin) InspectMemory(ctx context.Context, options ...ActionOption) (*commands.MemoryInfo, error) {
+	var out commands.MemoryInfo
+
+	args := []string{"go-filecoin", "inspect", "memory"}
+
+	for _, option := range options {
+		args = append(args, option()...)
+	}
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+// InspectConfig runs the `inspect config` command against the filecoin process
+func (f *Filecoin) InspectConfig(ctx context.Context, options ...ActionOption) (*config.Config, error) {
+	var out config.Config
+
+	args := []string{"go-filecoin", "inspect", "config"}
+
+	for _, option := range options {
+		args = append(args, option()...)
+	}
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}

--- a/tools/fast/environment_memory_genesis_test.go
+++ b/tools/fast/environment_memory_genesis_test.go
@@ -38,7 +38,9 @@ func TestEnvironmentMemoryGenesis(t *testing.T) {
 
 		testDir, err := ioutil.TempDir(".", "environmentTest")
 		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(testDir))
+		}()
 
 		env, err := NewEnvironmentMemoryGenesis(big.NewInt(100000), testDir, types.TestProofsMode)
 		localenv := env.(*EnvironmentMemoryGenesis)
@@ -61,7 +63,9 @@ func TestEnvironmentMemoryGenesis(t *testing.T) {
 
 		testDir, err := ioutil.TempDir(".", "environmentTest")
 		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		defer func() {
+			require.NoError(t, os.RemoveAll(testDir))
+		}()
 
 		env, err := NewEnvironmentMemoryGenesis(big.NewInt(100000), testDir, types.TestProofsMode)
 		require.NoError(t, err)

--- a/tools/fast/fastesting/basic.go
+++ b/tools/fast/fastesting/basic.go
@@ -122,7 +122,7 @@ func (env *TestEnvironment) RequireNewNodeConnected() *fast.Filecoin {
 	return p
 }
 
-// RequireNodeNodeWithFunds builds a new node using RequireNewNodeStarted, then
+// RequireNewNodeWithFunds builds a new node using RequireNewNodeStarted, then
 // sends it funds from the environment GenesisMiner node
 func (env *TestEnvironment) RequireNewNodeWithFunds(funds int) *fast.Filecoin {
 	p := env.RequireNewNodeConnected()
@@ -153,6 +153,6 @@ func dumpEnvOutputOnFail(t *testing.T, procs []*fast.Filecoin) {
 		for _, node := range procs {
 			node.DumpLastOutput(w)
 		}
-		w.Close()
+		require.NoError(t, w.Close())
 	}
 }

--- a/tools/fast/fastesting/log_writer_test.go
+++ b/tools/fast/fastesting/log_writer_test.go
@@ -22,8 +22,6 @@ func (w *tlogWriter) Logf(format string, args ...interface{}) {
 func TestLogWriter(t *testing.T) {
 	tf.UnitTest(t)
 
-	require := require.New(t)
-
 	input := []string{
 		"line1\n",
 		"line2\n",
@@ -37,10 +35,10 @@ func TestLogWriter(t *testing.T) {
 
 	for _, line := range input {
 		_, err := lw.Write([]byte(fmt.Sprintf("%s", line)))
-		require.NoError(err)
+		require.NoError(t, err)
 	}
 
-	lw.Close()
+	require.NoError(t, lw.Close())
 
-	require.Equal(strings.Join(input, ""), out.buf.String())
+	require.Equal(t, strings.Join(input, ""), out.buf.String())
 }

--- a/tools/iptb-plugins/filecoin/local/localfilecoin.go
+++ b/tools/iptb-plugins/filecoin/local/localfilecoin.go
@@ -549,7 +549,7 @@ func (l *Localfilecoin) SwarmAddrs() ([]string, error) {
 
 /** Config Interface **/
 
-// GetConfig returns the nodes config.
+// Config returns the nodes config.
 func (l *Localfilecoin) Config() (interface{}, error) {
 	return config.ReadFile(filepath.Join(l.dir, "config.json"))
 }

--- a/tools/iptb-plugins/filecoin/mock/mockfilecoin.go
+++ b/tools/iptb-plugins/filecoin/mock/mockfilecoin.go
@@ -107,10 +107,12 @@ func (m *Mockfilecoin) SwarmAddrs() ([]string, error) {
 	panic("not implemented")
 }
 
+// Config is not implemented
 func (m *Mockfilecoin) Config() (interface{}, error) {
 	panic("not implemented")
 }
 
+// WriteConfig is not implemented
 func (m *Mockfilecoin) WriteConfig(interface{}) error {
 	panic("not implemented")
 }

--- a/tools/migration/internal/default_migrations_provider.go
+++ b/tools/migration/internal/default_migrations_provider.go
@@ -1,0 +1,15 @@
+package internal
+
+// DefaultMigrationsProvider provides a list of migrations available for migrating
+// in production.
+
+// To add a migration:
+// 1. add a migration folder in tools/migration/migrations like repo-<fromversion>-<toversion>
+// 2. put the migration code in the folder in its own package
+// 2. add the new migration package to the imports above
+// 3. instantiate and append it to the list of migrations returned.
+//
+// See runner_test for examples.
+func DefaultMigrationsProvider() []Migration {
+	return []Migration{}
+}

--- a/tools/migration/internal/default_migrations_provider.go
+++ b/tools/migration/internal/default_migrations_provider.go
@@ -7,7 +7,8 @@ package internal
 // 1. add a migration folder in tools/migration/migrations like repo-<fromversion>-<toversion>
 // 2. put the migration code in the folder in its own package
 // 2. add the new migration package to the imports above
-// 3. instantiate and append it to the list of migrations returned.
+// 3. instantiate and append it to the list of migrations returned by
+// DefaultMigrationsProvider
 //
 // See runner_test for examples.
 func DefaultMigrationsProvider() []Migration {

--- a/tools/migration/internal/default_migrations_provider.go
+++ b/tools/migration/internal/default_migrations_provider.go
@@ -2,13 +2,11 @@ package internal
 
 // DefaultMigrationsProvider provides a list of migrations available for migrating
 // in production.
-
 // To add a migration:
 // 1. add a migration folder in tools/migration/migrations like repo-<fromversion>-<toversion>
 // 2. put the migration code in the folder in its own package
 // 2. add the new migration package to the imports above
-// 3. instantiate and append it to the list of migrations returned by
-// DefaultMigrationsProvider
+// 3. instantiate and append it to the list of migrations returned
 //
 // See runner_test for examples.
 func DefaultMigrationsProvider() []Migration {

--- a/tools/migration/internal/default_migrations_provider.go
+++ b/tools/migration/internal/default_migrations_provider.go
@@ -1,5 +1,9 @@
 package internal
 
+import (
+	"github.com/filecoin-project/go-filecoin/tools/migration/migrations/repo01"
+)
+
 // DefaultMigrationsProvider provides a list of migrations available for migrating
 // in production.
 // To add a migration:
@@ -10,5 +14,5 @@ package internal
 //
 // See runner_test for examples.
 func DefaultMigrationsProvider() []Migration {
-	return []Migration{}
+	return []Migration{&repo01.Migration{}}
 }

--- a/tools/migration/internal/logger.go
+++ b/tools/migration/internal/logger.go
@@ -1,0 +1,47 @@
+package internal
+
+import (
+	"io"
+	"log"
+	"os"
+)
+
+// Logger logs migration events to disk and, if initialized with verbose,
+// stdout too.
+type Logger struct {
+	closer io.WriteCloser
+	logger *log.Logger
+}
+
+// NewLogger creates a new Logger.  All log writes go to f, the logging file.
+// If the verbose flag is true all log writes also go to stdout.
+func NewLogger(wc io.WriteCloser, verbose bool) *Logger {
+	// by default just write to file
+	var w io.Writer
+	w = wc
+	if verbose {
+		w = io.MultiWriter(wc, os.Stdout)
+	}
+	return &Logger{
+		closer: wc,
+		logger: log.New(w, "", 0),
+	}
+}
+
+// Error logs an error to the logging output.
+func (l *Logger) Error(err error) {
+	if err == nil {
+		return
+	}
+	l.logger.Printf("ERROR: %s", err.Error())
+}
+
+// Print logs a string to the logging output.
+func (l *Logger) Print(msg string) {
+	l.logger.Print(msg)
+}
+
+// Close closes the logfile backing the Logger.
+func (l *Logger) Close() error {
+	return l.closer.Close()
+}

--- a/tools/migration/internal/logger_test.go
+++ b/tools/migration/internal/logger_test.go
@@ -1,0 +1,75 @@
+package internal_test
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/filecoin-project/go-filecoin/tools/migration/internal"
+)
+
+func TestLoggerWritesToFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "logfile")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.Remove(f.Name()))
+	}()
+
+	logger := NewLogger(f, false)
+	logger.Print("testing print 1")
+	errTest := errors.New("testing error 2")
+	logger.Error(errTest)
+
+	// Reopen file so we can read new writes
+	out, err := ioutil.ReadFile(f.Name())
+	require.NoError(t, err)
+	outStr := string(out)
+	assert.Contains(t, outStr, "testing print 1")
+	expectedErrStr := fmt.Sprintf("ERROR: %s", errTest.Error())
+	assert.Contains(t, outStr, expectedErrStr)
+}
+
+func TestLoggerWritesToBothVerbose(t *testing.T) {
+	// Point os.Stdout to a temp file
+	fStdout, err := ioutil.TempFile("", "stdout")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.Remove(fStdout.Name()))
+	}()
+	old := os.Stdout
+	os.Stdout = fStdout
+	defer func() { os.Stdout = old }()
+
+	// Create log file
+	fLogFile, err := ioutil.TempFile("", "logfile")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.Remove(fLogFile.Name()))
+	}()
+
+	// Log verbosely
+	logger := NewLogger(fLogFile, true)
+	logger.Print("test line")
+	errTest := errors.New("test err")
+	logger.Error(errTest)
+	expectedErrStr := fmt.Sprintf("ERROR: %s", errTest.Error())
+
+	// Check logfile
+	outLogFile, err := ioutil.ReadFile(fLogFile.Name())
+	require.NoError(t, err)
+	outLogFileStr := string(outLogFile)
+	assert.Contains(t, outLogFileStr, "test line")
+	assert.Contains(t, outLogFileStr, expectedErrStr)
+
+	// Check stdout alias file
+	outStdout, err := ioutil.ReadFile(fStdout.Name())
+	require.NoError(t, err)
+	outStdoutStr := string(outStdout)
+	assert.Contains(t, outStdoutStr, "test line")
+	assert.Contains(t, outStdoutStr, expectedErrStr)
+}

--- a/tools/migration/internal/repo_fs_helpers.go
+++ b/tools/migration/internal/repo_fs_helpers.go
@@ -60,6 +60,7 @@ func InstallNewRepo(oldRepoLink, newRepoPath string) error {
 	return nil
 }
 
+// OpenRepo opens repoPath
 func OpenRepo(repoPath string) (*os.File, error) {
 	return os.Open(repoPath)
 }

--- a/tools/migration/internal/repo_fs_helpers_test.go
+++ b/tools/migration/internal/repo_fs_helpers_test.go
@@ -2,7 +2,6 @@ package internal_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -19,16 +18,16 @@ func TestRepoMigrationHelper_CloneRepo(t *testing.T) {
 	tf.UnitTest(t)
 
 	t.Run("Creates the dir with the right permissions", func(t *testing.T) {
-		oldRepo := requireMakeTempDir(t, "")
-		defer requireRmDir(t, oldRepo)
+		oldRepo := RequireMakeTempDir(t, "")
+		defer RequireRmDir(t, oldRepo)
 
 		linkedRepoPath := oldRepo + "something"
 		require.NoError(t, os.Symlink(oldRepo, oldRepo+"something"))
-		defer requireRmDir(t, linkedRepoPath)
+		defer RequireRmDir(t, linkedRepoPath)
 
 		newRepoPath, err := CloneRepo(linkedRepoPath)
 		require.NoError(t, err)
-		defer requireRmDir(t, newRepoPath)
+		defer RequireRmDir(t, newRepoPath)
 
 		stat, err := os.Stat(newRepoPath)
 		require.NoError(t, err)
@@ -37,8 +36,8 @@ func TestRepoMigrationHelper_CloneRepo(t *testing.T) {
 	})
 
 	t.Run("fails if the old repo does not point to a symbolic link", func(t *testing.T) {
-		oldRepo := requireMakeTempDir(t, "")
-		defer requireRmDir(t, oldRepo)
+		oldRepo := RequireMakeTempDir(t, "")
+		defer RequireRmDir(t, oldRepo)
 
 		result, err := CloneRepo(oldRepo)
 		assert.Error(t, err, "old-repo must be a symbolic link.")
@@ -46,7 +45,7 @@ func TestRepoMigrationHelper_CloneRepo(t *testing.T) {
 
 		linkedRepoPath := oldRepo + "something"
 		require.NoError(t, os.Symlink(oldRepo, oldRepo+"something"))
-		defer requireRmDir(t, linkedRepoPath)
+		defer RequireRmDir(t, linkedRepoPath)
 
 		result, err = CloneRepo(linkedRepoPath)
 		assert.NoError(t, err)
@@ -54,12 +53,12 @@ func TestRepoMigrationHelper_CloneRepo(t *testing.T) {
 	})
 
 	t.Run("Increments the int on the end until a free filename is found", func(t *testing.T) {
-		oldRepo := requireMakeTempDir(t, "")
-		defer requireRmDir(t, oldRepo)
+		oldRepo := RequireMakeTempDir(t, "")
+		defer RequireRmDir(t, oldRepo)
 
 		linkedRepoPath := oldRepo + "something"
 		require.NoError(t, os.Symlink(oldRepo, oldRepo+"something"))
-		defer requireRmDir(t, linkedRepoPath)
+		defer RequireRmDir(t, linkedRepoPath)
 
 		// Call CloneRepo several times and ensure that the filename end
 		// is incremented, since these calls will happen in <1s.
@@ -78,7 +77,7 @@ func TestRepoMigrationHelper_CloneRepo(t *testing.T) {
 			assert.Regexp(t, regx, result)
 		}
 		for _, dir := range repos {
-			requireRmDir(t, dir)
+			RequireRmDir(t, dir)
 		}
 
 	})
@@ -87,11 +86,11 @@ func TestRepoMigrationHelper_CloneRepo(t *testing.T) {
 func TestRepoFSHelpers_InstallNewRepo(t *testing.T) {
 	tf.UnitTest(t)
 
-	oldRepo := requireMakeTempDir(t, "")
+	oldRepo := RequireMakeTempDir(t, "")
 
 	linkedRepoPath := oldRepo + "something"
 	require.NoError(t, os.Symlink(oldRepo, oldRepo+"something"))
-	defer requireRmDir(t, linkedRepoPath)
+	defer RequireRmDir(t, linkedRepoPath)
 
 	newRepoPath, err := CloneRepo(linkedRepoPath)
 	require.NoError(t, err)
@@ -108,15 +107,4 @@ func TestRepoFSHelpers_InstallNewRepo(t *testing.T) {
 	contents, err := dir.Readdirnames(0)
 	require.NoError(t, err)
 	assert.Contains(t, contents, "newRepoFile")
-}
-
-func requireMakeTempDir(t *testing.T, dirname string) string {
-	newdir, err := ioutil.TempDir("", dirname)
-	require.NoError(t, err)
-	return newdir
-}
-
-// ensure that the error condition is checked when we clean up after creating tmpdirs.
-func requireRmDir(t *testing.T, dirname string) {
-	require.NoError(t, os.RemoveAll(dirname))
 }

--- a/tools/migration/internal/runner.go
+++ b/tools/migration/internal/runner.go
@@ -37,6 +37,7 @@ type Migration interface {
 	//      read-only by this process
 	//  A successful validation returns nil.
 	Validate(oldRepoPath, newRepoPath string) error
+
 }
 
 // MigrationRunner represent a migration command

--- a/tools/migration/internal/runner.go
+++ b/tools/migration/internal/runner.go
@@ -38,7 +38,6 @@ type Migration interface {
 	//      read-only by this process
 	//  A successful validation returns nil.
 	Validate(oldRepoPath, newRepoPath string) error
-
 }
 
 // MigrationRunner represent a migration command
@@ -123,6 +122,8 @@ func (m *MigrationRunner) Run() error {
 	return fmt.Errorf("did not find valid repo migration for version %d to version %d", repoVersion, repoVersion+1)
 }
 
+// Close does any necessary cleanup after a migration is run.  Currently it just
+// closes the log file.
 func (m *MigrationRunner) Close() error {
 	return m.logger.Close()
 }

--- a/tools/migration/internal/runner.go
+++ b/tools/migration/internal/runner.go
@@ -1,7 +1,15 @@
 package internal
 
+import (
+	"github.com/filecoin-project/go-filecoin/repo"
+)
+
 // Migration is the interface to all repo migration versions.
 type Migration interface {
+	// Describe returns a list of steps, as a formatted string, that a given Migration will take.
+	// These should correspond to named functions in the given Migration.
+	Describe() string
+
 	// Migrate performs all migration steps for the Migration that implements the interface.
 	// Migrate  expects newRepo to be:
 	//		a directory
@@ -9,9 +17,7 @@ type Migration interface {
 	//      contain a copy of the old repo.
 	Migrate(newRepoPath string) error
 
-	// Describe returns a list of steps, as a formatted string, that a given Migration will take.
-	// These should correspond to named functions in the given Migration.
-	Describe() string
+	Versions() (from string, to string)
 
 	// Validate performs validation operations, using oldRepo for comparison.
 	// Validation requirements will be different for every migration.
@@ -24,17 +30,17 @@ type Migration interface {
 	//      read-only by this process
 	//  A successful validation returns nil.
 	Validate(oldRepoPath, newRepoPath string) error
+
 }
 
 type MigrationRunner struct {
 	verbose    bool
 	command    string
 	oldRepoOpt string
+	MigrationsProvider func() []Migration
 }
 
 func NewMigrationRunner(verb bool, command, oldRepoOpt string) *MigrationRunner {
-	// TODO: Issue #2585 Implement repo migration version detection and upgrade decisioning
-
 	return &MigrationRunner{
 		verbose:    verb,
 		command:    command,
@@ -44,5 +50,16 @@ func NewMigrationRunner(verb bool, command, oldRepoOpt string) *MigrationRunner 
 
 func (m *MigrationRunner) Run() error {
 	// TODO: Issue #2595 Implement first repo migration
+	// detect current version of old repo
+	_, err := repo.OpenFSRepo(m.oldRepoOpt)
+	if err != nil {
+		return err
+	}
+
+	// iterate over migrations provided by the Provider.
+		// look for a migration that upgrades the old repo by 1 version
+		// if there is one,
+			// perform the migration command
+	// else exit with error
 	return nil
 }

--- a/tools/migration/internal/runner.go
+++ b/tools/migration/internal/runner.go
@@ -39,6 +39,7 @@ type Migration interface {
 	Validate(oldRepoPath, newRepoPath string) error
 }
 
+// MigrationRunner represent a migration command
 type MigrationRunner struct {
 	// verbose controls the amount of output.
 	verbose bool
@@ -58,6 +59,7 @@ type MigrationRunner struct {
 	RepoVersionGetter func() uint
 }
 
+// NewMigrationRunner builds a MirgrationRunner for the given command and repo options
 func NewMigrationRunner(verb bool, command, oldRepoOpt string) *MigrationRunner {
 	return &MigrationRunner{
 		verbose:            verb,
@@ -73,6 +75,7 @@ func DefaultVersionGetter() uint {
 	return repo.Version
 }
 
+// Run executes the MigrationRunner
 func (m *MigrationRunner) Run() error {
 	// TODO: Issue #2595 Implement first repo migration
 	repoVersion, err := m.loadVersion()

--- a/tools/migration/internal/runner.go
+++ b/tools/migration/internal/runner.go
@@ -1,6 +1,13 @@
 package internal
 
 import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"strings"
+
 	"github.com/filecoin-project/go-filecoin/repo"
 )
 
@@ -17,7 +24,7 @@ type Migration interface {
 	//      contain a copy of the old repo.
 	Migrate(newRepoPath string) error
 
-	Versions() (from string, to string)
+	Versions() (from, to uint)
 
 	// Validate performs validation operations, using oldRepo for comparison.
 	// Validation requirements will be different for every migration.
@@ -30,13 +37,12 @@ type Migration interface {
 	//      read-only by this process
 	//  A successful validation returns nil.
 	Validate(oldRepoPath, newRepoPath string) error
-
 }
 
 type MigrationRunner struct {
-	verbose    bool
-	command    string
-	oldRepoOpt string
+	verbose            bool
+	command            string
+	oldRepoOpt         string
 	MigrationsProvider func() []Migration
 }
 
@@ -51,15 +57,47 @@ func NewMigrationRunner(verb bool, command, oldRepoOpt string) *MigrationRunner 
 func (m *MigrationRunner) Run() error {
 	// TODO: Issue #2595 Implement first repo migration
 	// detect current version of old repo
-	_, err := repo.OpenFSRepo(m.oldRepoOpt)
+	repoVersion, err := m.loadVersion()
 	if err != nil {
 		return err
 	}
-
+	if repoVersion == repo.Version {
+		return errors.New("binary version = repo version; migration not run")
+	}
 	// iterate over migrations provided by the Provider.
+	for _, mig := range m.MigrationsProvider() {
+		from, to := mig.Versions()
 		// look for a migration that upgrades the old repo by 1 version
-		// if there is one,
-			// perform the migration command
+		if from == repoVersion && to == from+1 {
+			// if there is one, perform the migration command
+			newRepoPath, err := getNewRepoPath(m.oldRepoOpt, "")
+
+			if err != nil {
+				return err
+			}
+
+			if err = mig.Migrate(newRepoPath); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
 	// else exit with error
-	return nil
+	return fmt.Errorf("did not find valid repo migration for version %d to version %d", repoVersion, repoVersion+1)
+}
+
+// Shamelessly lifted from FSRepo
+func (m *MigrationRunner) loadVersion() (uint, error) {
+	// TODO: limited file reading, to avoid attack vector
+	file, err := ioutil.ReadFile(filepath.Join(m.oldRepoOpt, "version"))
+	if err != nil {
+		return 0, err
+	}
+
+	version, err := strconv.Atoi(strings.Trim(string(file), "\n"))
+	if err != nil {
+		return 0, errors.New("corrupt version file: version is not an integer")
+	}
+
+	return uint(version), nil
 }

--- a/tools/migration/internal/runner.go
+++ b/tools/migration/internal/runner.go
@@ -1,12 +1,13 @@
 package internal
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/repo"
 )
@@ -77,16 +78,7 @@ func DefaultVersionGetter() uint {
 }
 
 // Run executes the MigrationRunner
-func (m *MigrationRunner) Run() err error {
-	defer func() {
-		if logErr := m.logger.Close(); logErr != nil {
-			if err != nil {
-				err = errors.Wrapf(err, "error closing logger while returning run error: %s", logErr.Error())
-			} else {
-				err = logErr
-			}
-		}
-	}()
+func (m *MigrationRunner) Run() error {
 	repoVersion, err := m.loadVersion()
 	if err != nil {
 		return err
@@ -129,6 +121,10 @@ func (m *MigrationRunner) Run() err error {
 		}
 	}
 	return fmt.Errorf("did not find valid repo migration for version %d to version %d", repoVersion, repoVersion+1)
+}
+
+func (m *MigrationRunner) Close() error {
+	return m.logger.Close()
 }
 
 // Shamelessly lifted from FSRepo, with version checking added.

--- a/tools/migration/internal/runner_test.go
+++ b/tools/migration/internal/runner_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestMigrationRunner_Run(t *testing.T) {
 	tf.UnitTest(t)
+	
 	// setup logger
 	dummyLogFile, err := ioutil.TempFile("", "logfile")
 	require.NoError(t, err)
@@ -126,6 +127,16 @@ func testProviderValidationFails() []Migration {
 
 func testProviderMigrationFails() []Migration {
 	return []Migration{&TestMigMigrationFails{}}
+
+func testMigrationsProvider1() []Migration {
+	return []Migration{
+		&TestMigration01{},
+		&TestMigMigrationFails{},
+	}
+}
+
+func testMigrationsProvider2() []Migration {
+	return []Migration{ &TestMigValidationFails{} }
 }
 
 type TestMigration01 struct {
@@ -138,6 +149,7 @@ func (m *TestMigration01) Describe() string {
 func (m *TestMigration01) Migrate(newRepoPath string) error {
 	return nil
 }
+
 func (m *TestMigration01) Versions() (from, to uint) {
 	return 0, 1
 }
@@ -146,8 +158,7 @@ func (m *TestMigration01) Validate(oldRepoPath, newRepoPath string) error {
 	return nil
 }
 
-type TestMigMigrationFails struct {
-}
+type TestMigMigrationFails struct {}
 
 func (m *TestMigMigrationFails) Versions() (from, to uint) {
 	return 0, 1
@@ -163,23 +174,4 @@ func (m *TestMigMigrationFails) Migrate(newRepoPath string) error {
 
 func (m *TestMigMigrationFails) Validate(oldRepoPath, newRepoPath string) error {
 	return nil
-}
-
-type TestMigValidationFails struct {
-}
-
-func (m *TestMigValidationFails) Versions() (from, to uint) {
-	return 0, 1
-}
-
-func (m *TestMigValidationFails) Describe() string {
-	return "the migration that doesn't do anything"
-}
-
-func (m *TestMigValidationFails) Migrate(newRepoPath string) error {
-	return nil
-}
-
-func (m *TestMigValidationFails) Validate(oldRepoPath, newRepoPath string) error {
-	return errors.New("validation has failed")
 }

--- a/tools/migration/internal/runner_test.go
+++ b/tools/migration/internal/runner_test.go
@@ -1,6 +1,11 @@
 package internal_test
 
 import (
+	"errors"
+	"github.com/filecoin-project/go-filecoin/config"
+	"github.com/filecoin-project/go-filecoin/repo"
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +18,95 @@ import (
 func TestMigrationRunner_Run(t *testing.T) {
 	tf.UnitTest(t)
 
-	runner := NewMigrationRunner(false, "describe", "/home/filecoin-symlink")
-	assert.NoError(t, runner.Run())
+	t.Run("returns error if repo not found", func(t *testing.T) {
+		runner := NewMigrationRunner(false, "describe", "/home/filecoin-symlink")
+		assert.Error(t, runner.Run(), "no filecoin repo found in /home/filecoin-symlink.")
+	})
+
+	t.Run("Can set MigrationsProvider", func(t *testing.T) {
+
+		repodir := RequireMakeTempDir(t, "testrepo")
+		defer RequireRmDir(t, repodir)
+
+		assert.NoError(t, repo.InitFSRepo(repodir, config.NewDefaultConfig()))
+
+		// set version to 0.
+		// Note this will break if the version file name changes
+		assert.NoError(t, ioutil.WriteFile(filepath.Join(repodir, "version"), []byte("0"), 0644))
+
+		runner := NewMigrationRunner(false, "describe", "/home/filecoin-symlink")
+		runner.MigrationsProvider = testMigrationsProvider1
+		migrations := runner.MigrationsProvider()
+		assert.NotEmpty(t, migrations)
+
+		err := runner.Run()
+		assert.NoError(t, err)
+	})
+}
+
+func testMigrationsProvider1() []Migration {
+	return []Migration{
+		&TestMigration01{},
+		&TestMigMigrationFails{},
+	}
+}
+
+func testMigrationsProvider2() []Migration {
+	return []Migration{ &TestMigValidationFails{} }
+}
+
+type TestMigration01 struct {
+}
+
+func (m *TestMigration01) Describe() string {
+	return "the migration that doesn't do anything"
+}
+
+func (m *TestMigration01) Migrate(newRepoPath string) error {
+	return nil
+}
+func (m *TestMigration01) Versions() (from, to string) {
+	return "0", "1"
+}
+
+func (m *TestMigration01) Validate(oldRepoPath, newRepoPath string) error {
+	return nil
+}
+
+type TestMigMigrationFails struct {
+}
+
+func (m *TestMigMigrationFails) Versions() (from, to string) {
+	return "1", "2"
+}
+
+func (m *TestMigMigrationFails) Describe() string {
+	return "the migration that doesn't do anything"
+}
+
+func (m *TestMigMigrationFails) Migrate(newRepoPath string) error {
+	return errors.New("migration has failed")
+}
+
+func (m *TestMigMigrationFails) Validate(oldRepoPath, newRepoPath string) error {
+	return nil
+}
+
+type TestMigValidationFails struct {
+}
+
+func (m *TestMigValidationFails) Versions() (from, to string) {
+	return "0", "1"
+}
+
+func (m *TestMigValidationFails) Describe() string {
+	return "the migration that doesn't do anything"
+}
+
+func (m *TestMigValidationFails) Migrate(newRepoPath string) error {
+	return nil
+}
+
+func (m *TestMigValidationFails) Validate(oldRepoPath, newRepoPath string) error {
+	return errors.New("validation has failed")
 }

--- a/tools/migration/internal/runner_test.go
+++ b/tools/migration/internal/runner_test.go
@@ -34,7 +34,7 @@ func TestMigrationRunner_Run(t *testing.T) {
 		// Note this will break if the version file name changes
 		assert.NoError(t, ioutil.WriteFile(filepath.Join(repodir, "version"), []byte("0"), 0644))
 
-		runner := NewMigrationRunner(false, "describe", "/home/filecoin-symlink")
+		runner := NewMigrationRunner(false, "describe", repodir)
 		runner.MigrationsProvider = testMigrationsProvider1
 		migrations := runner.MigrationsProvider()
 		assert.NotEmpty(t, migrations)
@@ -51,9 +51,9 @@ func testMigrationsProvider1() []Migration {
 	}
 }
 
-func testMigrationsProvider2() []Migration {
-	return []Migration{ &TestMigValidationFails{} }
-}
+//func testMigrationsProvider2() []Migration {
+//	return []Migration{&TestMigValidationFails{}}
+//}
 
 type TestMigration01 struct {
 }
@@ -65,8 +65,8 @@ func (m *TestMigration01) Describe() string {
 func (m *TestMigration01) Migrate(newRepoPath string) error {
 	return nil
 }
-func (m *TestMigration01) Versions() (from, to string) {
-	return "0", "1"
+func (m *TestMigration01) Versions() (from, to uint) {
+	return 0, 1
 }
 
 func (m *TestMigration01) Validate(oldRepoPath, newRepoPath string) error {
@@ -76,8 +76,8 @@ func (m *TestMigration01) Validate(oldRepoPath, newRepoPath string) error {
 type TestMigMigrationFails struct {
 }
 
-func (m *TestMigMigrationFails) Versions() (from, to string) {
-	return "1", "2"
+func (m *TestMigMigrationFails) Versions() (from, to uint) {
+	return 1, 2
 }
 
 func (m *TestMigMigrationFails) Describe() string {
@@ -95,8 +95,8 @@ func (m *TestMigMigrationFails) Validate(oldRepoPath, newRepoPath string) error 
 type TestMigValidationFails struct {
 }
 
-func (m *TestMigValidationFails) Versions() (from, to string) {
-	return "0", "1"
+func (m *TestMigValidationFails) Versions() (from, to uint) {
+	return 0, 1
 }
 
 func (m *TestMigValidationFails) Describe() string {

--- a/tools/migration/internal/runner_test.go
+++ b/tools/migration/internal/runner_test.go
@@ -2,21 +2,29 @@ package internal_test
 
 import (
 	"errors"
-	"github.com/filecoin-project/go-filecoin/config"
-	"github.com/filecoin-project/go-filecoin/repo"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-filecoin/config"
+	"github.com/filecoin-project/go-filecoin/repo"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	. "github.com/filecoin-project/go-filecoin/tools/migration/internal"
 )
 
-// TODO: Issue #2595 Implement first repo migration
 func TestMigrationRunner_Run(t *testing.T) {
 	tf.UnitTest(t)
+
+	repoTmpDir := RequireMakeTempDir(t, "testrepo")
+	defer RequireRmDir(t, repoTmpDir)
+	require.NoError(t, repo.InitFSRepo(repoTmpDir, config.NewDefaultConfig()))
+
+	repoDir := repoTmpDir + "-reposymlink"
+	require.NoError(t, os.Symlink(repoTmpDir, repoDir))
 
 	t.Run("returns error if repo not found", func(t *testing.T) {
 		runner := NewMigrationRunner(false, "describe", "/home/filecoin-symlink")
@@ -24,36 +32,94 @@ func TestMigrationRunner_Run(t *testing.T) {
 	})
 
 	t.Run("Can set MigrationsProvider", func(t *testing.T) {
-
-		repodir := RequireMakeTempDir(t, "testrepo")
-		defer RequireRmDir(t, repodir)
-
-		assert.NoError(t, repo.InitFSRepo(repodir, config.NewDefaultConfig()))
+		runner := NewMigrationRunner(false, "describe", repoDir)
+		runner.MigrationsProvider = testProviderPasses
 
 		// set version to 0.
 		// Note this will break if the version file name changes
-		assert.NoError(t, ioutil.WriteFile(filepath.Join(repodir, "version"), []byte("0"), 0644))
+		require.NoError(t, ioutil.WriteFile(filepath.Join(repoDir, "version"), []byte("0"), 0644))
 
-		runner := NewMigrationRunner(false, "describe", repodir)
-		runner.MigrationsProvider = testMigrationsProvider1
 		migrations := runner.MigrationsProvider()
 		assert.NotEmpty(t, migrations)
+		assert.NoError(t, runner.Run())
+	})
 
-		err := runner.Run()
-		assert.NoError(t, err)
+	t.Run("successful migration writes the new version to the repo", func(t *testing.T) {
+
+	})
+
+	t.Run("Returns error and does not not run the migration if the repo is already up to date", func(t *testing.T) {
+		runner := NewMigrationRunner(false, "describe", repoDir)
+		runner.MigrationsProvider = testProviderPasses
+
+		require.NoError(t, ioutil.WriteFile(filepath.Join(repoDir, "version"), []byte("1"), 0644))
+		assert.EqualError(t, runner.Run(), "binary version = repo version; migration not run")
+	})
+
+	t.Run("Runs the right migration version", func(t *testing.T) {
+		runner := NewMigrationRunner(false, "describe", repoDir)
+		runner.MigrationsProvider = testProviderValidationFails
+
+		require.NoError(t, ioutil.WriteFile(filepath.Join(repoDir, "version"), []byte("1"), 0644))
+		assert.EqualError(t, runner.Run(), "binary version = repo version; migration not run")
+	})
+
+	t.Run("Returns error when a valid migration is not found", func(t *testing.T) {
+		runner := NewMigrationRunner(false, "describe", repoDir)
+		runner.MigrationsProvider = testProviderPasses
+
+		// set version to something unreasonable
+		require.NoError(t, ioutil.WriteFile(filepath.Join(repoDir, "version"), []byte("99"), 0644))
+		assert.EqualError(t, runner.Run(), "did not find valid repo migration for version 99 to version 100")
+	})
+
+	t.Run("Returns error when repo version is invalid", func(t *testing.T) {
+		runner := NewMigrationRunner(false, "describe", repoDir)
+		runner.MigrationsProvider = testProviderPasses
+
+		require.NoError(t, ioutil.WriteFile(filepath.Join(repoDir, "version"), []byte("-1"), 0644))
+		assert.EqualError(t, runner.Run(), "repo version out of range: -1")
+
+		require.NoError(t, ioutil.WriteFile(filepath.Join(repoDir, "version"), []byte("32767"), 0644))
+		assert.EqualError(t, runner.Run(), "repo version out of range: 32767")
+	})
+
+	t.Run("Returns error when Migration fails", func(t *testing.T) {
+		require.NoError(t, ioutil.WriteFile(filepath.Join(repoDir, "version"), []byte("0"), 0644))
+		runner := NewMigrationRunner(false, "migrate", repoDir)
+		runner.MigrationsProvider = testProviderMigrationFails
+		assert.EqualError(t, runner.Run(), "migration has failed")
+	})
+
+	t.Run("Returns error when Validation fails", func(t *testing.T) {
+		require.NoError(t, ioutil.WriteFile(filepath.Join(repoDir, "version"), []byte("0"), 0644))
+		runner := NewMigrationRunner(false, "migrate", repoDir)
+		runner.MigrationsProvider = testProviderValidationFails
+		assert.EqualError(t, runner.Run(), "validation has failed")
+	})
+
+	t.Run("Subsequent calls to Migrate migrate subsequent migrations", func(t *testing.T) {
+
+	})
+
+	t.Run("Returns error if version file does not contain an integer string", func(t *testing.T) {
+
 	})
 }
 
-func testMigrationsProvider1() []Migration {
+func testProviderPasses() []Migration {
 	return []Migration{
 		&TestMigration01{},
-		&TestMigMigrationFails{},
 	}
 }
 
-//func testMigrationsProvider2() []Migration {
-//	return []Migration{&TestMigValidationFails{}}
-//}
+func testProviderValidationFails() []Migration {
+	return []Migration{&TestMigValidationFails{}}
+}
+
+func testProviderMigrationFails() []Migration {
+	return []Migration{&TestMigMigrationFails{}}
+}
 
 type TestMigration01 struct {
 }
@@ -77,7 +143,7 @@ type TestMigMigrationFails struct {
 }
 
 func (m *TestMigMigrationFails) Versions() (from, to uint) {
-	return 1, 2
+	return 0, 1
 }
 
 func (m *TestMigMigrationFails) Describe() string {

--- a/tools/migration/internal/test_helpers.go
+++ b/tools/migration/internal/test_helpers.go
@@ -1,11 +1,11 @@
 package internal
 
 import (
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 )
 
 // RequireMakeTempDir ensures that a temporary directory is created

--- a/tools/migration/internal/test_helpers.go
+++ b/tools/migration/internal/test_helpers.go
@@ -1,0 +1,22 @@
+package internal
+
+import (
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"os"
+	"testing"
+
+)
+
+// RequireMakeTempDir ensures that a temporary directory is created
+func RequireMakeTempDir(t *testing.T, dirname string) string {
+	newdir, err := ioutil.TempDir("", dirname)
+	require.NoError(t, err)
+	return newdir
+}
+
+// RequireRmDir ensures that the error condition is checked when we clean up
+// after creating a temporary directory.
+func RequireRmDir(t *testing.T, dirname string) {
+	require.NoError(t, os.RemoveAll(dirname))
+}

--- a/tools/migration/main.go
+++ b/tools/migration/main.go
@@ -11,7 +11,7 @@ import (
 
 const USAGE = `
 USAGE
-	go-filecoin-migrate (describe|buildonly|migrate) --old-repo=<repodir> [-h|--help] [-v|--verbose]
+	go-filecoin-migrate (describe|buildonly|migrate|install) --old-repo=<repodir> [-h|--help] [-v|--verbose]
 
 COMMANDS
 	describe

--- a/tools/migration/main.go
+++ b/tools/migration/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/tools/migration/internal"
 )
 
+// USAGE is the usage of the migration tool
 const USAGE = `
 USAGE
 	go-filecoin-migrate (describe|buildonly|migrate|install) --old-repo=<repodir> [-h|--help] [-v|--verbose]

--- a/tools/migration/migrations/repo-1-2/migration.go
+++ b/tools/migration/migrations/repo-1-2/migration.go
@@ -1,0 +1,1 @@
+package repo_1_2

--- a/tools/migration/migrations/repo-1-2/migration.go
+++ b/tools/migration/migrations/repo-1-2/migration.go
@@ -1,1 +1,1 @@
-package repo_1_2
+package repo12

--- a/tools/migration/migrations/repo-1-2/migration.go
+++ b/tools/migration/migrations/repo-1-2/migration.go
@@ -1,1 +1,0 @@
-package repo12

--- a/tools/migration/migrations/repo01/migration.go
+++ b/tools/migration/migrations/repo01/migration.go
@@ -1,23 +1,27 @@
 package repo01
 
+// Migration is the repo migration transforming repo version 0 to repo version 1.
 type Migration struct{}
 
+// Describe outputs description of migration 0 ==> 1
 func (m *Migration) Describe() string {
 	return "Update version file from 0 to 1"
 }
 
+// Migrate performs migration 0 ==> 1
 func (m *Migration) Migrate(newRepoPath string) error {
 	// Update version file from 0 to 1
 	// The runner takes care of this itself so this is a noop
 	return nil
 }
 
+// Versions outputs the to and from versions for migration 0 ==> 1
 func (m *Migration) Versions() (uint, uint) {
 	return 0, 1
 }
 
+// Validate does validation of migration 0 ==> 1
 func (m *Migration) Validate(oldRepoPath, newRepoPath string) error {
 	// Nothing to validate as version bump happens afer validation in runner
 	return nil
 }
-

--- a/tools/migration/migrations/repo01/migration.go
+++ b/tools/migration/migrations/repo01/migration.go
@@ -1,0 +1,23 @@
+package repo01
+
+type Migration struct{}
+
+func (m *Migration) Describe() string {
+	return "Update version file from 0 to 1"
+}
+
+func (m *Migration) Migrate(newRepoPath string) error {
+	// Update version file from 0 to 1
+	// The runner takes care of this itself so this is a noop
+	return nil
+}
+
+func (m *Migration) Versions() (uint, uint) {
+	return 0, 1
+}
+
+func (m *Migration) Validate(oldRepoPath, newRepoPath string) error {
+	// Nothing to validate as version bump happens afer validation in runner
+	return nil
+}
+

--- a/types/porep_proof_partitions.go
+++ b/types/porep_proof_partitions.go
@@ -6,10 +6,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+// PoRepProofPartitions represents the number of partitions used when creating a
+// PoRep proof, and impacts the size of the proof.
 type PoRepProofPartitions int
 
 const (
+	// UnknownPoRepProofPartitions is an opaque value signaling that an unknown number
+	// of partitions were used when creating a PoRep proof in test mode.
 	UnknownPoRepProofPartitions = PoRepProofPartitions(iota)
+
+	// TwoPoRepProofPartitions indicates that two partitions were used to create a PoRep proof.
 	TwoPoRepProofPartitions
 )
 

--- a/types/post_proof_partitions.go
+++ b/types/post_proof_partitions.go
@@ -5,10 +5,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+// PoStProofPartitions represents the number of partitions used when creating a
+// PoSt proof, and impacts the size of the proof.
 type PoStProofPartitions int
 
 const (
+	// UnknownPoStProofPartitions is an opaque value signaling that an unknown number of
+	// partitions were used when creating a PoSt proof in test mode.
 	UnknownPoStProofPartitions = PoStProofPartitions(iota)
+
+	// OnePoStProofPartition indicates that a single partition was used to create a PoSt proof.
 	OnePoStProofPartition
 )
 

--- a/types/sector_size.go
+++ b/types/sector_size.go
@@ -8,8 +8,13 @@ import "fmt"
 type SectorSize int
 
 const (
+	// UnknownSectorSize sector size
 	UnknownSectorSize = SectorSize(iota)
-	OneKiBSectorSize
+
+	// OneKiBSectorSize indicates a sector which, after sealing, contains 1024 bytes.
+	OneKiBSectorSize = SectorSize(iota)
+
+	// TwoHundredFiftySixMiBSectorSize indicates a sector which, after sealing, contains 256MiB.
 	TwoHundredFiftySixMiBSectorSize
 )
 

--- a/wallet/dsbackend_test.go
+++ b/wallet/dsbackend_test.go
@@ -5,16 +5,19 @@ import (
 	"testing"
 
 	"github.com/ipfs/go-datastore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDSBackendSimple(t *testing.T) {
 	tf.UnitTest(t)
 
 	ds := datastore.NewMapDatastore()
-	defer ds.Close()
+	defer func() {
+		require.NoError(t, ds.Close())
+	}()
 
 	fs, err := NewDSBackend(ds)
 	assert.NoError(t, err)
@@ -40,7 +43,9 @@ func TestDSBackendKeyPairMatchAddress(t *testing.T) {
 	tf.UnitTest(t)
 
 	ds := datastore.NewMapDatastore()
-	defer ds.Close()
+	defer func() {
+		require.NoError(t, ds.Close())
+	}()
 
 	fs, err := NewDSBackend(ds)
 	assert.NoError(t, err)
@@ -68,12 +73,16 @@ func TestDSBackendErrorsForUnknownAddress(t *testing.T) {
 
 	// create 2 backends
 	ds1 := datastore.NewMapDatastore()
-	defer ds1.Close()
+	defer func() {
+		require.NoError(t, ds1.Close())
+	}()
 	fs1, err := NewDSBackend(ds1)
 	assert.NoError(t, err)
 
 	ds2 := datastore.NewMapDatastore()
-	defer ds2.Close()
+	defer func() {
+		require.NoError(t, ds2.Close())
+	}()
 	fs2, err := NewDSBackend(ds2)
 	assert.NoError(t, err)
 
@@ -102,7 +111,9 @@ func TestDSBackendParallel(t *testing.T) {
 	tf.UnitTest(t)
 
 	ds := datastore.NewMapDatastore()
-	defer ds.Close()
+	defer func() {
+		require.NoError(t, ds.Close())
+	}()
 
 	fs, err := NewDSBackend(ds)
 	assert.NoError(t, err)


### PR DESCRIPTION
This will be a lot easier to diff once feat/repo-mig-version-#2585 is rebased on master. (The actual change is < 100 lines)

The migration and validation functions are both Noops because of the way the runner updates version files after validating.