### PR TITLE
Feat/caught up nodes ignore far future blocks 2782

### DIFF
--- a/chain/default_store_test.go
+++ b/chain/default_store_test.go
@@ -30,7 +30,7 @@ func initStoreTest(ctx context.Context, t *testing.T, dstP *DefaultSyncerTestPar
 	initGenesisWrapper := func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
 		return initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs)
 	}
-	initSyncTest(t, con, initGenesisWrapper, cst, bs, r, dstP, false)
+	initSyncTest(t, con, initGenesisWrapper, cst, bs, r, dstP, chain.Syncing)
 	requireSetTestChain(t, con, true, dstP)
 }
 

--- a/chain/default_store_test.go
+++ b/chain/default_store_test.go
@@ -30,7 +30,7 @@ func initStoreTest(ctx context.Context, t *testing.T, dstP *DefaultSyncerTestPar
 	initGenesisWrapper := func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
 		return initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs)
 	}
-	initSyncTest(t, con, initGenesisWrapper, cst, bs, r, dstP)
+	initSyncTest(t, con, initGenesisWrapper, cst, bs, r, dstP, false)
 	requireSetTestChain(t, con, true, dstP)
 }
 

--- a/chain/default_syncer.go
+++ b/chain/default_syncer.go
@@ -37,7 +37,9 @@ var (
 
 var logSyncer = logging.Logger("chain.syncer")
 
-// SyncMode is the
+// SyncMode represents which behavior mode the chain syncer is currently in. By
+// default, the node starts in "Syncing" mode, and once it syncs the most
+// recently generated block, it switches to "Caught Up" mode.
 type SyncMode int
 
 const (

--- a/chain/default_syncer.go
+++ b/chain/default_syncer.go
@@ -111,13 +111,13 @@ type DefaultSyncer struct {
 	// implementation in issue #1160.
 	//
 	// TODO: https://github.com/filecoin-project/go-filecoin/issues/1160
-	SyncMode SyncMode
+	syncMode SyncMode
 }
 
 var _ Syncer = (*DefaultSyncer)(nil)
 
 // NewDefaultSyncer constructs a DefaultSyncer ready for use.
-func NewDefaultSyncer(cst *hamt.CborIpldStore, c consensus.Protocol, s syncerChainReader, f syncFetcher) *DefaultSyncer {
+func NewDefaultSyncer(cst *hamt.CborIpldStore, c consensus.Protocol, s syncerChainReader, f syncFetcher, syncMode SyncMode) *DefaultSyncer {
 	return &DefaultSyncer{
 		fetcher:    f,
 		stateStore: cst,
@@ -126,7 +126,7 @@ func NewDefaultSyncer(cst *hamt.CborIpldStore, c consensus.Protocol, s syncerCha
 		},
 		consensus:  c,
 		chainStore: s,
-		SyncMode:   Syncing,
+		syncMode:   syncMode,
 	}
 }
 
@@ -167,7 +167,7 @@ func (syncer *DefaultSyncer) collectChain(ctx context.Context, tipsetCids types.
 	// height of the input blocks has not yet exceeded the sum of the current
 	// consensus height and the finalityLimit constant, otherwise ignore the input
 	// blocks as a likely invalid chain or denial of service attempt.
-	for syncer.SyncMode == Syncing || len(chain) < FinalityLimit {
+	for (syncer.syncMode == Syncing) || (len(chain) < FinalityLimit) {
 		var blks []*types.Block
 		// check the cache for bad tipsets before doing anything
 		tsKey := tipsetCids.String()

--- a/chain/default_syncer.go
+++ b/chain/default_syncer.go
@@ -166,9 +166,8 @@ func (syncer *DefaultSyncer) collectChain(ctx context.Context, tipsetCids types.
 	defer logSyncer.Infof("chain fetch from network complete %v", fetchedHead)
 
 	// Continue collecting the chain if we're either not yet caught up or the
-	// height of the input blocks has not yet exceeded the sum of the current
-	// consensus height and the finalityLimit constant, otherwise ignore the input
-	// blocks as a likely invalid chain or denial of service attempt.
+	// number of new input blocks is less than the FinalityLimit constant.
+	// Otherwise, halt assuming the new blocks come from an invalid chain.
 	for (syncer.syncMode == Syncing) || (len(chain) < FinalityLimit) {
 		var blks []*types.Block
 		// check the cache for bad tipsets before doing anything

--- a/node/node.go
+++ b/node/node.go
@@ -425,7 +425,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 	fcWallet := wallet.New(backend)
 
 	// only the syncer gets the storage which is online connected
-	chainSyncer := chain.NewDefaultSyncer(&cstOffline, nodeConsensus, chainStore, fetcher)
+	chainSyncer := chain.NewDefaultSyncer(&cstOffline, nodeConsensus, chainStore, fetcher, chain.Syncing)
 	msgPool := core.NewMessagePool(nc.Repo.Config().Mpool, consensus.NewIngestionValidator(chainState, nc.Repo.Config().Mpool))
 	inbox := core.NewInbox(msgPool, core.InboxMaxAgeTipsets, chainStore)
 


### PR DESCRIPTION
# Problem

Currently, a vulnerability exists in chain syncing when receiving a blocks for a chain extremely far ahead of the current consensus after entering `CaughtUp` mode which causes nodes to significantly slow down as they attempt to verify the new blocks.

# Solution

Once in `CaughtUp` mode, disregard any chains received more than 600 blocks ahead of the current consensus.

Resolves #2782