### PR TITLE
A storage miner's power should be measured in an amount of bytes contributed to the network, not number of sectors

### DIFF
--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -239,7 +239,7 @@ func TestMinerGetPower(t *testing.T) {
 
 		// retrieve power (trivial result for no proven sectors)
 		result := callQueryMethodSuccess("getPower", ctx, t, st, vms, address.TestAddress, minerAddr)
-		require.Equal(t, types.ZeroBytes.Uint64(), types.NewBytesAmountFromBytes(result[0]).Uint64())
+		require.True(t, types.ZeroBytes.Equal(types.NewBytesAmountFromBytes(result[0])))
 	})
 }
 

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -228,7 +228,7 @@ func TestMinerGetPledge(t *testing.T) {
 func TestMinerGetPower(t *testing.T) {
 	tf.UnitTest(t)
 
-	t.Run("GetPower returns proven sectors, 0, nil when successful", func(t *testing.T) {
+	t.Run("GetPower returns total storage committed to network", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -239,7 +239,7 @@ func TestMinerGetPower(t *testing.T) {
 
 		// retrieve power (trivial result for no proven sectors)
 		result := callQueryMethodSuccess("getPower", ctx, t, st, vms, address.TestAddress, minerAddr)
-		require.Equal(t, []byte{}, result[0])
+		require.Equal(t, types.ZeroBytes.Uint64(), types.NewBytesAmountFromBytes(result[0]).Uint64())
 	})
 }
 
@@ -326,7 +326,7 @@ func TestMinerSubmitPoSt(t *testing.T) {
 	require.Equal(t, uint8(0), res.Receipt.ExitCode)
 
 	// submit post
-	proof := th.MakeRandomPoSTProofForTest()
+	proof := th.MakeRandomPoStProofForTest()
 	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 8, "submitPoSt", ancestors, []types.PoStProof{proof})
 	require.NoError(t, err)
 	require.NoError(t, res.ExecutionError)
@@ -339,7 +339,7 @@ func TestMinerSubmitPoSt(t *testing.T) {
 	require.Equal(t, types.NewBlockHeightFromBytes(res.Receipt.Return[0]), types.NewBlockHeight(20003))
 
 	// fail to submit inside the proving period
-	proof = th.MakeRandomPoSTProofForTest()
+	proof = th.MakeRandomPoStProofForTest()
 	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 40008, "submitPoSt", ancestors, []types.PoStProof{proof})
 	require.NoError(t, err)
 	require.EqualError(t, res.ExecutionError, "submitted PoSt late, need to pay a fee")
@@ -390,7 +390,7 @@ func TestVerifyPIP(t *testing.T) {
 
 	t.Run("After submitting a PoSt", func(t *testing.T) {
 		// submit a post
-		proof := th.MakeRandomPoSTProofForTest()
+		proof := th.MakeRandomPoStProofForTest()
 		blockheightOfPoSt := uint64(8)
 		res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, blockheightOfPoSt, "submitPoSt", ancestors, []types.PoStProof{proof})
 		assert.NoError(t, err)

--- a/actor/builtin/storagemarket/storagemarket.go
+++ b/actor/builtin/storagemarket/storagemarket.go
@@ -57,9 +57,9 @@ type Actor struct{}
 type State struct {
 	Miners cid.Cid `refmt:",omitempty"`
 
-	// TotalCommitedStorage is the number of sectors that are currently committed
-	// in the whole network.
-	TotalCommittedStorage *big.Int
+	// TODO: Determine correct unit of measure. Could be denominated in the
+	// smallest sector size supported by the network.
+	TotalCommittedStorage *types.BytesAmount
 
 	ProofsMode types.ProofsMode
 }
@@ -74,7 +74,7 @@ func (sma *Actor) InitializeState(storage exec.Storage, proofsModeInterface inte
 	proofsMode := proofsModeInterface.(types.ProofsMode)
 
 	initStorage := &State{
-		TotalCommittedStorage: big.NewInt(0),
+		TotalCommittedStorage: types.NewBytesAmount(0),
 		ProofsMode:            proofsMode,
 	}
 	stateBytes, err := cbor.DumpObject(initStorage)
@@ -103,12 +103,12 @@ var storageMarketExports = exec.Exports{
 		Return: []abi.Type{abi.Address},
 	},
 	"updatePower": &exec.FunctionSignature{
-		Params: []abi.Type{abi.Integer},
+		Params: []abi.Type{abi.BytesAmount},
 		Return: nil,
 	},
 	"getTotalStorage": &exec.FunctionSignature{
 		Params: []abi.Type{},
-		Return: []abi.Type{abi.Integer},
+		Return: []abi.Type{abi.BytesAmount},
 	},
 	"getProofsMode": &exec.FunctionSignature{
 		Params: []abi.Type{},
@@ -185,7 +185,7 @@ func (sma *Actor) CreateMiner(vmctx exec.VMContext, pledge *big.Int, publicKey [
 // UpdatePower is called to reflect a change in the overall power of the network.
 // This occurs either when a miner adds a new commitment, or when one is removed
 // (via slashing or willful removal). The delta is in number of sectors.
-func (sma *Actor) UpdatePower(vmctx exec.VMContext, delta *big.Int) (uint8, error) {
+func (sma *Actor) UpdatePower(vmctx exec.VMContext, delta *types.BytesAmount) (uint8, error) {
 	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
 		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -208,7 +208,7 @@ func (sma *Actor) UpdatePower(vmctx exec.VMContext, delta *big.Int) (uint8, erro
 			return nil, errors.FaultErrorWrapf(err, "could not load lookup for miner with address: %s", miner)
 		}
 
-		state.TotalCommittedStorage = state.TotalCommittedStorage.Add(state.TotalCommittedStorage, delta)
+		state.TotalCommittedStorage = state.TotalCommittedStorage.Add(delta)
 
 		return nil, nil
 	})
@@ -220,7 +220,7 @@ func (sma *Actor) UpdatePower(vmctx exec.VMContext, delta *big.Int) (uint8, erro
 }
 
 // GetTotalStorage returns the total amount of proven storage in the system.
-func (sma *Actor) GetTotalStorage(vmctx exec.VMContext) (*big.Int, uint8, error) {
+func (sma *Actor) GetTotalStorage(vmctx exec.VMContext) (*types.BytesAmount, uint8, error) {
 	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
 		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -233,12 +233,12 @@ func (sma *Actor) GetTotalStorage(vmctx exec.VMContext) (*big.Int, uint8, error)
 		return nil, errors.CodeError(err), err
 	}
 
-	count, ok := ret.(*big.Int)
+	amt, ok := ret.(*types.BytesAmount)
 	if !ok {
 		return nil, 1, fmt.Errorf("expected *big.Int to be returned, but got %T instead", ret)
 	}
 
-	return count, 0, nil
+	return amt, 0, nil
 }
 
 // GetSectorSize returns the sector size of the block chain

--- a/actor/builtin/storagemarket/storagemarket.go
+++ b/actor/builtin/storagemarket/storagemarket.go
@@ -59,6 +59,9 @@ type State struct {
 
 	// TODO: Determine correct unit of measure. Could be denominated in the
 	// smallest sector size supported by the network.
+	//
+	// See: https://github.com/filecoin-project/specs/issues/6
+	//
 	TotalCommittedStorage *types.BytesAmount
 
 	ProofsMode types.ProofsMode

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -1022,14 +1022,14 @@ func TestTipSetWeightDeep(t *testing.T) {
 		MinerAddr: info.Miners[1].Address,
 	}
 	f1b2a := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f1b2a.Proof, f1b2a.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey1, info.Miners[1].Power, types.NewBytesAmount(1000), mockSigner)
+	f1b2a.Proof, f1b2a.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey1, info.Miners[1].Power, types.NewBytesAmount(1000).Mul(types.OneKiBSectorSize), mockSigner)
 	require.NoError(t, err)
 
 	fakeChildParams.Nonce = uint64(1)
 
 	fakeChildParams.MinerAddr = info.Miners[2].Address
 	f1b2b := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f1b2b.Proof, f1b2b.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey2, info.Miners[2].Power, types.NewBytesAmount(1000), mockSigner)
+	f1b2b.Proof, f1b2b.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey2, info.Miners[2].Power, types.NewBytesAmount(1000).Mul(types.OneKiBSectorSize), mockSigner)
 	require.NoError(t, err)
 
 	f1 := th.RequireNewTipSet(t, f1b2a, f1b2b)

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -923,6 +923,8 @@ func TestTipSetWeightDeep(t *testing.T) {
 		},
 	}
 
+	totalPower := types.NewBytesAmount(1000).Mul(types.OneKiBSectorSize)
+
 	info, err := gengen.GenGen(ctx, genCfg, cst, bs, 0)
 	require.NoError(t, err)
 
@@ -991,13 +993,13 @@ func TestTipSetWeightDeep(t *testing.T) {
 	}
 
 	f1b1 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f1b1.Proof, f1b1.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey1, info.Miners[1].Power, types.NewBytesAmount(1000).Mul(types.OneKiBSectorSize), mockSigner)
+	f1b1.Proof, f1b1.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey1, info.Miners[1].Power, totalPower, mockSigner)
 	require.NoError(t, err)
 
 	fakeChildParams.Nonce = uint64(1)
 	fakeChildParams.MinerAddr = info.Miners[2].Address
 	f2b1 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f2b1.Proof, f2b1.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey1, info.Miners[2].Power, types.NewBytesAmount(1000).Mul(types.OneKiBSectorSize), mockSigner)
+	f2b1.Proof, f2b1.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey1, info.Miners[2].Power, totalPower, mockSigner)
 	require.NoError(t, err)
 
 	tsShared := th.RequireNewTipSet(t, f1b1, f2b1)
@@ -1022,14 +1024,14 @@ func TestTipSetWeightDeep(t *testing.T) {
 		MinerAddr: info.Miners[1].Address,
 	}
 	f1b2a := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f1b2a.Proof, f1b2a.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey1, info.Miners[1].Power, types.NewBytesAmount(1000).Mul(types.OneKiBSectorSize), mockSigner)
