### PR TITLE
pre-release tool to clean up old nightlies

### DIFF
--- a/tools/prerelease-tool/main.go
+++ b/tools/prerelease-tool/main.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+)
+
+type prereleaseTool struct {
+	Data        []*github.RepositoryRelease
+	Limit       int
+	Owner       string
+	Repo        string
+	client      *github.Client
+	Prereleases []github.RepositoryRelease
+	DryRun      bool
+}
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	token, ok := os.LookupEnv("GITHUB_TOKEN")
+	if !ok {
+		log.Fatal("Github token must be provided through GITHUB_TOKEN environment variable")
+	}
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+	client := github.NewClient(tc)
+	dryRun := flag.Bool("dry-run", false, "perform a dry run instead of executing create/delete/update actions")
+	limit := flag.Int("limit", 7, "limit of prereleases to keep")
+	owner := flag.String("owner", "filecoin-project", "github owner or organization")
+	repo := flag.String("repo", "go-filecoin", "github project repository")
+	flag.Parse()
+	r := prereleaseTool{
+		Limit:  *limit,
+		Owner:  *owner,
+		Repo:   *repo,
+		client: client,
+		DryRun: *dryRun,
+	}
+	if err := r.get(ctx); err != nil {
+		log.Fatalf("Could not find any releases: %+v", err)
+	}
+	r.getPrereleases()
+	r.sortReleasesByDate()
+	ok, err := r.trim(ctx, r.oldReleaseIDs())
+	if err != nil {
+		log.Fatalf("Problem attempting to delete releases: %+v", err)
+	}
+	if !ok {
+		log.Print("Remove --dry-run flag to apply changes")
+	}
+}
+
+func (r *prereleaseTool) get(ctx context.Context) error {
+	releases, _, err := r.client.Repositories.ListReleases(ctx, r.Owner, r.Repo, nil)
+	r.Data = releases
+	return err
+}
+
+func (r *prereleaseTool) getPrereleases() {
+	switch {
+	case len(r.Data) > 0:
+		for _, release := range r.Data {
+			if *release.Prerelease {
+				r.Prereleases = append(r.Prereleases, *release)
+			}
+		}
+	default:
+		log.Print("no releases found")
+	}
+
+}
+
+func (r *prereleaseTool) sortReleasesByDate() {
+	sort.Slice(r.Prereleases, func(i, j int) bool {
+		first := r.Prereleases[i].CreatedAt
+		second := r.Prereleases[j].CreatedAt
+		switch {
+		case first.Unix() < second.Unix():
+			return false
+		default:
+			return true
+		}
+	})
+}
+
+func (r *prereleaseTool) oldReleaseIDs() []int64 {
+	var idsToDelete []int64
+	switch {
+	case len(r.Prereleases) > r.Limit:
+		trimmedPrereleaseList := r.Prereleases[r.Limit:]
+		for _, release := range trimmedPrereleaseList {
+			idsToDelete = append(idsToDelete, *release.ID)
+		}
+	default:
+		log.Print("There are no outdated prereleases")
+	}
+	return idsToDelete
+}
+
+func (r *prereleaseTool) trim(ctx context.Context, ids []int64) (bool, error) {
+	var ok bool
+	switch {
+	case len(ids) > 0:
+		log.Print("Removing outdated Prereleases")
+		for _, id := range ids {
+			log.Printf("Prerelease ID %d selected for deletion", id)
+			if !r.DryRun {
+				ok = true
+				log.Printf("Deleting Prerelease %d", id)
+				resp, err := r.client.Repositories.DeleteRelease(ctx, r.Owner, r.Repo, id)
+				if err != nil {
+					return ok, err
+				}
+				if resp.StatusCode != 204 {
+					return ok, fmt.Errorf("Unexpected HTTP status code. Expected: 204 Got: %d", resp.StatusCode)
+				}
+			}
+		}
+	default:
+		log.Print("No preleases to delete")
+	}
+	return ok, nil
+}

