### PR TITLE
Add `long` support for `chain head` command

### DIFF
--- a/commands/chain_daemon_test.go
+++ b/commands/chain_daemon_test.go
@@ -24,8 +24,8 @@ func TestChainHead(t *testing.T) {
 
 	jsonResult := d.RunSuccess("chain", "head", "--enc", "json").ReadStdoutTrimNewlines()
 
-	var cidsFromJSON []cid.Cid
-	err := json.Unmarshal([]byte(jsonResult), &cidsFromJSON)
+	var blocksFromJSON []types.Block
+	err := json.Unmarshal([]byte(jsonResult), &blocksFromJSON)
 	assert.NoError(t, err)
 
 	textResult := d.RunSuccess("chain", "ls", "--enc", "text").ReadStdoutTrimNewlines()
@@ -33,7 +33,7 @@ func TestChainHead(t *testing.T) {
 	textCid, err := cid.Decode(textResult)
 	require.NoError(t, err)
 
-	assert.Equal(t, textCid, cidsFromJSON[0])
+	assert.Equal(t, textCid.String(), blocksFromJSON[0].Cid().String())
 }
 
 func TestChainLs(t *testing.T) {

--- a/tools/fast/action_chain.go
+++ b/tools/fast/action_chain.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/ipfs/go-cid"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 // ChainHead runs the chain head command against the filecoin process.
-func (f *Filecoin) ChainHead(ctx context.Context) ([]cid.Cid, error) {
-	var out []cid.Cid
+func (f *Filecoin) ChainHead(ctx context.Context) ([]types.Block, error) {
+	var out []types.Block
 	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "chain", "head"); err != nil {
 		return nil, err
 	}

--- a/tools/fast/series/get_head_block_height.go
+++ b/tools/fast/series/get_head_block_height.go
@@ -14,10 +14,5 @@ func GetHeadBlockHeight(ctx context.Context, client *fast.Filecoin) (*types.Bloc
 		return nil, err
 	}
 
-	block, err := client.ShowBlock(ctx, tipset[0])
-	if err != nil {
-		return nil, err
-	}
-
-	return types.NewBlockHeight(uint64(block.Height)), nil
+	return types.NewBlockHeight(uint64(tipset[0].Height)), nil
 }


### PR DESCRIPTION
This PR adds the `[--long | -l]` option support for `go-filecoin chain head`.

So calling `go-filecoin chain head -l` will print:

```
zDPWYqFCx9xBQHpiwanHkAsc3hBc7enrWk8VLzQwddj1iGjfQyvW	t2f4t333piq5hq4wbvult2ovhz4jofuh7ze4pfyki	zdpuAyLKsuDwDzV83fRuDczAhaAysFFNb4bpQsAhnau5ZyRuc	1146	0
zDPWYqFCz6Sy59iTcw2NKCY5itdydyuN6pEXN4wggpHa8L35PRe4	t24dp6qmnqicuz5qchpleq5qt45hprdjmutrqcc7a	zdpuAztEcGebEkE6eFgHm5yw14f5Ch9B4oEYhtUsEusYL5DFF	1146	0
```

similarly to `go-filecoin chain ls -l`.