### PR TITLE
Separate new tipset handling from message pool implementation, wrap in an inbox.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -204,7 +204,7 @@ func newDefaultTraceConfig() *TraceConfig {
 // MessagePoolConfig holds all configuration options related to nodes message pool (mpool).
 type MessagePoolConfig struct {
 	// MaxPoolSize is the maximum number of pending messages will will allow in the message pool at any time
-	MaxPoolSize int `json:"maxPoolSize"`
+	MaxPoolSize uint `json:"maxPoolSize"`
 	// MaxNonceGap is the maximum nonce of a message past the last received on chain
 	MaxNonceGap types.Uint64 `json:"maxNonceGap"`
 }

--- a/core/inbox.go
+++ b/core/inbox.go
@@ -1,0 +1,128 @@
+package core
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/ipfs/go-cid"
+)
+
+// InboxMaxAgeTipsets is maximum age (in non-empty tipsets) to permit messages to stay in the pool after reception.
+// It should be a little shorter than the outbox max age so that messages expire from mining
+// pools a little before the sender gives up on them.
+const InboxMaxAgeTipsets = 6
+
+// Inbox maintains a pool of received messages.
+type Inbox struct {
+	// The pool storing received messages.
+	pool *MessagePool
+	// Maximum age of a pool message.
+	maxAgeTipsets uint
+
+	chain InboxChainProvider
+}
+
+// InboxChainProvider provides chain access for updating the message pool in response to new heads.
+// Exported for testing.
+type InboxChainProvider interface {
+	chain.BlockProvider
+	BlockHeight() (uint64, error)
+}
+
+// NewInbox constructs a new inbox.
+func NewInbox(pool *MessagePool, maxAgeRounds uint, chain InboxChainProvider) *Inbox {
+	return &Inbox{pool: pool, maxAgeTipsets: maxAgeRounds, chain: chain}
+}
+
+// Add adds a message to the pool, tagged with the current block height.
+// An error probably means the message failed to validate,
+// but it could indicate a more serious problem with the system.
+func (ib *Inbox) Add(ctx context.Context, msg *types.SignedMessage) (cid.Cid, error) {
+	blockTime, err := ib.chain.BlockHeight()
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	return ib.pool.Add(ctx, msg, blockTime)
+}
+
+// Pool returns the inbox's message pool.
+func (ib *Inbox) Pool() *MessagePool {
+	return ib.pool
+}
+
+// HandleNewHead updates the message pool in response to a new head tipset.
+// This removes messages from the pool that are found in the newly adopted chain and adds back
+// those from the removed chain (if any) that do not appear in the new chain.
+// We think that the right model for keeping the message pool up to date is
+// to think about it like a garbage collector.
+func (ib *Inbox) HandleNewHead(ctx context.Context, oldHead, newHead types.TipSet) error {
+	oldBlocks, newBlocks, err := CollectBlocksToCommonAncestor(ctx, ib.chain, oldHead, newHead)
+	if err != nil {
+		return err
+	}
+
+	// Add all message from the old blocks to the message pool, so they can be mined again.
+	for _, blk := range oldBlocks {
+		for _, msg := range blk.Messages {
+			_, err = ib.pool.Add(ctx, msg, uint64(blk.Height))
+			if err != nil {
+				log.Info(err)
+			}
+		}
+	}
+
+	// Remove all messages in the new blocks from the pool, now mined.
+	// Cid() can error, so collect all the CIDs up front.
+	var removeCids []cid.Cid
+	for _, blk := range newBlocks {
+		for _, msg := range blk.Messages {
+			cid, err := msg.Cid()
+			if err != nil {
+				return err
+			}
+			removeCids = append(removeCids, cid)
+		}
+	}
+	for _, c := range removeCids {
+		ib.pool.Remove(c)
+	}
+
+	// prune all messages that have been in the pool too long
+	return timeoutMessages(ctx, ib.pool, ib.chain, newHead, ib.maxAgeTipsets)
+}
+
+// timeoutMessages removes all messages from the pool that arrived more than maxAgeTipsets tip sets ago.
+// Note that we measure the timeout in the number of tip sets we have received rather than a fixed block
+// height. This prevents us from prematurely timing messages that arrive during long chains of null blocks.
+// Also when blocks fill, the rate of message processing will correspond more closely to rate of tip
+// sets than to the expected block time over short timescales.
+func timeoutMessages(ctx context.Context, pool *MessagePool, chains chain.BlockProvider, head types.TipSet, maxAgeTipsets uint) error {
+	var err error
+
+	lowestTipSet := head
+	minimumHeight, err := lowestTipSet.Height()
+	if err != nil {
+		return err
+	}
+
+	// walk back MessageTimeout tip sets to arrive at the lowest viable block height
+	for i := uint(0); minimumHeight > 0 && i < maxAgeTipsets; i++ {
+		lowestTipSet, err = chain.GetParentTipSet(ctx, chains, lowestTipSet)
+		if err != nil {
+			return err
+		}
+		minimumHeight, err = lowestTipSet.Height()
+		if err != nil {
+			return err
+		}
+	}
+
+	// remove all messages added before minimumHeight
+	for _, cid := range pool.PendingBefore(minimumHeight) {
+		pool.Remove(cid)
+	}
+
+	return nil
+}

