### PR TITLE
Close() should free the sector builder memory and release its locks

### DIFF
--- a/proofs/sectorbuilder/testing/interface_test.go
+++ b/proofs/sectorbuilder/testing/interface_test.go
@@ -239,7 +239,6 @@ func TestSectorBuilder(t *testing.T) {
 		}
 
 		hA := NewBuilder(t).StagingDir(stagingDir).SealedDir(sealedDir).Build()
-		defer hA.Close()
 
 		// holds id of each sector we expect to see sealed
 		sectorIDSet := sync.Map{}
@@ -248,6 +247,11 @@ func TestSectorBuilder(t *testing.T) {
 		sectorIDA, _, errA := hA.AddPiece(context.Background(), RequireRandomBytes(t, hA.MaxBytesPerSector-10))
 		require.NoError(t, errA)
 		sectorIDSet.Store(sectorIDA, true)
+
+		// destroy the first sector builder, which releases the metadata
+		// database lock and allows a new sector builder to be created using the
+		// same sectors dir
+		hA.Close()
 
 		// create new SectorBuilder which should start with a poller pre-seeded
 		// with state from previous SectorBuilder


### PR DESCRIPTION
Fixes #2722 

## Why does this PR exist?

One of the sector builder tests creates a sector builder and uses it to add a piece. It then creates a new sector builder pointed at the same metadata directory and expects it to behave as if the user shut the first sector builder down and then resumed (with the second) where it left off.

The problem with the existing implementation is that the first sector builder was never properly destroyed. We didn't notice this until recently, because the first and second sector builders could easily share a metadata directory (no locking took place). Recent changes (namely the sled-backed Rust metadata store) added a lock to the metadata database file, and this lock isn't released until the sector builder is destroyed.

## What's in this PR?

- properly destroy the sector builder when someone calls `RustSectorBuilder#Close`