### PR TITLE
Fix/message pool update 0.2.0

### DIFF
--- a/chain/get_ancestors.go
+++ b/chain/get_ancestors.go
@@ -19,6 +19,9 @@ type recentAncestorsChainReader interface {
 	GetTipSet(tsKey types.SortedCidSet) (*types.TipSet, error)
 }
 
+// ErrNoCommonAncestor is returned when two chains assumed to have a common ancestor do not.
+var ErrNoCommonAncestor = errors.New("no common ancestor")
+
 // GetRecentAncestorsOfHeaviestChain returns the ancestors of a `TipSet` with
 // height `descendantBlockHeight` in the heaviest chain.
 func GetRecentAncestorsOfHeaviestChain(ctx context.Context, chainReader recentAncestorsChainReader, descendantBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
@@ -130,4 +133,44 @@ func CollectAtMostNTipSets(ctx context.Context, iterator *TipsetIterator, n uint
 		}
 	}
 	return ret, nil
+}
+
+// FindCommonAncestor returns the common ancestor of the two tipsets pointed to
+// by the input iterators.  If they share no common ancestor ErrNoCommonAncestor
+// will be returned.
+func FindCommonAncestor(leftIter, rightIter *TipsetIterator) (types.TipSet, error) {
+	for !rightIter.Complete() && !leftIter.Complete() {
+		left := leftIter.Value()
+		right := rightIter.Value()
+
+		leftHeight, err := left.Height()
+		if err != nil {
+			return nil, err
+		}
+		rightHeight, err := right.Height()
+		if err != nil {
+			return nil, err
+		}
+
+		// Found common ancestor.
+		if left.Equals(right) {
+			return left, nil
+		}
+
+		// Update the pointers.  Pointers move back one tipset if they
+		// point to a tipset at the same height or higher than the
+		// other pointer's tipset.
+		if rightHeight >= leftHeight {
+			if err := rightIter.Next(); err != nil {
+				return nil, err
+			}
+		}
+
+		if leftHeight >= rightHeight {
+			if err := leftIter.Next(); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return nil, ErrNoCommonAncestor
 }

--- a/core/chains.go
+++ b/core/chains.go
@@ -12,66 +12,37 @@ import (
 // The resulting lists of blocks are ordered by decreasing height; the ordering of blocks with the same
 // height is undefined until https://github.com/filecoin-project/go-filecoin/issues/2310 is resolved.
 func CollectBlocksToCommonAncestor(ctx context.Context, store chain.BlockProvider, oldHead, newHead types.TipSet) (oldBlocks, newBlocks []*types.Block, err error) {
-	// Strategy: walk head-of-chain pointers old and new back until they are at the same height,
-	// then walk back in lockstep to find the common ancestor.
+	oldIter := chain.IterAncestors(ctx, store, oldHead)
+	newIter := chain.IterAncestors(ctx, store, newHead)
 
-	// If old is higher than new, collect all the messages from the old chain down to the height of new (exclusive).
-	newHeight, err := newHead.Height()
+	commonAncestor, err := chain.FindCommonAncestor(oldIter, newIter)
 	if err != nil {
 		return
 	}
-	oldBlocks, oldItr, err := collectBlocks(ctx, store, oldHead, newHeight)
-	if err != nil {
-		return
-	}
-
-	// If new is higher than old, collect all the messages from new's chain down to the height of old.
-	oldHeight, err := oldHead.Height()
-	if err != nil {
-		return
-	}
-	newBlocks, newItr, err := collectBlocks(ctx, store, newHead, oldHeight)
+	commonHeight, err := commonAncestor.Height()
 	if err != nil {
 		return
 	}
 
-	// The tipset iterators are now at the same height.
-	// Continue traversing tipsets in lockstep until they reach the common ancestor.
-	for !(oldItr.Complete() || newItr.Complete() || oldItr.Value().Equals(newItr.Value())) {
-		for _, b := range oldItr.Value() {
-			oldBlocks = append(oldBlocks, b)
-		}
-		for _, b := range newItr.Value() {
-			newBlocks = append(newBlocks, b)
-		}
+	// Refresh iterators modified by FindCommonAncestors
+	oldIter = chain.IterAncestors(ctx, store, oldHead)
+	newIter = chain.IterAncestors(ctx, store, newHead)
 
-		// Advance iterators
-		if err = oldItr.Next(); err != nil {
-			return
-		}
-		if err = newItr.Next(); err != nil {
-			return
-		}
+	// Add 1 to the height argument so that the common ancestor is not
+	// included in the outputs.
+	oldTipsets, err := chain.CollectTipSetsOfHeightAtLeast(ctx, oldIter, types.NewBlockHeight(commonHeight+uint64(1)))
+	if err != nil {
+		return
+	}
+	for _, ts := range oldTipsets {
+		oldBlocks = append(oldBlocks, ts.ToSlice()...)
+	}
+	newTipsets, err := chain.CollectTipSetsOfHeightAtLeast(ctx, newIter, types.NewBlockHeight(commonHeight+uint64(1)))
+	for _, ts := range newTipsets {
+		newBlocks = append(newBlocks, ts.ToSlice()...)
+	}
+	if err != nil {
+		return
 	}
 	return
-}
-
-// collectBlocks collects blocks by traversing the chain from a tipset towards its parents, until some
-// minimum height (excluding the tipset at that height).
-// Returns the blocks collected and a tipset iterator positioned at the tipset at `endHeight`
-func collectBlocks(ctx context.Context, store chain.BlockProvider, head types.TipSet, endHeight uint64) ([]*types.Block, *chain.TipsetIterator, error) {
-	var blocks []*types.Block
-	var err error
-	tsItr := chain.IterAncestors(ctx, store, head)
-	for ; err == nil && !tsItr.Complete(); err = tsItr.Next() {
-		ts := tsItr.Value()
-		height, err := ts.Height()
-		if err != nil || height <= endHeight {
-			break
-		}
-		for _, b := range ts {
-			blocks = append(blocks, b)
-		}
-	}
-	return blocks, tsItr, err
 }

--- a/core/message_pool_test.go
+++ b/core/message_pool_test.go
@@ -221,6 +221,7 @@ func TestUpdateMessagePool(t *testing.T) {
 		MustAdd(p, m[0], m[1])
 
 		parent := types.TipSet{}
+
 		blk := types.Block{Height: 0}
 		parent[blk.Cid()] = &blk
 
@@ -261,10 +262,14 @@ func TestUpdateMessagePool(t *testing.T) {
 		m := types.NewSignedMsgs(7, mockSigner)
 		MustAdd(p, m[2], m[5])
 
-		oldChain := NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{m[0], m[1]}})
+		parent := types.TipSet{}
+
+		blk := types.Block{Height: 0}
+		parent[blk.Cid()] = &blk
+		oldChain := NewChainWithMessages(store, parent, msgsSet{msgs{m[0], m[1]}})
 		oldTipSet := headOf(oldChain)
 
-		newChain := NewChainWithMessages(store, types.TipSet{},
+		newChain := NewChainWithMessages(store, parent,
 			msgsSet{msgs{m[2], m[3]}},
 			msgsSet{msgs{m[4]}},
 			msgsSet{msgs{m[0]}},
@@ -287,10 +292,15 @@ func TestUpdateMessagePool(t *testing.T) {
 		m := types.NewSignedMsgs(7, mockSigner)
 		MustAdd(p, m[2], m[5])
 
-		oldChain := NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{m[0]}, msgs{m[1]}})
+		parent := types.TipSet{}
+
+		blk := types.Block{Height: 0}
+		parent[blk.Cid()] = &blk
+
+		oldChain := NewChainWithMessages(store, parent, msgsSet{msgs{m[0]}, msgs{m[1]}})
 		oldTipSet := headOf(oldChain)
 
-		newChain := NewChainWithMessages(store, types.TipSet{},
+		newChain := NewChainWithMessages(store, parent,
 			msgsSet{msgs{m[2], m[3]}},
 			msgsSet{msgs{m[4]}, msgs{m[0]}, msgs{}, msgs{}},
 			msgsSet{msgs{}, msgs{m[5], m[6]}},
@@ -387,14 +397,19 @@ func TestUpdateMessagePool(t *testing.T) {
 		m := types.NewSignedMsgs(6, mockSigner)
 		MustAdd(p, m[3], m[5])
 
-		oldChain := NewChainWithMessages(store, types.TipSet{},
+		parent := types.TipSet{}
+
+		blk := types.Block{Height: 0}
+		parent[blk.Cid()] = &blk
+
+		oldChain := NewChainWithMessages(store, parent,
 			msgsSet{msgs{m[0]}},
 			msgsSet{msgs{m[1]}},
 			msgsSet{msgs{m[2]}},
 		)
 		oldTipSet := headOf(oldChain)
 
-		newChain := NewChainWithMessages(store, types.TipSet{},
+		newChain := NewChainWithMessages(store, parent,
 			msgsSet{msgs{m[0]}, msgs{m[1]}, msgs{m[2]}},
 		)
 		newTipSet := headOf(newChain)


### PR DESCRIPTION
This adds a correct FindCommonAncestor utility and updates the message pool to use it.  Tests still WIP

- [x] add correct findcommon ancestor utility
- [x] test findcommon ancestor
- [x] update message pool to use this utility
- [ ] test message pool with null block chains 