--- a/tools/prerelease-tool/main_test.go
+++ b/tools/prerelease-tool/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -19,42 +20,50 @@ func mock() *prereleaseTool {
 	name1 := "release"
 	prerelease1 := false
 	id1 := int64(1)
+	tag1 := "v" + strconv.FormatInt(id1, 10)
 	time1 := now.Add(-1 * time.Minute)
 	r.Releases = append(r.Releases, &github.RepositoryRelease{
 		Name:       &name1,
 		Prerelease: &prerelease1,
 		ID:         &id1,
 		CreatedAt:  &github.Timestamp{time1},
+		TagName:    &tag1,
 	})
 	name2 := "prerelease-middle"
 	prerelease2 := true
 	id2 := int64(2)
+	tag2 := "v" + strconv.FormatInt(id2, 10)
 	time2 := now.Add(-3 * time.Minute)
 	r.Releases = append(r.Releases, &github.RepositoryRelease{
 		Name:       &name2,
 		Prerelease: &prerelease2,
 		ID:         &id2,
 		CreatedAt:  &github.Timestamp{time2},
+		TagName:    &tag2,
 	})
 	name3 := "prerelease-oldest"
 	prerelease3 := true
 	id3 := int64(3)
+	tag3 := "v" + strconv.FormatInt(id3, 10)
 	time3 := now.Add(-4 * time.Minute)
 	r.Releases = append(r.Releases, &github.RepositoryRelease{
 		Name:       &name3,
 		Prerelease: &prerelease3,
 		ID:         &id3,
 		CreatedAt:  &github.Timestamp{time3},
+		TagName:    &tag3,
 	})
 	name4 := "prerelease-newest"
 	prerelease4 := true
 	id4 := int64(4)
+	tag4 := "v" + strconv.FormatInt(id4, 10)
 	time4 := now.Add(-2 * time.Minute)
 	r.Releases = append(r.Releases, &github.RepositoryRelease{
 		Name:       &name4,
 		Prerelease: &prerelease4,
 		ID:         &id4,
 		CreatedAt:  &github.Timestamp{time4},
+		TagName:    &tag4,
 	})
 	return &r
 }
