### PR TITLE
client adds conditions to payments

### DIFF
--- a/porcelain/payments.go
+++ b/porcelain/payments.go
@@ -14,6 +14,8 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
+const verifyPieceInclusionMethod = "verifyPieceInclusion"
+
 // cpPlumbing is the subset of the plumbing.API that CreatePayments uses.
 type cpPlumbing interface {
 	ChainBlockHeight() (*types.BlockHeight, error)
@@ -39,6 +41,13 @@ type CreatePaymentsParams struct {
 
 	// Duration is the amount of time (in block height) the payments will cover.
 	Duration uint64
+
+	// MinerAddress is the address of the miner actor representing the payment recipient.
+	// Conditions confirming that the miner is storing the client's piece will be directed towards this actor.
+	MinerAddress address.Address
+
+	// CommP is the clients data commitment. It will be the basis of piece inclusion conditions added to the payments.
+	CommP types.CommP
 
 	// PaymentInterval is the time between payments (in block height)
 	PaymentInterval uint64
@@ -72,7 +81,12 @@ type CreatePaymentsReturn struct {
 	Vouchers []*types.PaymentVoucher
 }
 
-// CreatePayments establishes a payment channel and create multiple payments against it
+// CreatePayments establishes a payment channel and create multiple payments against it.
+//
+// Each payment except the last will get a condition that calls verifyPieceInclusion on the recipient's miner
+// actor to ensure the storage miner is still storing the file at the time of redemption.
+// The last payment does not contain a condition so that the miner may collect payment without posting a
+// piece inclusion proof after the storage deal is complete.
 func CreatePayments(ctx context.Context, plumbing cpPlumbing, config CreatePaymentsParams) (*CreatePaymentsReturn, error) {
 	// validate
 	if config.From.Empty() {
@@ -135,6 +149,13 @@ func CreatePayments(ctx context.Context, plumbing cpPlumbing, config CreatePayme
 	durationAsAttoFIL := types.NewAttoFIL(big.NewInt(int64(config.Duration)))
 	valuePerPayment := *config.Value.MulBigInt(intervalAsBigInt).DivCeil(durationAsAttoFIL)
 
+	// condition is a condition that requires that the miner has the client's piece and is currently proving on it
+	condition := &types.Predicate{
+		To:     config.MinerAddress,
+		Method: verifyPieceInclusionMethod,
+		Params: []interface{}{config.CommP[:]},
+	}
+
 	// generate payments
 	response.Vouchers = []*types.PaymentVoucher{}
 	voucherAmount := types.ZeroAttoFIL
@@ -145,18 +166,17 @@ func CreatePayments(ctx context.Context, plumbing cpPlumbing, config CreatePayme
 		}
 
 		validAt := currentHeight.Add(types.NewBlockHeight(uint64(i+1) * config.PaymentInterval))
-		err = createPayment(ctx, plumbing, response, voucherAmount, validAt, nil)
+		err = createPayment(ctx, plumbing, response, voucherAmount, validAt, condition)
 		if err != nil {
 			return response, err
 		}
 	}
 
-	if voucherAmount.LessThan(&config.Value) {
-		validAt := currentHeight.Add(types.NewBlockHeight(config.Duration))
-		err = createPayment(ctx, plumbing, response, &config.Value, validAt, nil)
-		if err != nil {
-			return response, err
-		}
+	// create last payment if we haven't already created a voucher for the full amount
+	validAt := currentHeight.Add(types.NewBlockHeight(config.Duration))
+	err = createPayment(ctx, plumbing, response, &config.Value, validAt, nil)
+	if err != nil {
+		return response, err
 	}
 
 	return response, nil

--- a/porcelain/payments.go
+++ b/porcelain/payments.go
@@ -46,7 +46,7 @@ type CreatePaymentsParams struct {
 	// Conditions confirming that the miner is storing the client's piece will be directed towards this actor.
 	MinerAddress address.Address
 
-	// CommP is the clients data commitment. It will be the basis of piece inclusion conditions added to the payments.
+	// CommP is the client's data commitment. It will be the basis of piece inclusion conditions added to the payments.
 	CommP types.CommP
 
 	// PaymentInterval is the time between payments (in block height)
@@ -81,7 +81,7 @@ type CreatePaymentsReturn struct {
 	Vouchers []*types.PaymentVoucher
 }
 
-// CreatePayments establishes a payment channel and create multiple payments against it.
+// CreatePayments establishes a payment channel and creates multiple payments against it.
 //
 // Each payment except the last will get a condition that calls verifyPieceInclusion on the recipient's miner
 // actor to ensure the storage miner is still storing the file at the time of redemption.
@@ -172,7 +172,7 @@ func CreatePayments(ctx context.Context, plumbing cpPlumbing, config CreatePayme
 		}
 	}
 
-	// create last payment if we haven't already created a voucher for the full amount
+	// create last payment
 	validAt := currentHeight.Add(types.NewBlockHeight(config.Duration))
 	err = createPayment(ctx, plumbing, response, &config.Value, validAt, nil)
 	if err != nil {

--- a/protocol/storage/client.go
+++ b/protocol/storage/client.go
@@ -110,6 +110,10 @@ func (smc *Client) ProposeDeal(ctx context.Context, miner address.Address, data 
 		return nil, errors.Wrap(err, "failed to determine the size of the data")
 	}
 
+	// TODO This is fake. CommP should be the merkle root of data, rather than its CID (issue #2792)
+	var commP types.CommP
+	copy(commP[:], data.Bytes())
+
 	sectorSize, err := smc.api.MinerGetSectorSize(ctxSetup, miner)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get sector size")
@@ -174,6 +178,8 @@ func (smc *Client) ProposeDeal(ctx context.Context, miner address.Address, data 
 		To:              minerOwner,
 		Value:           *price.MulBigInt(big.NewInt(int64(size * duration))),
 		Duration:        duration,
+		MinerAddress:    miner,
+		CommP:           commP,
 		PaymentInterval: VoucherInterval,
 		ChannelExpiry:   *chainHeight.Add(types.NewBlockHeight(duration + ChannelExpiryInterval)),
 		GasPrice:        *types.NewAttoFIL(big.NewInt(CreateChannelGasPrice)),


### PR DESCRIPTION
closes #2705

### Problem

Storage clients need to ensure they can recover their money once they discover that a miner is not storing their piece. They can do that by adding conditions to payments that ensure the miner is storing the piece at the time of payment.

#### Solution

Have the client add a 'verifyPieceInclusion' condition to each payment except the last. The last payment should not have a condition so the miner can recover funds without posting a piece inclusion proof at the end of the deal.

### Note

The `verifyPieceInclusion` method on miner requires a `CommP` as it's first parameter. We currently do not have the ability to generate `CommP` so we create a fake one in this PR (by using the CID of the piece) and leaving CommP integration as future work (#2792). 

The PR tests that the conditions are created correctly. It doesn't test that miners will be able to redeem payments if they have valid piece inclusion proofs. This round-trip testing should be performed soon after this PR (#2822).