### PR TITLE
rename createMiner to createStorageMiner to conform to spec

### DIFF
--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -37,7 +37,7 @@ func createTestMinerWith(pledge int64,
 ) address.Address {
 	pdata := actor.MustConvertParams(big.NewInt(pledge), key, peerId)
 	nonce := core.MustGetNonce(stateTree, address.TestAddress)
-	msg := types.NewMessage(minerOwnerAddr, address.StorageMarketAddress, nonce, types.NewAttoFILFromFIL(collateral), "createMiner", pdata)
+	msg := types.NewMessage(minerOwnerAddr, address.StorageMarketAddress, nonce, types.NewAttoFILFromFIL(collateral), "createStorageMiner", pdata)
 
 	result, err := th.ApplyTestMessage(stateTree, vms, msg, types.NewBlockHeight(0))
 	require.NoError(t, err)

--- a/actor/builtin/miner_redeem_test.go
+++ b/actor/builtin/miner_redeem_test.go
@@ -44,7 +44,7 @@ func TestVerifyPieceInclusionInRedeem(t *testing.T) {
 	commP := []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
 	commD := []byte{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7}
 	lastPoSt := types.NewBlockHeight(10)
-	require.NoError(t, createMinerWithCommitment(ctx, st, vms, minerAddr, sectorID, commD, lastPoSt))
+	require.NoError(t, createStorageMinerWithCommitment(ctx, st, vms, minerAddr, sectorID, commD, lastPoSt))
 
 	// Create the payer actor
 	var mockSigner, _ = types.NewMockSignersAndKeyInfo(10)
@@ -163,7 +163,7 @@ func TestVerifyPieceInclusionInRedeem(t *testing.T) {
 	})
 }
 
