### PR TITLE
TipSet orders blocks by ticket, is immutable value type

### DIFF
--- a/chain/default_store.go
+++ b/chain/default_store.go
@@ -144,7 +144,7 @@ func (store *Store) Load(ctx context.Context) (err error) {
 		genesii = iterator.Value()
 	}
 	// Check genesis here.
-	if !genesii.IsSolo() {
+	if genesii.Len() != 1 {
 		return errors.Errorf("genesis tip set must be a single block, got %d blocks", genesii.Len())
 	}
 

--- a/chain/default_store.go
+++ b/chain/default_store.go
@@ -98,20 +98,20 @@ func (store *Store) Load(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	headTs := types.TipSet{}
+	var blocks []*types.Block
 	// traverse starting from head to begin loading the chain
-	var startHeight types.Uint64
 	for it := tipCids.Iter(); !it.Complete(); it.Next() {
 		blk, err := store.GetBlock(ctx, it.Value())
 		if err != nil {
 			return errors.Wrap(err, "failed to load block in head TipSet")
 		}
-		err = headTs.AddBlock(blk)
-		if err != nil {
-			return errors.Wrap(err, "failed to add validated block to TipSet")
-		}
-		startHeight = blk.Height
+		blocks = append(blocks, blk)
 	}
+	headTs, err := types.NewTipSet(blocks...)
+	if err != nil {
+		return errors.Wrap(err, "failed to add validated block to TipSet")
+	}
+	startHeight := headTs.At(0).Height
 	logStore.Infof("start loading chain at tipset: %s, height: %d", tipCids.String(), startHeight)
 	// esnures we only produce 10 log messages regardless of the chain height
 	logStatusEvery := startHeight / 10
@@ -144,11 +144,11 @@ func (store *Store) Load(ctx context.Context) (err error) {
 		genesii = iterator.Value()
 	}
 	// Check genesis here.
-	if len(genesii) != 1 {
-		return errors.Errorf("genesis tip set must be a single block, got %d blocks", len(genesii))
+	if !genesii.IsSolo() {
+		return errors.Errorf("genesis tip set must be a single block, got %d blocks", genesii.Len())
 	}
 
-	loadCid := genesii.ToSlice()[0].Cid()
+	loadCid := genesii.At(0).Cid()
 	if !loadCid.Equals(store.genesis) {
 		return errors.Errorf("expected genesis cid: %s, loaded genesis cid: %s", store.genesis, loadCid)
 	}
@@ -205,8 +205,8 @@ func (store *Store) putBlk(ctx context.Context, block *types.Block) error {
 // PutTipSetAndState persists the blocks of a tipset and the tipset index.
 func (store *Store) PutTipSetAndState(ctx context.Context, tsas *TipSetAndState) error {
 	// Persist blocks.
-	for _, blk := range tsas.TipSet {
-		if err := store.putBlk(ctx, blk); err != nil {
+	for i := 0; i < tsas.TipSet.Len(); i++ {
+		if err := store.putBlk(ctx, tsas.TipSet.At(i)); err != nil {
 			return err
 		}
 	}
@@ -312,7 +312,7 @@ func (store *Store) SetHead(ctx context.Context, ts types.TipSet) error {
 	logStore.Debugf("SetHead %s", ts.String())
 
 	// Add logging to debug sporadic test failure.
-	if len(ts) < 1 {
+	if !ts.Defined() {
 		logStore.Error("publishing empty tipset")
 		logStore.Error(debug.Stack())
 	}
@@ -374,7 +374,7 @@ func (store *Store) GetHead() types.SortedCidSet {
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 
-	if store.head == nil {
+	if !store.head.Defined() {
 		return types.SortedCidSet{}
 	}
 

--- a/chain/default_store_test.go
+++ b/chain/default_store_test.go
@@ -213,7 +213,7 @@ func TestGetMultipleByParent(t *testing.T) {
 	gotNew1 := requireGetTsasByParentAndHeight(t, chainStore, pk1, uint64(1))
 	require.Equal(t, 2, len(gotNew1))
 	for _, tsas := range gotNew1 {
-		if tsas.TipSet.IsSolo() {
+		if tsas.TipSet.Len() == 1 {
 			assert.Equal(t, newRoot, tsas.TipSetStateRoot)
 		} else {
 			assert.Equal(t, dstP.link1State, tsas.TipSetStateRoot)

--- a/chain/default_store_test.go
+++ b/chain/default_store_test.go
@@ -213,7 +213,7 @@ func TestGetMultipleByParent(t *testing.T) {
 	gotNew1 := requireGetTsasByParentAndHeight(t, chainStore, pk1, uint64(1))
 	require.Equal(t, 2, len(gotNew1))
 	for _, tsas := range gotNew1 {
-		if len(tsas.TipSet) == 1 {
+		if tsas.TipSet.IsSolo() {
 			assert.Equal(t, newRoot, tsas.TipSetStateRoot)
 		} else {
 			assert.Equal(t, dstP.link1State, tsas.TipSetStateRoot)

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -324,8 +324,8 @@ func requireTsAdded(t *testing.T, chain requireTsAddedChainStore, ts types.TipSe
 	require.True(t, containsTipSet(childTsasSlice, ts))
 
 	// Blocks exist in store
-	for _, blk := range ts {
-		require.True(t, chain.HasBlock(ctx, blk.Cid()))
+	for i := 0; i < ts.Len(); i++ {
+		require.True(t, chain.HasBlock(ctx, ts.At(i).Cid()))
 	}
 }
 
@@ -344,8 +344,8 @@ func assertTsAdded(t *testing.T, chainStore requireTsAddedChainStore, ts types.T
 	assert.True(t, containsTipSet(childTsasSlice, ts))
 
 	// Blocks exist in store
-	for _, blk := range ts {
-		assert.True(t, chainStore.HasBlock(ctx, blk.Cid()))
+	for i := 0; i < ts.Len(); i++ {
+		require.True(t, chainStore.HasBlock(ctx, ts.At(i).Cid()))
 	}
 }
 
@@ -1084,7 +1084,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 	con = consensus.NewExpected(cst, bs, th.NewTestProcessor(), &consensus.MarketView{}, calcGenBlk.Cid(), verifier)
 	syncer := chain.NewDefaultSyncer(cst, con, chainStore, blockSource, chain.Syncing)
 	baseTS := requireHeadTipset(t, chainStore) // this is the last block of the bootstrapping chain creating miners
-	require.Equal(t, 1, len(baseTS))
+	require.True(t, baseTS.IsSolo())
 	bootstrapStateRoot := baseTS.ToSlice()[0].StateRoot
 	pSt, err := state.LoadStateTree(ctx, cst, baseTS.ToSlice()[0].StateRoot, builtin.Actors)
 	require.NoError(t, err)

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -1084,7 +1084,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 	con = consensus.NewExpected(cst, bs, th.NewTestProcessor(), &consensus.MarketView{}, calcGenBlk.Cid(), verifier)
 	syncer := chain.NewDefaultSyncer(cst, con, chainStore, blockSource, chain.Syncing)
 	baseTS := requireHeadTipset(t, chainStore) // this is the last block of the bootstrapping chain creating miners
-	require.True(t, baseTS.IsSolo())
+	require.Equal(t, 1, baseTS.Len())
 	bootstrapStateRoot := baseTS.ToSlice()[0].StateRoot
 	pSt, err := state.LoadStateTree(ctx, cst, baseTS.ToSlice()[0].StateRoot, builtin.Actors)
 	require.NoError(t, err)

--- a/chain/get_ancestors.go
+++ b/chain/get_ancestors.go
@@ -145,11 +145,11 @@ func FindCommonAncestor(leftIter, rightIter *TipsetIterator) (types.TipSet, erro
 
 		leftHeight, err := left.Height()
 		if err != nil {
-			return nil, err
+			return types.NoTipSet, err
 		}
 		rightHeight, err := right.Height()
 		if err != nil {
-			return nil, err
+			return types.NoTipSet, err
 		}
 
 		// Found common ancestor.
@@ -162,15 +162,15 @@ func FindCommonAncestor(leftIter, rightIter *TipsetIterator) (types.TipSet, erro
 		// other pointer's tipset.
 		if rightHeight >= leftHeight {
 			if err := rightIter.Next(); err != nil {
-				return nil, err
+				return types.NoTipSet, err
 			}
 		}
 
 		if leftHeight >= rightHeight {
 			if err := leftIter.Next(); err != nil {
-				return nil, err
+				return types.NoTipSet, err
 			}
 		}
 	}
-	return nil, ErrNoCommonAncestor
+	return types.NoTipSet, ErrNoCommonAncestor
 }

--- a/chain/get_ancestors.go
+++ b/chain/get_ancestors.go
@@ -145,11 +145,11 @@ func FindCommonAncestor(leftIter, rightIter *TipsetIterator) (types.TipSet, erro
 
 		leftHeight, err := left.Height()
 		if err != nil {
-			return types.NoTipSet, err
+			return types.UndefTipSet, err
 		}
 		rightHeight, err := right.Height()
 		if err != nil {
-			return types.NoTipSet, err
+			return types.UndefTipSet, err
 		}
 
 		// Found common ancestor.
@@ -162,15 +162,15 @@ func FindCommonAncestor(leftIter, rightIter *TipsetIterator) (types.TipSet, erro
 		// other pointer's tipset.
 		if rightHeight >= leftHeight {
 			if err := rightIter.Next(); err != nil {
-				return types.NoTipSet, err
+				return types.UndefTipSet, err
 			}
 		}
 
 		if leftHeight >= rightHeight {
 			if err := leftIter.Next(); err != nil {
-				return types.NoTipSet, err
+				return types.UndefTipSet, err
 			}
 		}
 	}
-	return types.NoTipSet, ErrNoCommonAncestor
+	return types.UndefTipSet, ErrNoCommonAncestor
 }

--- a/chain/tip_index.go
+++ b/chain/tip_index.go
@@ -90,7 +90,7 @@ func (ti *TipIndex) Get(tsKey string) (*TipSetAndState, error) {
 func (ti *TipIndex) GetTipSet(tsKey string) (types.TipSet, error) {
 	tsas, err := ti.Get(tsKey)
 	if err != nil {
-		return nil, err
+		return types.UndefTipSet, err
 	}
 	return tsas.TipSet, nil
 }

--- a/chain/traversal.go
+++ b/chain/traversal.go
@@ -16,21 +16,19 @@ type BlockProvider interface {
 // GetParentTipSet returns the parent tipset of a tipset.
 // The result is empty if the tipset has no parents (including if it is empty itself)
 func GetParentTipSet(ctx context.Context, store BlockProvider, ts types.TipSet) (types.TipSet, error) {
-	newTipSet := types.TipSet{}
 	parents, err := ts.Parents()
-	if err != nil {
-		return nil, err
+	if err != nil || parents.Len() == 0 {
+		return types.NoTipSet, err
 	}
+	var newBlocks []*types.Block
 	for it := parents.Iter(); !it.Complete() && ctx.Err() == nil; it.Next() {
 		newBlk, err := store.GetBlock(ctx, it.Value())
 		if err != nil {
-			return nil, err
+			return types.NoTipSet, err
 		}
-		if err := newTipSet.AddBlock(newBlk); err != nil {
-			return nil, err
-		}
+		newBlocks = append(newBlocks, newBlk)
 	}
-	return newTipSet, nil
+	return types.NewTipSet(newBlocks...)
 }
 
 // IterAncestors returns an iterator over tipset ancestors, yielding first the start tipset and
@@ -53,7 +51,7 @@ func (it *TipsetIterator) Value() types.TipSet {
 
 // Complete tests whether the iterator is exhausted.
 func (it *TipsetIterator) Complete() bool {
-	return len(it.value) == 0
+	return !it.value.Defined()
 }
 
 // Next advances the iterator to the next value.

--- a/chain/traversal.go
+++ b/chain/traversal.go
@@ -14,17 +14,18 @@ type BlockProvider interface {
 }
 
 // GetParentTipSet returns the parent tipset of a tipset.
-// The result is empty if the tipset has no parents (including if it is empty itself)
+// The result is empty if the tipset has no parents, but an error if the tipset is undefined.
 func GetParentTipSet(ctx context.Context, store BlockProvider, ts types.TipSet) (types.TipSet, error) {
 	parents, err := ts.Parents()
+	// Parents is empty (without error) for the genesis tipset, and does't produce an error here either.
 	if err != nil || parents.Len() == 0 {
-		return types.NoTipSet, err
+		return types.UndefTipSet, err
 	}
 	var newBlocks []*types.Block
 	for it := parents.Iter(); !it.Complete() && ctx.Err() == nil; it.Next() {
 		newBlk, err := store.GetBlock(ctx, it.Value())
 		if err != nil {
-			return types.NoTipSet, err
+			return types.UndefTipSet, err
 		}
 		newBlocks = append(newBlocks, newBlk)
 	}

--- a/commands/chain.go
+++ b/commands/chain.go
@@ -66,7 +66,7 @@ var chainLsCmd = &cmds.Command{
 			if err != nil {
 				return err
 			}
-			if len(iter.Value()) == 0 {
+			if !iter.Value().Defined() {
 				panic("tipsets from this iterator should have at least one member")
 			}
 			if err := re.Emit(iter.Value().ToSlice()); err != nil {

--- a/consensus/expected.go
+++ b/consensus/expected.go
@@ -124,7 +124,7 @@ func NewExpected(cs *hamt.CborIpldStore, bs blockstore.Blockstore, processor Pro
 func (c *Expected) NewValidTipSet(ctx context.Context, blks []*types.Block) (types.TipSet, error) {
 	for _, blk := range blks {
 		if err := c.validateBlockStructure(ctx, blk); err != nil {
-			return types.NoTipSet, err
+			return types.UndefTipSet, err
 		}
 	}
 	return types.NewTipSet(blks...)
@@ -149,7 +149,7 @@ func (c *Expected) validateBlockStructure(ctx context.Context, b *types.Block) e
 func (c *Expected) Weight(ctx context.Context, ts types.TipSet, pSt state.Tree) (uint64, error) {
 	ctx = log.Start(ctx, "Expected.Weight")
 	log.LogKV(ctx, "Weight", ts.String())
-	if ts.IsSolo() && ts.At(0).Cid().Equals(c.genesisCid) {
+	if ts.Len() == 1 && ts.At(0).Cid().Equals(c.genesisCid) {
 		return uint64(0), nil
 	}
 	// Compute parent weight.
@@ -378,7 +378,7 @@ func (c *Expected) runMessages(ctx context.Context, st state.Tree, vms vm.Storag
 			return nil, ErrStateRootMismatch
 		}
 	}
-	if ts.IsSolo() { // block validation state == aggregate parent state
+	if ts.Len() <= 1 { // block validation state == aggregate parent state
 		return cpySt, nil
 	}
 	// multiblock tipsets require reapplying messages to get aggregate state

--- a/consensus/expected_test.go
+++ b/consensus/expected_test.go
@@ -90,7 +90,7 @@ func TestExpected_NewValidTipSet(t *testing.T) {
 
 		tipSet, err := exp.NewValidTipSet(ctx, blocks)
 		assert.Error(t, err, "Foo")
-		assert.Nil(t, tipSet)
+		assert.False(t, tipSet.Defined())
 	})
 }
 
@@ -311,13 +311,14 @@ func TestCreateChallenge(t *testing.T) {
 		decoded, err := hex.DecodeString(c.challenge)
 		assert.NoError(t, err)
 
-		parents := types.TipSet{}
+		var parents []*types.Block
 		for _, ticket := range c.parentTickets {
 			b := types.Block{Ticket: ticket}
-			err = parents.AddBlock(&b)
-			assert.NoError(t, err)
+			parents = append(parents, &b)
 		}
-		r, err := consensus.CreateChallengeSeed(parents, c.nullBlockCount)
+		parentTs, err := types.NewTipSet(parents...)
+		assert.NoError(t, err)
+		r, err := consensus.CreateChallengeSeed(parentTs, c.nullBlockCount)
 		assert.NoError(t, err)
 		assert.Equal(t, decoded, r[:])
 	}

--- a/consensus/processor.go
+++ b/consensus/processor.go
@@ -156,13 +156,11 @@ func (p *DefaultProcessor) ProcessTipSet(ctx context.Context, st state.Tree, vms
 	bh := types.NewBlockHeight(h)
 	msgFilter := make(map[string]struct{})
 
-	tips := ts.ToSlice()
-	types.SortBlocks(tips)
-
 	// TODO: this can be made slightly more efficient by reusing the validation
 	// transition of the first validated block (change would reach here and
 	// consensus functions).
-	for _, blk := range tips {
+	for i := 0; i < ts.Len(); i++ {
+		blk := ts.At(i)
 		// find miner's owner address
 		minerOwnerAddr, err := minerOwnerAddress(ctx, st, vms, blk.Miner)
 		if err != nil {

--- a/consensus/testing.go
+++ b/consensus/testing.go
@@ -41,13 +41,6 @@ func RequireNewTipSet(require *require.Assertions, blks ...*types.Block) types.T
 	return ts
 }
 
-// RequireTipSetAdd adds a block to the provided tipset and requires that this
-// does not error.
-func RequireTipSetAdd(require *require.Assertions, blk *types.Block, ts types.TipSet) {
-	err := ts.AddBlock(blk)
-	require.NoError(err)
-}
-
 // TestPowerTableView is an implementation of the powertable view used for testing mining
 // wherein each miner has totalPower/minerPower power.
 type TestPowerTableView struct{ minerPower, totalPower uint64 }

--- a/core/inbox_test.go
+++ b/core/inbox_test.go
@@ -36,10 +36,8 @@ func TestUpdateMessagePool(t *testing.T) {
 		m := types.NewSignedMsgs(2, mockSigner)
 		mustAdd(ib, m[0], m[1])
 
-		parent := types.TipSet{}
-
 		blk := types.Block{Height: 0}
-		parent[blk.Cid()] = &blk
+		parent := th.MustNewTipSet(&blk)
 
 		oldChain := core.NewChainWithMessages(store, parent, msgsSet{})
 		oldTipSet := headOf(oldChain)
@@ -80,10 +78,8 @@ func TestUpdateMessagePool(t *testing.T) {
 		m := types.NewSignedMsgs(7, mockSigner)
 		mustAdd(ib, m[2], m[5])
 
-		parent := types.TipSet{}
-
 		blk := types.Block{Height: 0}
-		parent[blk.Cid()] = &blk
+		parent := th.MustNewTipSet(&blk)
 		oldChain := core.NewChainWithMessages(store, parent, msgsSet{msgs{m[0], m[1]}})
 		oldTipSet := headOf(oldChain)
 
@@ -111,10 +107,8 @@ func TestUpdateMessagePool(t *testing.T) {
 		m := types.NewSignedMsgs(7, mockSigner)
 		mustAdd(ib, m[2], m[5])
 
-		parent := types.TipSet{}
-
 		blk := types.Block{Height: 0}
-		parent[blk.Cid()] = &blk
+		parent := th.MustNewTipSet(&blk)
 
 		oldChain := core.NewChainWithMessages(store, parent, msgsSet{msgs{m[0]}, msgs{m[1]}})
 		oldTipSet := headOf(oldChain)
@@ -220,10 +214,8 @@ func TestUpdateMessagePool(t *testing.T) {
 		m := types.NewSignedMsgs(6, mockSigner)
 		mustAdd(ib, m[3], m[5])
 
-		parent := types.TipSet{}
-
 		blk := types.Block{Height: 0}
-		parent[blk.Cid()] = &blk
+		parent := th.MustNewTipSet(&blk)
 
 		oldChain := core.NewChainWithMessages(store, parent,
 			msgsSet{msgs{m[0]}},
@@ -375,14 +367,13 @@ func TestUpdateMessagePool(t *testing.T) {
 			require.NoError(t, err)
 
 			// create a tipset at given height with one block containing no messages
-			next := types.TipSet{}
 			nextHeight := types.Uint64(height + 5) // simulate 4 null blocks
 			blk := &types.Block{
 				Height:  nextHeight,
 				Parents: head.ToSortedCidSet(),
 			}
 			core.MustPut(store, blk)
-			next[blk.Cid()] = blk
+			next := th.MustNewTipSet(blk)
 
 			assert.NoError(t, ib.HandleNewHead(ctx, head, next))
 

--- a/core/outbox_test.go
+++ b/core/outbox_test.go
@@ -162,7 +162,7 @@ func (p *fakeProvider) GetHead() types.SortedCidSet {
 
 func (p *fakeProvider) GetTipSet(tsKey types.SortedCidSet) (types.TipSet, error) {
 	if !tsKey.Equals(p.head) {
-		return nil, errors.Errorf("No such tipset %s, expected %s", tsKey, p.head)
+		return types.UndefTipSet, errors.Errorf("No such tipset %s, expected %s", tsKey, p.head)
 	}
 	return p.tipset, nil
 }

--- a/mining/scheduler.go
+++ b/mining/scheduler.go
@@ -110,7 +110,7 @@ func (s *timingScheduler) Start(miningCtx context.Context) (<-chan Output, *sync
 			time.Sleep(s.mineDelay)
 			// Ask for the heaviest tipset.
 			base, _ := s.pollHeadFunc()
-			if base == nil { // Don't try to mine on an unset head.
+			if !base.Defined() { // Don't try to mine on an unset head.
 				outCh <- NewOutput(nil, errors.New("cannot mine on unset (nil) head"))
 				return
 			}

--- a/mining/scheduler.go
+++ b/mining/scheduler.go
@@ -152,7 +152,7 @@ func (s *timingScheduler) IsStarted() bool {
 // previous number of null blocks mined on the previous base, prevNullBlkCount.
 func nextNullBlkCount(prevNullBlkCount int, prevBase, currBase types.TipSet) int {
 	// We haven't mined on this base before, start with 0 null blocks.
-	if prevBase == nil {
+	if !prevBase.Defined() {
 		return 0
 	}
 	if prevBase.String() != currBase.String() {

--- a/mining/scheduler_test.go
+++ b/mining/scheduler_test.go
@@ -9,12 +9,13 @@ import (
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func newTestUtils() types.TipSet {
+func newTestUtils(t *testing.T) types.TipSet {
 	baseBlock := &types.Block{StateRoot: types.SomeCid()}
-
-	ts := types.TipSet{baseBlock.Cid(): baseBlock}
+	ts, err := types.NewTipSet(baseBlock)
+	require.NoError(t, err)
 	return ts
 }
 
@@ -23,7 +24,7 @@ func newTestUtils() types.TipSet {
 func TestMineOnce(t *testing.T) {
 	tf.UnitTest(t)
 
-	ts := newTestUtils()
+	ts := newTestUtils(t)
 
 	// Echoes the sent block to output.
 	worker := NewTestWorkerWithDeps(MakeEchoMine(t))
@@ -36,7 +37,7 @@ func TestMineOnce(t *testing.T) {
 func TestSchedulerPassesValue(t *testing.T) {
 	tf.UnitTest(t)
 
-	ts := newTestUtils()
+	ts := newTestUtils(t)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	checkValsMine := func(c context.Context, inTS types.TipSet, nBC int, outCh chan<- Output) bool {
@@ -81,7 +82,7 @@ func TestSchedulerErrorsOnUnsetHead(t *testing.T) {
 func TestSchedulerUpdatesNullBlkCount(t *testing.T) {
 	tf.UnitTest(t)
 
-	ts := newTestUtils()
+	ts := newTestUtils(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	blk2 := &types.Block{StateRoot: types.SomeCid(), Height: 1}
 	ts2 := th.RequireNewTipSet(t, blk2)
@@ -122,7 +123,7 @@ func TestSchedulerUpdatesNullBlkCount(t *testing.T) {
 func TestSchedulerPassesManyValues(t *testing.T) {
 	tf.UnitTest(t)
 
-	ts1 := newTestUtils()
+	ts1 := newTestUtils(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	var checkTS types.TipSet
 	// make tipsets with progressively higher heights
@@ -162,7 +163,7 @@ func TestSchedulerPassesManyValues(t *testing.T) {
 func TestSchedulerCollect(t *testing.T) {
 	tf.UnitTest(t)
 
-	ts1 := newTestUtils()
+	ts1 := newTestUtils(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	blk2 := &types.Block{StateRoot: types.SomeCid(), Height: 1}
 	ts2 := th.RequireNewTipSet(t, blk2)
@@ -224,7 +225,7 @@ func TestCannotInterruptMiner(t *testing.T) {
 func TestSchedulerCancelMiningCtx(t *testing.T) {
 	tf.UnitTest(t)
 
-	ts := newTestUtils()
+	ts := newTestUtils(t)
 	// Test that canceling the mining context stops mining, cancels
 	// the inner context, and closes the output channel.
 	miningCtx, miningCtxCancel := context.WithCancel(context.Background())
@@ -253,7 +254,7 @@ func TestSchedulerCancelMiningCtx(t *testing.T) {
 func TestSchedulerMultiRoundWithCollect(t *testing.T) {
 	tf.UnitTest(t)
 
-	ts1 := newTestUtils()
+	ts1 := newTestUtils(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	var checkTS types.TipSet
 	var head types.TipSet

--- a/mining/scheduler_test.go
+++ b/mining/scheduler_test.go
@@ -68,7 +68,7 @@ func TestSchedulerErrorsOnUnsetHead(t *testing.T) {
 		return false
 	}
 	nilHeadFunc := func() (types.TipSet, error) {
-		return nil, nil
+		return types.UndefTipSet, nil
 	}
 	worker := NewTestWorkerWithDeps(nothingMine)
 	scheduler := NewScheduler(worker, MineDelayTest, nilHeadFunc)

--- a/mining/testing.go
+++ b/mining/testing.go
@@ -66,8 +66,8 @@ func NewTestWorkerWithDeps(f func(context.Context, types.TipSet, int, chan<- Out
 // block of the input tipset as output.
 func MakeEchoMine(t *testing.T) func(context.Context, types.TipSet, int, chan<- Output) bool {
 	echoMine := func(c context.Context, ts types.TipSet, nullBlkCount int, outCh chan<- Output) bool {
-		require.NotEqual(t, 0, len(ts))
-		b := ts.ToSlice()[0]
+		require.True(t, ts.Defined())
+		b := ts.At(0)
 		select {
 		case outCh <- Output{NewBlock: b}:
 		case <-c.Done():

--- a/mining/worker.go
+++ b/mining/worker.go
@@ -175,7 +175,7 @@ func (w *DefaultWorker) Mine(ctx context.Context, base types.TipSet, nullBlkCoun
 	log.Info("Worker.Mine")
 	ctx = log.Start(ctx, "Worker.Mine")
 	defer log.Finish(ctx)
-	if len(base) == 0 {
+	if !base.Defined() {
 		log.Warning("Worker.Mine returning because it can't mine on an empty tipset")
 		outCh <- Output{Err: errors.New("bad input tipset with no blocks sent to Mine()")}
 		return false

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -459,7 +459,7 @@ func getWeightTest(c context.Context, ts types.TipSet) (uint64, error) {
 	if err != nil {
 		return uint64(0), err
 	}
-	return w + uint64(len(ts))*consensus.ECV, nil
+	return w + uint64(ts.Len())*consensus.ECV, nil
 }
 
 func makeExplodingGetStateTree(st state.Tree) func(context.Context, types.TipSet) (state.Tree, error) {

--- a/node/node.go
+++ b/node/node.go
@@ -658,7 +658,7 @@ func (node *Node) handleNewHeaviestTipSet(ctx context.Context, head types.TipSet
 				log.Error("non-tipset published on heaviest tipset channel")
 				continue
 			}
-			if len(newHead) == 0 {
+			if !newHead.Defined() {
 				log.Error("tipset of size 0 published on heaviest tipset channel. ignoring and waiting for a new heaviest tipset.")
 				continue
 			}

--- a/plumbing/cst/chain_state.go
+++ b/plumbing/cst/chain_state.go
@@ -54,7 +54,7 @@ func NewChainStateProvider(chainReader chainReader, cst *hamt.CborIpldStore) *Ch
 func (chn *ChainStateProvider) Head() (types.TipSet, error) {
 	ts, err := chn.reader.GetTipSet(chn.reader.GetHead())
 	if err != nil {
-		return nil, err
+		return types.UndefTipSet, err
 	}
 	return ts, nil
 }

--- a/plumbing/msg/waiter.go
+++ b/plumbing/msg/waiter.go
@@ -177,7 +177,7 @@ func (w *Waiter) waitForMessage(ctx context.Context, ch <-chan interface{}, msgC
 func (w *Waiter) receiptFromTipSet(ctx context.Context, msgCid cid.Cid, ts types.TipSet) (*types.MessageReceipt, error) {
 	// Receipts always match block if tipset has only 1 member.
 	var rcpt *types.MessageReceipt
-	if ts.IsSolo() {
+	if ts.Len() == 1 {
 		b := ts.At(0)
 		// TODO: this should return an error if a receipt doesn't exist.
 		// Right now doing so breaks tests because our test helpers

--- a/plumbing/msg/waiter_test.go
+++ b/plumbing/msg/waiter_test.go
@@ -71,7 +71,7 @@ func testWaitExisting(ctx context.Context, t *testing.T, cst *hamt.CborIpldStore
 	require.NoError(t, err)
 	chainWithMsgs := core.NewChainWithMessages(cst, headTipSet, smsgsSet{smsgs{m1, m2}})
 	ts := chainWithMsgs[len(chainWithMsgs)-1]
-	require.Equal(t, 1, len(ts))
+	require.Equal(t, 1, ts.Len())
 	require.NoError(t, chainStore.PutTipSetAndState(ctx, &chain.TipSetAndState{
 		TipSet:          ts,
 		TipSetStateRoot: ts.ToSlice()[0].StateRoot,
@@ -98,7 +98,7 @@ func testWaitNew(ctx context.Context, t *testing.T, cst *hamt.CborIpldStore, cha
 	time.Sleep(10 * time.Millisecond)
 
 	ts := chainWithMsgs[len(chainWithMsgs)-1]
-	require.Equal(t, 1, len(ts))
+	require.Equal(t, 1, ts.Len())
 	require.NoError(t, chainStore.PutTipSetAndState(ctx, &chain.TipSetAndState{
 		TipSet:          ts,
 		TipSetStateRoot: ts.ToSlice()[0].StateRoot,
@@ -161,7 +161,7 @@ func TestWaitConflicting(t *testing.T) {
 	headTipSet, err := chainStore.GetTipSet(head)
 	require.NoError(t, err)
 	baseTS := headTipSet
-	require.Equal(t, 1, len(baseTS))
+	require.Equal(t, 1, baseTS.Len())
 	baseBlock := baseTS.ToSlice()[0]
 
 	require.NotNil(t, chainStore.GenesisCid())

--- a/types/block.go
+++ b/types/block.go
@@ -1,10 +1,8 @@
 package types
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"sort"
 
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
@@ -145,11 +143,4 @@ func (b *Block) Score() uint64 {
 // Equals returns true if the Block is equal to other.
 func (b *Block) Equals(other *Block) bool {
 	return b.Cid().Equals(other.Cid())
-}
-
-// SortBlocks sorts a slice of blocks in the canonical order (by min tickets)
-func SortBlocks(blks []*Block) {
-	sort.Slice(blks, func(i, j int) bool {
-		return bytes.Compare(blks[i].Ticket, blks[j].Ticket) == -1
-	})
 }

--- a/types/tipset.go
+++ b/types/tipset.go
@@ -2,155 +2,148 @@ package types
 
 import (
 	"bytes"
+	"sort"
 
 	"github.com/ipfs/go-cid"
 	"github.com/pkg/errors"
 )
 
-// Tip is what expected consensus needs from a Block. For now it *is* a
-// Block.
-type Tip = Block
-
-// TipSet is a set of Tips, blocks at the same height with the same parent set,
-// keyed by Cid.
-type TipSet map[cid.Cid]*Tip
+// TipSet is a non-empty, immutable set of blocks at the same height with the same parent set.
+// Blocks in a tipset are canonically ordered by ticket. Blocks may be iterated either via
+// ToSlice() (which involves a shallow copy) or efficiently by index with At().
+// TipSet is a lightweight value type; passing by pointer is usually unnecessary.
+//
+// Canonical tipset block ordering does not match the order of CIDs in a SortedCidSet used as
+// a tipset "key".
+type TipSet struct {
+	// This slice is wrapped in a struct to enforce immutability.
+	blocks []*Block
+}
 
 var (
-	// ErrEmptyTipSet is returned when a method requiring a non-empty tipset is called on an empty tipset
-	ErrEmptyTipSet = errors.New("empty tipset calling unallowed method")
+	// ErrEmptyTipSet is returned no blocks are provided to a tipset contructor
+	ErrEmptyTipSet = errors.New("no blocks for tipset")
 )
 
-// NewTipSet returns a TipSet wrapping the input blocks.
-// PRECONDITION: all blocks are the same height and have the same parent set.
-func NewTipSet(blks ...*Block) (TipSet, error) {
-	if len(blks) == 0 {
-		return nil, errors.New("Cannot create tipset: no blocks")
+// NoTipSet is a singleton representing a nil or undefined tipset.
+var NoTipSet = TipSet{}
+
+// NewTipSet builds a new TipSet from a collection of blocks.
+// The blocks must be distinct (different CIDs), have the same height, and same parent set.
+func NewTipSet(blocks ...*Block) (TipSet, error) {
+	if len(blocks) == 0 {
+		return NoTipSet, ErrEmptyTipSet
 	}
-	ts := TipSet{}
-	for _, b := range blks {
-		if err := ts.AddBlock(b); err != nil {
-			return nil, errors.Wrapf(err, "Cannot create tipset")
+
+	first := blocks[0]
+	height := first.Height
+	parents := first.Parents
+	weight := first.ParentWeight
+	cids := make(map[cid.Cid]bool)
+
+	sorted := make([]*Block, len(blocks))
+	for i, blk := range blocks {
+		if i > 0 { // Skip redundant checks for first block
+			if blk.Height != height {
+				return NoTipSet, errors.Errorf("Inconsistent block heights %d and %d", height, blk.Height)
+			}
+			if !blk.Parents.Equals(parents) {
+				return NoTipSet, errors.Errorf("Inconsistent block parents %s and %s", parents.String(), blk.Parents.String())
+			}
+			if blk.ParentWeight != weight {
+				return NoTipSet, errors.Errorf("Inconsistent block parent weights %d and %d", weight, blk.ParentWeight)
+			}
 		}
+		// Reject duplicate blocks (by CID).
+		c := blk.Cid()
+		if cids[c] {
+			return NoTipSet, errors.Errorf("Duplicate block CID %s", c)
+		}
+		cids[c] = true
+		sorted[i] = blk
 	}
-	return ts, nil
+
+	// Sort blocks by ticket.
+	sort.Slice(sorted, func(i, j int) bool {
+		cmp := bytes.Compare(sorted[i].Ticket, sorted[j].Ticket)
+		if cmp == 0 {
+			// Break ticket ties with the block CIDs, which are distinct.
+			cmp = bytes.Compare(sorted[i].Cid().Bytes(), sorted[j].Cid().Bytes())
+		}
+		return cmp < 0
+	})
+
+	return TipSet{sorted}, nil
 }
 
-// AddBlock adds the provided block to this tipset.
-// PRECONDITION: this block has the same height parent set as other members of ts.
-func (ts TipSet) AddBlock(b *Block) error {
-	if len(ts) == 0 {
-		id := b.Cid()
-		ts[id] = b
-		return nil
-	}
-
-	h, err := ts.Height()
-	if err != nil {
-		return err
-	}
-	p, err := ts.Parents()
-	if err != nil {
-		return err
-	}
-	weight, err := ts.ParentWeight()
-	if err != nil {
-		return err
-	}
-	if uint64(b.Height) != h {
-		return errors.Errorf("block height %d doesn't match existing tipset height %d", uint64(b.Height), h)
-	}
-	if !b.Parents.Equals(p) {
-		return errors.Errorf("block parents %s don't match tipset parents %s", b.Parents.String(), p.String())
-	}
-	if uint64(b.ParentWeight) != weight {
-		return errors.Errorf("bBlock parent weight: %d doesn't match existing tipset parent weight: %d", uint64(b.ParentWeight), weight)
-	}
-
-	id := b.Cid()
-	ts[id] = b
-	return nil
+// Defined checks whether the tipset is defined.
+// Invoking any other methods on an undefined tipset will result in undefined behaviour (c.f. cid.Undef)
+func (ts TipSet) Defined() bool {
+	return len(ts.blocks) > 0
 }
 
-// Clone returns a shallow copy of the TipSet.
-func (ts TipSet) Clone() TipSet {
-	r := TipSet{}
-	for k, v := range ts {
-		r[k] = v
-	}
-
-	return r
+// Len returns the number of blocks in the tipset.
+func (ts TipSet) Len() int {
+	return len(ts.blocks)
 }
 
-// String returns a formatted string of the TipSet:
-// { <cid1> <cid2> <cid3> }
-func (ts TipSet) String() string {
-	return ts.ToSortedCidSet().String()
+// At returns the i'th block in the tipset.
+// An index outside the half-open range [0, Len()) will panic.
+func (ts TipSet) At(i int) *Block {
+	return ts.blocks[i]
 }
 
-// Equals returns true if the tipset contains the same blocks as another set.
-// Equality is not tested deeply.  If blocks of two tipsets are stored at
-// different memory addresses but have the same cids the tipsets will be equal.
-func (ts TipSet) Equals(ts2 TipSet) bool {
-	return ts.ToSortedCidSet().Equals(ts2.ToSortedCidSet())
+// IsSolo tests whether the tipset has a single block.
+func (ts TipSet) IsSolo() bool {
+	return len(ts.blocks) == 1
 }
 
-// ToSortedCidSet returns a SortedCidSet containing the Cids in the
-// TipSet.
+// ToSortedCidSet returns a SortedCidSet containing the CIDs in the tipset.
 func (ts TipSet) ToSortedCidSet() SortedCidSet {
 	s := SortedCidSet{}
-	for _, b := range ts {
+	for _, b := range ts.blocks {
 		s.Add(b.Cid())
 	}
 	return s
 }
 
-// ToSlice returns the slice of *Block containing the tipset's blocks.
-// Sorted.
+// ToSlice returns an ordered slice of pointers to the tipset's blocks.
 func (ts TipSet) ToSlice() []*Block {
-	sl := make([]*Block, len(ts))
-	var i int
-	for it := ts.ToSortedCidSet().Iter(); !it.Complete(); it.Next() {
-		sl[i] = ts[it.Value()]
-		i++
-	}
-	return sl
+	slice := make([]*Block, len(ts.blocks))
+	copy(slice, ts.blocks)
+	return slice
 }
 
-// MinTicket returns the smallest ticket of all blocks in the tipset.
+// MinTicket returns the smallest ticket of all blocks in the tipset, and nil error.
 func (ts TipSet) MinTicket() (Signature, error) {
-	if len(ts) == 0 {
-		return nil, ErrEmptyTipSet
-	}
-	blks := ts.ToSlice()
-	min := blks[0].Ticket
-	for i := range blks[0:] {
-		if bytes.Compare(blks[i].Ticket, min) < 0 {
-			min = blks[i].Ticket
-		}
-	}
-	return min, nil
+	return ts.blocks[0].Ticket, nil
 }
 
-// Height returns the height of a tipset.
+// Height returns the height of a tipset, and nil error.
 func (ts TipSet) Height() (uint64, error) {
-	if len(ts) == 0 {
-		return uint64(0), ErrEmptyTipSet
-	}
-	return uint64(ts.ToSlice()[0].Height), nil
+	return uint64(ts.blocks[0].Height), nil
 }
 
-// Parents returns the parents of a tipset.
+// Parents returns the CIDs of the parents of the blocks in the tipset, and nil error.
 func (ts TipSet) Parents() (SortedCidSet, error) {
-	if len(ts) == 0 {
-		return SortedCidSet{}, ErrEmptyTipSet
-	}
-	return ts.ToSlice()[0].Parents, nil
+	return ts.blocks[0].Parents, nil
 }
 
-// ParentWeight returns the tipset's ParentWeight in fixed point form.
+// ParentWeight returns the tipset's ParentWeight in fixed point form, and nil error.
 func (ts TipSet) ParentWeight() (uint64, error) {
-	if len(ts) == 0 {
-		return uint64(0), ErrEmptyTipSet
-	}
-	return uint64(ts.ToSlice()[0].ParentWeight), nil
+	return uint64(ts.blocks[0].ParentWeight), nil
+}
+
+// Equals tests whether the tipset contains the same blocks as another.
+// Equality is not tested deeply: two tipsets are considered equal if their keys (ordered block CIDs) are equal.
+func (ts TipSet) Equals(ts2 TipSet) bool {
+	return ts.ToSortedCidSet().Equals(ts2.ToSortedCidSet())
+}
+
+// String returns a formatted string of the CIDs in the TipSet.
+// "{ <cid1> <cid2> <cid3> }"
+// Note: existing callers use this as a unique key for the tipset. We should change them
+// to use the sorted CID set explicitly
+func (ts TipSet) String() string {
+	return ts.ToSortedCidSet().String()
 }

--- a/types/tipset.go
+++ b/types/tipset.go
@@ -21,8 +21,10 @@ type TipSet struct {
 }
 
 var (
-	// ErrEmptyTipSet is returned no blocks are provided to a tipset contructor
-	ErrEmptyTipSet = errors.New("no blocks for tipset")
+	// errNoBlocks is returned from the tipset constructor when given no blocks.
+	errNoBlocks = errors.New("no blocks for tipset")
+	// errUndefTipSet is returned from tipset methods invoked on an undefined tipset.
+	errUndefTipSet = errors.New("undefined tipset")
 )
 
 // UndefTipSet is a singleton representing a nil or undefined tipset.
@@ -32,7 +34,7 @@ var UndefTipSet = TipSet{}
 // The blocks must be distinct (different CIDs), have the same height, and same parent set.
 func NewTipSet(blocks ...*Block) (TipSet, error) {
 	if len(blocks) == 0 {
-		return UndefTipSet, ErrEmptyTipSet
+		return UndefTipSet, errNoBlocks
 	}
 
 	first := blocks[0]
@@ -109,24 +111,35 @@ func (ts TipSet) ToSlice() []*Block {
 	return slice
 }
 
-// MinTicket returns the smallest ticket of all blocks in the tipset, and nil error.
-// The nil error is to be removed shortly.
+// MinTicket returns the smallest ticket of all blocks in the tipset.
 func (ts TipSet) MinTicket() (Signature, error) {
+	if len(ts.blocks) == 0 {
+		return nil, errUndefTipSet
+	}
 	return ts.blocks[0].Ticket, nil
 }
 
-// Height returns the height of a tipset, and nil error.
+// Height returns the height of a tipset.
 func (ts TipSet) Height() (uint64, error) {
+	if len(ts.blocks) == 0 {
+		return 0, errUndefTipSet
+	}
 	return uint64(ts.blocks[0].Height), nil
 }
 
-// Parents returns the CIDs of the parents of the blocks in the tipset, and nil error.
+// Parents returns the CIDs of the parents of the blocks in the tipset.
 func (ts TipSet) Parents() (SortedCidSet, error) {
+	if len(ts.blocks) == 0 {
+		return SortedCidSet{}, errUndefTipSet
+	}
 	return ts.blocks[0].Parents, nil
 }
 
-// ParentWeight returns the tipset's ParentWeight in fixed point form, and nil error.
+// ParentWeight returns the tipset's ParentWeight in fixed point form.
 func (ts TipSet) ParentWeight() (uint64, error) {
+	if len(ts.blocks) == 0 {
+		return 0, errUndefTipSet
+	}
 	return uint64(ts.blocks[0].ParentWeight), nil
 }
 

--- a/types/tipset.go
+++ b/types/tipset.go
@@ -25,14 +25,14 @@ var (
 	ErrEmptyTipSet = errors.New("no blocks for tipset")
 )
 
-// NoTipSet is a singleton representing a nil or undefined tipset.
-var NoTipSet = TipSet{}
+// UndefTipSet is a singleton representing a nil or undefined tipset.
+var UndefTipSet = TipSet{}
 
 // NewTipSet builds a new TipSet from a collection of blocks.
 // The blocks must be distinct (different CIDs), have the same height, and same parent set.
 func NewTipSet(blocks ...*Block) (TipSet, error) {
 	if len(blocks) == 0 {
-		return NoTipSet, ErrEmptyTipSet
+		return UndefTipSet, ErrEmptyTipSet
 	}
 
 	first := blocks[0]
@@ -45,19 +45,19 @@ func NewTipSet(blocks ...*Block) (TipSet, error) {
 	for i, blk := range blocks {
 		if i > 0 { // Skip redundant checks for first block
 			if blk.Height != height {
-				return NoTipSet, errors.Errorf("Inconsistent block heights %d and %d", height, blk.Height)
+				return UndefTipSet, errors.Errorf("Inconsistent block heights %d and %d", height, blk.Height)
 			}
 			if !blk.Parents.Equals(parents) {
-				return NoTipSet, errors.Errorf("Inconsistent block parents %s and %s", parents.String(), blk.Parents.String())
+				return UndefTipSet, errors.Errorf("Inconsistent block parents %s and %s", parents.String(), blk.Parents.String())
 			}
 			if blk.ParentWeight != weight {
-				return NoTipSet, errors.Errorf("Inconsistent block parent weights %d and %d", weight, blk.ParentWeight)
+				return UndefTipSet, errors.Errorf("Inconsistent block parent weights %d and %d", weight, blk.ParentWeight)
 			}
 		}
 		// Reject duplicate blocks (by CID).
 		c := blk.Cid()
 		if cids[c] {
-			return NoTipSet, errors.Errorf("Duplicate block CID %s", c)
+			return UndefTipSet, errors.Errorf("Duplicate block CID %s", c)
 		}
 		cids[c] = true
 		sorted[i] = blk
@@ -93,11 +93,6 @@ func (ts TipSet) At(i int) *Block {
 	return ts.blocks[i]
 }
 
-// IsSolo tests whether the tipset has a single block.
-func (ts TipSet) IsSolo() bool {
-	return len(ts.blocks) == 1
-}
-
 // ToSortedCidSet returns a SortedCidSet containing the CIDs in the tipset.
 func (ts TipSet) ToSortedCidSet() SortedCidSet {
 	s := SortedCidSet{}
@@ -115,6 +110,7 @@ func (ts TipSet) ToSlice() []*Block {
 }
 
 // MinTicket returns the smallest ticket of all blocks in the tipset, and nil error.
+// The nil error is to be removed shortly.
 func (ts TipSet) MinTicket() (Signature, error) {
 	return ts.blocks[0].Ticket, nil
 }

--- a/types/tipset_test.go
+++ b/types/tipset_test.go
@@ -1,15 +1,16 @@
 package types
 
 import (
-	"sort"
+	"bytes"
 	"testing"
 
 	"github.com/ipfs/go-cid"
 
-	"github.com/filecoin-project/go-filecoin/address"
-	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 )
 
 var (
@@ -25,14 +26,7 @@ func init() {
 	mockSignerForTest, _ = NewMockSignersAndKeyInfo(2)
 }
 
-// requireTipSetAdd adds a block to the provided tipset and requires that this
-// does not error.
-func requireTipSetAdd(t *testing.T, blk *Block, ts TipSet) {
-	err := ts.AddBlock(blk)
-	require.NoError(t, err)
-}
-
-func block(t *testing.T, height int, parentCid cid.Cid, parentWeight uint64, msg string) *Block {
+func block(t *testing.T, ticket []byte, height int, parentCid cid.Cid, parentWeight uint64, msg string) *Block {
 	addrGetter := address.NewForTestGetter()
 
 	m1 := NewMessage(mockSignerForTest.Addresses[0], addrGetter(), 0, NewAttoFILFromFIL(10), "hello", []byte(msg))
@@ -41,6 +35,7 @@ func block(t *testing.T, height int, parentCid cid.Cid, parentWeight uint64, msg
 	ret := []byte{1, 2}
 
 	return &Block{
+		Ticket:          ticket,
 		Parents:         NewSortedCidSet(parentCid),
 		ParentWeight:    Uint64(parentWeight),
 		Height:          Uint64(42 + uint64(height)),
@@ -54,220 +49,138 @@ func block(t *testing.T, height int, parentCid cid.Cid, parentWeight uint64, msg
 func TestTipSet(t *testing.T) {
 	tf.UnitTest(t)
 
-	b1 := block(t, 1, cid1, uint64(1137), "1")
-	b2 := block(t, 1, cid1, uint64(1137), "2")
-	b3 := block(t, 1, cid1, uint64(1137), "3")
+	b1, b2, b3 := makeTestBlocks(t)
 
-	ts := TipSet{}
-	ts[b1.Cid()] = b1
+	assert.False(t, NoTipSet.Defined())
 
-	ts2 := ts.Clone()
-	assert.Equal(t, ts2, ts) // note: assert.Equal() does a deep comparison, not same as Golang == operator
-	assert.False(t, &ts2 == &ts)
+	t.Run("construction of singleton", func(t *testing.T) {
+		ts := RequireNewTipSet(t, b1)
+		assert.True(t, ts.Defined())
+		assert.True(t, ts.IsSolo())
+		assert.Equal(t, 1, ts.Len())
+		assert.Equal(t, b1, ts.At(0))
+		assert.Equal(t, []*Block{b1}, ts.ToSlice())
 
-	ts[b2.Cid()] = b2
-	assert.NotEqual(t, ts2, ts)
-	assert.Equal(t, 2, len(ts))
-	assert.Equal(t, 1, len(ts2))
+		tsParentWeight, _ := ts.ParentWeight()
+		assert.Equal(t, uint64(1337000), tsParentWeight)
+		assert.Equal(t, NewSortedCidSet(b1.Cid()), ts.ToSortedCidSet())
+		tsParents, _ := ts.Parents()
+		assert.Equal(t, b1.Parents, tsParents)
+		tsHeight, _ := ts.Height()
+		assert.Equal(t, uint64(b1.Height), tsHeight)
+		tsTicket, _ := ts.MinTicket()
+		assert.Equal(t, b1.Ticket, tsTicket)
 
-	ts2 = ts.Clone()
-	assert.Equal(t, ts2, ts)
-	ts2[b1.Cid()] = b3
-	assert.NotEqual(t, ts2, ts)
-	assert.Equal(t, []byte("3"), ts2[b1.Cid()].Messages[0].Params)
-	assert.Equal(t, []byte("1"), ts[b1.Cid()].Messages[0].Params)
+		assert.Equal(t, "{ "+b1.Cid().String()+" }", ts.String())
+	})
 
-	// The actual values inside the TipSets are not copied - we assume they are used immutably.
-	ts2 = ts.Clone()
-	assert.Equal(t, ts2, ts)
-	oldB1 := ts[b1.Cid()]
-	ts[oldB1.Cid()].Nonce = 17
-	assert.Equal(t, ts2, ts)
+	t.Run("construction of multiblock", func(t *testing.T) {
+		ts := RequireNewTipSet(t, b3, b2, b1) // Presented in reverse order
+		assert.True(t, ts.Defined())
+		assert.False(t, ts.IsSolo())
+		assert.Equal(t, 3, ts.Len())
+		assert.Equal(t, b1, ts.At(0))
+		assert.Equal(t, b2, ts.At(1))
+		assert.Equal(t, b3, ts.At(2))
+		assert.Equal(t, []*Block{b1, b2, b3}, ts.ToSlice())
+
+		tsParentWeight, _ := ts.ParentWeight()
+		assert.Equal(t, uint64(1337000), tsParentWeight)
+		assert.Equal(t, NewSortedCidSet(b1.Cid(), b2.Cid(), b3.Cid()), ts.ToSortedCidSet())
+		tsParents, _ := ts.Parents()
+		assert.Equal(t, b1.Parents, tsParents)
+		tsHeight, _ := ts.Height()
+		assert.Equal(t, uint64(b1.Height), tsHeight)
+		tsTicket, _ := ts.MinTicket()
+		assert.Equal(t, b1.Ticket, tsTicket)
+
+		assert.Equal(t, "{ "+b1.Cid().String()+" "+b2.Cid().String()+" "+b3.Cid().String()+" }", ts.String())
+	})
+
+	t.Run("break ties with CID", func(t *testing.T) {
+		pq := uint64(1337000)
+
+		b1 := block(t, []byte{1}, 1, cid1, pq, "1")
+		b2 := block(t, []byte{1}, 1, cid1, pq, "2")
+
+		ts := RequireNewTipSet(t, b1, b2)
+		if bytes.Compare(b1.Cid().Bytes(), b2.Cid().Bytes()) < 0 {
+			assert.Equal(t, []*Block{b1, b2}, ts.ToSlice())
+		} else {
+			assert.Equal(t, []*Block{b2, b1}, ts.ToSlice())
+		}
+	})
+
+	t.Run("equality", func(t *testing.T) {
+		ts1a := RequireNewTipSet(t, b3, b2, b1)
+		ts1b := RequireNewTipSet(t, b1, b2, b3)
+		ts2 := RequireNewTipSet(t, b1, b2)
+		ts3 := RequireNewTipSet(t, b2)
+
+		assert.Equal(t, ts1a, ts1a)
+		assert.Equal(t, ts1a, ts1b)
+		assert.NotEqual(t, ts1a, ts2)
+		assert.NotEqual(t, ts1a, ts3)
+		assert.NotEqual(t, ts1a, NoTipSet)
+		assert.NotEqual(t, ts2, NoTipSet)
+		assert.NotEqual(t, ts3, NoTipSet)
+	})
+
+	t.Run("slice", func(t *testing.T) {
+		ts := RequireNewTipSet(t, b3, b2, b1) // Presented in reverse order
+		slice := ts.ToSlice()
+		assert.Equal(t, []*Block{b1, b2, b3}, slice)
+		slice[1] = b1
+		slice[2] = b2
+
+		assert.NotEqual(t, slice, ts.ToSlice())
+		assert.Equal(t, []*Block{b1, b2, b3}, ts.ToSlice()) // tipset is immutable
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		_, err := NewTipSet()
+		assert.Error(t, err)
+		assert.Equal(t, ErrEmptyTipSet, err)
+	})
+
+	t.Run("duplicate block", func(t *testing.T) {
+		b1, b2, b3 = makeTestBlocks(t)
+		ts, err := NewTipSet(b1, b2, b1)
+		assert.Error(t, err)
+		assert.False(t, ts.Defined())
+	})
+
+	t.Run("mismatched height", func(t *testing.T) {
+		b1, b2, b3 = makeTestBlocks(t)
+		b1.Height = 3
+		ts, err := NewTipSet(b1, b2, b3)
+		assert.Error(t, err)
+		assert.False(t, ts.Defined())
+	})
+
+	t.Run("mismatched parents", func(t *testing.T) {
+		b1, b2, b3 = makeTestBlocks(t)
+		b1.Parents = NewSortedCidSet(cid1, cid2)
+		ts, err := NewTipSet(b1, b2, b3)
+		assert.Error(t, err)
+		assert.False(t, ts.Defined())
+	})
+
+	t.Run("mismatched parent weight", func(t *testing.T) {
+		b1, b2, b3 = makeTestBlocks(t)
+		b1.ParentWeight = Uint64(3000)
+		ts, err := NewTipSet(b1, b2, b3)
+		assert.Error(t, err)
+		assert.False(t, ts.Defined())
+	})
 }
 
 // Test methods: String, ToSortedCidSet, ToSlice, MinTicket, Height, NewTipSet, Equals
-func RequireTestBlocks(t *testing.T) (*Block, *Block, *Block) {
+func makeTestBlocks(t *testing.T) (*Block, *Block, *Block) {
 	pW := uint64(1337000)
 
-	b1 := block(t, 1, cid1, pW, "1")
-	b1.Ticket = []byte{0}
-	b2 := block(t, 1, cid1, pW, "2")
-	b2.Ticket = []byte{1}
-	b3 := block(t, 1, cid1, pW, "3")
-	b3.Ticket = []byte{0}
+	b1 := block(t, []byte{1}, 1, cid1, pW, "1")
+	b2 := block(t, []byte{2}, 1, cid1, pW, "2")
+	b3 := block(t, []byte{3}, 1, cid1, pW, "3")
 	return b1, b2, b3
-}
-
-func RequireTestTipSet(t *testing.T) TipSet {
-	b1, b2, b3 := RequireTestBlocks(t)
-	return RequireNewTipSet(t, b1, b2, b3)
-}
-
-func TestTipSetAddBlock(t *testing.T) {
-	tf.UnitTest(t)
-
-	b1, b2, b3 := RequireTestBlocks(t)
-
-	// Add Valid
-	ts1 := TipSet{}
-	requireTipSetAdd(t, b1, ts1)
-	assert.Equal(t, 1, len(ts1))
-	requireTipSetAdd(t, b2, ts1)
-	requireTipSetAdd(t, b3, ts1)
-
-	ts2 := RequireNewTipSet(t, b1, b2, b3)
-	assert.Equal(t, ts2, ts1)
-
-	// Invalid height
-	b2.Height = 5
-	ts := TipSet{}
-	requireTipSetAdd(t, b1, ts)
-	err := ts.AddBlock(b2)
-	assert.Error(t, err)
-	b2.Height = b1.Height
-
-	// Invalid parent set
-	b2.Parents = NewSortedCidSet(cid1, cid2)
-	ts = TipSet{}
-	requireTipSetAdd(t, b1, ts)
-	err = ts.AddBlock(b2)
-	assert.Error(t, err)
-	b2.Parents = b1.Parents
-
-	// Invalid weight
-	b2.ParentWeight = Uint64(3000)
-	ts = TipSet{}
-	requireTipSetAdd(t, b1, ts)
-	err = ts.AddBlock(b2)
-	assert.Error(t, err)
-}
-
-func TestNewTipSet(t *testing.T) {
-	tf.UnitTest(t)
-
-	b1, b2, b3 := RequireTestBlocks(t)
-
-	// Valid blocks
-	ts, err := NewTipSet(b1, b2, b3)
-	assert.NoError(t, err)
-	assert.Equal(t, ts[b1.Cid()], b1)
-	assert.Equal(t, ts[b2.Cid()], b2)
-	assert.Equal(t, ts[b3.Cid()], b3)
-	assert.Equal(t, 3, len(ts))
-
-	// Invalid heights
-	b1, b2, b3 = RequireTestBlocks(t)
-	b1.Height = 3
-	ts, err = NewTipSet(b1, b2, b3)
-	assert.Error(t, err)
-	assert.Nil(t, ts)
-	b1.Height = b2.Height
-
-	// Invalid parent sets
-	b1, b2, b3 = RequireTestBlocks(t)
-	b1.Parents = NewSortedCidSet(cid1, cid2)
-	ts, err = NewTipSet(b1, b2, b3)
-	assert.Error(t, err)
-	assert.Nil(t, ts)
-	b1.Parents = b2.Parents
-
-	// Invalid parent weights
-	b1, b2, b3 = RequireTestBlocks(t)
-	b1.ParentWeight = Uint64(3000)
-	ts, err = NewTipSet(b1, b2, b3)
-	assert.Error(t, err)
-	assert.Nil(t, ts)
-}
-
-func TestTipSetMinTicket(t *testing.T) {
-	tf.UnitTest(t)
-
-	ts := RequireTestTipSet(t)
-	mt, err := ts.MinTicket()
-	assert.NoError(t, err)
-	assert.Equal(t, Signature([]byte{0}), mt)
-}
-
-func TestTipSetHeight(t *testing.T) {
-	tf.UnitTest(t)
-
-	ts := RequireTestTipSet(t)
-	h, err := ts.Height()
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(43), h)
-}
-
-func TestTipSetParents(t *testing.T) {
-	tf.UnitTest(t)
-
-	b1, _, _ := RequireTestBlocks(t)
-	ts := RequireTestTipSet(t)
-	ps, err := ts.Parents()
-	assert.NoError(t, err)
-	assert.Equal(t, ps, b1.Parents)
-}
-
-func TestTipSetParentWeight(t *testing.T) {
-	tf.UnitTest(t)
-
-	ts := RequireTestTipSet(t)
-	w, err := ts.ParentWeight()
-	assert.NoError(t, err)
-	assert.Equal(t, w, uint64(1337000))
-}
-
-func TestTipSetToSortedCidSet(t *testing.T) {
-	tf.UnitTest(t)
-
-	ts := RequireTestTipSet(t)
-	b1, b2, b3 := RequireTestBlocks(t)
-
-	cidsExp := NewSortedCidSet(b1.Cid(), b2.Cid(), b3.Cid())
-	assert.Equal(t, cidsExp, ts.ToSortedCidSet())
-}
-
-func TestTipSetString(t *testing.T) {
-	tf.UnitTest(t)
-
-	ts := RequireTestTipSet(t)
-	b1, b2, b3 := RequireTestBlocks(t)
-
-	cidsExp := NewSortedCidSet(b1.Cid(), b2.Cid(), b3.Cid())
-	strExp := cidsExp.String()
-	assert.Equal(t, strExp, ts.String())
-}
-
-func TestTipSetToSlice(t *testing.T) {
-	tf.UnitTest(t)
-
-	ts := RequireTestTipSet(t)
-	b1, b2, b3 := RequireTestBlocks(t)
-	tips := []*Block{b1, b2, b3}
-
-	blks := ts.ToSlice()
-	sort.Slice(tips, func(i, j int) bool {
-		return tips[i].Cid().String() < tips[j].Cid().String()
-	})
-	sort.Slice(blks, func(i, j int) bool {
-		return blks[i].Cid().String() < blks[j].Cid().String()
-	})
-	assert.Equal(t, tips, blks)
-
-	assert.Equal(t, ts.ToSlice(), ts.ToSlice())
-
-	tsEmpty := TipSet{}
-	slEmpty := tsEmpty.ToSlice()
-	assert.Equal(t, 0, len(slEmpty))
-}
-
-func TestTipSetEquals(t *testing.T) {
-	tf.UnitTest(t)
-
-	ts := RequireTestTipSet(t)
-	b1, b2, b3 := RequireTestBlocks(t)
-
-	ts2 := RequireNewTipSet(t, b1, b2)
-	assert.True(t, !ts2.Equals(ts))
-	assert.NoError(t, ts2.AddBlock(b3))
-	assert.True(t, ts.Equals(ts2))
 }

--- a/types/tipset_test.go
+++ b/types/tipset_test.go
@@ -137,7 +137,7 @@ func TestTipSet(t *testing.T) {
 	})
 
 	t.Run("slice", func(t *testing.T) {
-		assert.Equal(t, []*Block{b1}, RequireNewTipSet(t, b1))
+		assert.Equal(t, []*Block{b1}, RequireNewTipSet(t, b1).ToSlice())
 
 		ts := RequireNewTipSet(t, b3, b2, b1) // Presented in reverse order
 		slice := ts.ToSlice()
@@ -160,7 +160,7 @@ func TestTipSet(t *testing.T) {
 	t.Run("empty new tipset fails", func(t *testing.T) {
 		_, err := NewTipSet()
 		assert.Error(t, err)
-		assert.Equal(t, ErrEmptyTipSet, err)
+		assert.Equal(t, errNoBlocks, err)
 	})
 
 	t.Run("duplicate block fails new tipset", func(t *testing.T) {


### PR DESCRIPTION
Block ticket is the canonical traversal order when a tipset is processed. This changes the critical traversal in consensus/expected.go to match that (previously iterated in sorted CID order). This is most of the resolution to #2310. See also https://github.com/filecoin-project/specs/issues/285

The representation is more memory efficient and can be iterated without allocating an intermediate slice. An empty/undefined tipset is now harder to construct and explicitly undefined; a few methods now always return nil error and I intend to remove the error return value from them in a follow-up.

SortedCidSet remains as the "key" type for a tipset. In a follow-up, I intend to also upgrade this to an immutable structure.