+	f1b2a.Proof, f1b2a.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey1, info.Miners[1].Power, totalPower, mockSigner)
 	require.NoError(t, err)
 
 	fakeChildParams.Nonce = uint64(1)
 
 	fakeChildParams.MinerAddr = info.Miners[2].Address
 	f1b2b := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f1b2b.Proof, f1b2b.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey2, info.Miners[2].Power, types.NewBytesAmount(1000).Mul(types.OneKiBSectorSize), mockSigner)
+	f1b2b.Proof, f1b2b.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey2, info.Miners[2].Power, totalPower, mockSigner)
 	require.NoError(t, err)
 
 	f1 := th.RequireNewTipSet(t, f1b2a, f1b2b)
@@ -1053,7 +1055,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 		MinerAddr: info.Miners[3].Address,
 	}
 	f2b2 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f2b2.Proof, f2b2.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey2, info.Miners[3].Power, types.NewBytesAmount(1000), mockSigner)
+	f2b2.Proof, f2b2.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey2, info.Miners[3].Power, totalPower, mockSigner)
 	require.NoError(t, err)
 
 	f2 := th.RequireNewTipSet(t, f2b2)

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -89,8 +89,8 @@ func requireSetTestChain(t *testing.T, con consensus.Protocol, mockStateRoots bo
 
 	var err error
 	// see powerTableForWidenTest
-	minerPower := uint64(25)
-	totalPower := uint64(100)
+	minerPower := types.NewBytesAmount(25)
+	totalPower := types.NewBytesAmount(100)
 	mockSigner, _ := types.NewMockSignersAndKeyInfo(1)
 	mockSignerPubKey := mockSigner.PubKeys[0]
 
@@ -374,7 +374,7 @@ func TestSyncOneTipSet(t *testing.T) {
 func TestSyncTipSetBlockByBlock(t *testing.T) {
 	tf.BadUnitTestWithSideEffects(t)
 
-	pt := th.NewTestPowerTableView(1, 1)
+	pt := th.NewTestPowerTableView(types.NewBytesAmount(1), types.NewBytesAmount(1))
 	syncer, chainStore, _, blockSource := initSyncTestWithPowerTable(t, pt)
 	ctx := context.Background()
 	expTs1 := th.RequireNewTipSet(t, link1blk1)
@@ -777,12 +777,12 @@ func TestWidenChainAncestor(t *testing.T) {
 
 type powerTableForWidenTest struct{}
 
-func (pt *powerTableForWidenTest) Total(ctx context.Context, st state.Tree, bs bstore.Blockstore) (uint64, error) {
-	return uint64(100), nil
+func (pt *powerTableForWidenTest) Total(ctx context.Context, st state.Tree, bs bstore.Blockstore) (*types.BytesAmount, error) {
+	return types.NewBytesAmount(100), nil
 }
 
-func (pt *powerTableForWidenTest) Miner(ctx context.Context, st state.Tree, bs bstore.Blockstore, mAddr address.Address) (uint64, error) {
-	return uint64(25), nil
+func (pt *powerTableForWidenTest) Miner(ctx context.Context, st state.Tree, bs bstore.Blockstore, mAddr address.Address) (*types.BytesAmount, error) {
+	return types.NewBytesAmount(25), nil
 }
 
 func (pt *powerTableForWidenTest) HasPower(ctx context.Context, st state.Tree, bs bstore.Blockstore, mAddr address.Address) bool {
@@ -818,8 +818,8 @@ func TestHeaviestIsWidenedAncestor(t *testing.T) {
 	syncer, chainStore, con, blockSource := initSyncTestWithPowerTable(t, pt)
 	ctx := context.Background()
 
-	minerPower := uint64(25)
-	totalPower := uint64(100)
+	minerPower := types.NewBytesAmount(25)
+	totalPower := types.NewBytesAmount(100)
 	signer, ki := types.NewMockSignersAndKeyInfo(2)
 	mockSignerPubKey := ki[0].PublicKey()
 
@@ -909,16 +909,16 @@ func TestTipSetWeightDeep(t *testing.T) {
 		Keys: 4,
 		Miners: []gengen.Miner{
 			{
-				Power: uint64(0),
+				NumCommittedSectors: 0,
 			},
 			{
-				Power: uint64(10),
+				NumCommittedSectors: 10,
 			},
 			{
-				Power: uint64(10),
+				NumCommittedSectors: 10,
 			},
 			{
-				Power: uint64(980),
+				NumCommittedSectors: 980,
 			},
 		},
 	}
@@ -991,13 +991,13 @@ func TestTipSetWeightDeep(t *testing.T) {
 	}
 
 	f1b1 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f1b1.Proof, f1b1.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey1, info.Miners[1].Power, 1000, mockSigner)
+	f1b1.Proof, f1b1.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey1, info.Miners[1].Power, types.NewBytesAmount(1000).Mul(types.OneKiBSectorSize), mockSigner)
 	require.NoError(t, err)
 
 	fakeChildParams.Nonce = uint64(1)
 	fakeChildParams.MinerAddr = info.Miners[2].Address
 	f2b1 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f2b1.Proof, f2b1.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey1, info.Miners[2].Power, 1000, mockSigner)
+	f2b1.Proof, f2b1.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey1, info.Miners[2].Power, types.NewBytesAmount(1000).Mul(types.OneKiBSectorSize), mockSigner)
 	require.NoError(t, err)
 
 	tsShared := th.RequireNewTipSet(t, f1b1, f2b1)
@@ -1022,14 +1022,14 @@ func TestTipSetWeightDeep(t *testing.T) {
 		MinerAddr: info.Miners[1].Address,
 	}
 	f1b2a := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f1b2a.Proof, f1b2a.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey1, info.Miners[1].Power, 1000, mockSigner)
+	f1b2a.Proof, f1b2a.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey1, info.Miners[1].Power, types.NewBytesAmount(1000), mockSigner)
 	require.NoError(t, err)
 
 	fakeChildParams.Nonce = uint64(1)
 
 	fakeChildParams.MinerAddr = info.Miners[2].Address
 	f1b2b := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f1b2b.Proof, f1b2b.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey2, info.Miners[2].Power, 1000, mockSigner)
+	f1b2b.Proof, f1b2b.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey2, info.Miners[2].Power, types.NewBytesAmount(1000), mockSigner)
 	require.NoError(t, err)
 
 	f1 := th.RequireNewTipSet(t, f1b2a, f1b2b)