@@ -62,7 +71,8 @@ func mock() *prereleaseTool {
 func TestGetPrereleases(t *testing.T) {
 	tf.UnitTest(t)
 	r := mock()
-	r.getPrereleases()
+	ok := r.getPrereleases()
+	assert.True(t, ok, "releases should be found and this be true")
 	assert.Len(t, r.Prereleases, 3, "Prelease count is wrong")
 	for _, release := range r.Prereleases {
 		assert.NotEqual(t, *release.Name, "release", "Not a Pre-Release")
@@ -75,7 +85,8 @@ func TestGetPrereleases(t *testing.T) {
 func TestGetPrereleasesBoundsCheck(t *testing.T) {
 	tf.UnitTest(t)
 	r := prereleaseTool{}
-	r.getPrereleases()
+	ok := r.getPrereleases()
+	assert.False(t, ok, "releases should be found and this be true")
 	assert.Len(t, r.Prereleases, 0, "Prelease count is wrong")
 }
 
@@ -83,9 +94,12 @@ func TestOutdatedPreleaseIDs(t *testing.T) {
 	tf.UnitTest(t)
 	r := mock()
 	r.getPrereleases()
-	oldIDs := r.outdatedPreleaseIDs()
-	assert.Len(t, oldIDs, 1, "There should only be one ID")
-	assert.Equal(t, oldIDs[0], int64(3), "Wrong ID to remove")
+	outdated := r.outdatedPreleaseIDs()
+	assert.Len(t, outdated, 1, "There should only be one ID")
+	t.Logf("outdated: %+v", outdated)
+	tag, ok := outdated[3]
+	assert.True(t, ok, "map key should exist")
+	assert.Equal(t, tag, "v3", "unexpected prerelease name")
 }
 
 func TestOutdatedPreleaseIDsBoundsCheck(t *testing.T) {

--- a/tools/prerelease-tool/main_test.go
+++ b/tools/prerelease-tool/main_test.go
@@ -20,7 +20,7 @@ func mock() *prereleaseTool {
 	prerelease1 := false
 	id1 := int64(1)
 	time1 := now.Add(-1 * time.Minute)
-	r.Data = append(r.Data, &github.RepositoryRelease{
+	r.Releases = append(r.Releases, &github.RepositoryRelease{
 		Name:       &name1,
 		Prerelease: &prerelease1,
 		ID:         &id1,
@@ -30,7 +30,7 @@ func mock() *prereleaseTool {
 	prerelease2 := true
 	id2 := int64(2)
 	time2 := now.Add(-3 * time.Minute)
-	r.Data = append(r.Data, &github.RepositoryRelease{
+	r.Releases = append(r.Releases, &github.RepositoryRelease{
 		Name:       &name2,
 		Prerelease: &prerelease2,
 		ID:         &id2,
@@ -40,7 +40,7 @@ func mock() *prereleaseTool {
 	prerelease3 := true
 	id3 := int64(3)
 	time3 := now.Add(-4 * time.Minute)
-	r.Data = append(r.Data, &github.RepositoryRelease{
+	r.Releases = append(r.Releases, &github.RepositoryRelease{
 		Name:       &name3,
 		Prerelease: &prerelease3,
 		ID:         &id3,
@@ -50,7 +50,7 @@ func mock() *prereleaseTool {
 	prerelease4 := true
 	id4 := int64(4)
 	time4 := now.Add(-2 * time.Minute)
-	r.Data = append(r.Data, &github.RepositoryRelease{
+	r.Releases = append(r.Releases, &github.RepositoryRelease{
 		Name:       &name4,
 		Prerelease: &prerelease4,
 		ID:         &id4,

--- a/tools/prerelease-tool/main_test.go
+++ b/tools/prerelease-tool/main_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/google/go-github/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func mock() *prereleaseTool {
+	r := prereleaseTool{
+		Limit:  2,
+		DryRun: true,
+	}
+	now := time.Now()
+	name1 := "release"
+	prerelease1 := false
+	id1 := int64(1)
+	time1 := now.Add(-1 * time.Minute)
+	r.Data = append(r.Data, &github.RepositoryRelease{
+		Name:       &name1,
+		Prerelease: &prerelease1,
+		ID:         &id1,
+		CreatedAt:  &github.Timestamp{time1},
+	})
+	name2 := "prerelease-middle"
+	prerelease2 := true
+	id2 := int64(2)
+	time2 := now.Add(-3 * time.Minute)
+	r.Data = append(r.Data, &github.RepositoryRelease{
+		Name:       &name2,
+		Prerelease: &prerelease2,
+		ID:         &id2,
+		CreatedAt:  &github.Timestamp{time2},
+	})
+	name3 := "prerelease-oldest"
+	prerelease3 := true
+	id3 := int64(3)
+	time3 := now.Add(-4 * time.Minute)
+	r.Data = append(r.Data, &github.RepositoryRelease{
+		Name:       &name3,
+		Prerelease: &prerelease3,
+		ID:         &id3,
+		CreatedAt:  &github.Timestamp{time3},
+	})
+	name4 := "prerelease-newest"
+	prerelease4 := true
+	id4 := int64(4)
+	time4 := now.Add(-2 * time.Minute)
+	r.Data = append(r.Data, &github.RepositoryRelease{
+		Name:       &name4,
+		Prerelease: &prerelease4,
+		ID:         &id4,
+		CreatedAt:  &github.Timestamp{time4},
+	})
+	return &r
+}
+
+func TestGetPrereleases(t *testing.T) {
+	tf.UnitTest(t)
+	r := mock()
+	r.getPrereleases()
+	assert.Len(t, r.Prereleases, 3, "Prelease count is wrong")
+	for _, release := range r.Prereleases {
+		assert.NotEqual(t, *release.Name, "release", "Not a Pre-Release")
+	}
+}
+
+func TestGetPrereleasesBoundsCheck(t *testing.T) {
+	tf.UnitTest(t)
+	r := prereleaseTool{}
+	r.getPrereleases()
+	assert.Len(t, r.Prereleases, 0, "Prelease count is wrong")
+}
+
+func TestSortReleasesByDate(t *testing.T) {
+	tf.UnitTest(t)
+	r := mock()
+	r.getPrereleases()
+	r.sortReleasesByDate()
+	assert.Equal(t, *r.Prereleases[0].Name, "prerelease-newest", "Wrong Name at first index")
+	assert.Equal(t, *r.Prereleases[1].Name, "prerelease-middle", "Wrong Name at middle index")
+	assert.Equal(t, *r.Prereleases[2].Name, "prerelease-oldest", "Wrong Name at last index")
+}
+
+func TestSortReleasesByDateBoundsCheck(t *testing.T) {
+	tf.UnitTest(t)
+	r := prereleaseTool{}
+	r.getPrereleases()
+	r.sortReleasesByDate()
+}
+
+func TestOldReleaseIDs(t *testing.T) {
+	tf.UnitTest(t)
+	r := mock()
+	r.getPrereleases()
+	r.sortReleasesByDate()
+	oldIDs := r.oldReleaseIDs()
+	assert.Len(t, oldIDs, 1, "There should only be one ID")
+	assert.Equal(t, oldIDs[0], int64(3), "Wrong ID to remove")
+}
+
+func TestOldReleaseIDsBoundsCheck(t *testing.T) {
+	tf.UnitTest(t)
+	r := prereleaseTool{}
+	r.getPrereleases()
+	r.sortReleasesByDate()
+	oldIDs := r.oldReleaseIDs()
+	assert.Len(t, oldIDs, 0, "There should only be no IDs")
+}
+
+func TestTrim(t *testing.T) {
+	tf.UnitTest(t)
+	ctx := context.Background()
+	r := mock()
+	r.getPrereleases()
+	r.sortReleasesByDate()
+	ok, err := r.trim(ctx, r.oldReleaseIDs())
+	assert.False(t, ok, "This was a dry run, ok should be false")
+	assert.NoError(t, err, "No error should exist")
+}
+
+func TestTrimBoundsCheck(t *testing.T) {
+	tf.UnitTest(t)
+	ctx := context.Background()
+	r := prereleaseTool{
+		DryRun: true,
+	}
+	r.getPrereleases()
+	r.sortReleasesByDate()
+	ok, err := r.trim(ctx, r.oldReleaseIDs())
+	assert.False(t, ok, "This was a dry run, ok should be false")
+	assert.NoError(t, err, "No error should exist")
+}


### PR DESCRIPTION
allows setting a limit of prereleases aka nightlies to keep.
requires a github api token to function.
tool is parameterized via flags otherwise