--- a/core/inbox_test.go
+++ b/core/inbox_test.go
@@ -1,0 +1,472 @@
+package core_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/filecoin-project/go-filecoin/config"
+	"github.com/filecoin-project/go-filecoin/core"
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-hamt-ipld"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateMessagePool(t *testing.T) {
+	tf.UnitTest(t)
+	ctx := context.Background()
+	type msgs []*types.SignedMessage
+	type msgsSet [][]*types.SignedMessage
+
+	var mockSigner, _ = types.NewMockSignersAndKeyInfo(10)
+
+	t.Run("Replace head", func(t *testing.T) {
+		// Msg pool: [m0, m1], Chain: b[]
+		// to
+		// Msg pool: [m0],     Chain: b[m1]
+		store, chainProvider := newStoreAndProvider(0)
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		ib := core.NewInbox(p, 10, chainProvider)
+
+		m := types.NewSignedMsgs(2, mockSigner)
+		mustAdd(ib, m[0], m[1])
+
+		parent := types.TipSet{}
+
+		blk := types.Block{Height: 0}
+		parent[blk.Cid()] = &blk
+
+		oldChain := core.NewChainWithMessages(store, parent, msgsSet{})
+		oldTipSet := headOf(oldChain)
+
+		newChain := core.NewChainWithMessages(store, parent, msgsSet{msgs{m[1]}})
+		newTipSet := headOf(newChain)
+
+		assert.NoError(t, ib.HandleNewHead(ctx, oldTipSet, newTipSet))
+		assertPoolEquals(t, p, m[0])
+	})
+
+	t.Run("Replace head with self", func(t *testing.T) {
+		// Msg pool: [m0, m1], Chain: b[m2]
+		// to
+		// Msg pool: [m0, m1], Chain: b[m2]
+		store, chainProvider := newStoreAndProvider(0)
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		ib := core.NewInbox(p, 10, chainProvider)
+
+		m := types.NewSignedMsgs(3, mockSigner)
+		mustAdd(ib, m[0], m[1])
+
+		oldChain := core.NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{m[2]}})
+		oldTipSet := headOf(oldChain)
+
+		assert.NoError(t, ib.HandleNewHead(ctx, oldTipSet, oldTipSet)) // sic
+		assertPoolEquals(t, p, m[0], m[1])
+	})
+
+	t.Run("Replace head with a long chain", func(t *testing.T) {
+		// Msg pool: [m2, m5],     Chain: b[m0, m1]
+		// to
+		// Msg pool: [m1],         Chain: b[m2, m3] -> b[m4] -> b[m0] -> b[] -> b[m5, m6]
+		store, chainProvider := newStoreAndProvider(0)
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		ib := core.NewInbox(p, 10, chainProvider)
+
+		m := types.NewSignedMsgs(7, mockSigner)
+		mustAdd(ib, m[2], m[5])
+
+		parent := types.TipSet{}
+
+		blk := types.Block{Height: 0}
+		parent[blk.Cid()] = &blk
+		oldChain := core.NewChainWithMessages(store, parent, msgsSet{msgs{m[0], m[1]}})
+		oldTipSet := headOf(oldChain)
+
+		newChain := core.NewChainWithMessages(store, parent,
+			msgsSet{msgs{m[2], m[3]}},
+			msgsSet{msgs{m[4]}},
+			msgsSet{msgs{m[0]}},
+			msgsSet{msgs{}},
+			msgsSet{msgs{m[5], m[6]}},
+		)
+		newTipSet := headOf(newChain)
+
+		assert.NoError(t, ib.HandleNewHead(ctx, oldTipSet, newTipSet))
+		assertPoolEquals(t, p, m[1])
+	})
+
+	t.Run("Replace head with multi-block tipset chains", func(t *testing.T) {
+		// Msg pool: [m2, m5],     Chain: {b[m0], b[m1]}
+		// to
+		// Msg pool: [m1],         Chain: b[m2, m3] -> {b[m4], b[m0], b[], b[]} -> {b[], b[m6,m5]}
+		store, chainProvider := newStoreAndProvider(0)
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		ib := core.NewInbox(p, 10, chainProvider)
+
+		m := types.NewSignedMsgs(7, mockSigner)
+		mustAdd(ib, m[2], m[5])
+
+		parent := types.TipSet{}
+
+		blk := types.Block{Height: 0}
+		parent[blk.Cid()] = &blk
+
+		oldChain := core.NewChainWithMessages(store, parent, msgsSet{msgs{m[0]}, msgs{m[1]}})
+		oldTipSet := headOf(oldChain)
+
+		newChain := core.NewChainWithMessages(store, parent,
+			msgsSet{msgs{m[2], m[3]}},
+			msgsSet{msgs{m[4]}, msgs{m[0]}, msgs{}, msgs{}},
+			msgsSet{msgs{}, msgs{m[5], m[6]}},
+		)
+		newTipSet := headOf(newChain)
+
+		assert.NoError(t, ib.HandleNewHead(ctx, oldTipSet, newTipSet))
+		assertPoolEquals(t, p, m[1])
+	})
+
+	t.Run("Replace internal node (second one)", func(t *testing.T) {
+		// Msg pool: [m3, m5],     Chain: b[m0] -> b[m1] -> b[m2]
+		// to
+		// Msg pool: [m1, m2],     Chain: b[m0] -> b[m3] -> b[m4, m5]
+		store, chainProvider := newStoreAndProvider(0)
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		ib := core.NewInbox(p, 10, chainProvider)
+
+		m := types.NewSignedMsgs(6, mockSigner)
+		mustAdd(ib, m[3], m[5])
+
+		oldChain := core.NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{m[0]}}, msgsSet{msgs{m[1]}}, msgsSet{msgs{m[2]}})
+		oldTipSet := headOf(oldChain)
+
+		newChain := core.NewChainWithMessages(store, oldChain[0], msgsSet{msgs{m[3]}}, msgsSet{msgs{m[4], m[5]}})
+		newTipSet := headOf(newChain)
+
+		assert.NoError(t, ib.HandleNewHead(ctx, oldTipSet, newTipSet))
+		assertPoolEquals(t, p, m[1], m[2])
+	})
+
+	t.Run("Replace internal node (second one) with a long chain", func(t *testing.T) {
+		// Msg pool: [m6],         Chain: b[m0] -> b[m1] -> b[m2]
+		// to
+		// Msg pool: [m6],         Chain: b[m0] -> b[m3] -> b[m4] -> b[m5] -> b[m1, m2]
+		store, chainProvider := newStoreAndProvider(0)
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		ib := core.NewInbox(p, 10, chainProvider)
+
+		m := types.NewSignedMsgs(7, mockSigner)
+		mustAdd(ib, m[6])
+
+		oldChain := core.NewChainWithMessages(store, types.TipSet{},
+			msgsSet{msgs{m[0]}},
+			msgsSet{msgs{m[1]}},
+			msgsSet{msgs{m[2]}},
+		)
+		oldTipSet := headOf(oldChain)
+
+		newChain := core.NewChainWithMessages(store, oldChain[0],
+			msgsSet{msgs{m[3]}},
+			msgsSet{msgs{m[4]}},
+			msgsSet{msgs{m[5]}},
+			msgsSet{msgs{m[1], m[2]}},
+		)
+		newTipSet := headOf(newChain)
+
+		assert.NoError(t, ib.HandleNewHead(ctx, oldTipSet, newTipSet))
+		assertPoolEquals(t, p, m[6])
+	})
+
+	t.Run("Replace internal node with multi-block tipset chains", func(t *testing.T) {
+		// Msg pool: [m6],         Chain: {b[m0], b[m1]} -> b[m2]
+		// to
+		// Msg pool: [m6],         Chain: {b[m0], b[m1]} -> b[m3] -> b[m4] -> {b[m5], b[m1, m2]}
+		store, chainProvider := newStoreAndProvider(0)
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		ib := core.NewInbox(p, 10, chainProvider)
+
+		m := types.NewSignedMsgs(7, mockSigner)
+		mustAdd(ib, m[6])
+
+		oldChain := core.NewChainWithMessages(store, types.TipSet{},
+			msgsSet{msgs{m[0]}, msgs{m[1]}},
+			msgsSet{msgs{m[2]}},
+		)
+		oldTipSet := headOf(oldChain)
+
+		newChain := core.NewChainWithMessages(store, oldChain[0],
+			msgsSet{msgs{m[3]}},
+			msgsSet{msgs{m[4]}},
+			msgsSet{msgs{m[5]}, msgs{m[1], m[2]}},
+		)
+		newTipSet := headOf(newChain)
+
+		assert.NoError(t, ib.HandleNewHead(ctx, oldTipSet, newTipSet))
+		assertPoolEquals(t, p, m[6])
+	})
+
+	t.Run("Replace with same messages in different block structure", func(t *testing.T) {
+		// Msg pool: [m3, m5],     Chain: b[m0] -> b[m1] -> b[m2]
+		// to
+		// Msg pool: [m3, m5],     Chain: {b[m0], b[m1], b[m2]}
+		store, chainProvider := newStoreAndProvider(0)
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		ib := core.NewInbox(p, 10, chainProvider)
+
+		m := types.NewSignedMsgs(6, mockSigner)
+		mustAdd(ib, m[3], m[5])
+
+		parent := types.TipSet{}
+
+		blk := types.Block{Height: 0}
+		parent[blk.Cid()] = &blk
+
+		oldChain := core.NewChainWithMessages(store, parent,
+			msgsSet{msgs{m[0]}},
+			msgsSet{msgs{m[1]}},
+			msgsSet{msgs{m[2]}},
+		)
+		oldTipSet := headOf(oldChain)
+
+		newChain := core.NewChainWithMessages(store, parent,
+			msgsSet{msgs{m[0]}, msgs{m[1]}, msgs{m[2]}},
+		)
+		newTipSet := headOf(newChain)
+
+		assert.NoError(t, ib.HandleNewHead(ctx, oldTipSet, newTipSet))
+		assertPoolEquals(t, p, m[3], m[5])
+	})
+
+	t.Run("Truncate to internal node", func(t *testing.T) {
+		// Msg pool: [],               Chain: b[m0] -> b[m1] -> b[m2] -> b[m3]
+		// to
+		// Msg pool: [m2, m3],         Chain: b[m0] -> b[m1]
+		store, chainProvider := newStoreAndProvider(0)
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		ib := core.NewInbox(p, 10, chainProvider)
+		m := types.NewSignedMsgs(4, mockSigner)
+
+		oldChain := core.NewChainWithMessages(store, types.TipSet{},
+			msgsSet{msgs{m[0]}},
+			msgsSet{msgs{m[1]}},
+			msgsSet{msgs{m[2]}},
+			msgsSet{msgs{m[3]}},
+		)
+		oldTipSet := headOf(oldChain)
+
+		oldTipSetPrev := oldChain[1]
+		assert.NoError(t, ib.HandleNewHead(ctx, oldTipSet, oldTipSetPrev))
+		assertPoolEquals(t, p, m[2], m[3])
+	})
+
+	t.Run("Extend head", func(t *testing.T) {
+		// Msg pool: [m0, m1], Chain: b[]
+		// to
+		// Msg pool: [m0],     Chain: b[] -> b[m1, m2]
+		store, chainProvider := newStoreAndProvider(0)
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		ib := core.NewInbox(p, 10, chainProvider)
+
+		m := types.NewSignedMsgs(3, mockSigner)
+		mustAdd(ib, m[0], m[1])
+
+		oldChain := core.NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{}})
+		oldTipSet := headOf(oldChain)
+
+		newChain := core.NewChainWithMessages(store, oldChain[len(oldChain)-1], msgsSet{msgs{m[1], m[2]}})
+		newTipSet := headOf(newChain)
+
+		assert.NoError(t, ib.HandleNewHead(ctx, oldTipSet, newTipSet))
+		assertPoolEquals(t, p, m[0])
+	})
+
+	t.Run("Extend head with a longer chain and more messages", func(t *testing.T) {
+		// Msg pool: [m2, m5],     Chain: b[m0] -> b[m1]
+		// to
+		// Msg pool: [],           Chain: b[m0] -> b[m1] -> b[m2, m3] -> b[m4] -> b[m5, m6]
+		store, chainProvider := newStoreAndProvider(0)
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		ib := core.NewInbox(p, 10, chainProvider)
+
+		m := types.NewSignedMsgs(7, mockSigner)
+		mustAdd(ib, m[2], m[5])
+
+		oldChain := core.NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{m[0]}}, msgsSet{msgs{m[1]}})
+		oldTipSet := headOf(oldChain)
+
+		newChain := core.NewChainWithMessages(store, oldChain[1],
+			msgsSet{msgs{m[2], m[3]}},
+			msgsSet{msgs{m[4]}},
+			msgsSet{msgs{m[5], m[6]}},
+		)
+		newTipSet := headOf(newChain)
+
+		assert.NoError(t, ib.HandleNewHead(ctx, oldTipSet, newTipSet))
+		assertPoolEquals(t, p)
+	})
+
+	t.Run("Times out old messages", func(t *testing.T) {
+		var err error
+		store, chainProvider := newStoreAndProvider(0)
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		maxAge := uint(10)
+		ib := core.NewInbox(p, maxAge, chainProvider)
+
+		m := types.NewSignedMsgs(maxAge, mockSigner)
+
+		head := headOf(core.NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{}}))
+
+		// Add a message at each block height until maxAge is reached
+		for i := uint(0); i < maxAge; i++ {
+			// api.Height determines block time at which message is added
+			chainProvider.height, err = head.Height()
+			require.NoError(t, err)
+
+			mustAdd(ib, m[i])
+
+			// update pool with tipset that has no messages
+			next := headOf(core.NewChainWithMessages(store, head, msgsSet{msgs{}}))
+			assert.NoError(t, ib.HandleNewHead(ctx, head, next))
+
+			// assert all added messages still in pool
+			assertPoolEquals(t, p, m[:i+1]...)
+
+			head = next
+		}
+
+		// next tipset times out first message only
+		next := headOf(core.NewChainWithMessages(store, head, msgsSet{msgs{}}))
+		assert.NoError(t, ib.HandleNewHead(ctx, head, next))
+		assertPoolEquals(t, p, m[1:]...)
+
+		// adding a chain of multiple tipsets times out based on final state
+		for i := 0; i < 4; i++ {
+			next = headOf(core.NewChainWithMessages(store, next, msgsSet{msgs{}}))
+		}
+		assert.NoError(t, ib.HandleNewHead(ctx, head, next))
+		assertPoolEquals(t, p, m[5:]...)
+	})
+
+	t.Run("Message timeout is unaffected by null tipsets", func(t *testing.T) {
+		var err error
+		store, chainProvider := newStoreAndProvider(0)
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		maxAge := uint(10)
+		ib := core.NewInbox(p, maxAge, chainProvider)
+
+		m := types.NewSignedMsgs(maxAge, mockSigner)
+
+		head := headOf(core.NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{}}))
+
+		// Add a message at each block height until maxAge is reached
+		for i := uint(0); i < maxAge; i++ {
+			// blockTimer.Height determines block time at which message is added
+			chainProvider.height, err = head.Height()
+			require.NoError(t, err)
+
+			mustAdd(ib, m[i])
+
+			// update pool with tipset that has no messages
+			height, err := head.Height()
+			require.NoError(t, err)
+
+			// create a tipset at given height with one block containing no messages
+			next := types.TipSet{}
+			nextHeight := types.Uint64(height + 5) // simulate 4 null blocks
+			blk := &types.Block{
+				Height:  nextHeight,
+				Parents: head.ToSortedCidSet(),
+			}
+			core.MustPut(store, blk)
+			next[blk.Cid()] = blk
+
+			assert.NoError(t, ib.HandleNewHead(ctx, head, next))
+
+			// assert all added messages still in pool
+			assertPoolEquals(t, p, m[:i+1]...)
+
+			head = next
+		}
+
+		// next tipset times out first message only
+		next := headOf(core.NewChainWithMessages(store, head, msgsSet{msgs{}}))
+		assert.NoError(t, ib.HandleNewHead(ctx, head, next))
+		assertPoolEquals(t, p, m[1:]...)
+	})
+}
+
+func newStoreAndProvider(height uint64) (*hamt.CborIpldStore, *fakeChainProvider) {
+	store := hamt.NewCborStore()
+	return store, &fakeChainProvider{height, store}
+}
+
+type fakeChainProvider struct {
+	height uint64
+	store  *hamt.CborIpldStore
+}
+
+func (p *fakeChainProvider) GetBlock(ctx context.Context, cid cid.Cid) (*types.Block, error) {
+	var blk types.Block
+	if err := p.store.Get(ctx, cid, &blk); err != nil {
+		return nil, errors.Wrapf(err, "failed to get block %s", cid)
+	}
+	return &blk, nil
+}
+
+func (p *fakeChainProvider) BlockHeight() (uint64, error) {
+	return p.height, nil
+}
+
+func mustAdd(ib *core.Inbox, msgs ...*types.SignedMessage) {
+	ctx := context.Background()
+	for _, m := range msgs {
+		if _, err := ib.Add(ctx, m); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func msgAsString(msg *types.SignedMessage) string {
+	// When using NewMessageForTestGetter msg.Method is set
+	// to "msgN" so we print that (it will correspond
+	// to a variable of the same name in the tests
+	// below).
+	return msg.Message.Method
+}
+
+func msgsAsString(msgs []*types.SignedMessage) string {
+	s := ""
+	for _, m := range msgs {
+		s = fmt.Sprintf("%s%s ", s, msgAsString(m))
+	}
+	return "[" + s + "]"
+}
+
+// assertPoolEquals returns true if p contains exactly the expected messages.
+func assertPoolEquals(t *testing.T, p *core.MessagePool, expMsgs ...*types.SignedMessage) {
+	msgs := p.Pending()
+	if len(msgs) != len(expMsgs) {
+		assert.Failf(t, "wrong messages in pool", "expMsgs %v, got msgs %v", msgsAsString(expMsgs), msgsAsString(msgs))
+
+	}
+	for _, m1 := range expMsgs {
+		found := false
+		for _, m2 := range msgs {
+			if types.SmsgCidsEqual(m1, m2) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			assert.Failf(t, "wrong messages in pool", "expMsgs %v, got msgs %v (msgs doesn't contain %v)", msgsAsString(expMsgs), msgsAsString(msgs), msgAsString(m1))
+		}
+	}
+}
+
+func headOf(chain []types.TipSet) types.TipSet {
+	return chain[len(chain)-1]
+}

--- a/core/message_pool_test.go
+++ b/core/message_pool_test.go
@@ -1,14 +1,11 @@
-package core
+package core_test
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 
-	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-hamt-ipld"
-	"github.com/pkg/errors"
+	"github.com/filecoin-project/go-filecoin/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -27,7 +24,7 @@ func TestMessagePoolAddRemove(t *testing.T) {
 
 	ctx := context.Background()
 
-	pool := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+	pool := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
 	msg1 := newSignedMessage()
 	msg2 := mustSetNonce(mockSigner, newSignedMessage(), 1)
 
@@ -41,11 +38,11 @@ func TestMessagePoolAddRemove(t *testing.T) {
 	assert.Nil(t, m)
 	assert.False(t, ok)
 
-	_, err = pool.Add(ctx, msg1)
+	_, err = pool.Add(ctx, msg1, 0)
 	assert.NoError(t, err)
 	assert.Len(t, pool.Pending(), 1)
 
-	_, err = pool.Add(ctx, msg2)
+	_, err = pool.Add(ctx, msg2, 0)
 	assert.NoError(t, err)
 	assert.Len(t, pool.Pending(), 2)
 
@@ -70,47 +67,46 @@ func TestMessagePoolValidate(t *testing.T) {
 		mpoolCfg := config.NewDefaultConfig().Mpool
 		maxMessagePoolSize := mpoolCfg.MaxPoolSize
 		ctx := context.Background()
-		pool := NewMessagePool(th.NewTestMessagePoolAPI(0), mpoolCfg, th.NewMockMessagePoolValidator())
+		pool := core.NewMessagePool(mpoolCfg, th.NewMockMessagePoolValidator())
 
 		smsgs := types.NewSignedMsgs(maxMessagePoolSize+1, mockSigner)
 		for _, smsg := range smsgs[:maxMessagePoolSize] {
-			_, err := pool.Add(ctx, smsg)
+			_, err := pool.Add(ctx, smsg, 0)
 			require.NoError(t, err)
 		}
 
-		assert.Len(t, pool.Pending(), maxMessagePoolSize)
+		assert.Len(t, pool.Pending(), int(maxMessagePoolSize))
 
 		// attempt to add one more
-		_, err := pool.Add(ctx, smsgs[maxMessagePoolSize])
+		_, err := pool.Add(ctx, smsgs[maxMessagePoolSize], 0)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "message pool is full")
 
-		assert.Len(t, pool.Pending(), maxMessagePoolSize)
+		assert.Len(t, pool.Pending(), int(maxMessagePoolSize))
 	})
 
 	t.Run("validates no two messages are added with same nonce", func(t *testing.T) {
 		ctx := context.Background()
-		pool := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		pool := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
 
 		smsg1 := newSignedMessage()
-		_, err := pool.Add(ctx, smsg1)
+		_, err := pool.Add(ctx, smsg1, 0)
 		require.NoError(t, err)
 
 		smsg2 := mustSetNonce(mockSigner, newSignedMessage(), smsg1.Nonce)
-		_, err = pool.Add(ctx, smsg2)
+		_, err = pool.Add(ctx, smsg2, 0)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "message with same actor and nonce")
 	})
 
 	t.Run("validates using supplied validator", func(t *testing.T) {
 		ctx := context.Background()
-		api := th.NewTestMessagePoolAPI(0)
 		validator := th.NewMockMessagePoolValidator()
 		validator.Valid = false
-		pool := NewMessagePool(api, config.NewDefaultConfig().Mpool, validator)
+		pool := core.NewMessagePool(config.NewDefaultConfig().Mpool, validator)
 
 		smsg1 := mustSetNonce(mockSigner, newSignedMessage(), 0)
-		_, err := pool.Add(ctx, smsg1)
+		_, err := pool.Add(ctx, smsg1, 0)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "mock validation error")
 	})
