### PR TITLE
Replace hardcoded test timeout and parallelism flags with defaults.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -780,8 +780,8 @@ commands:
           command: |
             trap "go run github.com/jstemmer/go-junit-report < test-results/go-test-suite/go-test.out > test-results/go-test-suite/go-test-report.xml" EXIT
             export TEST_PACKAGES="$(go list ./... | circleci tests split)"
-            export TEST_PARALLELISM="4"
-            go run ./build test -functional=<< parameters.functional >> -integration=<< parameters.integration >> -sectorbuilder=<< parameters.sector_builder_tests >> -unit=<< parameters.unit >> -v 2>&1 | tee test-results/go-test-suite/go-test.out
+            # Parallelism and timeout set to support medium-class containers, for builds on forked repos.
+            go run ./build test -timeout=30m -parallel=4 -functional=<< parameters.functional >> -integration=<< parameters.integration >> -sectorbuilder=<< parameters.sector_builder_tests >> -unit=<< parameters.unit >> -v 2>&1 | tee test-results/go-test-suite/go-test.out
   linux_configure_env:
     steps:
      - run:

--- a/build/main.go
+++ b/build/main.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/filecoin-project/go-filecoin/util/version"
 )
@@ -228,23 +229,20 @@ func install() {
 }
 
 // test executes tests and passes along all additional arguments to `go test`.
-func test(args ...string) {
-	log.Println("Testing...")
+func test(userArgs ...string) {
+	log.Println("Running tests...")
 
-	parallelism, ok := os.LookupEnv("TEST_PARALLELISM")
-
-	if !ok {
-		parallelism = "8"
-	}
-
+	// Consult environment for test packages, in order to support CI container-level parallelism.
 	packages, ok := os.LookupEnv("TEST_PACKAGES")
-
 	if !ok {
 		packages = "./..."
 	}
 
-	runCmd(cmd(fmt.Sprintf("go test -timeout 30m -parallel %s %s %s",
-		parallelism, strings.Replace(packages, "\n", " ", -1), strings.Join(args, " "))))
+	begin := time.Now()
+	runCmd(cmd(fmt.Sprintf("go test %s %s",
+		strings.Replace(packages, "\n", " ", -1), strings.Join(userArgs, " "))))
+	end := time.Now()
+	log.Printf("Tests finished in %.1f seconds\n", end.Sub(begin).Seconds())
 }
 
 func main() {


### PR DESCRIPTION
The specified parallelism of 8 was counter-productive on machines with fewer cores, and the
hardcoded flag was impossible to override from the outside. This now uses the Go default
of GOMAXPROCS (which is #cores). The CI config sets parallelism explicitly to suit container
size.

The specified timeout was also impossible to override when a shorter value was wanted for development. The CI config now sets the 30m value, but this is much more than we currently need.

I think these issues contributed to #2711.