### PR TITLE
Refactor/deal get respects errors 2762

### DIFF
--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -55,7 +55,7 @@ func (a *API) CreatePayments(ctx context.Context, config CreatePaymentsParams) (
 }
 
 // DealGet returns a single deal matching a given cid or an error
-func (a *API) DealGet(proposalCid cid.Cid) *storagedeal.Deal {
+func (a *API) DealGet(proposalCid cid.Cid) (*storagedeal.Deal, error) {
 	return DealGet(a, proposalCid)
 }
 

--- a/porcelain/storagedeals.go
+++ b/porcelain/storagedeals.go
@@ -2,8 +2,14 @@ package porcelain
 
 import (
 	"github.com/ipfs/go-cid"
+	errors "github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
+)
+
+var (
+	// ErrDealNotFound means DealGet failed to find a matching deal
+	ErrDealNotFound = errors.New("deal not found")
 )
 
 type strgdlsPlumbing interface {
@@ -11,15 +17,15 @@ type strgdlsPlumbing interface {
 }
 
 // DealGet returns a single deal matching a given cid or an error
-func DealGet(plumbing strgdlsPlumbing, dealCid cid.Cid) *storagedeal.Deal {
+func DealGet(plumbing strgdlsPlumbing, dealCid cid.Cid) (*storagedeal.Deal, error) {
 	deals, err := plumbing.DealsLs()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	for _, storageDeal := range deals {
 		if storageDeal.Response.ProposalCid == dealCid {
-			return storageDeal
+			return storageDeal, nil
 		}
 	}
-	return nil
+	return nil, errors.New("deal not found")
 }

--- a/porcelain/storagedeals.go
+++ b/porcelain/storagedeals.go
@@ -27,5 +27,5 @@ func DealGet(plumbing strgdlsPlumbing, dealCid cid.Cid) (*storagedeal.Deal, erro
 			return storageDeal, nil
 		}
 	}
-	return nil, errors.New("deal not found")
+	return nil, ErrDealNotFound
 }

--- a/protocol/storage/client.go
+++ b/protocol/storage/client.go
@@ -249,7 +249,7 @@ func (smc *Client) checkDealResponse(ctx context.Context, resp *storagedeal.Resp
 func (smc *Client) minerForProposal(c cid.Cid) (address.Address, error) {
 	storageDeal, err := smc.api.DealGet(c)
 	if err != nil {
-		return address.Undef, fmt.Errorf("no such proposal by cid: %s", c)
+		return address.Undef, errors.Wrapf(err, "no such proposal by cid: %s", c)
 	}
 	return storageDeal.Miner, nil
 }
@@ -298,7 +298,7 @@ func (smc *Client) isMaybeDupDeal(p *storagedeal.Proposal) bool {
 func (smc *Client) LoadVouchersForDeal(dealCid cid.Cid) ([]*types.PaymentVoucher, error) {
 	storageDeal, err := smc.api.DealGet(dealCid)
 	if err != nil {
-		return []*types.PaymentVoucher{}, fmt.Errorf("could not retrieve deal with proposal CID %s", dealCid)
+		return []*types.PaymentVoucher{}, errors.Wrapf(err, "could not retrieve deal with proposal CID %s", dealCid)
 	}
 	return storageDeal.Proposal.Payment.Vouchers, nil
 }

--- a/protocol/storage/client.go
+++ b/protocol/storage/client.go
@@ -256,7 +256,7 @@ func (smc *Client) checkDealResponse(ctx context.Context, resp *storagedeal.Resp
 func (smc *Client) minerForProposal(c cid.Cid) (address.Address, error) {
 	storageDeal, err := smc.api.DealGet(c)
 	if err != nil {
-		return address.Undef, errors.Wrapf(err, "no such proposal by cid: %s", c)
+		return address.Undef, errors.Wrapf(err, "failed to fetch deal: %s", c)
 	}
 	return storageDeal.Miner, nil
 }

--- a/protocol/storage/client.go
+++ b/protocol/storage/client.go
@@ -225,6 +225,13 @@ func (smc *Client) recordResponse(resp *storagedeal.Response, miner address.Addr
 	if !proposalCid.Equals(resp.ProposalCid) {
 		return fmt.Errorf("cids not equal %s %s", proposalCid, resp.ProposalCid)
 	}
+	_, err = smc.api.DealGet(proposalCid)
+	if err == nil {
+		return fmt.Errorf("deal [%s] is already in progress", proposalCid.String())
+	}
+	if err != porcelain.ErrDealNotFound {
+		return errors.Wrapf(err, "failed to check for existing deal: %s", proposalCid.String())
+	}
 
 	return smc.api.DealPut(&storagedeal.Deal{
 		Miner:    miner,

--- a/protocol/storage/client_test.go
+++ b/protocol/storage/client_test.go
@@ -106,7 +106,8 @@ func TestProposeDeal(t *testing.T) {
 
 		assert.Equal(t, storagedeal.Accepted, dealResponse.State)
 
-		retrievedDeal := testAPI.DealGet(dealResponse.ProposalCid)
+		retrievedDeal, err := testAPI.DealGet(dealResponse.ProposalCid)
+		require.NoError(t, err)
 
 		assert.Equal(t, retrievedDeal.Response, dealResponse)
 	})
@@ -240,8 +241,8 @@ func (ctp *clientTestAPI) DealsLs() ([]*storagedeal.Deal, error) {
 	return results, nil
 }
 
-func (ctp *clientTestAPI) DealGet(dealCid cid.Cid) *storagedeal.Deal {
-	return ctp.deals[dealCid]
+func (ctp *clientTestAPI) DealGet(dealCid cid.Cid) (*storagedeal.Deal, error) {
+	return ctp.deals[dealCid], nil
 }
 
 func (ctp *clientTestAPI) DealPut(storageDeal *storagedeal.Deal) error {

--- a/protocol/storage/client_test.go
+++ b/protocol/storage/client_test.go
@@ -242,7 +242,11 @@ func (ctp *clientTestAPI) DealsLs() ([]*storagedeal.Deal, error) {
 }
 
 func (ctp *clientTestAPI) DealGet(dealCid cid.Cid) (*storagedeal.Deal, error) {
-	return ctp.deals[dealCid], nil
+	deal, ok := ctp.deals[dealCid]
+	if ok {
+		return deal, nil
+	}
+	return nil, porcelain.ErrDealNotFound
 }
 
 func (ctp *clientTestAPI) DealPut(storageDeal *storagedeal.Deal) error {

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -385,7 +385,7 @@ func rejectProposal(sm *Miner, p *storagedeal.Proposal, reason string) (*storage
 func (sm *Miner) updateDealResponse(proposalCid cid.Cid, f func(*storagedeal.Response)) error {
 	storageDeal, err := sm.porcelainAPI.DealGet(proposalCid)
 	if err != nil {
-		return fmt.Errorf("failed to get retrive deal with proposal CID %s", proposalCid.String())
+		return errors.Wrapf(err, "failed to get retrive deal with proposal CID %s", proposalCid.String())
 	}
 	f(storageDeal.Response)
 	err = sm.porcelainAPI.DealPut(storageDeal)
@@ -646,7 +646,7 @@ func (sm *Miner) onCommitSuccess(dealCid cid.Cid, sector *sectorbuilder.SealedSe
 func (sm *Miner) findPieceInfo(dealCid cid.Cid, sector *sectorbuilder.SealedSectorMetadata) (*sectorbuilder.PieceInfo, error) {
 	deal, err := sm.porcelainAPI.DealGet(dealCid)
 	if err == porcelain.ErrDealNotFound || deal.Response.State == storagedeal.Unknown {
-		return nil, errors.Errorf("Could not find deal with deal cid %s", dealCid)
+		return nil, errors.Wrapf(err, "Could not find deal with deal cid %s", dealCid)
 	}
 	if err != nil {
 		return nil, err

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -404,7 +404,7 @@ func (sm *Miner) processStorageDeal(proposalCid cid.Cid) {
 
 	d, err := sm.porcelainAPI.DealGet(proposalCid)
 	if err != nil {
-		log.Errorf("could not retrieve deal with proposal CID %s", proposalCid.String())
+		log.Errorf("could not retrieve deal with proposal CID %s: %s", proposalCid.String(), err)
 	}
 	if d.Response.State != storagedeal.Accepted {
 		// TODO: handle resumption of deal processing across miner restarts

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/plumbing/cfg"
+	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/repo"
@@ -616,12 +617,12 @@ func (mtp *minerTestPorcelain) DealsLs() ([]*storagedeal.Deal, error) {
 	return results, nil
 }
 
-func (mtp *minerTestPorcelain) DealGet(dealCid cid.Cid) *storagedeal.Deal {
+func (mtp *minerTestPorcelain) DealGet(dealCid cid.Cid) (*storagedeal.Deal, error) {
 	storageDeal, ok := mtp.deals[dealCid]
 	if !ok {
-		return nil
+		return nil, porcelain.ErrDealNotFound
 	}
-	return storageDeal
+	return storageDeal, nil
 }
 
 func (mtp *minerTestPorcelain) DealPut(storageDeal *storagedeal.Deal) error {


### PR DESCRIPTION
# Problem

The current implementation of `DealGet` does not return errors properly in the event of datastore failure.

# Solution

Change `DealGet` to return errors.

Resolves #2762 