@@ -121,15 +117,15 @@ func TestMessagePoolDedup(t *testing.T) {
 
 	ctx := context.Background()
 
-	pool := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+	pool := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
 	msg1 := newSignedMessage()
 
 	assert.Len(t, pool.Pending(), 0)
-	_, err := pool.Add(ctx, msg1)
+	_, err := pool.Add(ctx, msg1, 0)
 	assert.NoError(t, err)
 	assert.Len(t, pool.Pending(), 1)
 
-	_, err = pool.Add(ctx, msg1)
+	_, err = pool.Add(ctx, msg1, 0)
 	assert.NoError(t, err)
 	assert.Len(t, pool.Pending(), 1)
 }
@@ -139,19 +135,19 @@ func TestMessagePoolAsync(t *testing.T) {
 
 	ctx := context.Background()
 
-	count := 400
+	count := uint(400)
 	mpoolCfg := config.NewDefaultConfig().Mpool
 	mpoolCfg.MaxPoolSize = count
 	msgs := types.NewSignedMsgs(count, mockSigner)
 
-	pool := NewMessagePool(th.NewTestMessagePoolAPI(0), mpoolCfg, th.NewMockMessagePoolValidator())
+	pool := core.NewMessagePool(mpoolCfg, th.NewMockMessagePoolValidator())
 	var wg sync.WaitGroup
 
-	for i := 0; i < 4; i++ {
+	for i := uint(0); i < 4; i++ {
 		wg.Add(1)
-		go func(i int) {
-			for j := 0; j < count/4; j++ {
-				_, err := pool.Add(ctx, msgs[j+(count/4)*i])
+		go func(i uint) {
+			for j := uint(0); j < count/4; j++ {
+				_, err := pool.Add(ctx, msgs[j+(count/4)*i], 0)
 				assert.NoError(t, err)
 			}
 			wg.Done()
@@ -159,433 +155,24 @@ func TestMessagePoolAsync(t *testing.T) {
 	}
 
 	wg.Wait()
-	assert.Len(t, pool.Pending(), count)
-}
-
-func msgAsString(msg *types.SignedMessage) string {
-	// When using NewMessageForTestGetter msg.Method is set
-	// to "msgN" so we print that (it will correspond
-	// to a variable of the same name in the tests
-	// below).
-	return msg.Message.Method
-}
-
-func msgsAsString(msgs []*types.SignedMessage) string {
-	s := ""
-	for _, m := range msgs {
-		s = fmt.Sprintf("%s%s ", s, msgAsString(m))
-	}
-	return "[" + s + "]"
-}
-
-// assertPoolEquals returns true if p contains exactly the expected messages.
-func assertPoolEquals(t *testing.T, p *MessagePool, expMsgs ...*types.SignedMessage) {
-	msgs := p.Pending()
-	if len(msgs) != len(expMsgs) {
-		assert.Failf(t, "wrong messages in pool", "expMsgs %v, got msgs %v", msgsAsString(expMsgs), msgsAsString(msgs))
-
-	}
-	for _, m1 := range expMsgs {
-		found := false
-		for _, m2 := range msgs {
-			if types.SmsgCidsEqual(m1, m2) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			assert.Failf(t, "wrong messages in pool", "expMsgs %v, got msgs %v (msgs doesn't contain %v)", msgsAsString(expMsgs), msgsAsString(msgs), msgAsString(m1))
-		}
-	}
-}
-
-func headOf(chain []types.TipSet) types.TipSet {
-	return chain[len(chain)-1]
-}
-
-func TestUpdateMessagePool(t *testing.T) {
-	tf.UnitTest(t)
-
-	ctx := context.Background()
-	type msgs []*types.SignedMessage
-	type msgsSet [][]*types.SignedMessage
-
-	t.Run("Replace head", func(t *testing.T) {
-		// Msg pool: [m0, m1], Chain: b[]
-		// to
-		// Msg pool: [m0],     Chain: b[m1]
-		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
-
-		m := types.NewSignedMsgs(2, mockSigner)
-		MustAdd(p, m[0], m[1])
-
-		parent := types.TipSet{}
-
-		blk := types.Block{Height: 0}
-		parent[blk.Cid()] = &blk
-
-		oldChain := NewChainWithMessages(store, parent, msgsSet{})
-		oldTipSet := headOf(oldChain)
-
-		newChain := NewChainWithMessages(store, parent, msgsSet{msgs{m[1]}})
-		newTipSet := headOf(newChain)
-
-		assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet))
-		assertPoolEquals(t, p, m[0])
-	})
-
-	t.Run("Replace head with self", func(t *testing.T) {
-		// Msg pool: [m0, m1], Chain: b[m2]
-		// to
-		// Msg pool: [m0, m1], Chain: b[m2]
-		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
-
-		m := types.NewSignedMsgs(3, mockSigner)
-		MustAdd(p, m[0], m[1])
-
-		oldChain := NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{m[2]}})
-		oldTipSet := headOf(oldChain)
-
-		assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, oldTipSet)) // sic
-		assertPoolEquals(t, p, m[0], m[1])
-	})
-
-	t.Run("Replace head with a long chain", func(t *testing.T) {
-		// Msg pool: [m2, m5],     Chain: b[m0, m1]
-		// to
-		// Msg pool: [m1],         Chain: b[m2, m3] -> b[m4] -> b[m0] -> b[] -> b[m5, m6]
-		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
-
-		m := types.NewSignedMsgs(7, mockSigner)
-		MustAdd(p, m[2], m[5])
-
-		parent := types.TipSet{}
-
-		blk := types.Block{Height: 0}
-		parent[blk.Cid()] = &blk
-		oldChain := NewChainWithMessages(store, parent, msgsSet{msgs{m[0], m[1]}})
-		oldTipSet := headOf(oldChain)
-
-		newChain := NewChainWithMessages(store, parent,
-			msgsSet{msgs{m[2], m[3]}},
-			msgsSet{msgs{m[4]}},
-			msgsSet{msgs{m[0]}},
-			msgsSet{msgs{}},
-			msgsSet{msgs{m[5], m[6]}},
-		)
-		newTipSet := headOf(newChain)
-
-		assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet))
-		assertPoolEquals(t, p, m[1])
-	})
-
-	t.Run("Replace head with multi-block tipset chains", func(t *testing.T) {
-		// Msg pool: [m2, m5],     Chain: {b[m0], b[m1]}
-		// to
-		// Msg pool: [m1],         Chain: b[m2, m3] -> {b[m4], b[m0], b[], b[]} -> {b[], b[m6,m5]}
-		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
-
-		m := types.NewSignedMsgs(7, mockSigner)
-		MustAdd(p, m[2], m[5])
-
-		parent := types.TipSet{}
-
-		blk := types.Block{Height: 0}
-		parent[blk.Cid()] = &blk
-
-		oldChain := NewChainWithMessages(store, parent, msgsSet{msgs{m[0]}, msgs{m[1]}})
-		oldTipSet := headOf(oldChain)
-
-		newChain := NewChainWithMessages(store, parent,
-			msgsSet{msgs{m[2], m[3]}},
-			msgsSet{msgs{m[4]}, msgs{m[0]}, msgs{}, msgs{}},
-			msgsSet{msgs{}, msgs{m[5], m[6]}},
-		)
-		newTipSet := headOf(newChain)
-
-		assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet))
-		assertPoolEquals(t, p, m[1])
-	})
-
-	t.Run("Replace internal node (second one)", func(t *testing.T) {
-		// Msg pool: [m3, m5],     Chain: b[m0] -> b[m1] -> b[m2]
-		// to
-		// Msg pool: [m1, m2],     Chain: b[m0] -> b[m3] -> b[m4, m5]
-		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
-
-		m := types.NewSignedMsgs(6, mockSigner)
-		MustAdd(p, m[3], m[5])
-
-		oldChain := NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{m[0]}}, msgsSet{msgs{m[1]}}, msgsSet{msgs{m[2]}})
-		oldTipSet := headOf(oldChain)
-
-		newChain := NewChainWithMessages(store, oldChain[0], msgsSet{msgs{m[3]}}, msgsSet{msgs{m[4], m[5]}})
-		newTipSet := headOf(newChain)
-
-		assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet))
-		assertPoolEquals(t, p, m[1], m[2])
-	})
-
-	t.Run("Replace internal node (second one) with a long chain", func(t *testing.T) {
-		// Msg pool: [m6],         Chain: b[m0] -> b[m1] -> b[m2]
-		// to
-		// Msg pool: [m6],         Chain: b[m0] -> b[m3] -> b[m4] -> b[m5] -> b[m1, m2]
-		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
-
-		m := types.NewSignedMsgs(7, mockSigner)
-		MustAdd(p, m[6])
-
-		oldChain := NewChainWithMessages(store, types.TipSet{},
-			msgsSet{msgs{m[0]}},
-			msgsSet{msgs{m[1]}},
-			msgsSet{msgs{m[2]}},
-		)
-		oldTipSet := headOf(oldChain)
-
-		newChain := NewChainWithMessages(store, oldChain[0],
-			msgsSet{msgs{m[3]}},
-			msgsSet{msgs{m[4]}},
-			msgsSet{msgs{m[5]}},
-			msgsSet{msgs{m[1], m[2]}},
-		)
-		newTipSet := headOf(newChain)
-
-		assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet))
-		assertPoolEquals(t, p, m[6])
-	})
-
-	t.Run("Replace internal node with multi-block tipset chains", func(t *testing.T) {
-		// Msg pool: [m6],         Chain: {b[m0], b[m1]} -> b[m2]
-		// to
-		// Msg pool: [m6],         Chain: {b[m0], b[m1]} -> b[m3] -> b[m4] -> {b[m5], b[m1, m2]}
-		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
-
-		m := types.NewSignedMsgs(7, mockSigner)
-		MustAdd(p, m[6])
-
-		oldChain := NewChainWithMessages(store, types.TipSet{},
-			msgsSet{msgs{m[0]}, msgs{m[1]}},
-			msgsSet{msgs{m[2]}},
-		)
-		oldTipSet := headOf(oldChain)
-
-		newChain := NewChainWithMessages(store, oldChain[0],
-			msgsSet{msgs{m[3]}},
-			msgsSet{msgs{m[4]}},
-			msgsSet{msgs{m[5]}, msgs{m[1], m[2]}},
-		)
-		newTipSet := headOf(newChain)
-
-		assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet))
-		assertPoolEquals(t, p, m[6])
-	})
-
-	t.Run("Replace with same messages in different block structure", func(t *testing.T) {
-		// Msg pool: [m3, m5],     Chain: b[m0] -> b[m1] -> b[m2]
-		// to
-		// Msg pool: [m3, m5],     Chain: {b[m0], b[m1], b[m2]}
-		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
-
-		m := types.NewSignedMsgs(6, mockSigner)
-		MustAdd(p, m[3], m[5])
-
-		parent := types.TipSet{}
-
-		blk := types.Block{Height: 0}
-		parent[blk.Cid()] = &blk
-
-		oldChain := NewChainWithMessages(store, parent,
-			msgsSet{msgs{m[0]}},
-			msgsSet{msgs{m[1]}},
-			msgsSet{msgs{m[2]}},
-		)
-		oldTipSet := headOf(oldChain)
-
-		newChain := NewChainWithMessages(store, parent,
-			msgsSet{msgs{m[0]}, msgs{m[1]}, msgs{m[2]}},
-		)
-		newTipSet := headOf(newChain)
-
-		assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet))
-		assertPoolEquals(t, p, m[3], m[5])
-	})
-
-	t.Run("Truncate to internal node", func(t *testing.T) {
-		// Msg pool: [],               Chain: b[m0] -> b[m1] -> b[m2] -> b[m3]
-		// to
-		// Msg pool: [m2, m3],         Chain: b[m0] -> b[m1]
-		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
-		m := types.NewSignedMsgs(4, mockSigner)
-
-		oldChain := NewChainWithMessages(store, types.TipSet{},
-			msgsSet{msgs{m[0]}},
-			msgsSet{msgs{m[1]}},
-			msgsSet{msgs{m[2]}},
-			msgsSet{msgs{m[3]}},
-		)
-		oldTipSet := headOf(oldChain)
-
-		oldTipSetPrev := oldChain[1]
-		assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, oldTipSetPrev))
-		assertPoolEquals(t, p, m[2], m[3])
-	})
-
-	t.Run("Extend head", func(t *testing.T) {
-		// Msg pool: [m0, m1], Chain: b[]
-		// to
-		// Msg pool: [m0],     Chain: b[] -> b[m1, m2]
-		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
-
-		m := types.NewSignedMsgs(3, mockSigner)
-		MustAdd(p, m[0], m[1])
-
-		oldChain := NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{}})
-		oldTipSet := headOf(oldChain)
-
-		newChain := NewChainWithMessages(store, oldChain[len(oldChain)-1], msgsSet{msgs{m[1], m[2]}})
-		newTipSet := headOf(newChain)
-
-		assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet))
-		assertPoolEquals(t, p, m[0])
-	})
-
-	t.Run("Extend head with a longer chain and more messages", func(t *testing.T) {
-		// Msg pool: [m2, m5],     Chain: b[m0] -> b[m1]
-		// to
-		// Msg pool: [],           Chain: b[m0] -> b[m1] -> b[m2, m3] -> b[m4] -> b[m5, m6]
-		store := hamt.NewCborStore()
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
-
-		m := types.NewSignedMsgs(7, mockSigner)
-		MustAdd(p, m[2], m[5])
-
-		oldChain := NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{m[0]}}, msgsSet{msgs{m[1]}})
-		oldTipSet := headOf(oldChain)
-
-		newChain := NewChainWithMessages(store, oldChain[1],
-			msgsSet{msgs{m[2], m[3]}},
-			msgsSet{msgs{m[4]}},
-			msgsSet{msgs{m[5], m[6]}},
-		)
-		newTipSet := headOf(newChain)
-
-		assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, oldTipSet, newTipSet))
-		assertPoolEquals(t, p)
-	})
-
-	t.Run("Times out old messages", func(t *testing.T) {
-		var err error
-		store := hamt.NewCborStore()
-		api := th.NewTestMessagePoolAPI(0)
-		p := NewMessagePool(api, config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
-
-		m := types.NewSignedMsgs(MessageTimeOut, mockSigner)
-
-		head := headOf(NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{}}))
-
-		// Add a message at each block height until MessageTimeOut is reached
-		for i := 0; i < MessageTimeOut; i++ {
-			// api.Height determines block time at which message is added
-			api.Height, err = head.Height()
-			require.NoError(t, err)
-
-			MustAdd(p, m[i])
-
-			// update pool with tipset that has no messages
-			next := headOf(NewChainWithMessages(store, head, msgsSet{msgs{}}))
-			assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, head, next))
-
-			// assert all added messages still in pool
-			assertPoolEquals(t, p, m[:i+1]...)
-
-			head = next
-		}
-
-		// next tipset times out first message only
-		next := headOf(NewChainWithMessages(store, head, msgsSet{msgs{}}))
-		assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, head, next))
-		assertPoolEquals(t, p, m[1:]...)
-
-		// adding a chain of multiple tipsets times out based on final state
-		for i := 0; i < 4; i++ {
-			next = headOf(NewChainWithMessages(store, next, msgsSet{msgs{}}))
-		}
-		assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, head, next))
-		assertPoolEquals(t, p, m[5:]...)
-	})
-
-	t.Run("Message timeout is unaffected by null tipsets", func(t *testing.T) {
-		var err error
-		store := hamt.NewCborStore()
-		blockTimer := th.NewTestMessagePoolAPI(0)
-		p := NewMessagePool(blockTimer, config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
-
-		m := types.NewSignedMsgs(MessageTimeOut, mockSigner)
-
-		head := headOf(NewChainWithMessages(store, types.TipSet{}, msgsSet{msgs{}}))
-
-		// Add a message at each block height until MessageTimeOut is reached
-		for i := 0; i < MessageTimeOut; i++ {
-			// blockTimer.Height determines block time at which message is added
-			blockTimer.Height, err = head.Height()
-			require.NoError(t, err)
-
-			MustAdd(p, m[i])
-
-			// update pool with tipset that has no messages
-			height, err := head.Height()
-			require.NoError(t, err)
-
-			// create a tipset at given height with one block containing no messages
-			next := types.TipSet{}
-			nextHeight := types.Uint64(height + 5) // simulate 4 null blocks
-			blk := &types.Block{
-				Height:  nextHeight,
-				Parents: head.ToSortedCidSet(),
-			}
-			MustPut(store, blk)
-			next[blk.Cid()] = blk
-
-			assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, head, next))
-
-			// assert all added messages still in pool
-			assertPoolEquals(t, p, m[:i+1]...)
-
-			head = next
-		}
-
-		// next tipset times out first message only
-		next := headOf(NewChainWithMessages(store, head, msgsSet{msgs{}}))
-		assert.NoError(t, p.UpdateMessagePool(ctx, &storeBlockProvider{store}, head, next))
-		assertPoolEquals(t, p, m[1:]...)
-	})
+	assert.Len(t, pool.Pending(), int(count))
 }
 
 func TestLargestNonce(t *testing.T) {
 	tf.UnitTest(t)
 
 	t.Run("No matches", func(t *testing.T) {
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
 
 		m := types.NewSignedMsgs(2, mockSigner)
-		MustAdd(p, m[0], m[1])
+		core.MustAdd(p, 0, m[0], m[1])
 
 		_, found := p.LargestNonce(address.NewForTestGetter()())
 		assert.False(t, found)
 	})
 
 	t.Run("Match, largest is zero", func(t *testing.T) {
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
 
 		m := types.NewMsgsWithAddrs(1, mockSigner.Addresses)
 		m[0].Nonce = 0
@@ -593,7 +180,7 @@ func TestLargestNonce(t *testing.T) {
 		sm, err := types.SignMsgs(mockSigner, m)
 		require.NoError(t, err)
 
-		MustAdd(p, sm...)
+		core.MustAdd(p, 0, sm...)
 
 		largest, found := p.LargestNonce(m[0].From)
 		assert.True(t, found)
@@ -601,7 +188,7 @@ func TestLargestNonce(t *testing.T) {
 	})
 
 	t.Run("Match", func(t *testing.T) {
-		p := NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+		p := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
 
 		m := types.NewMsgsWithAddrs(3, mockSigner.Addresses)
 		m[1].Nonce = 1
@@ -611,24 +198,12 @@ func TestLargestNonce(t *testing.T) {
 		sm, err := types.SignMsgs(mockSigner, m)
 		require.NoError(t, err)
 
-		MustAdd(p, sm...)
+		core.MustAdd(p, 0, sm...)
 
 		largest, found := p.LargestNonce(m[2].From)
 		assert.True(t, found)
 		assert.Equal(t, uint64(2), largest)
 	})
-}
-
-type storeBlockProvider struct {
-	store *hamt.CborIpldStore
-}
-
-func (p *storeBlockProvider) GetBlock(ctx context.Context, cid cid.Cid) (*types.Block, error) {
-	var blk types.Block
-	if err := p.store.Get(ctx, cid, &blk); err != nil {
-		return nil, errors.Wrapf(err, "failed to get block %s", cid)
-	}
-	return &blk, nil
 }
 
 func mustSetNonce(signer types.Signer, message *types.SignedMessage, nonce types.Uint64) *types.SignedMessage {

--- a/core/outbox.go
+++ b/core/outbox.go
@@ -30,14 +30,14 @@ type Outbox struct {
 	// Maintains message queue in response to new tipsets.
 	policy QueuePolicy
 
-	chains chainProvider
+	chains outboxChainProvider
 	actors actorProvider
 
 	// Protects the "next nonce" calculation to avoid collisions.
 	nonceLock sync.Mutex
 }
 
-type chainProvider interface {
+type outboxChainProvider interface {
 	GetHead() types.SortedCidSet
 	GetTipSet(tsKey types.SortedCidSet) (*types.TipSet, error)
 }
@@ -55,7 +55,7 @@ var msgSendErrCt = metrics.NewInt64Counter("message_sender_error", "Number of er
 
 // NewOutbox creates a new outbox
 func NewOutbox(signer types.Signer, validator consensus.SignedMessageValidator, queue *MessageQueue,
-	publisher publisher, policy QueuePolicy, chains chainProvider, actors actorProvider) *Outbox {
+	publisher publisher, policy QueuePolicy, chains outboxChainProvider, actors actorProvider) *Outbox {
 	return &Outbox{
 		signer:    signer,
 		validator: validator,
@@ -151,7 +151,7 @@ func nextNonce(act *actor.Actor, queue *MessageQueue, address address.Address) (
 	return actorNonce, nil
 }
 
-func tipsetHeight(provider chainProvider, key types.SortedCidSet) (uint64, error) {
+func tipsetHeight(provider outboxChainProvider, key types.SortedCidSet) (uint64, error) {
 	head, err := provider.GetTipSet(key)
 	if err != nil {
 		return 0, err

--- a/core/policy.go
+++ b/core/policy.go
@@ -43,7 +43,7 @@ type DefaultQueuePolicy struct {
 }
 
 // NewMessageQueuePolicy returns a new policy which removes mined messages from the queue and expires
-// messages older than `maxAgeRounds` rounds.
+// messages older than `maxAgeTipsets` rounds.
 func NewMessageQueuePolicy(store chain.BlockProvider, maxAge uint64) *DefaultQueuePolicy {
 	return &DefaultQueuePolicy{store, maxAge}
 }

--- a/core/testing.go
+++ b/core/testing.go
@@ -38,19 +38,10 @@ func MustGetNonce(st state.Tree, a address.Address) uint64 {
 }
 
 // MustAdd adds the given messages to the messagepool or panics if it cannot.
-func MustAdd(p *MessagePool, msgs ...*types.SignedMessage) {
+func MustAdd(p *MessagePool, height uint64, msgs ...*types.SignedMessage) {
 	ctx := context.Background()
 	for _, m := range msgs {
-		if _, err := p.Add(ctx, m); err != nil {
-			panic(err)
-		}
-	}
-}
-
-// MustEnqueue adds the given messages to the messagepool or panics if it cannot.
-func MustEnqueue(q *MessageQueue, stamp uint64, msgs ...*types.SignedMessage) {
-	for _, m := range msgs {
-		if err := q.Enqueue(m, stamp); err != nil {
+		if _, err := p.Add(ctx, m, height); err != nil {
 			panic(err)
 		}
 	}

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -98,7 +98,7 @@ func Test_Mine(t *testing.T) {
 
 func sharedSetupInitial() (*hamt.CborIpldStore, *core.MessagePool, cid.Cid) {
 	cst := hamt.NewCborStore()
-	pool := core.NewMessagePool(th.NewTestMessagePoolAPI(0), config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
+	pool := core.NewMessagePool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.AccountActorCodeCid
 	return cst, pool, fakeActorCodeCid
@@ -276,13 +276,13 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 	smsg4, err := types.NewSignedMessage(*msg4, &mockSigner, types.NewGasPrice(1), types.NewGasUnits(0))
 	require.NoError(t, err)
 
-	_, err = pool.Add(ctx, smsg1)
+	_, err = pool.Add(ctx, smsg1, 0)
 	assert.NoError(t, err)
-	_, err = pool.Add(ctx, smsg2)
+	_, err = pool.Add(ctx, smsg2, 0)
 	assert.NoError(t, err)
-	_, err = pool.Add(ctx, smsg3)
+	_, err = pool.Add(ctx, smsg3, 0)
 	assert.NoError(t, err)
-	_, err = pool.Add(ctx, smsg4)
+	_, err = pool.Add(ctx, smsg4, 0)
 	assert.NoError(t, err)
 
 	assert.Len(t, pool.Pending(), 4)
@@ -419,7 +419,7 @@ func TestGenerateError(t *testing.T) {
 	msg := types.NewMessage(addrs[0], addrs[1], 0, nil, "", nil)
 	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(t, err)
-	_, err = pool.Add(ctx, smsg)
+	_, err = pool.Add(ctx, smsg, 0)
 	require.NoError(t, err)
 
 	assert.Len(t, pool.Pending(), 1)

--- a/node/message.go
+++ b/node/message.go
@@ -21,6 +21,6 @@ func (node *Node) processMessage(ctx context.Context, pubSubMsg pubsub.Message) 
 
 	log.Debugf("Received new message from network: %s", unmarshaled)
 
-	_, err = node.MsgPool.Add(ctx, unmarshaled)
+	_, err = node.Inbox.Add(ctx, unmarshaled)
 	return err
 }

--- a/node/message_propagate_test.go
+++ b/node/message_propagate_test.go
@@ -61,9 +61,9 @@ func TestMessagePropagation(t *testing.T) {
 	// Wait for network connection notifications to propagate
 	time.Sleep(time.Millisecond * 50)
 
-	require.Equal(t, 0, len(nodes[0].MsgPool.Pending()))
-	require.Equal(t, 0, len(nodes[1].MsgPool.Pending()))
-	require.Equal(t, 0, len(nodes[2].MsgPool.Pending()))
+	require.Equal(t, 0, len(nodes[1].Inbox.Pool().Pending()))
+	require.Equal(t, 0, len(nodes[2].Inbox.Pool().Pending()))
+	require.Equal(t, 0, len(nodes[0].Inbox.Pool().Pending()))
 
 	t.Run("message propagates", func(t *testing.T) {
 		_, err = sender.PorcelainAPI.MessageSendWithDefaultAddress(
@@ -78,13 +78,13 @@ func TestMessagePropagation(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, th.WaitForIt(50, 100*time.Millisecond, func() (bool, error) {
-			return len(nodes[0].MsgPool.Pending()) == 1 &&
-				len(nodes[1].MsgPool.Pending()) == 1 &&
-				len(nodes[2].MsgPool.Pending()) == 1, nil
+			return len(nodes[0].Inbox.Pool().Pending()) == 1 &&
+				len(nodes[1].Inbox.Pool().Pending()) == 1 &&
+				len(nodes[2].Inbox.Pool().Pending()) == 1, nil
 		}), "failed to propagate messages")
 
-		assert.True(t, nodes[0].MsgPool.Pending()[0].Message.Method == "foo")
-		assert.True(t, nodes[1].MsgPool.Pending()[0].Message.Method == "foo")
-		assert.True(t, nodes[2].MsgPool.Pending()[0].Message.Method == "foo")
+		assert.True(t, nodes[0].Inbox.Pool().Pending()[0].Message.Method == "foo")
+		assert.True(t, nodes[1].Inbox.Pool().Pending()[0].Message.Method == "foo")
+		assert.True(t, nodes[2].Inbox.Pool().Pending()[0].Message.Method == "foo")
 	})
 }

--- a/node/msg_publisher.go
+++ b/node/msg_publisher.go
@@ -27,7 +27,7 @@ func (p *defaultMessagePublisher) Publish(ctx context.Context, message *types.Si
 		return errors.Wrap(err, "failed to marshal message")
 	}
 
-	if _, err := p.pool.Add(ctx, message); err != nil {
+	if _, err := p.pool.Add(ctx, message, height); err != nil {
 		return errors.Wrap(err, "failed to add message to message pool")
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -118,7 +118,7 @@ type Node struct {
 	HeaviestTipSetHandled func()
 
 	// Incoming messages for block mining.
-	MsgPool *core.MessagePool
+	Inbox *core.Inbox
 	// Messages sent and not yet mined.
 	Outbox *core.Outbox
 
@@ -426,9 +426,10 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 
 	// only the syncer gets the storage which is online connected
 	chainSyncer := chain.NewDefaultSyncer(&cstOffline, nodeConsensus, chainStore, fetcher)
-	msgPool := core.NewMessagePool(chainStore, nc.Repo.Config().Mpool, consensus.NewIngestionValidator(chainState, nc.Repo.Config().Mpool))
-	msgQueue := core.NewMessageQueue()
+	msgPool := core.NewMessagePool(nc.Repo.Config().Mpool, consensus.NewIngestionValidator(chainState, nc.Repo.Config().Mpool))
+	inbox := core.NewInbox(msgPool, core.InboxMaxAgeTipsets, chainStore)
 
+	msgQueue := core.NewMessageQueue()
 	outboxPolicy := core.NewMessageQueuePolicy(chainStore, core.OutboxMaxAgeRounds)
 	msgPublisher := newDefaultMessagePublisher(pubsub.NewPublisher(fsub), core.Topic, msgPool)
 	outbox := core.NewOutbox(fcWallet, consensus.NewOutboundMessageValidator(), msgQueue, msgPublisher, outboxPolicy, chainStore, chainState)
@@ -460,7 +461,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 		Fetcher:      fetcher,
 		Exchange:     bswap,
 		host:         peerHost,
-		MsgPool:      msgPool,
+		Inbox:        inbox,
 		OfflineMode:  nc.OfflineMode,
 		Outbox:       outbox,
 		PeerHost:     peerHost,
@@ -665,7 +666,7 @@ func (node *Node) handleNewHeaviestTipSet(ctx context.Context, head types.TipSet
 			if err := node.Outbox.HandleNewHead(ctx, head, newHead); err != nil {
 				log.Error("updating outbound message queue for new tipset", err)
 			}
-			if err := node.MsgPool.UpdateMessagePool(ctx, node.ChainReader, head, newHead); err != nil {
+			if err := node.Inbox.HandleNewHead(ctx, head, newHead); err != nil {
 				log.Error("updating message pool for new tipset", err)
 			}
 			head = newHead
@@ -1053,7 +1054,7 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (mining.Worker, error)
 		return nil, err
 	}
 	return mining.NewDefaultWorker(
-		node.MsgPool, node.getStateTree, node.getWeight, node.getAncestors, processor, node.PowerTable,
+		node.Inbox.Pool(), node.getStateTree, node.getWeight, node.getAncestors, processor, node.PowerTable,
 		node.Blockstore, node.CborStore(), minerAddr, minerOwnerAddr, minerPubKey,
 		node.Wallet, node.blockTime), nil
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -188,7 +188,10 @@ func TestUpdateMessagePool(t *testing.T) {
 	require.NoError(t, err)
 	genTS := *headTipSet
 	m := types.NewSignedMsgs(4, mockSigner)
-	core.MustAdd(node.MsgPool, m[0], m[1])
+	_, err = node.Inbox.Add(ctx, m[0])
+	require.NoError(t, err)
+	_, err = node.Inbox.Add(ctx, m[1])
+	require.NoError(t, err)
 
 	oldChain := core.NewChainWithMessages(node.CborStore(), genTS, [][]*types.SignedMessage{{m[2], m[3]}})
 	newChain := core.NewChainWithMessages(node.CborStore(), genTS, [][]*types.SignedMessage{{}}, [][]*types.SignedMessage{{m[1], m[2]}})
@@ -212,8 +215,8 @@ func TestUpdateMessagePool(t *testing.T) {
 	})
 	assert.NoError(t, chainForTest.SetHead(ctx, newChain[len(newChain)-1]))
 	<-updateMsgPoolDoneCh
-	assert.Equal(t, 2, len(node.MsgPool.Pending()))
-	pending := node.MsgPool.Pending()
+	assert.Equal(t, 2, len(node.Inbox.Pool().Pending()))
+	pending := node.Inbox.Pool().Pending()
 
 	assert.True(t, types.SmsgCidsEqual(m[0], pending[0]) || types.SmsgCidsEqual(m[0], pending[1]))
 	assert.True(t, types.SmsgCidsEqual(m[3], pending[0]) || types.SmsgCidsEqual(m[3], pending[1]))

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -90,16 +90,6 @@ func RequireRandomPeerID(t *testing.T) peer.ID {
 	return pid
 }
 
-// TestMessagePoolAPI provides a simple BlockTimer interface implementation.
-type TestMessagePoolAPI struct {
-	Height uint64
-}
-
-// NewTestMessagePoolAPI creates a new TestMessagePoolAPI.
-func NewTestMessagePoolAPI(h uint64) *TestMessagePoolAPI {
-	return &TestMessagePoolAPI{Height: h}
-}
-
 // MockMessagePoolValidator is a mock validator
 type MockMessagePoolValidator struct {
 	Valid bool
@@ -116,11 +106,6 @@ func (v *MockMessagePoolValidator) Validate(ctx context.Context, msg *types.Sign
 		return nil
 	}
 	return errors.New("mock validation error")
-}
-
-// BlockHeight represents the height of the highest tipset.
-func (tbt *TestMessagePoolAPI) BlockHeight() (uint64, error) {
-	return tbt.Height, nil
 }
 
 // VMStorage creates a new storage object backed by an in memory datastore

--- a/types/testing.go
+++ b/types/testing.go
@@ -236,11 +236,11 @@ func NewMsgs(n int) []*Message {
 // NewSignedMsgs returns n signed messages. The messages returned are unique to this invocation
 // but are not unique globally (ie, a second call to NewSignedMsgs will return the same
 // set of messages).
-func NewSignedMsgs(n int, ms MockSigner) []*SignedMessage {
+func NewSignedMsgs(n uint, ms MockSigner) []*SignedMessage {
 	var err error
 	newMsg := NewMessageForTestGetter()
 	smsgs := make([]*SignedMessage, n)
-	for i := 0; i < n; i++ {
+	for i := uint(0); i < n; i++ {
 		msg := newMsg()
 		msg.From = ms.Addresses[0]
 		msg.Nonce = Uint64(i)


### PR DESCRIPTION
With this change, the incoming and outbound message queue/pool follow a similar pattern.
They're not quite the same, since validation is performed inside the message pool but
prior to the outbound queue (which we could also align).