-func createMinerWithCommitment(ctx context.Context, st state.Tree, vms vm.StorageMap, minerAddr address.Address, sectorID uint64, commD []byte, lastPoSt *types.BlockHeight) error {
+func createStorageMinerWithCommitment(ctx context.Context, st state.Tree, vms vm.StorageMap, minerAddr address.Address, sectorID uint64, commD []byte, lastPoSt *types.BlockHeight) error {
 	minerActor := miner.NewActor()
 	storage := vms.NewStorage(minerAddr, minerActor)
 

--- a/actor/builtin/storagemarket/storagemarket.go
+++ b/actor/builtin/storagemarket/storagemarket.go
@@ -101,7 +101,7 @@ func (sma *Actor) Exports() exec.Exports {
 }
 
 var storageMarketExports = exec.Exports{
-	"createMiner": &exec.FunctionSignature{
+	"createStorageMiner": &exec.FunctionSignature{
 		Params: []abi.Type{abi.Integer, abi.Bytes, abi.PeerID},
 		Return: []abi.Type{abi.Address},
 	},
@@ -119,16 +119,16 @@ var storageMarketExports = exec.Exports{
 	},
 }
 
-// CreateMiner creates a new miner with the a pledge of the given amount of sectors. The
+// CreateStorageMiner creates a new miner with the a pledge of the given amount of sectors. The
 // miners collateral is set by the value in the message.
-func (sma *Actor) CreateMiner(vmctx exec.VMContext, pledge *big.Int, publicKey []byte, pid peer.ID) (address.Address, uint8, error) {
+func (sma *Actor) CreateStorageMiner(vmctx exec.VMContext, pledge *big.Int, publicKey []byte, pid peer.ID) (address.Address, uint8, error) {
 	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
 		return address.Undef, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
 
 	var state State
 	ret, err := actor.WithState(vmctx, &state, func() (interface{}, error) {
-		// TODO: #2530 - Add a sector size parameter to the Actor#CreateMiner
+		// TODO: #2530 - Add a sector size parameter to the Actor#CreateStorageMiner
 		// method and accept the value from the CLI.
 		sectorSize := types.OneKiBSectorSize
 		if state.ProofsMode == types.LiveProofsMode {

--- a/actor/builtin/storagemarket/storagemarket_test.go
+++ b/actor/builtin/storagemarket/storagemarket_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStorageMarketCreateMiner(t *testing.T) {
+func TestStorageMarketCreateStorageMiner(t *testing.T) {
 	tf.UnitTest(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -31,7 +31,7 @@ func TestStorageMarketCreateMiner(t *testing.T) {
 
 	pid := th.RequireRandomPeerID(t)
 	pdata := actor.MustConvertParams(big.NewInt(10), []byte{}, pid)
-	msg := types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(100), "createMiner", pdata)
+	msg := types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(100), "createStorageMiner", pdata)
 	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 	require.NoError(t, err)
 	require.Nil(t, result.ExecutionError)
@@ -56,7 +56,7 @@ func TestStorageMarketCreateMiner(t *testing.T) {
 	assert.Equal(t, mstor.PeerID, pid)
 }
 
-func TestStorageMarketCreateMinerPledgeTooLow(t *testing.T) {
+func TestStorageMarketCreateStorageMinerPledgeTooLow(t *testing.T) {
 	tf.UnitTest(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -65,7 +65,7 @@ func TestStorageMarketCreateMinerPledgeTooLow(t *testing.T) {
 	pledge := big.NewInt(5)
 	st, vms := core.CreateStorages(ctx, t)
 	pdata := actor.MustConvertParams(pledge, []byte{}, th.RequireRandomPeerID(t))
-	msg := types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, MinimumCollateral(pledge), "createMiner", pdata)
+	msg := types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, MinimumCollateral(pledge), "createStorageMiner", pdata)
 	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 
 	assert.NoError(t, err)
@@ -73,7 +73,7 @@ func TestStorageMarketCreateMinerPledgeTooLow(t *testing.T) {
 	assert.Contains(t, result.ExecutionError.Error(), Errors[ErrPledgeTooLow].Error())
 }
 
-func TestStorageMarketCreateMinerInsufficientCollateral(t *testing.T) {
+func TestStorageMarketCreateStorageMinerInsufficientCollateral(t *testing.T) {
 	tf.UnitTest(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -81,7 +81,7 @@ func TestStorageMarketCreateMinerInsufficientCollateral(t *testing.T) {
 
 	st, vms := core.CreateStorages(ctx, t)
 	pdata := actor.MustConvertParams(big.NewInt(15000), []byte{}, th.RequireRandomPeerID(t))
-	msg := types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(14), "createMiner", pdata)
+	msg := types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(14), "createStorageMiner", pdata)
 	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 
 	assert.NoError(t, err)
@@ -89,7 +89,7 @@ func TestStorageMarketCreateMinerInsufficientCollateral(t *testing.T) {
 	assert.Contains(t, result.ExecutionError.Error(), Errors[ErrInsufficientCollateral].Error())
 }
 
-func TestStorageMarkeCreateMinerDoesNotOverwriteActorBalance(t *testing.T) {
+func TestStorageMarkeCreateStorageMinerDoesNotOverwriteActorBalance(t *testing.T) {
 	tf.UnitTest(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -107,7 +107,7 @@ func TestStorageMarkeCreateMinerDoesNotOverwriteActorBalance(t *testing.T) {
 	require.Equal(t, uint8(0), result.Receipt.ExitCode)
 
 	pdata := actor.MustConvertParams(big.NewInt(15), []byte{}, th.RequireRandomPeerID(t))
-	msg = types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(200), "createMiner", pdata)
+	msg = types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(200), "createStorageMiner", pdata)
 	result, err = th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 	require.NoError(t, err)
 	require.Equal(t, uint8(0), result.Receipt.ExitCode)
@@ -124,7 +124,7 @@ func TestStorageMarkeCreateMinerDoesNotOverwriteActorBalance(t *testing.T) {
 	assert.Equal(t, types.NewAttoFILFromFIL(300), miner.Balance)
 }
 
-func TestStorageMarkeCreateMinerErrorsOnInvalidKey(t *testing.T) {
+func TestStorageMarkeCreateStorageMinerErrorsOnInvalidKey(t *testing.T) {
 	tf.UnitTest(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -135,7 +135,7 @@ func TestStorageMarkeCreateMinerErrorsOnInvalidKey(t *testing.T) {
 	publicKey := []byte("012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567")
 	pdata := actor.MustConvertParams(big.NewInt(15), publicKey, th.RequireRandomPeerID(t))
 
-	msg := types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(200), "createMiner", pdata)
+	msg := types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(200), "createStorageMiner", pdata)
 	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 	require.NoError(t, err)
 	assert.Contains(t, result.ExecutionError.Error(), miner.Errors[miner.ErrPublicKeyTooBig].Error())

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -917,7 +917,7 @@ func TestHeaviestIsWidenedAncestor(t *testing.T) {
 
 // Syncer handles MarketView weight comparisons.
 // Current issue: when creating miner mining with addr0, addr0's storage head isn't found in the blockstore
-// and I can't figure out why because we pass in the correct blockstore to createminerwithpower.
+// and I can't figure out why because we pass in the correct blockstore to createStorageMinerWithpower.
 
 func TestTipSetWeightDeep(t *testing.T) {
 	tf.UnitTest(t)

--- a/commands/client_daemon_test.go
+++ b/commands/client_daemon_test.go
@@ -138,7 +138,7 @@ func TestDealWithSameDataAndDifferentMiners(t *testing.T) {
 	miner1.ConnectSuccess(client)
 	miner2.ConnectSuccess(client)
 
-	miner2Addr := miner2.CreateMinerAddr(miner1, minerOwner2)
+	miner2Addr := miner2.CreateStorageMinerAddr(miner1, minerOwner2)
 	miner2.UpdatePeerID()
 
 	miner2.RunSuccess("mining start")
@@ -260,7 +260,7 @@ func TestSelfDialStorageGoodError(t *testing.T) {
 	collateral := big.NewInt(int64(1))
 	price := big.NewFloat(float64(0.001))
 	expiry := big.NewInt(int64(500))
-	ask, err := series.CreateMinerWithAsk(ctx, miningNode, pledge, collateral, price, expiry)
+	ask, err := series.CreateStorageMinerWithAsk(ctx, miningNode, pledge, collateral, price, expiry)
 	minerCreateDoneCh <- struct{}{}
 	require.NoError(t, err)
 

--- a/consensus/processor_test.go
+++ b/consensus/processor_test.go
@@ -122,7 +122,7 @@ func TestProcessTipSetSuccess(t *testing.T) {
 	vms := th.VMStorage()
 	minerOwner, err := address.NewActorAddress([]byte("mo"))
 	require.NoError(t, err)
-	stCid, miner := mustCreateMiner(ctx, t, st, vms, minerAddr, minerOwner)
+	stCid, miner := mustCreateStorageMiner(ctx, t, st, vms, minerAddr, minerOwner)
 
 	msg1 := types.NewMessage(fromAddr1, toAddr, 0, types.NewAttoFILFromFIL(550), "", nil)
 	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(1), types.NewGasUnits(0))
@@ -189,7 +189,7 @@ func TestProcessTipsConflicts(t *testing.T) {
 
 	minerOwner, err := address.NewActorAddress([]byte("mo"))
 	require.NoError(t, err)
-	stCid, miner := mustCreateMiner(ctx, t, st, vms, minerAddr, minerOwner)
+	stCid, miner := mustCreateStorageMiner(ctx, t, st, vms, minerAddr, minerOwner)
 
 	msg1 := types.NewMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(501), "", nil)
 	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(1), types.NewGasUnits(0))
@@ -255,7 +255,7 @@ func TestProcessBlockBadMsgSig(t *testing.T) {
 	require.NoError(t, err)
 	minerOwner, err := address.NewActorAddress([]byte("mo"))
 	require.NoError(t, err)
-	stCid, _ := mustCreateMiner(ctx, t, st, vms, minerAddr, minerOwner)
+	stCid, _ := mustCreateStorageMiner(ctx, t, st, vms, minerAddr, minerOwner)
 
 	msg := types.NewMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(550), "", nil)
 	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(1), types.NewGasUnits(0))
@@ -296,7 +296,7 @@ func TestProcessBlockReward(t *testing.T) {
 	})
 
 	vms := th.VMStorage()
-	stCid, _ := mustCreateMiner(ctx, t, st, vms, minerAddr, minerOwnerAddr)
+	stCid, _ := mustCreateStorageMiner(ctx, t, st, vms, minerAddr, minerOwnerAddr)
 
 	blk := &types.Block{
 		Miner:     minerAddr,
@@ -344,7 +344,7 @@ func TestProcessBlockVMErrors(t *testing.T) {
 		toAddr:                 act2,
 	})
 
-	stCid, miner := mustCreateMiner(ctx, t, st, vms, minerAddr, minerOwnerAddr)
+	stCid, miner := mustCreateStorageMiner(ctx, t, st, vms, minerAddr, minerOwnerAddr)
 
 	msg := types.NewMessage(fromAddr, toAddr, 0, nil, "returnRevertError", nil)
 	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(1), types.NewGasUnits(0))
@@ -1068,7 +1068,7 @@ func mustSetup2Actors(t *testing.T, balance1 *types.AttoFIL, balance2 *types.Att
 	return addr1, act1, addr2, act2, st, mockSigner
 }
 
-func mustCreateMiner(ctx context.Context, t *testing.T, st state.Tree, vms vm.StorageMap, minerAddr, minerOwner address.Address) (cid.Cid, *actor.Actor) {
+func mustCreateStorageMiner(ctx context.Context, t *testing.T, st state.Tree, vms vm.StorageMap, minerAddr, minerOwner address.Address) (cid.Cid, *actor.Actor) {
 	miner := th.RequireNewMinerActor(t, vms, minerAddr, minerOwner, []byte{}, 1000, th.RequireRandomPeerID(t), types.ZeroAttoFIL)
 	require.NoError(t, st.SetActor(ctx, minerAddr, miner))
 	stCid, err := st.Flush(ctx)

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -254,7 +254,7 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 		// create miner
 		pubkey := keys[m.Owner].PublicKey()
 
-		ret, err := applyMessageDirect(ctx, st, sm, addr, address.StorageMarketAddress, types.NewAttoFILFromFIL(100000), "createMiner", big.NewInt(10000), pubkey[:], pid)
+		ret, err := applyMessageDirect(ctx, st, sm, addr, address.StorageMarketAddress, types.NewAttoFILFromFIL(100000), "createStorageMiner", big.NewInt(10000), pubkey[:], pid)
 		if err != nil {
 			return nil, err
 		}
@@ -265,7 +265,7 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 			return nil, err
 		}
 
-		// Sector size will ultimately become an argument to the createMiner
+		// Sector size will ultimately become an argument to the createStorageMiner
 		// method. For now, sector size is a function of the storage market
 		// actor's proofs mode.
 		sectorSize := types.OneKiBSectorSize

--- a/node/testing.go
+++ b/node/testing.go
@@ -212,8 +212,8 @@ func StopNodes(nds []*Node) {
 	}
 }
 
-// MustCreateMinerResult contains the result of a CreateMiner command
-type MustCreateMinerResult struct {
+// MustCreateStorageMinerResult contains the result of a CreateStorageMiner command
+type MustCreateStorageMinerResult struct {
 	MinerAddress *address.Address
 	Err          error
 }

--- a/porcelain/miner.go
+++ b/porcelain/miner.go
@@ -52,7 +52,7 @@ func MinerCreate(
 		}
 	}
 
-	ctx = log.Start(ctx, "Node.CreateMiner")
+	ctx = log.Start(ctx, "Node.CreateStorageMiner")
 	defer func() {
 		log.FinishWithErr(ctx, err)
 	}()
@@ -77,7 +77,7 @@ func MinerCreate(
 		collateral,
 		gasPrice,
 		gasLimit,
-		"createMiner",
+		"createStorageMiner",
 		big.NewInt(int64(pledge)),
 		pubKey,
 		pid,
@@ -138,7 +138,7 @@ func MinerPreviewCreate(
 		return types.NewGasUnits(0), fmt.Errorf("can only have one miner per node")
 	}
 
-	ctx = log.Start(ctx, "Node.CreateMiner")
+	ctx = log.Start(ctx, "Node.CreateStorageMiner")
 	defer func() {
 		log.FinishWithErr(ctx, err)
 	}()
@@ -157,7 +157,7 @@ func MinerPreviewCreate(
 		ctx,
 		fromAddr,
 		address.StorageMarketAddress,
-		"createMiner",
+		"createStorageMiner",
 		big.NewInt(int64(pledge)),
 		pubkey,
 		pid,

--- a/testhelpers/commands.go
+++ b/testhelpers/commands.go
@@ -467,11 +467,11 @@ func (td *TestDaemon) WaitForAPI() error {
 	return fmt.Errorf("filecoin node failed to come online in given time period (10 seconds); last err = %s", err)
 }
 
-// CreateMinerAddr issues a new message to the network, mines the message
+// CreateStorageMinerAddr issues a new message to the network, mines the message
 // and returns the address of the new miner
 // equivalent to:
 //     `go-filecoin miner create --from $TEST_ACCOUNT 100000 20`
-func (td *TestDaemon) CreateMinerAddr(peer *TestDaemon, fromAddr string) address.Address {
+func (td *TestDaemon) CreateStorageMinerAddr(peer *TestDaemon, fromAddr string) address.Address {
 	var wg sync.WaitGroup
 	var minerAddr address.Address
 	wg.Add(1)

--- a/tools/fast/bin/localnet/main.go
+++ b/tools/fast/bin/localnet/main.go
@@ -242,7 +242,7 @@ func main() {
 	// SendFilecoinDefaults
 	// 4. Issue FIL to node
 	//
-	// CreateMinerWithAsk
+	// CreateStorageMinerWithAsk
 	// 5. Create a new miner
 	// 6. Set the miner price, and get ask
 	//
@@ -274,9 +274,9 @@ func main() {
 			return
 		}
 
-		ask, err := series.CreateMinerWithAsk(ctx, miner, minerPledge, minerCollateral, minerPrice, minerExpiry)
+		ask, err := series.CreateStorageMinerWithAsk(ctx, miner, minerPledge, minerCollateral, minerPrice, minerExpiry)
 		if err != nil {
-			exitcode = handleError(err, "failed series.CreateMinerWithAsk;")
+			exitcode = handleError(err, "failed series.CreateStorageMinerWithAsk;")
 			return
 		}
 

--- a/tools/fast/series/create_miner_with_ask.go
+++ b/tools/fast/series/create_miner_with_ask.go
@@ -8,9 +8,9 @@ import (
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 )
 
-// CreateMinerWithAsk setups a miner and sets an ask price. The created ask is
+// CreateStorageMinerWithAsk setups a miner and sets an ask price. The created ask is
 // returned. The node will be mining as well.
-func CreateMinerWithAsk(ctx context.Context, miner *fast.Filecoin, pledge uint64, collateral *big.Int, price *big.Float, expiry *big.Int) (porcelain.Ask, error) {
+func CreateStorageMinerWithAsk(ctx context.Context, miner *fast.Filecoin, pledge uint64, collateral *big.Int, price *big.Float, expiry *big.Int) (porcelain.Ask, error) {
 
 	// Create miner
 	_, err := miner.MinerCreate(ctx, pledge, collateral, fast.AOPrice(big.NewFloat(1.0)), fast.AOLimit(300))

--- a/tools/fast/tests/retrieval_test.go
+++ b/tools/fast/tests/retrieval_test.go
@@ -124,7 +124,7 @@ func TestRetrieval(t *testing.T) {
 	expiry := big.NewInt(24 * 60 * 60 / 30) // ~24 hours
 
 	// Create a miner on the miner node
-	ask, err := series.CreateMinerWithAsk(ctx, miner, pledge, collateral, price, expiry)
+	ask, err := series.CreateStorageMinerWithAsk(ctx, miner, pledge, collateral, price, expiry)
 	require.NoError(t, err)
 
 	// Connect the client and the miner


### PR DESCRIPTION
Fixes #2807.

## Why does this PR exist?

The [spec](https://github.com/filecoin-project/specs/blob/master/actors.md#createstorageminer) shows a `CreateStorageMiner` method, but our implementation uses `CreateMiner`.

## What's in this PR?

This PR simply changes the name of the message/method to conform to the spec.