### PR TITLE
Fix migration logging

### DIFF
--- a/tools/migration/internal/logger.go
+++ b/tools/migration/internal/logger.go
@@ -24,7 +24,7 @@ func NewLogger(wc io.WriteCloser, verbose bool) *Logger {
 	}
 	return &Logger{
 		closer: wc,
-		logger: log.New(w, "", 0),
+		logger: log.New(w, "[Filecoin Migration] ", log.LstdFlags),
 	}
 }
 

--- a/tools/migration/internal/runner.go
+++ b/tools/migration/internal/runner.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/mitchellh/go-homedir"
@@ -242,15 +241,15 @@ func (m *MigrationRunner) findMigration(repoVersion uint) (mig Migration, err er
 	for _, mig := range m.MigrationsProvider() {
 		from, to := mig.Versions()
 		if to != from+1 {
-			log.Printf("refusing multi-version migration from %d to %d", from, to)
+			m.logger.Printf("refusing multi-version migration from %d to %d", from, to)
 		} else if from == repoVersion {
 			applicableMigs = append(applicableMigs, mig)
 		} else {
-			log.Printf("skipping migration from %d to %d", from, to)
+			m.logger.Printf("skipping migration from %d to %d", from, to)
 		}
 	}
 	if len(applicableMigs) == 0 {
-		log.Printf("did not find valid repo migration for version %d", repoVersion)
+		m.logger.Printf("did not find valid repo migration for version %d", repoVersion)
 		return nil, nil
 	}
 	if len(applicableMigs) > 1 {

--- a/tools/migration/internal/runner_test.go
+++ b/tools/migration/internal/runner_test.go
@@ -66,11 +66,12 @@ func TestMigrationRunner_Run(t *testing.T) {
 		require.NoError(t, err)
 		runner.MigrationsProvider = testProviderPasses
 
-		out := CaptureOutput(func() {
-			assert.NoError(t, runner.Run().Err)
-		})
-		assert.Contains(t, out, "skipping migration from 0 to 1")
-		assert.Contains(t, out, "did not find valid repo migration for version 199")
+		assert.NoError(t, runner.Run().Err)
+
+		out, err := ioutil.ReadFile(dummyLogPath)
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "skipping migration from 0 to 1")
+		assert.Contains(t, string(out), "did not find valid repo migration for version 199")
 	})
 
 	t.Run("Returns error when repo version is invalid", func(t *testing.T) {
@@ -144,10 +145,11 @@ func TestMigrationRunner_Run(t *testing.T) {
 				&TestMigMultiversion,
 			}
 		}
-		output := CaptureOutput(func() {
-			assert.NoError(t, runner.Run().Err)
-		})
-		assert.Contains(t, output, "refusing multi-version migration from 1 to 3")
+		assert.NoError(t, runner.Run().Err)
+
+		out, err := ioutil.ReadFile(dummyLogPath)
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "refusing multi-version migration from 1 to 3")
 	})
 
 	t.Run("newRepoOpt is ignored for commands other than install", func(t *testing.T) {

--- a/tools/migration/internal/test_helpers.go
+++ b/tools/migration/internal/test_helpers.go
@@ -1,9 +1,7 @@
 package internal
 
 import (
-	"bytes"
 	"io/ioutil"
-	"log"
 	"os"
 	"strconv"
 	"testing"
@@ -56,16 +54,6 @@ func RequireSetupTestRepo(t *testing.T, repoVersion uint) (repoDir, symLink stri
 
 	require.NoError(t, repo.WriteVersion(repoDir, repoVersion))
 	return repoDir, symLink
-}
-
-// CaptureOutput redirects log content into a buffer and calls the function provided,
-// and returns buffer content.
-func CaptureOutput(f func()) string {
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	f()
-	log.SetOutput(os.Stderr)
-	return buf.String()
 }
 
 // AssertNotInstalled verifies that repoLink still points to oldRepoDir

--- a/tools/migration/main_test.go
+++ b/tools/migration/main_test.go
@@ -57,15 +57,11 @@ func TestOptions(t *testing.T) {
 
 		out, err := exec.Command(command, "describe", "--old-repo="+symlink, "--verbose").CombinedOutput()
 		assert.NoError(t, err)
-		// TODO: fix after logging is fixed, Issue 2731
-		//assert.Equal(t, "binary version 0 = repo version 0; migration not run\n", string(out))
-		assert.Equal(t, "", string(out))
+		assert.Contains(t, string(out), "Repo up-to-date: binary version 0 = repo version 0\n")
 
 		_, err = exec.Command(command, "describe", "--old-repo="+symlink, "-v").CombinedOutput()
 		assert.NoError(t, err)
-		// TODO: fix after logging is fixed, Issue 2731
-		//assert.Equal(t, "binary version 0 = repo version 0; migration not run\n", string(out))
-		assert.Equal(t, "", string(out))
+		assert.Contains(t, string(out), "Repo up-to-date: binary version 0 = repo version 0\n")
 	})
 
 	t.Run("requires --old-repo argument", func(t *testing.T) {


### PR DESCRIPTION
    - logfile closed when main exits
    - correct flags during file open to enable logging
    - correct usage of global log in runner