### PR TITLE
Remove arbitrary context deadlines from daemon tests.

### DIFF
--- a/commands/client_daemon_test.go
+++ b/commands/client_daemon_test.go
@@ -230,9 +230,7 @@ func TestPieceRejectionInProposeStorageDeal(t *testing.T) {
 func TestSelfDialStorageGoodError(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx := context.Background()
-
-	ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.EnvironmentOpts{})
+	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.EnvironmentOpts{})
 	// Teardown after test ends.
 	defer func() {
 		err := env.Teardown(ctx)

--- a/commands/inspector_daemon_test.go
+++ b/commands/inspector_daemon_test.go
@@ -3,7 +3,6 @@ package commands_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,11 +15,7 @@ import (
 func TestInspectConfig(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
-	defer cancel()
-
-	// Get basic testing environment
-	ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.EnvironmentOpts{})
+	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
 	defer func() {

--- a/commands/payment_channel_daemon_test.go
+++ b/commands/payment_channel_daemon_test.go
@@ -21,11 +21,7 @@ import (
 func TestPaymentChannelCreateSuccess(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
-	defer cancel()
-
-	// Get basic testing environment
-	ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.EnvironmentOpts{})
+	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
 	defer func() {
@@ -46,11 +42,7 @@ func TestPaymentChannelLs(t *testing.T) {
 	tf.IntegrationTest(t)
 
 	t.Run("Works with default payer", func(t *testing.T) {
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
-		defer cancel()
-
-		// Get basic testing environment
-		ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.EnvironmentOpts{})
+		ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.EnvironmentOpts{})
 
 		// Teardown after test ends
 		defer func() {
@@ -80,11 +72,7 @@ func TestPaymentChannelLs(t *testing.T) {
 	})
 
 	t.Run("Works with specified payer", func(t *testing.T) {
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
-		defer cancel()
-
-		// Get basic testing environment
-		ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.EnvironmentOpts{})
+		ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.EnvironmentOpts{})
 
 		// Teardown after test ends
 		defer func() {
@@ -145,11 +133,7 @@ func TestPaymentChannelLs(t *testing.T) {
 func TestPaymentChannelVoucherSuccess(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
-	defer cancel()
-
-	// Get basic testing environment
-	ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.EnvironmentOpts{})
+	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
 	defer func() {
@@ -179,11 +163,7 @@ func TestPaymentChannelVoucherSuccess(t *testing.T) {
 func TestPaymentChannelRedeemSuccess(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
-	defer cancel()
-
-	// Get basic testing environment
-	ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.EnvironmentOpts{})
+	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
 	defer func() {
@@ -224,11 +204,7 @@ func TestPaymentChannelRedeemSuccess(t *testing.T) {
 func TestPaymentChannelRedeemTooEarlyFails(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
-	defer cancel()
-
-	// Get basic testing environment
-	ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.EnvironmentOpts{})
+	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
 	defer func() {
@@ -269,11 +245,7 @@ func TestPaymentChannelRedeemTooEarlyFails(t *testing.T) {
 func TestPaymentChannelReclaimSuccess(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
-	defer cancel()
-
-	// Get basic testing environment
-	ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.EnvironmentOpts{})
+	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
 	defer func() {
@@ -345,11 +317,7 @@ func TestPaymentChannelReclaimSuccess(t *testing.T) {
 func TestPaymentChannelCloseSuccess(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
-	defer cancel()
-
-	// Get basic testing environment
-	ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.EnvironmentOpts{})
+	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
 	defer func() {
@@ -401,11 +369,7 @@ func TestPaymentChannelCloseSuccess(t *testing.T) {
 func TestPaymentChannelExtendSuccess(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
-	defer cancel()
-
-	// Get basic testing environment
-	ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.EnvironmentOpts{})
+	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
 	defer func() {
@@ -461,11 +425,7 @@ func TestPaymentChannelExtendSuccess(t *testing.T) {
 func TestPaymentChannelCancelSuccess(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
-	defer cancel()
-
-	// Get basic testing environment
-	ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.EnvironmentOpts{})
+	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.EnvironmentOpts{})
 
 	// Teardown after test ends
 	defer func() {

--- a/commands/retrieval_client_daemon_test.go
+++ b/commands/retrieval_client_daemon_test.go
@@ -20,9 +20,7 @@ import (
 func TestSelfDialRetrievalGoodError(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx := context.Background()
-
-	ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.EnvironmentOpts{})
+	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.EnvironmentOpts{})
 	// Teardown after test ends.
 	defer func() {
 		err := env.Teardown(ctx)


### PR DESCRIPTION
These deadlines could expire on a loaded machine or when test parallelism was set too high.
This resolves at least some of the issues reported in #2711.

I don't think test code can make reliable deadline estimates–they depend too much on the environment. Instead we should rely on the externally-injected `-timeout` (which I will shorten separately).