### PR TITLE
expose StdErr() from iptb.Output with a dump function

### DIFF
--- a/commands/client_daemon_test.go
+++ b/commands/client_daemon_test.go
@@ -270,10 +270,5 @@ func TestSelfDialStorageGoodError(t *testing.T) {
 	f := files.NewBytesFile([]byte("satyamevajayate"))
 	_, _, err = series.ImportAndStore(ctx, miningNode, ask, f)
 	assert.Error(t, err)
-	var cmdOutBytes []byte
-	w := bytes.NewBuffer(cmdOutBytes)
-	miningNode.DumpLastOutput(w)
-	outputStr := string(w.Bytes())
-	expectedErrStr := "attempting to make storage deal with self"
-	assert.Contains(t, outputStr, expectedErrStr)
+	fastesting.AssertStdErrContains(t, miningNode, "attempting to make storage deal with self")
 }

--- a/commands/retrieval_client_daemon_test.go
+++ b/commands/retrieval_client_daemon_test.go
@@ -1,7 +1,6 @@
 package commands_test
 
 import (
-	"bytes"
 	"context"
 	"math/big"
 	"testing"
@@ -50,10 +49,5 @@ func TestSelfDialRetrievalGoodError(t *testing.T) {
 	// Genesis Miner fails on self dial when retrieving from itself.
 	_, err = env.GenesisMiner.RetrievalClientRetrievePiece(ctx, cid, minerAddr)
 	assert.Error(t, err)
-	var cmdOutBytes []byte
-	w := bytes.NewBuffer(cmdOutBytes)
-	env.GenesisMiner.DumpLastStdErr(w)
-	outputStr := string(w.Bytes())
-	expectedErrStr := "attempting to retrieve piece from self"
-	assert.Contains(t, outputStr, expectedErrStr)
+	fastesting.AssertStdErrContains(t, env.GenesisMiner, "attempting to retrieve piece from self")
 }

--- a/commands/retrieval_client_daemon_test.go
+++ b/commands/retrieval_client_daemon_test.go
@@ -52,7 +52,7 @@ func TestSelfDialRetrievalGoodError(t *testing.T) {
 	assert.Error(t, err)
 	var cmdOutBytes []byte
 	w := bytes.NewBuffer(cmdOutBytes)
-	env.GenesisMiner.DumpLastOutput(w)
+	env.GenesisMiner.DumpLastStdErr(w)
 	outputStr := string(w.Bytes())
 	expectedErrStr := "attempting to retrieve piece from self"
 	assert.Contains(t, outputStr, expectedErrStr)

--- a/tools/fast/environment_memory_genesis_test.go
+++ b/tools/fast/environment_memory_genesis_test.go
@@ -54,6 +54,7 @@ func TestEnvironmentMemoryGenesis(t *testing.T) {
 
 		// did we teardown correctly?
 		assert.NoError(t, env.Teardown(ctx))
+		assert.Equal(t, 0, len(env.Processes()))
 		_, existsErr := os.Stat(localenv.location)
 		assert.True(t, os.IsNotExist(existsErr))
 	})

--- a/tools/fast/fastesting/assertions.go
+++ b/tools/fast/fastesting/assertions.go
@@ -1,0 +1,23 @@
+package fastesting
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+)
+
+// AssertStdErrContains verifies that the last command stderr of 'fast' contains the
+// string 'expected'
+func AssertStdErrContains(t *testing.T, fast *fast.Filecoin, expected string) {
+	var cmdOutBytes []byte
+	w := bytes.NewBuffer(cmdOutBytes)
+	written, err := io.Copy(w, fast.LastCmdStdErr())
+	require.NoError(t, err)
+	require.True(t, written > 0)
+	assert.Contains(t, string(w.Bytes()), expected)
+}

--- a/tools/fast/fastutil/debug_utils.go
+++ b/tools/fast/fastutil/debug_utils.go
@@ -54,3 +54,11 @@ func DumpOutputJSON(w io.Writer, output testbedi.Output) {
 	enc := json.NewEncoder(w)
 	_ = enc.Encode(jout) // nolint: errcheck
 }
+
+// DumpStdErr writes just the last stderr content of the output to the
+// writer buffer w in a human readable way
+func DumpStdErr(w io.Writer, output testbedi.Output) {
+	fmt.Fprintf(w, ">>>> start-dump\n") // nolint: errcheck
+	fmt.Fprintf(w, "---- stderr\n")     // nolint: errcheck
+	io.Copy(w, output.Stderr())         // nolint: errcheck
+}

--- a/tools/fast/fastutil/debug_utils.go
+++ b/tools/fast/fastutil/debug_utils.go
@@ -54,11 +54,3 @@ func DumpOutputJSON(w io.Writer, output testbedi.Output) {
 	enc := json.NewEncoder(w)
 	_ = enc.Encode(jout) // nolint: errcheck
 }
-
-// DumpStdErr writes just the last stderr content of the output to the
-// writer buffer w in a human readable way
-func DumpStdErr(w io.Writer, output testbedi.Output) {
-	fmt.Fprintf(w, ">>>> start-dump\n") // nolint: errcheck
-	fmt.Fprintf(w, "---- stderr\n")     // nolint: errcheck
-	io.Copy(w, output.Stderr())         // nolint: errcheck
-}

--- a/tools/fast/process.go
+++ b/tools/fast/process.go
@@ -183,12 +183,9 @@ func (f *Filecoin) DumpLastOutputJSON(w io.Writer) {
 	}
 }
 
-// DumpLastStdErr writes all the stderr output of the last run command from
-// RunCmdWithStdin, RunCmdJSONWithStdin, or RunCmdLDJSONWithStdin as json.
-func (f *Filecoin) DumpLastStdErr(w io.Writer) {
-	if f.lastCmdOutput != nil {
-		fastutil.DumpStdErr(w, f.lastCmdOutput)
-	}
+// LastCmdStdErr is the standard error output from the last command run
+func (f *Filecoin) LastCmdStdErr() io.ReadCloser {
+	return f.lastCmdOutput.Stderr()
 }
 
 // RunCmdWithStdin runs `args` against Filecoin process `f`, a testbedi.Output and an error are returned.

--- a/tools/fast/process.go
+++ b/tools/fast/process.go
@@ -183,6 +183,14 @@ func (f *Filecoin) DumpLastOutputJSON(w io.Writer) {
 	}
 }
 
+// DumpLastStdErr writes all the stderr output of the last run command from
+// RunCmdWithStdin, RunCmdJSONWithStdin, or RunCmdLDJSONWithStdin as json.
+func (f *Filecoin) DumpLastStdErr(w io.Writer) {
+	if f.lastCmdOutput != nil {
+		fastutil.DumpStdErr(w, f.lastCmdOutput)
+	}
+}
+
 // RunCmdWithStdin runs `args` against Filecoin process `f`, a testbedi.Output and an error are returned.
 func (f *Filecoin) RunCmdWithStdin(ctx context.Context, stdin io.Reader, args ...string) (testbedi.Output, error) {
 	if ctx == nil {


### PR DESCRIPTION
Closes #2611 , providing an easy way to check the StdErr of the Output from running a given FAST command.