### PR TITLE
Refactor deals awaiting seals into its own file.

### DIFF
--- a/plumbing/strgdls/store_test.go
+++ b/plumbing/strgdls/store_test.go
@@ -57,6 +57,9 @@ func TestDealStoreRoundTrip(t *testing.T) {
 	proposalCid, err := convert.ToCid(proposal)
 	require.NoError(t, err)
 
+	messageCid, err := convert.ToCid("messageCid")
+	require.NoError(t, err)
+
 	storageDeal := &storagedeal.Deal{
 		Miner:    minerAddr,
 		Proposal: proposal,
@@ -64,7 +67,7 @@ func TestDealStoreRoundTrip(t *testing.T) {
 			State:       storagedeal.Accepted,
 			Message:     responseMessage,
 			ProposalCid: proposalCid,
-			ProofInfo:   &storagedeal.ProofInfo{},
+			ProofInfo:   &storagedeal.ProofInfo{CommitmentMessage: messageCid},
 			Signature:   []byte("signature"),
 		},
 	}

--- a/protocol/storage/deals_awaiting_seal.go
+++ b/protocol/storage/deals_awaiting_seal.go
@@ -15,7 +15,7 @@ func init() {
 // sectorInfo combines sector Metadata from rust proofs with go-filecoin specific data
 type sectorInfo struct {
 	Metadata         *sectorbuilder.SealedSectorMetadata
-	CommitMessageCid *cid.Cid
+	CommitMessageCid cid.Cid
 	Succeeded        bool
 	ErrorMessage     string
 }
@@ -77,14 +77,14 @@ func (dealsAwaitingSeal *dealsAwaitingSeal) add(sectorID uint64, dealCid cid.Cid
 	delete(dealsAwaitingSeal.SealedSectors, sectorID)
 }
 
-func (dealsAwaitingSeal *dealsAwaitingSeal) success(sector *sectorbuilder.SealedSectorMetadata, commitMessage *cid.Cid) {
+func (dealsAwaitingSeal *dealsAwaitingSeal) success(sector *sectorbuilder.SealedSectorMetadata, commitMessageCID cid.Cid) {
 	dealsAwaitingSeal.l.Lock()
 	defer dealsAwaitingSeal.l.Unlock()
 
 	dealsAwaitingSeal.SealedSectors[sector.SectorID] = &sectorInfo{
 		Succeeded:        true,
 		Metadata:         sector,
-		CommitMessageCid: commitMessage,
+		CommitMessageCid: commitMessageCID,
 	}
 
 	for _, dealCid := range dealsAwaitingSeal.SectorsToDeals[sector.SectorID] {
@@ -108,10 +108,10 @@ func (dealsAwaitingSeal *dealsAwaitingSeal) fail(sectorID uint64, message string
 	delete(dealsAwaitingSeal.SectorsToDeals, sectorID)
 }
 
-func (dealsAwaitingSeal *dealsAwaitingSeal) commitMessageCid(sectorID uint64) (*cid.Cid, bool) {
+func (dealsAwaitingSeal *dealsAwaitingSeal) commitMessageCid(sectorID uint64) (cid.Cid, bool) {
 	sectorData, ok := dealsAwaitingSeal.SealedSectors[sectorID]
 	if !ok {
-		return nil, false
+		return cid.Undef, false
 	}
-	return sectorData.CommitMessageCid, sectorData.CommitMessageCid != nil
+	return sectorData.CommitMessageCid, sectorData.CommitMessageCid != cid.Undef
 }

--- a/protocol/storage/deals_awaiting_seal.go
+++ b/protocol/storage/deals_awaiting_seal.go
@@ -1,0 +1,117 @@
+package storage
+
+import (
+	"sync"
+
+	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
+	"github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+)
+
+func init() {
+	cbor.RegisterCborType(dealsAwaitingSeal{})
+}
+
+// sectorInfo combines sector Metadata from rust proofs with go-filecoin specific data
+type sectorInfo struct {
+	Metadata         *sectorbuilder.SealedSectorMetadata
+	CommitMessageCid *cid.Cid
+	Succeeded        bool
+	ErrorMessage     string
+}
+
+// dealsAwaitingSeal is a container for keeping track of which sectors have
+// pieces from which deals. We need it to accommodate a race condition where
+// a sector commit message is added to chain before we can add the sector/deal
+// book-keeping. It effectively caches success and failure results for sectors
+// for tardy add() calls.
+type dealsAwaitingSeal struct {
+	l sync.Mutex
+	// Maps from sector id to the deal cids with pieces in the sector.
+	SectorsToDeals map[uint64][]cid.Cid
+	// Maps from sector id to information about sector seal.
+	SealedSectors map[uint64]*sectorInfo
+
+	onSuccess func(dealCid cid.Cid, sector *sectorbuilder.SealedSectorMetadata)
+	onFail    func(dealCid cid.Cid, message string)
+}
+
+func newDealsAwaitingSeal() *dealsAwaitingSeal {
+	return &dealsAwaitingSeal{
+		SectorsToDeals: make(map[uint64][]cid.Cid),
+		SealedSectors:  make(map[uint64]*sectorInfo),
+	}
+}
+
+func (dealsAwaitingSeal *dealsAwaitingSeal) add(sectorID uint64, dealCid cid.Cid) {
+	dealsAwaitingSeal.l.Lock()
+	defer dealsAwaitingSeal.l.Unlock()
+
+	sector, ok := dealsAwaitingSeal.SealedSectors[sectorID]
+
+	// if sector sealing hasn't succeed or failed yet, just add to SectorToDeals and exit
+	if !ok {
+		deals, ok := dealsAwaitingSeal.SectorsToDeals[sectorID]
+		if ok {
+			dealsAwaitingSeal.SectorsToDeals[sectorID] = append(deals, dealCid)
+		} else {
+			dealsAwaitingSeal.SectorsToDeals[sectorID] = []cid.Cid{dealCid}
+		}
+		return
+	}
+
+	// We have sealing information, so process deal with sector data immediately
+	if sector.Succeeded {
+		dealsAwaitingSeal.onSuccess(dealCid, sector.Metadata)
+	} else {
+		dealsAwaitingSeal.onFail(dealCid, sector.ErrorMessage)
+	}
+
+	// Don't keep references to sectors around forever. Assume that at most
+	// one success-before-add call will happen (eg, in a test). Sector sealing
+	// outside of tests is so slow that it shouldn't happen in practice.
+	// So now that it has happened once, clean it up. If we wanted to keep
+	// the state around for longer for some reason we need to limit how many
+	// sectors we hang onto, eg keep a fixed-length slice of successes
+	// and failures and shift the oldest off and the newest on.
+	delete(dealsAwaitingSeal.SealedSectors, sectorID)
+}
+
+func (dealsAwaitingSeal *dealsAwaitingSeal) success(sector *sectorbuilder.SealedSectorMetadata, commitMessage *cid.Cid) {
+	dealsAwaitingSeal.l.Lock()
+	defer dealsAwaitingSeal.l.Unlock()
+
+	dealsAwaitingSeal.SealedSectors[sector.SectorID] = &sectorInfo{
+		Succeeded:        true,
+		Metadata:         sector,
+		CommitMessageCid: commitMessage,
+	}
+
+	for _, dealCid := range dealsAwaitingSeal.SectorsToDeals[sector.SectorID] {
+		dealsAwaitingSeal.onSuccess(dealCid, sector)
+	}
+	delete(dealsAwaitingSeal.SectorsToDeals, sector.SectorID)
+}
+
+func (dealsAwaitingSeal *dealsAwaitingSeal) fail(sectorID uint64, message string) {
+	dealsAwaitingSeal.l.Lock()
+	defer dealsAwaitingSeal.l.Unlock()
+
+	dealsAwaitingSeal.SealedSectors[sectorID] = &sectorInfo{
+		Succeeded:    false,
+		ErrorMessage: message,
+	}
+
+	for _, dealCid := range dealsAwaitingSeal.SectorsToDeals[sectorID] {
+		dealsAwaitingSeal.onFail(dealCid, message)
+	}
+	delete(dealsAwaitingSeal.SectorsToDeals, sectorID)
+}
+
+func (dealsAwaitingSeal *dealsAwaitingSeal) commitMessageCid(sectorID uint64) (*cid.Cid, bool) {
+	sectorData, ok := dealsAwaitingSeal.SealedSectors[sectorID]
+	if !ok {
+		return nil, false
+	}
+	return sectorData.CommitMessageCid, sectorData.CommitMessageCid != nil
+}

--- a/protocol/storage/deals_awaiting_seal.go
+++ b/protocol/storage/deals_awaiting_seal.go
@@ -14,10 +14,17 @@ func init() {
 
 // sectorInfo combines sector Metadata from rust proofs with go-filecoin specific data
 type sectorInfo struct {
-	Metadata         *sectorbuilder.SealedSectorMetadata
+	// Metadata contains information about the sealed sector needed to verify the seal
+	Metadata *sectorbuilder.SealedSectorMetadata
+
+	// CommitMessageCid is the cid of the commitSector message sent for sealed sector. It allows the client to coordinate on timing.
 	CommitMessageCid cid.Cid
-	Succeeded        bool
-	ErrorMessage     string
+
+	// Succeeded indicates whether sealing was and committing was successful
+	Succeeded bool
+
+	// ErrorMessage indicate what went wrong if sealing or committing was not successful
+	ErrorMessage string
 }
 
 // dealsAwaitingSeal is a container for keeping track of which sectors have

--- a/protocol/storage/deals_awaiting_seal_test.go
+++ b/protocol/storage/deals_awaiting_seal_test.go
@@ -26,7 +26,7 @@ func TestDealsAwaitingSealAdd(t *testing.T) {
 
 	wantMessage := "boom"
 
-	t.Run("add before success", func(t *testing.T) {
+	t.Run("process before success", func(t *testing.T) {
 		dealsAwaitingSeal := newDealsAwaitingSeal()
 		gotCids := []cid.Cid{}
 		dealsAwaitingSeal.onSuccess = func(dealCid cid.Cid, sector *sectorbuilder.SealedSectorMetadata) {
@@ -34,15 +34,15 @@ func TestDealsAwaitingSealAdd(t *testing.T) {
 			gotCids = append(gotCids, dealCid)
 		}
 
-		dealsAwaitingSeal.add(wantSectorID, cid0)
-		dealsAwaitingSeal.add(wantSectorID, cid1)
-		dealsAwaitingSeal.add(someOtherSectorID, cid2)
+		dealsAwaitingSeal.process(wantSectorID, cid0)
+		dealsAwaitingSeal.process(wantSectorID, cid1)
+		dealsAwaitingSeal.process(someOtherSectorID, cid2)
 		dealsAwaitingSeal.success(wantSector, commitSectorCid)
 
 		assert.Len(t, gotCids, 2, "onSuccess should've been called twice")
 	})
 
-	t.Run("add after success", func(t *testing.T) {
+	t.Run("process after success", func(t *testing.T) {
 		dealsAwaitingSeal := newDealsAwaitingSeal()
 		gotCids := []cid.Cid{}
 		dealsAwaitingSeal.onSuccess = func(dealCid cid.Cid, sector *sectorbuilder.SealedSectorMetadata) {
@@ -51,14 +51,14 @@ func TestDealsAwaitingSealAdd(t *testing.T) {
 		}
 
 		dealsAwaitingSeal.success(wantSector, commitSectorCid)
-		dealsAwaitingSeal.add(wantSectorID, cid0)
-		dealsAwaitingSeal.add(wantSectorID, cid1) // Shouldn't trigger a call, see add().
-		dealsAwaitingSeal.add(someOtherSectorID, cid2)
+		dealsAwaitingSeal.process(wantSectorID, cid0)
+		dealsAwaitingSeal.process(wantSectorID, cid1) // Shouldn't trigger a call, see process().
+		dealsAwaitingSeal.process(someOtherSectorID, cid2)
 
 		assert.Len(t, gotCids, 1, "onSuccess should've been called once")
 	})
 
-	t.Run("add before fail", func(t *testing.T) {
+	t.Run("process before fail", func(t *testing.T) {
 		dealsAwaitingSeal := newDealsAwaitingSeal()
 		gotCids := []cid.Cid{}
 		dealsAwaitingSeal.onFail = func(dealCid cid.Cid, message string) {
@@ -66,15 +66,15 @@ func TestDealsAwaitingSealAdd(t *testing.T) {
 			gotCids = append(gotCids, dealCid)
 		}
 
-		dealsAwaitingSeal.add(wantSectorID, cid0)
-		dealsAwaitingSeal.add(wantSectorID, cid1)
+		dealsAwaitingSeal.process(wantSectorID, cid0)
+		dealsAwaitingSeal.process(wantSectorID, cid1)
 		dealsAwaitingSeal.fail(wantSectorID, wantMessage)
 		dealsAwaitingSeal.fail(someOtherSectorID, "some message")
 
 		assert.Len(t, gotCids, 2, "onFail should've been called twice")
 	})
 
-	t.Run("add after fail", func(t *testing.T) {
+	t.Run("process after fail", func(t *testing.T) {
 		dealsAwaitingSeal := newDealsAwaitingSeal()
 		gotCids := []cid.Cid{}
 		dealsAwaitingSeal.onFail = func(dealCid cid.Cid, message string) {
@@ -84,8 +84,8 @@ func TestDealsAwaitingSealAdd(t *testing.T) {
 
 		dealsAwaitingSeal.fail(wantSectorID, wantMessage)
 		dealsAwaitingSeal.fail(someOtherSectorID, "some message")
-		dealsAwaitingSeal.add(wantSectorID, cid0)
-		dealsAwaitingSeal.add(wantSectorID, cid1) // Shouldn't trigger a call, see add().
+		dealsAwaitingSeal.process(wantSectorID, cid0)
+		dealsAwaitingSeal.process(wantSectorID, cid1) // Shouldn't trigger a call, see process().
 
 		assert.Len(t, gotCids, 1, "onFail should've been called once")
 	})

--- a/protocol/storage/deals_awaiting_seal_test.go
+++ b/protocol/storage/deals_awaiting_seal_test.go
@@ -33,6 +33,9 @@ func TestDealsAwaitingSealAdd(t *testing.T) {
 			assert.Equal(t, sector, wantSector)
 			gotCids = append(gotCids, dealCid)
 		}
+		dealsAwaitingSeal.onFail = func(dealCid cid.Cid, message string) {
+			require.Fail(t, "onFail should not have been called")
+		}
 
 		dealsAwaitingSeal.process(wantSectorID, cid0)
 		dealsAwaitingSeal.process(wantSectorID, cid1)
@@ -49,6 +52,9 @@ func TestDealsAwaitingSealAdd(t *testing.T) {
 			assert.Equal(t, sector, wantSector)
 			gotCids = append(gotCids, dealCid)
 		}
+		dealsAwaitingSeal.onFail = func(dealCid cid.Cid, message string) {
+			require.Fail(t, "onFail should not have been called")
+		}
 
 		dealsAwaitingSeal.success(wantSector, commitSectorCid)
 		dealsAwaitingSeal.process(wantSectorID, cid0)
@@ -61,6 +67,9 @@ func TestDealsAwaitingSealAdd(t *testing.T) {
 	t.Run("process before fail", func(t *testing.T) {
 		dealsAwaitingSeal := newDealsAwaitingSeal()
 		gotCids := []cid.Cid{}
+		dealsAwaitingSeal.onSuccess = func(dealCid cid.Cid, sector *sectorbuilder.SealedSectorMetadata) {
+			require.Fail(t, "onSuccess should not have been called")
+		}
 		dealsAwaitingSeal.onFail = func(dealCid cid.Cid, message string) {
 			assert.Equal(t, message, wantMessage)
 			gotCids = append(gotCids, dealCid)
@@ -77,6 +86,9 @@ func TestDealsAwaitingSealAdd(t *testing.T) {
 	t.Run("process after fail", func(t *testing.T) {
 		dealsAwaitingSeal := newDealsAwaitingSeal()
 		gotCids := []cid.Cid{}
+		dealsAwaitingSeal.onSuccess = func(dealCid cid.Cid, sector *sectorbuilder.SealedSectorMetadata) {
+			require.Fail(t, "onSuccess should not have been called")
+		}
 		dealsAwaitingSeal.onFail = func(dealCid cid.Cid, message string) {
 			assert.Equal(t, message, wantMessage)
 			gotCids = append(gotCids, dealCid)
@@ -107,6 +119,9 @@ func TestDealsAwaitingSealSuccess(t *testing.T) {
 		dealsAwaitingSeal.onSuccess = func(dealCid cid.Cid, sector *sectorbuilder.SealedSectorMetadata) {
 			require.True(t, unseenDealCids[dealCid])
 			delete(unseenDealCids, dealCid)
+		}
+		dealsAwaitingSeal.onFail = func(dealCid cid.Cid, message string) {
+			require.Fail(t, "onFail should not have been called")
 		}
 
 		dealsAwaitingSeal.success(sector, msgCid)

--- a/protocol/storage/deals_awaiting_seal_test.go
+++ b/protocol/storage/deals_awaiting_seal_test.go
@@ -1,0 +1,198 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDealsAwaitingSealAdd(t *testing.T) {
+	tf.UnitTest(t)
+
+	newCid := types.NewCidForTestGetter()
+	cid0 := newCid()
+	cid1 := newCid()
+	cid2 := newCid()
+	commitSectorCid := newCid()
+
+	wantSectorID := uint64(42)
+	wantSector := &sectorbuilder.SealedSectorMetadata{SectorID: wantSectorID}
+	someOtherSectorID := uint64(100)
+
+	wantMessage := "boom"
+
+	t.Run("add before success", func(t *testing.T) {
+		dealsAwaitingSeal := newDealsAwaitingSeal()
+		gotCids := []cid.Cid{}
+		dealsAwaitingSeal.onSuccess = func(dealCid cid.Cid, sector *sectorbuilder.SealedSectorMetadata) {
+			assert.Equal(t, sector, wantSector)
+			gotCids = append(gotCids, dealCid)
+		}
+
+		dealsAwaitingSeal.add(wantSectorID, cid0)
+		dealsAwaitingSeal.add(wantSectorID, cid1)
+		dealsAwaitingSeal.add(someOtherSectorID, cid2)
+		dealsAwaitingSeal.success(wantSector, &commitSectorCid)
+
+		assert.Len(t, gotCids, 2, "onSuccess should've been called twice")
+	})
+
+	t.Run("add after success", func(t *testing.T) {
+		dealsAwaitingSeal := newDealsAwaitingSeal()
+		gotCids := []cid.Cid{}
+		dealsAwaitingSeal.onSuccess = func(dealCid cid.Cid, sector *sectorbuilder.SealedSectorMetadata) {
+			assert.Equal(t, sector, wantSector)
+			gotCids = append(gotCids, dealCid)
+		}
+
+		dealsAwaitingSeal.success(wantSector, &commitSectorCid)
+		dealsAwaitingSeal.add(wantSectorID, cid0)
+		dealsAwaitingSeal.add(wantSectorID, cid1) // Shouldn't trigger a call, see add().
+		dealsAwaitingSeal.add(someOtherSectorID, cid2)
+
+		assert.Len(t, gotCids, 1, "onSuccess should've been called once")
+	})
+
+	t.Run("add before fail", func(t *testing.T) {
+		dealsAwaitingSeal := newDealsAwaitingSeal()
+		gotCids := []cid.Cid{}
+		dealsAwaitingSeal.onFail = func(dealCid cid.Cid, message string) {
+			assert.Equal(t, message, wantMessage)
+			gotCids = append(gotCids, dealCid)
+		}
+
+		dealsAwaitingSeal.add(wantSectorID, cid0)
+		dealsAwaitingSeal.add(wantSectorID, cid1)
+		dealsAwaitingSeal.fail(wantSectorID, wantMessage)
+		dealsAwaitingSeal.fail(someOtherSectorID, "some message")
+
+		assert.Len(t, gotCids, 2, "onFail should've been called twice")
+	})
+
+	t.Run("add after fail", func(t *testing.T) {
+		dealsAwaitingSeal := newDealsAwaitingSeal()
+		gotCids := []cid.Cid{}
+		dealsAwaitingSeal.onFail = func(dealCid cid.Cid, message string) {
+			assert.Equal(t, message, wantMessage)
+			gotCids = append(gotCids, dealCid)
+		}
+
+		dealsAwaitingSeal.fail(wantSectorID, wantMessage)
+		dealsAwaitingSeal.fail(someOtherSectorID, "some message")
+		dealsAwaitingSeal.add(wantSectorID, cid0)
+		dealsAwaitingSeal.add(wantSectorID, cid1) // Shouldn't trigger a call, see add().
+
+		assert.Len(t, gotCids, 1, "onFail should've been called once")
+	})
+}
+
+func TestDealsAwaitingSealSuccess(t *testing.T) {
+	newCid := types.NewCidForTestGetter()
+	cid1 := newCid()
+	cid2 := newCid()
+
+	sectorId := uint64(42)
+	sector := &sectorbuilder.SealedSectorMetadata{SectorID: sectorId}
+	msgCid := newCid()
+
+	t.Run("success calls onSuccess for all deals", func(t *testing.T) {
+		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorId, cid1, cid2)
+		unseenDealCids := map[cid.Cid]bool{cid1: true, cid2: true}
+
+		dealsAwaitingSeal.onSuccess = func(dealCid cid.Cid, sector *sectorbuilder.SealedSectorMetadata) {
+			require.True(t, unseenDealCids[dealCid])
+			delete(unseenDealCids, dealCid)
+		}
+
+		dealsAwaitingSeal.success(sector, &msgCid)
+
+		// called onSuccess for all deals
+		assert.Equal(t, 0, len(unseenDealCids))
+	})
+
+	t.Run("success clears sector from sector to deals cache", func(t *testing.T) {
+		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorId, cid1, cid2)
+
+		dealsAwaitingSeal.success(sector, &msgCid)
+
+		// cleared SectorsToDeals for this sector
+		assert.Nil(t, dealsAwaitingSeal.SectorsToDeals[sectorId])
+	})
+
+	t.Run("success adds sector to successful sectors", func(t *testing.T) {
+		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorId, cid1, cid2)
+
+		dealsAwaitingSeal.success(sector, &msgCid)
+
+		sectorData, ok := dealsAwaitingSeal.SealedSectors[sectorId]
+		require.True(t, ok)
+		assert.Equal(t, sector, sectorData.Metadata)
+	})
+
+	t.Run("success stores commit message cid with sector data", func(t *testing.T) {
+		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorId, cid1, cid2)
+
+		dealsAwaitingSeal.success(sector, &msgCid)
+
+		actualMsgCid, ok := dealsAwaitingSeal.commitMessageCid(sectorId)
+		require.True(t, ok)
+		assert.Equal(t, msgCid, *actualMsgCid)
+	})
+}
+
+func TestDealsAwaitingSealFail(t *testing.T) {
+	newCid := types.NewCidForTestGetter()
+	cid1 := newCid()
+	cid2 := newCid()
+
+	sectorId := uint64(42)
+	errorMessage := "test error message"
+
+	t.Run("fail calls onFail with correct message for all deals", func(t *testing.T) {
+		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorId, cid1, cid2)
+		unseenDealCids := map[cid.Cid]bool{cid1: true, cid2: true}
+
+		dealsAwaitingSeal.onFail = func(dealCid cid.Cid, message string) {
+			require.True(t, unseenDealCids[dealCid])
+			assert.Equal(t, errorMessage, message)
+			delete(unseenDealCids, dealCid)
+		}
+
+		dealsAwaitingSeal.fail(sectorId, errorMessage)
+
+		// called onSuccess for all deals
+		assert.Equal(t, 0, len(unseenDealCids))
+	})
+
+	t.Run("fail clears sector from sector to deals cache", func(t *testing.T) {
+		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorId, cid1, cid2)
+
+		dealsAwaitingSeal.fail(sectorId, errorMessage)
+
+		// cleared SectorsToDeals for this sector
+		assert.Nil(t, dealsAwaitingSeal.SectorsToDeals[sectorId])
+	})
+
+	t.Run("fail adds error message to failure map", func(t *testing.T) {
+		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorId, cid1, cid2)
+
+		dealsAwaitingSeal.fail(sectorId, errorMessage)
+
+		sectorData, ok := dealsAwaitingSeal.SealedSectors[sectorId]
+		require.True(t, ok)
+		assert.Equal(t, errorMessage, sectorData.ErrorMessage)
+	})
+}
+
+func setupTestDealsAwaitingSeals(sectorId uint64, deals ...cid.Cid) *dealsAwaitingSeal {
+	dealsAwaitingSeal := newDealsAwaitingSeal()
+	dealsAwaitingSeal.SectorsToDeals[sectorId] = deals
+	dealsAwaitingSeal.onSuccess = func(dealCid cid.Cid, sector *sectorbuilder.SealedSectorMetadata) {}
+	dealsAwaitingSeal.onFail = func(dealCid cid.Cid, message string) {}
+	return dealsAwaitingSeal
+}

--- a/protocol/storage/deals_awaiting_seal_test.go
+++ b/protocol/storage/deals_awaiting_seal_test.go
@@ -96,12 +96,12 @@ func TestDealsAwaitingSealSuccess(t *testing.T) {
 	cid1 := newCid()
 	cid2 := newCid()
 
-	sectorId := uint64(42)
-	sector := &sectorbuilder.SealedSectorMetadata{SectorID: sectorId}
+	sectorID := uint64(42)
+	sector := &sectorbuilder.SealedSectorMetadata{SectorID: sectorID}
 	msgCid := newCid()
 
 	t.Run("success calls onSuccess for all deals", func(t *testing.T) {
-		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorId, cid1, cid2)
+		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorID, cid1, cid2)
 		unseenDealCids := map[cid.Cid]bool{cid1: true, cid2: true}
 
 		dealsAwaitingSeal.onSuccess = func(dealCid cid.Cid, sector *sectorbuilder.SealedSectorMetadata) {
@@ -116,30 +116,30 @@ func TestDealsAwaitingSealSuccess(t *testing.T) {
 	})
 
 	t.Run("success clears sector from sector to deals cache", func(t *testing.T) {
-		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorId, cid1, cid2)
+		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorID, cid1, cid2)
 
 		dealsAwaitingSeal.success(sector, &msgCid)
 
 		// cleared SectorsToDeals for this sector
-		assert.Nil(t, dealsAwaitingSeal.SectorsToDeals[sectorId])
+		assert.Nil(t, dealsAwaitingSeal.SectorsToDeals[sectorID])
 	})
 
 	t.Run("success adds sector to successful sectors", func(t *testing.T) {
-		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorId, cid1, cid2)
+		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorID, cid1, cid2)
 
 		dealsAwaitingSeal.success(sector, &msgCid)
 
-		sectorData, ok := dealsAwaitingSeal.SealedSectors[sectorId]
+		sectorData, ok := dealsAwaitingSeal.SealedSectors[sectorID]
 		require.True(t, ok)
 		assert.Equal(t, sector, sectorData.Metadata)
 	})
 
 	t.Run("success stores commit message cid with sector data", func(t *testing.T) {
-		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorId, cid1, cid2)
+		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorID, cid1, cid2)
 
 		dealsAwaitingSeal.success(sector, &msgCid)
 
-		actualMsgCid, ok := dealsAwaitingSeal.commitMessageCid(sectorId)
+		actualMsgCid, ok := dealsAwaitingSeal.commitMessageCid(sectorID)
 		require.True(t, ok)
 		assert.Equal(t, msgCid, *actualMsgCid)
 	})
@@ -150,11 +150,11 @@ func TestDealsAwaitingSealFail(t *testing.T) {
 	cid1 := newCid()
 	cid2 := newCid()
 
-	sectorId := uint64(42)
+	sectorID := uint64(42)
 	errorMessage := "test error message"
 
 	t.Run("fail calls onFail with correct message for all deals", func(t *testing.T) {
-		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorId, cid1, cid2)
+		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorID, cid1, cid2)
 		unseenDealCids := map[cid.Cid]bool{cid1: true, cid2: true}
 
 		dealsAwaitingSeal.onFail = func(dealCid cid.Cid, message string) {
@@ -163,35 +163,35 @@ func TestDealsAwaitingSealFail(t *testing.T) {
 			delete(unseenDealCids, dealCid)
 		}
 
-		dealsAwaitingSeal.fail(sectorId, errorMessage)
+		dealsAwaitingSeal.fail(sectorID, errorMessage)
 
 		// called onSuccess for all deals
 		assert.Equal(t, 0, len(unseenDealCids))
 	})
 
 	t.Run("fail clears sector from sector to deals cache", func(t *testing.T) {
-		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorId, cid1, cid2)
+		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorID, cid1, cid2)
 
-		dealsAwaitingSeal.fail(sectorId, errorMessage)
+		dealsAwaitingSeal.fail(sectorID, errorMessage)
 
 		// cleared SectorsToDeals for this sector
-		assert.Nil(t, dealsAwaitingSeal.SectorsToDeals[sectorId])
+		assert.Nil(t, dealsAwaitingSeal.SectorsToDeals[sectorID])
 	})
 
 	t.Run("fail adds error message to failure map", func(t *testing.T) {
-		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorId, cid1, cid2)
+		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorID, cid1, cid2)
 
-		dealsAwaitingSeal.fail(sectorId, errorMessage)
+		dealsAwaitingSeal.fail(sectorID, errorMessage)
 
-		sectorData, ok := dealsAwaitingSeal.SealedSectors[sectorId]
+		sectorData, ok := dealsAwaitingSeal.SealedSectors[sectorID]
 		require.True(t, ok)
 		assert.Equal(t, errorMessage, sectorData.ErrorMessage)
 	})
 }
 
-func setupTestDealsAwaitingSeals(sectorId uint64, deals ...cid.Cid) *dealsAwaitingSeal {
+func setupTestDealsAwaitingSeals(sectorID uint64, deals ...cid.Cid) *dealsAwaitingSeal {
 	dealsAwaitingSeal := newDealsAwaitingSeal()
-	dealsAwaitingSeal.SectorsToDeals[sectorId] = deals
+	dealsAwaitingSeal.SectorsToDeals[sectorID] = deals
 	dealsAwaitingSeal.onSuccess = func(dealCid cid.Cid, sector *sectorbuilder.SealedSectorMetadata) {}
 	dealsAwaitingSeal.onFail = func(dealCid cid.Cid, message string) {}
 	return dealsAwaitingSeal

--- a/protocol/storage/deals_awaiting_seal_test.go
+++ b/protocol/storage/deals_awaiting_seal_test.go
@@ -37,7 +37,7 @@ func TestDealsAwaitingSealAdd(t *testing.T) {
 		dealsAwaitingSeal.add(wantSectorID, cid0)
 		dealsAwaitingSeal.add(wantSectorID, cid1)
 		dealsAwaitingSeal.add(someOtherSectorID, cid2)
-		dealsAwaitingSeal.success(wantSector, &commitSectorCid)
+		dealsAwaitingSeal.success(wantSector, commitSectorCid)
 
 		assert.Len(t, gotCids, 2, "onSuccess should've been called twice")
 	})
@@ -50,7 +50,7 @@ func TestDealsAwaitingSealAdd(t *testing.T) {
 			gotCids = append(gotCids, dealCid)
 		}
 
-		dealsAwaitingSeal.success(wantSector, &commitSectorCid)
+		dealsAwaitingSeal.success(wantSector, commitSectorCid)
 		dealsAwaitingSeal.add(wantSectorID, cid0)
 		dealsAwaitingSeal.add(wantSectorID, cid1) // Shouldn't trigger a call, see add().
 		dealsAwaitingSeal.add(someOtherSectorID, cid2)
@@ -109,7 +109,7 @@ func TestDealsAwaitingSealSuccess(t *testing.T) {
 			delete(unseenDealCids, dealCid)
 		}
 
-		dealsAwaitingSeal.success(sector, &msgCid)
+		dealsAwaitingSeal.success(sector, msgCid)
 
 		// called onSuccess for all deals
 		assert.Equal(t, 0, len(unseenDealCids))
@@ -118,7 +118,7 @@ func TestDealsAwaitingSealSuccess(t *testing.T) {
 	t.Run("success clears sector from sector to deals cache", func(t *testing.T) {
 		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorID, cid1, cid2)
 
-		dealsAwaitingSeal.success(sector, &msgCid)
+		dealsAwaitingSeal.success(sector, msgCid)
 
 		// cleared SectorsToDeals for this sector
 		assert.Nil(t, dealsAwaitingSeal.SectorsToDeals[sectorID])
@@ -127,7 +127,7 @@ func TestDealsAwaitingSealSuccess(t *testing.T) {
 	t.Run("success adds sector to successful sectors", func(t *testing.T) {
 		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorID, cid1, cid2)
 
-		dealsAwaitingSeal.success(sector, &msgCid)
+		dealsAwaitingSeal.success(sector, msgCid)
 
 		sectorData, ok := dealsAwaitingSeal.SealedSectors[sectorID]
 		require.True(t, ok)
@@ -137,11 +137,11 @@ func TestDealsAwaitingSealSuccess(t *testing.T) {
 	t.Run("success stores commit message cid with sector data", func(t *testing.T) {
 		dealsAwaitingSeal := setupTestDealsAwaitingSeals(sectorID, cid1, cid2)
 
-		dealsAwaitingSeal.success(sector, &msgCid)
+		dealsAwaitingSeal.success(sector, msgCid)
 
 		actualMsgCid, ok := dealsAwaitingSeal.commitMessageCid(sectorID)
 		require.True(t, ok)
-		assert.Equal(t, msgCid, *actualMsgCid)
+		assert.Equal(t, msgCid, actualMsgCid)
 	})
 }
 

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -518,7 +518,7 @@ func (sm *Miner) OnCommitmentSent(sector *sectorbuilder.SealedSectorMetadata, ms
 		errMsg := fmt.Sprintf("failed sealing sector: %d", sectorID)
 		sm.dealsAwaitingSeal.fail(sector.SectorID, errMsg)
 	} else {
-		sm.dealsAwaitingSeal.success(sector, &msgCid)
+		sm.dealsAwaitingSeal.success(sector, msgCid)
 	}
 	if err := sm.saveDealsAwaitingSeal(); err != nil {
 		log.Errorf("failed persisting deals awaiting seal: %s", err)

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -474,7 +474,7 @@ func (sm *Miner) processStorageDeal(proposalCid cid.Cid) {
 
 	// Careful: this might update state to success or failure so it should go after
 	// updating state to Staged.
-	sm.dealsAwaitingSeal.process(sectorID, proposalCid)
+	sm.dealsAwaitingSeal.attachDealToSector(sectorID, proposalCid)
 	if err := sm.saveDealsAwaitingSeal(); err != nil {
 		log.Errorf("could not save deal awaiting seal: %s", err)
 	}
@@ -516,13 +516,13 @@ func (sm *Miner) OnCommitmentSent(sector *sectorbuilder.SealedSectorMetadata, ms
 	if err != nil {
 		log.Errorf("failed sealing sector: %d: %s:", sectorID, err)
 		errMsg := fmt.Sprintf("failed sealing sector: %d", sectorID)
-		sm.dealsAwaitingSeal.fail(sector.SectorID, errMsg)
+		sm.dealsAwaitingSeal.onSealFail(sector.SectorID, errMsg)
 	} else {
-		sm.dealsAwaitingSeal.success(sector, msgCid)
+		sm.dealsAwaitingSeal.onSealSuccess(sector, msgCid)
 	}
 	if err := sm.saveDealsAwaitingSeal(); err != nil {
 		log.Errorf("failed persisting deals awaiting seal: %s", err)
-		sm.dealsAwaitingSeal.fail(sector.SectorID, "failed persisting deals awaiting seal")
+		sm.dealsAwaitingSeal.onSealFail(sector.SectorID, "failed persisting deals awaiting seal")
 	}
 }
 

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -474,7 +474,7 @@ func (sm *Miner) processStorageDeal(proposalCid cid.Cid) {
 
 	// Careful: this might update state to success or failure so it should go after
 	// updating state to Staged.
-	sm.dealsAwaitingSeal.add(sectorID, proposalCid)
+	sm.dealsAwaitingSeal.process(sectorID, proposalCid)
 	if err := sm.saveDealsAwaitingSeal(); err != nil {
 		log.Errorf("could not save deal awaiting seal: %s", err)
 	}

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -59,7 +59,7 @@ type Miner struct {
 	postInProcessLk sync.Mutex
 	postInProcess   *types.BlockHeight
 
-	dealsAwaitingSeal *dealsAwaitingSealStruct
+	dealsAwaitingSeal *dealsAwaitingSeal
 
 	porcelainAPI minerPorcelain
 	node         node
@@ -104,10 +104,6 @@ type generatePostInput struct {
 	commR     types.CommR
 	commRStar types.CommRStar
 	sectorID  uint64
-}
-
-func init() {
-	cbor.RegisterCborType(dealsAwaitingSealStruct{})
 }
 
 // NewMiner is
@@ -457,9 +453,9 @@ func (sm *Miner) processStorageDeal(proposalCid cid.Cid) {
 	// There is a race here that requires us to use dealsAwaitingSeal below. If the
 	// sector gets sealed and OnCommitmentSent is called right after
 	// AddPiece returns but before we record the sector/deal mapping we might
-	// miss it. Hence, dealsAwaitingSealStruct. I'm told that sealing in practice is
+	// miss it. Hence, dealsAwaitingSeal. I'm told that sealing in practice is
 	// so slow that the race only exists in tests, but tests were flaky so
-	// we fixed it with dealsAwaitingSealStruct.
+	// we fixed it with dealsAwaitingSeal.
 	//
 	// Also, this pattern of not being able to set up book-keeping ahead of
 	// the call is inelegant.
@@ -484,33 +480,8 @@ func (sm *Miner) processStorageDeal(proposalCid cid.Cid) {
 	}
 }
 
-// dealsAwaitingSealStruct is a container for keeping track of which sectors have
-// pieces from which deals. We need it to accommodate a race condition where
-// a sector commit message is added to chain before we can add the sector/deal
-// book-keeping. It effectively caches success and failure results for sectors
-// for tardy add() calls.
-type dealsAwaitingSealStruct struct {
-	l sync.Mutex
-	// Maps from sector id to the deal cids with pieces in the sector.
-	SectorsToDeals map[uint64][]cid.Cid
-	// Maps from sector id to sector.
-	SuccessfulSectors map[uint64]*sectorbuilder.SealedSectorMetadata
-	// Maps from sector id to seal failure error string.
-	FailedSectors map[uint64]string
-	// Maps from sector id to the sector's commitSector message CID
-	CommitmentMessages map[uint64]cid.Cid
-
-	onSuccess func(dealCid cid.Cid, sector *sectorbuilder.SealedSectorMetadata)
-	onFail    func(dealCid cid.Cid, message string)
-}
-
 func (sm *Miner) loadDealsAwaitingSeal() error {
-	sm.dealsAwaitingSeal = &dealsAwaitingSealStruct{
-		SectorsToDeals:     make(map[uint64][]cid.Cid),
-		SuccessfulSectors:  make(map[uint64]*sectorbuilder.SealedSectorMetadata),
-		FailedSectors:      make(map[uint64]string),
-		CommitmentMessages: make(map[uint64]cid.Cid),
-	}
+	sm.dealsAwaitingSeal = newDealsAwaitingSeal()
 
 	key := datastore.KeyWithNamespaces([]string{dealsAwatingSealDatastorePrefix})
 	result, notFound := sm.dealsAwaitingSealDs.Get(key)
@@ -537,67 +508,7 @@ func (sm *Miner) saveDealsAwaitingSeal() error {
 	return nil
 }
 
-func (dealsAwaitingSeal *dealsAwaitingSealStruct) addCommitmentMessageCid(sectorID uint64, msgCid cid.Cid) {
-	dealsAwaitingSeal.l.Lock()
-	defer dealsAwaitingSeal.l.Unlock()
-
-	dealsAwaitingSeal.CommitmentMessages[sectorID] = msgCid
-}
-
-func (dealsAwaitingSeal *dealsAwaitingSealStruct) add(sectorID uint64, dealCid cid.Cid) {
-	dealsAwaitingSeal.l.Lock()
-	defer dealsAwaitingSeal.l.Unlock()
-
-	if sector, ok := dealsAwaitingSeal.SuccessfulSectors[sectorID]; ok {
-		dealsAwaitingSeal.onSuccess(dealCid, sector)
-		// Don't keep references to sectors around forever. Assume that at most
-		// one success-before-add call will happen (eg, in a test). Sector sealing
-		// outside of tests is so slow that it shouldn't happen in practice.
-		// So now that it has happened once, clean it up. If we wanted to keep
-		// the state around for longer for some reason we need to limit how many
-		// sectors we hang onto, eg keep a fixed-length slice of successes
-		// and failures and shift the oldest off and the newest on.
-		delete(dealsAwaitingSeal.SuccessfulSectors, sectorID)
-		delete(dealsAwaitingSeal.CommitmentMessages, sectorID)
-	} else if message, ok := dealsAwaitingSeal.FailedSectors[sectorID]; ok {
-		dealsAwaitingSeal.onFail(dealCid, message)
-		// Same as above.
-		delete(dealsAwaitingSeal.FailedSectors, sectorID)
-	} else {
-		deals, ok := dealsAwaitingSeal.SectorsToDeals[sectorID]
-		if ok {
-			dealsAwaitingSeal.SectorsToDeals[sectorID] = append(deals, dealCid)
-		} else {
-			dealsAwaitingSeal.SectorsToDeals[sectorID] = []cid.Cid{dealCid}
-		}
-	}
-}
-
-func (dealsAwaitingSeal *dealsAwaitingSealStruct) success(sector *sectorbuilder.SealedSectorMetadata) {
-	dealsAwaitingSeal.l.Lock()
-	defer dealsAwaitingSeal.l.Unlock()
-
-	dealsAwaitingSeal.SuccessfulSectors[sector.SectorID] = sector
-
-	for _, dealCid := range dealsAwaitingSeal.SectorsToDeals[sector.SectorID] {
-		dealsAwaitingSeal.onSuccess(dealCid, sector)
-	}
-	delete(dealsAwaitingSeal.SectorsToDeals, sector.SectorID)
-}
-
-func (dealsAwaitingSeal *dealsAwaitingSealStruct) fail(sectorID uint64, message string) {
-	dealsAwaitingSeal.l.Lock()
-	defer dealsAwaitingSeal.l.Unlock()
-
-	dealsAwaitingSeal.FailedSectors[sectorID] = message
-
-	for _, dealCid := range dealsAwaitingSeal.SectorsToDeals[sectorID] {
-		dealsAwaitingSeal.onFail(dealCid, message)
-	}
-	delete(dealsAwaitingSeal.SectorsToDeals, sectorID)
-}
-
-// OnCommitmentSent is a callback, called when a sector seal message was posted to the chain.
+// OnCommitmentAddedToChain is a callback, called when a sector seal message was posted to the chain.
 func (sm *Miner) OnCommitmentSent(sector *sectorbuilder.SealedSectorMetadata, msgCid cid.Cid, err error) {
 	sectorID := sector.SectorID
 	log.Debug("Miner.OnCommitmentSent")
@@ -607,8 +518,7 @@ func (sm *Miner) OnCommitmentSent(sector *sectorbuilder.SealedSectorMetadata, ms
 		errMsg := fmt.Sprintf("failed sealing sector: %d", sectorID)
 		sm.dealsAwaitingSeal.fail(sector.SectorID, errMsg)
 	} else {
-		sm.dealsAwaitingSeal.addCommitmentMessageCid(sectorID, msgCid)
-		sm.dealsAwaitingSeal.success(sector)
+		sm.dealsAwaitingSeal.success(sector, &msgCid)
 	}
 	if err := sm.saveDealsAwaitingSeal(); err != nil {
 		log.Errorf("failed persisting deals awaiting seal: %s", err)
@@ -624,14 +534,17 @@ func (sm *Miner) onCommitSuccess(dealCid cid.Cid, sector *sectorbuilder.SealedSe
 	}
 
 	// failure to locate commitmentMessage should not block update
-	commitmentMessage := sm.dealsAwaitingSeal.CommitmentMessages[sector.SectorID]
+	commitMessageCid, ok := sm.dealsAwaitingSeal.commitMessageCid(sector.SectorID)
+	if !ok {
+		log.Errorf("commit succeeded, but could not find commit message cid.")
+	}
 
+	// update response
 	err = sm.updateDealResponse(dealCid, func(resp *storagedeal.Response) {
-
 		resp.State = storagedeal.Posted
 		resp.ProofInfo = &storagedeal.ProofInfo{
 			SectorID:          sector.SectorID,
-			CommitmentMessage: &commitmentMessage,
+			CommitmentMessage: commitMessageCid,
 		}
 		if pieceInfo != nil {
 			resp.ProofInfo.PieceInclusionProof = pieceInfo.InclusionProof

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -508,7 +508,7 @@ func (sm *Miner) saveDealsAwaitingSeal() error {
 	return nil
 }
 
-// OnCommitmentAddedToChain is a callback, called when a sector seal message was posted to the chain.
+// OnCommitmentSent is a callback, called when a sector seal message was posted to the chain.
 func (sm *Miner) OnCommitmentSent(sector *sectorbuilder.SealedSectorMetadata, msgCid cid.Cid, err error) {
 	sectorID := sector.SectorID
 	log.Debug("Miner.OnCommitmentSent")

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -251,10 +251,7 @@ func TestDealsAwaitingSealPersistence(t *testing.T) {
 		miner.dealsAwaitingSeal = &dealsAwaitingSeal{}
 		require.NoError(t, miner.loadDealsAwaitingSeal())
 
-		savedSector, ok := miner.dealsAwaitingSeal.SuccessfulSectors[sector.SectorID]
-		require.True(t, ok)
-		assert.Equal(t, sector, savedSector.Metadata)
-		assert.Equal(t, msgCid, *savedSector.CommitMessage)
+		assert.Equal(t, dealCid, miner.dealsAwaitingSeal.SectorsToDeals[42][0])
 	})
 }
 

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -434,7 +434,8 @@ func minerWithAcceptedDealTestSetup(t *testing.T, proposalCid cid.Cid, sectorID 
 	miner.dealsAwaitingSealDs = repo.NewInMemoryRepo().DealsDs
 
 	// create the dealsAwaitingSeal to manage the deal prior to sealing
-	miner.loadDealsAwaitingSeal()
+	err := miner.loadDealsAwaitingSeal()
+	require.NoError(t, err)
 
 	// wire dealsAwaitingSeal with the actual commit success functionality
 	miner.dealsAwaitingSeal.onSuccess = miner.onCommitSuccess

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -226,7 +226,7 @@ func TestDealsAwaitingSealPersistence(t *testing.T) {
 			dealsAwaitingSealDs: repo.NewInMemoryRepo().DealsDatastore(),
 		}
 
-		miner.dealsAwaitingSeal.add(wantSectorID, dealCid)
+		miner.dealsAwaitingSeal.process(wantSectorID, dealCid)
 
 		require.NoError(t, miner.saveDealsAwaitingSeal())
 		miner.dealsAwaitingSeal = &dealsAwaitingSeal{}
@@ -241,7 +241,7 @@ func TestDealsAwaitingSealPersistence(t *testing.T) {
 			dealsAwaitingSealDs: repo.NewInMemoryRepo().DealsDatastore(),
 		}
 
-		miner.dealsAwaitingSeal.add(wantSectorID, dealCid)
+		miner.dealsAwaitingSeal.process(wantSectorID, dealCid)
 		sector := testSectorMetadata(newCid())
 		msgCid := newCid()
 
@@ -456,7 +456,7 @@ func minerWithAcceptedDealTestSetup(t *testing.T, proposalCid cid.Cid, sectorID 
 	// Simulates miner.acceptProposal without going to the network to fetch the data by storing the deal.
 	// Mapping the proposalCid to a sectorID simulates staging the sector.
 	require.NoError(t, porcelainAPI.DealPut(storageDeal))
-	miner.dealsAwaitingSeal.add(sectorID, proposalCid)
+	miner.dealsAwaitingSeal.process(sectorID, proposalCid)
 
 	return porcelainAPI, miner, proposal
 }

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -245,7 +245,7 @@ func TestDealsAwaitingSealPersistence(t *testing.T) {
 		sector := testSectorMetadata(newCid())
 		msgCid := newCid()
 
-		miner.dealsAwaitingSeal.success(sector, &msgCid)
+		miner.dealsAwaitingSeal.success(sector, msgCid)
 
 		require.NoError(t, miner.saveDealsAwaitingSeal())
 		miner.dealsAwaitingSeal = &dealsAwaitingSeal{}
@@ -276,7 +276,7 @@ func TestOnCommitmentAddedToChain(t *testing.T) {
 		assert.Equal(t, storagedeal.Posted, dealResponse.State, "deal should be in posted state")
 		require.NotNil(t, dealResponse.ProofInfo, "deal should have proof info")
 		assert.Equal(t, sector.SectorID, dealResponse.ProofInfo.SectorID, "sector id should match committed sector")
-		assert.Equal(t, &msgCid, dealResponse.ProofInfo.CommitmentMessage, "CommitmentMessage should be cid of commitSector messsage")
+		assert.Equal(t, msgCid, dealResponse.ProofInfo.CommitmentMessage, "CommitmentMessage should be cid of commitSector messsage")
 		assert.Equal(t, sector.Pieces[0].InclusionProof, dealResponse.ProofInfo.PieceInclusionProof, "PieceInclusionProof should be proof generated after sealing")
 	})
 

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -226,7 +226,7 @@ func TestDealsAwaitingSealPersistence(t *testing.T) {
 			dealsAwaitingSealDs: repo.NewInMemoryRepo().DealsDatastore(),
 		}
 
-		miner.dealsAwaitingSeal.process(wantSectorID, dealCid)
+		miner.dealsAwaitingSeal.attachDealToSector(wantSectorID, dealCid)
 
 		require.NoError(t, miner.saveDealsAwaitingSeal())
 		miner.dealsAwaitingSeal = &dealsAwaitingSeal{}
@@ -241,11 +241,11 @@ func TestDealsAwaitingSealPersistence(t *testing.T) {
 			dealsAwaitingSealDs: repo.NewInMemoryRepo().DealsDatastore(),
 		}
 
-		miner.dealsAwaitingSeal.process(wantSectorID, dealCid)
+		miner.dealsAwaitingSeal.attachDealToSector(wantSectorID, dealCid)
 		sector := testSectorMetadata(newCid())
 		msgCid := newCid()
 
-		miner.dealsAwaitingSeal.success(sector, msgCid)
+		miner.dealsAwaitingSeal.onSealSuccess(sector, msgCid)
 
 		require.NoError(t, miner.saveDealsAwaitingSeal())
 		miner.dealsAwaitingSeal = &dealsAwaitingSeal{}
@@ -456,7 +456,7 @@ func minerWithAcceptedDealTestSetup(t *testing.T, proposalCid cid.Cid, sectorID 
 	// Simulates miner.acceptProposal without going to the network to fetch the data by storing the deal.
 	// Mapping the proposalCid to a sectorID simulates staging the sector.
 	require.NoError(t, porcelainAPI.DealPut(storageDeal))
-	miner.dealsAwaitingSeal.process(sectorID, proposalCid)
+	miner.dealsAwaitingSeal.attachDealToSector(sectorID, proposalCid)
 
 	return porcelainAPI, miner, proposal
 }

--- a/protocol/storage/storagedeal/types.go
+++ b/protocol/storage/storagedeal/types.go
@@ -129,7 +129,7 @@ type ProofInfo struct {
 	SectorID uint64
 
 	// CommitmentMessage is the cid of the message that committed the sector. It's used to track when the sector goes on chain.
-	CommitmentMessage *cid.Cid
+	CommitmentMessage cid.Cid
 
 	// PieceInclusionProof is a proof that a the piece is included within a sector
 	PieceInclusionProof []byte


### PR DESCRIPTION
This PR is a refactor that ballooned out of #2693 into enough work for a new PR.

### Problem

dealsAwaitingSeals is burried within protocol/storage/miner. I found its logic confusing and under-tested. 

### Solution

This PR streamlines the logic, moves it to its own file with a separate file for tests, and adds testing for its features.