@@ -1053,7 +1053,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 		MinerAddr: info.Miners[3].Address,
 	}
 	f2b2 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f2b2.Proof, f2b2.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey2, info.Miners[3].Power, 1000, mockSigner)
+	f2b2.Proof, f2b2.Ticket, err = th.MakeProofAndWinningTicket(signerPubKey2, info.Miners[3].Power, types.NewBytesAmount(1000), mockSigner)
 	require.NoError(t, err)
 
 	f2 := th.RequireNewTipSet(t, f2b2)

--- a/chain/power_table_view_test.go
+++ b/chain/power_table_view_test.go
@@ -25,13 +25,15 @@ func TestTotal(t *testing.T) {
 
 	ctx := context.Background()
 
-	power := uint64(19)
-	bs, _, st := requireMinerWithPower(ctx, t, power)
+	numCommittedSectors := uint64(19)
+	bs, _, st := requireMinerWithPower(ctx, t, numCommittedSectors)
 
 	actual, err := (&consensus.MarketView{}).Total(ctx, st, bs)
 	require.NoError(t, err)
 
-	assert.Equal(t, power, actual)
+	expected := types.OneKiBSectorSize.Mul(types.NewBytesAmount(numCommittedSectors))
+
+	assert.Equal(t, expected.Uint64(), actual.Uint64())
 }
 
 func TestMiner(t *testing.T) {
@@ -39,26 +41,28 @@ func TestMiner(t *testing.T) {
 
 	ctx := context.Background()
 
-	power := uint64(12)
-	bs, addr, st := requireMinerWithPower(ctx, t, power)
+	numCommittedSectors := uint64(12)
+	bs, addr, st := requireMinerWithPower(ctx, t, numCommittedSectors)
 
 	actual, err := (&consensus.MarketView{}).Miner(ctx, st, bs, addr)
 	require.NoError(t, err)
 
-	assert.Equal(t, power, actual)
+	expected := types.OneKiBSectorSize.Mul(types.NewBytesAmount(numCommittedSectors))
+
+	assert.Equal(t, expected.Uint64(), actual.Uint64())
 }
 
-func requireMinerWithPower(ctx context.Context, t *testing.T, power uint64) (bstore.Blockstore, address.Address, state.Tree) {
+func requireMinerWithPower(ctx context.Context, t *testing.T, numCommittedSectors uint64) (bstore.Blockstore, address.Address, state.Tree) {
 	r := repo.NewInMemoryRepo()
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := hamt.NewCborStore()
 
-	// set up genesis block with power
+	// set up genesis block with numCommittedSectors
 	genCfg := &gengen.GenesisCfg{
 		Keys: 1,
 		Miners: []gengen.Miner{
 			{
-				Power: power,
+				NumCommittedSectors: numCommittedSectors,
 			},
 		},
 	}

--- a/chain/power_table_view_test.go
+++ b/chain/power_table_view_test.go
@@ -57,7 +57,7 @@ func requireMinerWithPower(ctx context.Context, t *testing.T, numCommittedSector
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := hamt.NewCborStore()
 
-	// set up genesis block with numCommittedSectors
+	// set up genesis block containing some miners with non-zero power
 	genCfg := &gengen.GenesisCfg{
 		Keys: 1,
 		Miners: []gengen.Miner{

--- a/chain/power_table_view_test.go
+++ b/chain/power_table_view_test.go
@@ -33,7 +33,7 @@ func TestTotal(t *testing.T) {
 
 	expected := types.OneKiBSectorSize.Mul(types.NewBytesAmount(numCommittedSectors))
 
-	assert.Equal(t, expected.Uint64(), actual.Uint64())
+	assert.True(t, expected.Equal(actual))
 }
 
 func TestMiner(t *testing.T) {
@@ -49,7 +49,7 @@ func TestMiner(t *testing.T) {
 
 	expected := types.OneKiBSectorSize.Mul(types.NewBytesAmount(numCommittedSectors))
 
-	assert.Equal(t, expected.Uint64(), actual.Uint64())
+	assert.True(t, expected.Equal(actual))
 }
 
 func requireMinerWithPower(ctx context.Context, t *testing.T, numCommittedSectors uint64) (bstore.Blockstore, address.Address, state.Tree) {

--- a/chain/power_table_view_test.go
+++ b/chain/power_table_view_test.go
@@ -26,7 +26,7 @@ func TestTotal(t *testing.T) {
 	ctx := context.Background()
 
 	numCommittedSectors := uint64(19)
-	bs, _, st := requireMinerWithPower(ctx, t, numCommittedSectors)
+	bs, _, st := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors)
 
 	actual, err := (&consensus.MarketView{}).Total(ctx, st, bs)
 	require.NoError(t, err)
@@ -42,7 +42,7 @@ func TestMiner(t *testing.T) {
 	ctx := context.Background()
 
 	numCommittedSectors := uint64(12)
-	bs, addr, st := requireMinerWithPower(ctx, t, numCommittedSectors)
+	bs, addr, st := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors)
 
 	actual, err := (&consensus.MarketView{}).Miner(ctx, st, bs, addr)
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestMiner(t *testing.T) {
 	assert.True(t, expected.Equal(actual))
 }
 
-func requireMinerWithPower(ctx context.Context, t *testing.T, numCommittedSectors uint64) (bstore.Blockstore, address.Address, state.Tree) {
+func requireMinerWithNumCommittedSectors(ctx context.Context, t *testing.T, numCommittedSectors uint64) (bstore.Blockstore, address.Address, state.Tree) {
 	r := repo.NewInMemoryRepo()
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := hamt.NewCborStore()

--- a/chain/power_table_view_test.go
+++ b/chain/power_table_view_test.go
@@ -31,7 +31,7 @@ func TestTotal(t *testing.T) {
 	actual, err := (&consensus.MarketView{}).Total(ctx, st, bs)
 	require.NoError(t, err)
 
-	expected := types.OneKiBSectorSize.Mul(types.NewBytesAmount(numCommittedSectors))
+	expected := types.NewBytesAmount(types.OneKiBSectorSize.Uint64() * numCommittedSectors)
 
 	assert.True(t, expected.Equal(actual))
 }
@@ -47,7 +47,7 @@ func TestMiner(t *testing.T) {
 	actual, err := (&consensus.MarketView{}).Miner(ctx, st, bs, addr)
 	require.NoError(t, err)
 
-	expected := types.OneKiBSectorSize.Mul(types.NewBytesAmount(numCommittedSectors))
+	expected := types.NewBytesAmount(types.OneKiBSectorSize.Uint64() * numCommittedSectors)
 
 	assert.True(t, expected.Equal(actual))
 }

--- a/commands/miner.go
+++ b/commands/miner.go
@@ -448,7 +448,7 @@ Values will be output as a ratio where the first number is the miner power and s
 		if err != nil {
 			return err
 		}
-		total := big.NewInt(0).SetBytes(bytes[0])
+		total := types.NewBytesAmountFromBytes(bytes[0])
 
 		str := fmt.Sprintf("%d / %d", power, total) // nolint: govet
 		return re.Emit(str)

--- a/commands/miner.go
+++ b/commands/miner.go
@@ -437,7 +437,7 @@ Values will be output as a ratio where the first number is the miner power and s
 		if err != nil {
 			return err
 		}
-		power := big.NewInt(0).SetBytes(bytes[0])
+		power := types.NewBytesAmountFromBytes(bytes[0])
 
 		bytes, err = GetPorcelainAPI(env).MessageQuery(
 			req.Context,
@@ -450,7 +450,7 @@ Values will be output as a ratio where the first number is the miner power and s
 		}
 		total := types.NewBytesAmountFromBytes(bytes[0])
 
-		str := fmt.Sprintf("%d / %d", power, total) // nolint: govet
+		str := fmt.Sprintf("%s / %s", power, total) // nolint: govet
 		return re.Emit(str)
 	},
 	Arguments: []cmdkit.Argument{

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -454,12 +454,12 @@ var testConfig = &gengen.GenesisCfg{
 	},
 	Miners: []gengen.Miner{
 		{
-			Owner: 0,
-			Power: 3,
+			Owner:               0,
+			NumCommittedSectors: 3,
 		},
 		{
-			Owner: 1,
-			Power: 3,
+			Owner:               1,
+			NumCommittedSectors: 3,
 		},
 	},
 }

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -443,7 +443,7 @@ func TestMinerPower(t *testing.T) {
 	power := powerOutput.ReadStdoutTrimNewlines()
 
 	assert.NoError(t, err)
-	assert.Equal(t, "3 / 6", power)
+	assert.Equal(t, "3072 / 6144", power)
 }
 
 var testConfig = &gengen.GenesisCfg{

--- a/consensus/expected.go
+++ b/consensus/expected.go
@@ -178,7 +178,7 @@ func (c *Expected) Weight(ctx context.Context, ts types.TipSet, pSt state.Tree) 
 		floatOwnBytes := new(big.Float).SetUint64(minerBytes.Uint64())
 		wBlk := new(big.Float)
 		wBlk.Quo(floatOwnBytes, floatTotalBytes)
-		wBlk.Mul(wBlk, floatECPrM) // NumCommittedSectors addition
+		wBlk.Mul(wBlk, floatECPrM) // Power addition
 		wBlk.Add(wBlk, floatECV)   // Constant addition
 		w.Add(w, wBlk)
 	}

--- a/consensus/expected.go
+++ b/consensus/expected.go
@@ -167,7 +167,7 @@ func (c *Expected) Weight(ctx context.Context, ts types.TipSet, pSt state.Tree) 
 	if err != nil {
 		return uint64(0), err
 	}
-	floatTotalBytes := new(big.Float).SetInt64(int64(totalBytes.Uint64()))
+	floatTotalBytes := new(big.Float).SetInt(totalBytes.BigInt())
 	floatECV := new(big.Float).SetInt64(int64(ECV))
 	floatECPrM := new(big.Float).SetInt64(int64(ECPrM))
 	for _, blk := range ts.ToSlice() {
@@ -175,7 +175,7 @@ func (c *Expected) Weight(ctx context.Context, ts types.TipSet, pSt state.Tree) 
 		if err != nil {
 			return uint64(0), err
 		}
-		floatOwnBytes := new(big.Float).SetUint64(minerBytes.Uint64())
+		floatOwnBytes := new(big.Float).SetInt(minerBytes.BigInt())
 		wBlk := new(big.Float)
 		wBlk.Quo(floatOwnBytes, floatTotalBytes)
 		wBlk.Mul(wBlk, floatECPrM) // Power addition
@@ -325,9 +325,9 @@ func IsWinningTicket(ctx context.Context, bs blockstore.Blockstore, ptv PowerTab
 func CompareTicketPower(ticket types.Signature, minerPower *types.BytesAmount, totalPower *types.BytesAmount) bool {
 	lhs := &big.Int{}
 	lhs.SetBytes(ticket)
-	lhs.Mul(lhs, (&big.Int{}).SetUint64(totalPower.Uint64()))
+	lhs.Mul(lhs, totalPower.BigInt())
 	rhs := &big.Int{}
-	rhs.Mul((&big.Int{}).SetUint64(minerPower.Uint64()), ticketDomain)
+	rhs.Mul(minerPower.BigInt(), ticketDomain)
 	return lhs.Cmp(rhs) < 0
 }
 

--- a/consensus/expected.go
+++ b/consensus/expected.go
@@ -167,7 +167,7 @@ func (c *Expected) Weight(ctx context.Context, ts types.TipSet, pSt state.Tree) 
 	if err != nil {
 		return uint64(0), err
 	}
-	floatTotalBytes := new(big.Float).SetInt64(int64(totalBytes))
+	floatTotalBytes := new(big.Float).SetInt64(int64(totalBytes.Uint64()))
 	floatECV := new(big.Float).SetInt64(int64(ECV))
 	floatECPrM := new(big.Float).SetInt64(int64(ECPrM))
 	for _, blk := range ts.ToSlice() {
@@ -175,10 +175,10 @@ func (c *Expected) Weight(ctx context.Context, ts types.TipSet, pSt state.Tree) 
 		if err != nil {
 			return uint64(0), err
 		}
-		floatOwnBytes := new(big.Float).SetInt64(int64(minerBytes))
+		floatOwnBytes := new(big.Float).SetUint64(minerBytes.Uint64())
 		wBlk := new(big.Float)
 		wBlk.Quo(floatOwnBytes, floatTotalBytes)
-		wBlk.Mul(wBlk, floatECPrM) // Power addition
+		wBlk.Mul(wBlk, floatECPrM) // NumCommittedSectors addition
 		wBlk.Add(wBlk, floatECV)   // Constant addition
 		w.Add(w, wBlk)
 	}
@@ -322,12 +322,12 @@ func IsWinningTicket(ctx context.Context, bs blockstore.Blockstore, ptv PowerTab
 
 // CompareTicketPower abstracts the actual comparison logic so it can be used by some test
 // helpers
-func CompareTicketPower(ticket types.Signature, minerPower uint64, totalPower uint64) bool {
+func CompareTicketPower(ticket types.Signature, minerPower *types.BytesAmount, totalPower *types.BytesAmount) bool {
 	lhs := &big.Int{}
 	lhs.SetBytes(ticket)
-	lhs.Mul(lhs, big.NewInt(int64(totalPower)))
+	lhs.Mul(lhs, (&big.Int{}).SetUint64(totalPower.Uint64()))
 	rhs := &big.Int{}
-	rhs.Mul(big.NewInt(int64(minerPower)), ticketDomain)
+	rhs.Mul((&big.Int{}).SetUint64(minerPower.Uint64()), ticketDomain)
 	return lhs.Cmp(rhs) < 0
 }
 

--- a/consensus/expected_test.go
+++ b/consensus/expected_test.go
@@ -32,7 +32,7 @@ func TestNewExpected(t *testing.T) {
 
 	t.Run("a new Expected can be created", func(t *testing.T) {
 		cst, bstore, verifier := setupCborBlockstoreProofs()
-		ptv := testhelpers.NewTestPowerTableView(1, 5)
+		ptv := testhelpers.NewTestPowerTableView(types.NewBytesAmount(1), types.NewBytesAmount(5))
 		exp := consensus.NewExpected(cst, bstore, consensus.NewDefaultProcessor(), ptv, types.SomeCid(), verifier)
 		assert.NotNil(t, exp)
 	})
@@ -44,7 +44,7 @@ func TestExpected_NewValidTipSet(t *testing.T) {
 
 	ctx := context.Background()
 	cistore, bstore, verifier := setupCborBlockstoreProofs()
-	ptv := testhelpers.NewTestPowerTableView(1, 5)
+	ptv := testhelpers.NewTestPowerTableView(types.NewBytesAmount(1), types.NewBytesAmount(5))
 
 	t.Run("NewValidTipSet returns a tipset + nil (no errors) when valid blocks", func(t *testing.T) {
 
@@ -145,8 +145,8 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 	t.Run("passes the validateMining section when given valid mining blocks", func(t *testing.T) {
 
-		minerPower := uint64(1)
-		totalPower := uint64(1)
+		minerPower := types.NewBytesAmount(1)
+		totalPower := types.NewBytesAmount(1)
 
 		ptv := testhelpers.NewTestPowerTableView(minerPower, totalPower)
 		exp := consensus.NewExpected(cistore, bstore, testhelpers.NewTestProcessor(), ptv, genesisBlock.Cid(), verifier)
@@ -169,7 +169,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 	t.Run("returns nil + mining error when IsWinningTicket fails due to miner power error", func(t *testing.T) {
 
-		ptv := NewFailingMinerTestPowerTableView(1, 5)
+		ptv := NewFailingMinerTestPowerTableView(types.NewBytesAmount(1), types.NewBytesAmount(5))
 		exp := consensus.NewExpected(cistore, bstore, consensus.NewDefaultProcessor(), ptv, types.SomeCid(), verifier)
 
 		pTipSet, err := exp.NewValidTipSet(ctx, []*types.Block{genesisBlock})
@@ -218,7 +218,7 @@ func TestIsWinningTicket(t *testing.T) {
 		var st state.Tree
 
 		for _, c := range cases {
-			ptv := testhelpers.NewTestPowerTableView(c.myPower, c.totalPower)
+			ptv := testhelpers.NewTestPowerTableView(types.NewBytesAmount(c.myPower), types.NewBytesAmount(c.totalPower))
 			ticket := [65]byte{}
 			ticket[0] = c.ticket
 			r, err := consensus.IsWinningTicket(ctx, bs, ptv, st, ticket[:], minerAddress)

--- a/consensus/power_table_view.go
+++ b/consensus/power_table_view.go
@@ -2,7 +2,7 @@ package consensus
 
 import (
 	"context"
-	"math/big"
+	"github.com/filecoin-project/go-filecoin/types"
 
 	"github.com/ipfs/go-ipfs-blockstore"
 	"github.com/pkg/errors"
@@ -17,11 +17,11 @@ import (
 type PowerTableView interface {
 	// Total returns the total bytes stored by all miners in the given
 	// state.
-	Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (uint64, error)
+	Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (*types.BytesAmount, error)
 
 	// Miner returns the total bytes stored by the miner of the
 	// input address in the given state.
-	Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (uint64, error)
+	Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (*types.BytesAmount, error)
 
 	// HasPower returns true if the input address is associated with a
 	// miner that has storage power in the network.
@@ -35,45 +35,43 @@ type MarketView struct{}
 
 var _ PowerTableView = &MarketView{}
 
-// Total returns the total storage as a uint64.  If the total storage
-// value exceeds the max value of a uint64 this method errors.
+// Total returns the total storage as a BytesAmount. If the total storage value
+// exceeds the max value of a uint64 this method errors.
+//
 // TODO: uint64 has enough bits to express about 1 exabyte of total storage.
 // This should be increased for v1.
-func (v *MarketView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (uint64, error) {
+func (v *MarketView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (*types.BytesAmount, error) {
 	vms := vm.NewStorageMap(bstore)
 	rets, ec, err := CallQueryMethod(ctx, st, vms, address.StorageMarketAddress, "getTotalStorage", []byte{}, address.Undef, nil)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	if ec != 0 {
-		return 0, errors.Errorf("non-zero return code from query message: %d", ec)
+		return nil, errors.Errorf("non-zero return code from query message: %d", ec)
 	}
-	res := big.NewInt(0)
-	res.SetBytes(rets[0])
 
-	return res.Uint64(), nil
+	return types.NewBytesAmountFromBytes(rets[0]), nil
 }
 
-// Miner returns the storage that this miner has committed as a uint64.
-// If the total storage value exceeds the max value of a uint64 this method
+// Miner returns the storage that this miner has committed to the network. If
+// the total storage value exceeds the max value of BytesAmount, this method
 // errors.
-// TODO: currently power is in sectors, figure out if & how it should be converted to bytes.
-// TODO: uint64 has enough bits to express about 1 exabyte.  This
-// should probably be increased for v1.
-func (v *MarketView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (uint64, error) {
+//
+// TODO: uint64 has enough bits to express about 1 exabyte. This should probably
+// be increased for v1.
+func (v *MarketView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (*types.BytesAmount, error) {
 	vms := vm.NewStorageMap(bstore)
 	rets, ec, err := CallQueryMethod(ctx, st, vms, mAddr, "getPower", []byte{}, address.Undef, nil)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	if ec != 0 {
-		return 0, errors.Errorf("non-zero return code from query message: %d", ec)
+		return nil, errors.Errorf("non-zero return code from query message: %d", ec)
 	}
-	ret := big.NewInt(0).SetBytes(rets[0])
 
-	return ret.Uint64(), nil
+	return types.NewBytesAmountFromBytes(rets[0]), nil
 }
 
 // HasPower returns true if the provided address belongs to a miner with power
@@ -88,5 +86,5 @@ func (v *MarketView) HasPower(ctx context.Context, st state.Tree, bstore blockst
 		panic(err) //hey guys, dropping errors is BAD
 	}
 
-	return numBytes > 0
+	return numBytes.GreaterThan(types.ZeroBytes)
 }

--- a/consensus/power_table_view.go
+++ b/consensus/power_table_view.go
@@ -35,8 +35,7 @@ type MarketView struct{}
 
 var _ PowerTableView = &MarketView{}
 
-// Total returns the total storage as a BytesAmount. If the total storage value
-// exceeds the max value of a uint64 this method errors.
+// Total returns the total storage as a BytesAmount.
 func (v *MarketView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (*types.BytesAmount, error) {
 	vms := vm.NewStorageMap(bstore)
 	rets, ec, err := CallQueryMethod(ctx, st, vms, address.StorageMarketAddress, "getTotalStorage", []byte{}, address.Undef, nil)
@@ -51,8 +50,7 @@ func (v *MarketView) Total(ctx context.Context, st state.Tree, bstore blockstore
 	return types.NewBytesAmountFromBytes(rets[0]), nil
 }
 
-// Miner returns the storage that this miner has committed to the network. If
-// the total storage value exceeds the max value of a uint64 this method errors.
+// Miner returns the storage that this miner has committed to the network.
 func (v *MarketView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (*types.BytesAmount, error) {
 	vms := vm.NewStorageMap(bstore)
 	rets, ec, err := CallQueryMethod(ctx, st, vms, mAddr, "getPower", []byte{}, address.Undef, nil)

--- a/consensus/power_table_view.go
+++ b/consensus/power_table_view.go
@@ -37,9 +37,6 @@ var _ PowerTableView = &MarketView{}
 
 // Total returns the total storage as a BytesAmount. If the total storage value
 // exceeds the max value of a uint64 this method errors.
-//
-// TODO: uint64 has enough bits to express about 18.44 exabytes of total
-// storage. This should be increased for v1.
 func (v *MarketView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (*types.BytesAmount, error) {
 	vms := vm.NewStorageMap(bstore)
 	rets, ec, err := CallQueryMethod(ctx, st, vms, address.StorageMarketAddress, "getTotalStorage", []byte{}, address.Undef, nil)
@@ -56,9 +53,6 @@ func (v *MarketView) Total(ctx context.Context, st state.Tree, bstore blockstore
 
 // Miner returns the storage that this miner has committed to the network. If
 // the total storage value exceeds the max value of a uint64 this method errors.
-//
-// TODO: uint64 has enough bits to express about 18.44 exabytes of total
-// storage. This should be increased for v1.
 func (v *MarketView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (*types.BytesAmount, error) {
 	vms := vm.NewStorageMap(bstore)
 	rets, ec, err := CallQueryMethod(ctx, st, vms, mAddr, "getPower", []byte{}, address.Undef, nil)

--- a/consensus/power_table_view.go
+++ b/consensus/power_table_view.go
@@ -2,13 +2,13 @@ package consensus
 
 import (
 	"context"
-	"github.com/filecoin-project/go-filecoin/types"
 
 	"github.com/ipfs/go-ipfs-blockstore"
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/state"
+	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
 )
 

--- a/consensus/power_table_view.go
+++ b/consensus/power_table_view.go
@@ -38,8 +38,8 @@ var _ PowerTableView = &MarketView{}
 // Total returns the total storage as a BytesAmount. If the total storage value
 // exceeds the max value of a uint64 this method errors.
 //
-// TODO: uint64 has enough bits to express about 1 exabyte of total storage.
-// This should be increased for v1.
+// TODO: uint64 has enough bits to express about 18.44 exabytes of total
+// storage. This should be increased for v1.
 func (v *MarketView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (*types.BytesAmount, error) {
 	vms := vm.NewStorageMap(bstore)
 	rets, ec, err := CallQueryMethod(ctx, st, vms, address.StorageMarketAddress, "getTotalStorage", []byte{}, address.Undef, nil)
@@ -55,11 +55,10 @@ func (v *MarketView) Total(ctx context.Context, st state.Tree, bstore blockstore
 }
 
 // Miner returns the storage that this miner has committed to the network. If
-// the total storage value exceeds the max value of BytesAmount, this method
-// errors.
+// the total storage value exceeds the max value of a uint64 this method errors.
 //
-// TODO: uint64 has enough bits to express about 1 exabyte. This should probably
-// be increased for v1.
+// TODO: uint64 has enough bits to express about 18.44 exabytes of total
+// storage. This should be increased for v1.
 func (v *MarketView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (*types.BytesAmount, error) {
 	vms := vm.NewStorageMap(bstore)
 	rets, ec, err := CallQueryMethod(ctx, st, vms, mAddr, "getPower", []byte{}, address.Undef, nil)

--- a/consensus/testing.go
+++ b/consensus/testing.go
@@ -19,13 +19,13 @@ type TestView struct{}
 var _ PowerTableView = &TestView{}
 
 // Total always returns 1.
-func (tv *TestView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (uint64, error) {
-	return uint64(1), nil
+func (tv *TestView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (*types.BytesAmount, error) {
+	return types.NewBytesAmount(1), nil
 }
 
 // Miner always returns 1.
-func (tv *TestView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (uint64, error) {
-	return uint64(1), nil
+func (tv *TestView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (*types.BytesAmount, error) {
+	return types.NewBytesAmount(1), nil
 }
 
 // HasPower always returns true.

--- a/fixtures/constants.go
+++ b/fixtures/constants.go
@@ -35,9 +35,9 @@ var TestMiners []string
 type detailsStruct struct {
 	Keys   []*types.KeyInfo
 	Miners []struct {
-		Owner   int
-		Address string
-		Power   uint64
+		Owner               int
+		Address             string
+		NumCommittedSectors uint64
 	}
 	GenesisCid cid.Cid `refmt:",omitempty"`
 }

--- a/fixtures/setup.json
+++ b/fixtures/setup.json
@@ -9,6 +9,6 @@
   ],
   "miners": [{
     "owner": 0,
-    "power": 1
+    "numCommittedSectors": 1
   }]
 }

--- a/gengen/main.go
+++ b/gengen/main.go
@@ -133,7 +133,7 @@ func main() {
 	}
 
 	for _, m := range info.Miners {
-		fmt.Fprintf(os.Stderr, "created miner %s, owned by %d, power = %d\n", m.Address, m.Owner, m.Power) // nolint: errcheck
+		fmt.Fprintf(os.Stderr, "created miner %s, owned by %d, power = %s\n", m.Address, m.Owner, m.Power) // nolint: errcheck
 	}
 }
 

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -271,10 +271,12 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 			sectorSize = types.TwoHundredFiftySixMiBSectorSize
 		}
 
+		power := types.NewBytesAmount(sectorSize.Uint64() * m.NumCommittedSectors)
+
 		minfos = append(minfos, RenderedMinerInfo{
 			Address: maddr,
 			Owner:   m.Owner,
-			Power:   sectorSize.Mul(types.NewBytesAmount(m.NumCommittedSectors)),
+			Power:   power,
 		})
 
 		// commit sector to add power

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -45,7 +45,9 @@ type Miner struct {
 	//
 	// TODO: This struct needs a field which represents the size of sectors
 	// that this miner has committed. For now, sector size is configured by
-	// the StorageMarketActor's ProofsMode.
+	// the StorageMarketActor's ProofsMode. We should add this field as part of:
+	//
+	// https://github.com/filecoin-project/go-filecoin/issues/2530
 	//
 	// TODO: this will get more complicated when we actually have to
 	// prove real files.

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -40,10 +40,16 @@ type Miner struct {
 	// PeerID is the peer ID to set as the miners owner
 	PeerID string
 
-	// Power is the amount of power this miner should start off with
+	// NumCommittedSectors is the number of sectors that this miner has
+	// committed to the network.
+	//
+	// TODO: This struct needs a field which represents the size of sectors
+	// that this miner has committed. For now, sector size is configured by
+	// the StorageMarketActor's ProofsMode.
+	//
 	// TODO: this will get more complicated when we actually have to
-	// prove real files
-	Power uint64
+	// prove real files.
+	NumCommittedSectors uint64
 }
 
 // GenesisCfg is
@@ -83,8 +89,8 @@ type RenderedMinerInfo struct {
 	// Address is the address generated on-chain for the miner
 	Address address.Address
 
-	// Power is the amount of storage power this miner was created with
-	Power uint64
+	// NumCommittedSectors is the amount of storage power this miner was created with
+	Power *types.BytesAmount
 }
 
 // GenGen takes the genesis configuration and creates a genesis block that
@@ -260,11 +266,11 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 		minfos = append(minfos, RenderedMinerInfo{
 			Address: maddr,
 			Owner:   m.Owner,
-			Power:   m.Power,
+			Power:   types.NewBytesAmount(m.NumCommittedSectors),
 		})
 
 		// commit sector to add power
-		for i := uint64(0); i < m.Power; i++ {
+		for i := uint64(0); i < m.NumCommittedSectors; i++ {
 			// the following statement fakes out the behavior of the SectorBuilder.sectorIDNonce,
 			// which is initialized to 0 and incremented (for the first sector) to 1
 			sectorID := i + 1

--- a/gengen/util/gengen_test.go
+++ b/gengen/util/gengen_test.go
@@ -23,12 +23,12 @@ var testConfig = &GenesisCfg{
 	PreAlloc: []string{"10", "50"},
 	Miners: []Miner{
 		{
-			Owner: 0,
-			Power: 50,
+			Owner:               0,
+			NumCommittedSectors: 50,
 		},
 		{
-			Owner: 1,
-			Power: 10,
+			Owner:               1,
+			NumCommittedSectors: 10,
 		},
 	},
 }

--- a/mining/testing.go
+++ b/mining/testing.go
@@ -128,13 +128,13 @@ func NewTestPowerTableView(n uint64) *TestPowerTableView {
 }
 
 // Total always returns n.
-func (tv *TestPowerTableView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (uint64, error) {
-	return tv.n, nil
+func (tv *TestPowerTableView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (*types.BytesAmount, error) {
+	return types.NewBytesAmount(tv.n), nil
 }
 
 // Miner always returns 1.
-func (tv *TestPowerTableView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (uint64, error) {
-	return uint64(1), nil
+func (tv *TestPowerTableView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (*types.BytesAmount, error) {
+	return types.NewBytesAmount(uint64(1)), nil
 }
 
 // HasPower always returns true.

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -56,7 +56,7 @@ func TestBlockPropsManyNodes(t *testing.T) {
 	require.NoError(t, err)
 	baseTS := *headTipSet
 	require.NotNil(t, baseTS)
-	proof := testhelpers.MakeRandomPoSTProofForTest()
+	proof := testhelpers.MakeRandomPoStProofForTest()
 
 	ticket, err := signer.CreateTicket(proof, mockSignerPubKey)
 	require.NoError(t, err)

--- a/node/testing.go
+++ b/node/testing.go
@@ -229,9 +229,9 @@ var TestGenCfg = &gengen.GenesisCfg{
 	Keys: 2,
 	Miners: []gengen.Miner{
 		{
-			Owner:  0,
-			Power:  100,
-			PeerID: mustPeerID(PeerKeys[0]).Pretty(),
+			Owner:               0,
+			NumCommittedSectors: 100,
+			PeerID:              mustPeerID(PeerKeys[0]).Pretty(),
 		},
 	},
 	PreAlloc: []string{

--- a/testhelpers/chain.go
+++ b/testhelpers/chain.go
@@ -183,7 +183,7 @@ func MakeProofAndWinningTicket(signerPubKey []byte, minerPower *types.BytesAmoun
 	poStProof := make([]byte, types.OnePoStProofPartition.ProofLen())
 	var ticket types.Signature
 
-	quot := totalPower.Quo(totalPower, minerPower)
+	quot := totalPower.Quo(minerPower)
 	threshold := types.NewBytesAmount(100000).Mul(types.OneKiBSectorSize)
 
 	if quot.GreaterThan(threshold) {

--- a/testhelpers/chain.go
+++ b/testhelpers/chain.go
@@ -179,17 +179,19 @@ func RequirePutTsas(ctx context.Context, t *testing.T, chn chain.Store, tsas *ch
 }
 
 // MakeProofAndWinningTicket generates a proof and ticket that will pass validateMining.
-func MakeProofAndWinningTicket(signerPubKey []byte, minerPower uint64, totalPower uint64, signer consensus.TicketSigner) (types.PoStProof, types.Signature, error) {
-
+func MakeProofAndWinningTicket(signerPubKey []byte, minerPower *types.BytesAmount, totalPower *types.BytesAmount, signer consensus.TicketSigner) (types.PoStProof, types.Signature, error) {
 	poStProof := make([]byte, types.OnePoStProofPartition.ProofLen())
 	var ticket types.Signature
 
-	if totalPower/minerPower > 100000 {
+	quot := totalPower.Quo(totalPower, minerPower)
+	threshold := types.NewBytesAmount(100000).Mul(types.OneKiBSectorSize)
+
+	if quot.GreaterThan(threshold) {
 		return poStProof, ticket, errors.New("MakeProofAndWinningTicket: minerPower is too small for totalPower to generate a winning ticket")
 	}
 
 	for {
-		poStProof = MakeRandomPoSTProofForTest()
+		poStProof = MakeRandomPoStProofForTest()
 		ticket, err := consensus.CreateTicket(poStProof, signerPubKey, signer)
 		if err != nil {
 			errStr := fmt.Sprintf("error creating ticket: %s", err)

--- a/testhelpers/consensus.go
+++ b/testhelpers/consensus.go
@@ -24,13 +24,13 @@ type TestView struct{}
 var _ consensus.PowerTableView = &TestView{}
 
 // Total always returns 1.
-func (tv *TestView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (uint64, error) {
-	return uint64(1), nil
+func (tv *TestView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (*types.BytesAmount, error) {
+	return types.NewBytesAmount(1), nil
 }
 
 // Miner always returns 1.
-func (tv *TestView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (uint64, error) {
-	return uint64(1), nil
+func (tv *TestView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (*types.BytesAmount, error) {
+	return types.NewBytesAmount(1), nil
 }
 
 // HasPower always returns true.
@@ -46,29 +46,22 @@ func RequireNewTipSet(t *testing.T, blks ...*types.Block) types.TipSet {
 	return ts
 }
 
-// RequireTipSetAdd adds a block to the provided tipset and requires that this
-// does not error.
-func RequireTipSetAdd(require *require.Assertions, blk *types.Block, ts types.TipSet) {
-	err := ts.AddBlock(blk)
-	require.NoError(err)
-}
-
 // TestPowerTableView is an implementation of the powertable view used for testing mining
 // wherein each miner has totalPower/minerPower power.
-type TestPowerTableView struct{ minerPower, totalPower uint64 }
+type TestPowerTableView struct{ minerPower, totalPower *types.BytesAmount }
 
 // NewTestPowerTableView creates a test power view with the given total power
-func NewTestPowerTableView(minerPower uint64, totalPower uint64) *TestPowerTableView {
+func NewTestPowerTableView(minerPower *types.BytesAmount, totalPower *types.BytesAmount) *TestPowerTableView {
 	return &TestPowerTableView{minerPower: minerPower, totalPower: totalPower}
 }
 
 // Total always returns value that was supplied to NewTestPowerTableView.
-func (tv *TestPowerTableView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (uint64, error) {
+func (tv *TestPowerTableView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (*types.BytesAmount, error) {
 	return tv.totalPower, nil
 }
 
 // Miner always returns value that was supplied to NewTestPowerTableView.
-func (tv *TestPowerTableView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (uint64, error) {
+func (tv *TestPowerTableView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (*types.BytesAmount, error) {
 	return tv.minerPower, nil
 }
 
@@ -80,7 +73,7 @@ func (tv *TestPowerTableView) HasPower(ctx context.Context, st state.Tree, bstor
 // NewValidTestBlockFromTipSet creates a block for when proofs & power table don't need
 // to be correct
 func NewValidTestBlockFromTipSet(baseTipSet types.TipSet, stateRootCid cid.Cid, height uint64, minerAddr address.Address, minerPubKey []byte, signer consensus.TicketSigner) *types.Block {
-	poStProof := MakeRandomPoSTProofForTest()
+	poStProof := MakeRandomPoStProofForTest()
 	ticket, _ := consensus.CreateTicket(poStProof, minerPubKey, signer)
 
 	return &types.Block{
@@ -95,8 +88,8 @@ func NewValidTestBlockFromTipSet(baseTipSet types.TipSet, stateRootCid cid.Cid, 
 	}
 }
 
-// MakeRandomPoSTProofForTest creates a random proof.
-func MakeRandomPoSTProofForTest() []byte {
+// MakeRandomPoStProofForTest creates a random proof.
+func MakeRandomPoStProofForTest() []byte {
 	proofSize := types.OnePoStProofPartition.ProofLen()
 	p := MakeRandomBytes(proofSize)
 	p[0] = 42

--- a/testhelpers/iptbtester/genesis.go
+++ b/testhelpers/iptbtester/genesis.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-filecoin/commands"
-	gengen "github.com/filecoin-project/go-filecoin/gengen/util"
+	"github.com/filecoin-project/go-filecoin/gengen/util"
 )
 
 // GenesisInfo chains require information to start a single node with funds

--- a/testhelpers/iptbtester/genesis.go
+++ b/testhelpers/iptbtester/genesis.go
@@ -35,8 +35,8 @@ func MustGenerateGenesis(t *testing.T, funds int64, dir string) *GenesisInfo {
 		},
 		Miners: []gengen.Miner{
 			{
-				Owner: 0,
-				Power: 1,
+				Owner:               0,
+				NumCommittedSectors: 1,
 			},
 		},
 	}

--- a/tools/fast/environment_memory_genesis.go
+++ b/tools/fast/environment_memory_genesis.go
@@ -219,8 +219,8 @@ func (e *EnvironmentMemoryGenesis) buildGenesis(funds *big.Int) error {
 		},
 		Miners: []gengen.Miner{
 			{
-				Owner: 0,
-				Power: 1,
+				Owner:               0,
+				NumCommittedSectors: 1,
 			},
 		},
 		ProofsMode: e.proofsMode,

--- a/types/bytes_amount.go
+++ b/types/bytes_amount.go
@@ -116,6 +116,16 @@ func (z *BytesAmount) Mul(y *BytesAmount) *BytesAmount {
 	return &newZ
 }
 
+// Quo sets z to the quotient x/y for y != 0 and returns z.
+// If y == 0, a division-by-zero run-time panic occurs.
+func (z *BytesAmount) Quo(x, y *BytesAmount) *BytesAmount {
+	ensureBytesAmounts(&z, &y)
+	newVal := big.NewInt(0)
+	newVal.Quo(x.val, y.val)
+	newZ := BytesAmount{val: newVal}
+	return &newZ
+}
+
 // Equal returns true if z = y
 func (z *BytesAmount) Equal(y *BytesAmount) bool {
 	ensureBytesAmounts(&z, &y)

--- a/types/bytes_amount.go
+++ b/types/bytes_amount.go
@@ -116,12 +116,12 @@ func (z *BytesAmount) Mul(y *BytesAmount) *BytesAmount {
 	return &newZ
 }
 
-// Quo sets z to the quotient x/y for y != 0 and returns z.
-// If y == 0, a division-by-zero run-time panic occurs.
-func (z *BytesAmount) Quo(x, y *BytesAmount) *BytesAmount {
+// Quo returns the quotient z/y for y != 0. If y == 0, a division-by-zero
+// run-time panic occurs.
+func (z *BytesAmount) Quo(y *BytesAmount) *BytesAmount {
 	ensureBytesAmounts(&z, &y)
 	newVal := big.NewInt(0)
-	newVal.Quo(x.val, y.val)
+	newVal.Quo(z.val, y.val)
 	newZ := BytesAmount{val: newVal}
 	return &newZ
 }

--- a/types/bytes_amount.go
+++ b/types/bytes_amount.go
@@ -174,7 +174,7 @@ func (z *BytesAmount) IsZero() bool {
 	return z.Equal(ZeroBytes)
 }
 
-// Bytes returns the absolute value of x as a big-endian byte slice.
+// Bytes returns the absolute value of z as a big-endian byte slice.
 func (z *BytesAmount) Bytes() []byte {
 	ensureBytesAmounts(&z)
 	return leb128.FromBigInt(z.val)
@@ -185,7 +185,15 @@ func (z *BytesAmount) String() string {
 	return z.val.String()
 }
 
-// Uint64 returns the uint64 representation of x. If x cannot be represented in a uint64, the result is undefined.
+// Uint64 returns the uint64 representation of z. If z cannot be represented as
+// a uint64, the result is undefined.
 func (z *BytesAmount) Uint64() uint64 {
+	ensureBytesAmounts(&z)
 	return z.val.Uint64()
+}
+
+// BigInt returns the big.Int representation of z.
+func (z *BytesAmount) BigInt() *big.Int {
+	ensureBytesAmounts(&z)
+	return (&big.Int{}).Set(z.val)
 }

--- a/types/bytes_amount.go
+++ b/types/bytes_amount.go
@@ -89,7 +89,7 @@ func NewBytesAmountFromString(s string, base int) (*BytesAmount, bool) {
 	return ba, ok
 }
 
-// Add sets z to the sum x+y and returns z.
+// Add returns the sum z+y.
 func (z *BytesAmount) Add(y *BytesAmount) *BytesAmount {
 	ensureBytesAmounts(&z, &y)
 	newVal := big.NewInt(0)
@@ -98,7 +98,7 @@ func (z *BytesAmount) Add(y *BytesAmount) *BytesAmount {
 	return &newZ
 }
 
-// Sub sets z to the difference x-y and returns z.
+// Sub returns the difference z-y.
 func (z *BytesAmount) Sub(y *BytesAmount) *BytesAmount {
 	ensureBytesAmounts(&z, &y)
 	newVal := big.NewInt(0)
@@ -107,7 +107,7 @@ func (z *BytesAmount) Sub(y *BytesAmount) *BytesAmount {
 	return &newZ
 }
 
-// Mul sets z to  x*y and returns z.
+// Mul returns the product z*y.
 func (z *BytesAmount) Mul(y *BytesAmount) *BytesAmount {
 	ensureBytesAmounts(&z, &y)
 	newVal := big.NewInt(0)
@@ -126,31 +126,31 @@ func (z *BytesAmount) Quo(y *BytesAmount) *BytesAmount {
 	return &newZ
 }
 
-// Equal returns true if z = y
+// Equal returns true if z = y.
 func (z *BytesAmount) Equal(y *BytesAmount) bool {
 	ensureBytesAmounts(&z, &y)
 	return z.val.Cmp(y.val) == 0
 }
 
-// LessThan returns true if z < y
+// LessThan returns true if z < y.
 func (z *BytesAmount) LessThan(y *BytesAmount) bool {
 	ensureBytesAmounts(&z, &y)
 	return z.val.Cmp(y.val) < 0
 }
 
-// GreaterThan returns true if z > y
+// GreaterThan returns true if z > y.
 func (z *BytesAmount) GreaterThan(y *BytesAmount) bool {
 	ensureBytesAmounts(&z, &y)
 	return z.val.Cmp(y.val) > 0
 }
 
-// LessEqual returns true if z <= y
+// LessEqual returns true if z <= y.
 func (z *BytesAmount) LessEqual(y *BytesAmount) bool {
 	ensureBytesAmounts(&z, &y)
 	return z.val.Cmp(y.val) <= 0
 }
 
-// GreaterEqual returns true if z >= y
+// GreaterEqual returns true if z >= y.
 func (z *BytesAmount) GreaterEqual(y *BytesAmount) bool {
 	ensureBytesAmounts(&z, &y)
 	return z.val.Cmp(y.val) >= 0


### PR DESCRIPTION
Fixes #2601 

## Why does this PR exist?

This PR brings the go-filecoin implementation a bit closer to the spec w/respect to how miner power is tracked. Today, miner power is recorded in the number of sectors which they have committed to the network. With the multiple sector sizes feature, miners X, Y, and Z on the same network may be committing sectors of different sizes and the power table needs to accommodate for that. 

## What's in this PR?

This PR modifies the power table and EC code and storage market actor (and tests, and ...) to track miner power in bytes amount instead of number of sectors committed to the network. Total storage is also tracked by bytes amount.

## Next Steps

Now that miner power (and total storage capacity) is measured in bytes, we can loosen the restriction that prevents a single network from supporting more than one sector size. My next task is to modify the create miner flow to prompt an operator to pick the appropriate sector size for their miner.
