### PR TITLE
output submodule SHAs when building

### DIFF
--- a/scripts/install-bls-signatures.sh
+++ b/scripts/install-bls-signatures.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
+RELEASE_SHA1=`git rev-parse @:./bls-signatures/bls-signatures`
+
 install_precompiled() {
-  RELEASE_SHA1=`git rev-parse @:./bls-signatures/bls-signatures`
   RELEASE_NAME="bls-signatures-`uname`"
   RELEASE_TAG="${RELEASE_SHA1:0:16}"
 
@@ -71,10 +72,10 @@ install_local() {
 }
 
 if [ -z "$FILECOIN_USE_PRECOMPILED_BLS_SIGNATURES" ]; then
-  echo "using local bls-signatures"
+  echo "using local bls-signatures @ ${RELEASE_SHA1}"
   install_local
 else
-  echo "using precompiled bls-signatures"
+  echo "using precompiled bls-signatures @ ${RELEASE_SHA1}"
   install_precompiled
 
   if [ $? -ne "0" ]; then

--- a/scripts/install-rust-fil-proofs.sh
+++ b/scripts/install-rust-fil-proofs.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
+RELEASE_SHA1=`git rev-parse @:./proofs/rust-fil-proofs`
+
 install_precompiled() {
-  RELEASE_SHA1=`git rev-parse @:./proofs/rust-fil-proofs`
   RELEASE_NAME="rust-fil-proofs-`uname`"
   RELEASE_TAG="${RELEASE_SHA1:0:16}"
 
@@ -78,10 +79,10 @@ install_local() {
 git submodule update --init --recursive proofs/rust-fil-proofs
 
 if [ -z "$FILECOIN_USE_PRECOMPILED_RUST_PROOFS" ]; then
-  echo "using local rust-fil-proofs"
+  echo "using local rust-fil-proofs @ ${RELEASE_SHA1}"
   install_local
 else
-  echo "using precompiled rust-fil-proofs"
+  echo "using precompiled rust-fil-proofs @ ${RELEASE_SHA1}"
   install_precompiled
 
   if [ $? -ne "0" ]; then


### PR DESCRIPTION
## Why does this PR exist?

I oftentimes need the exact submodule SHAs built in order to fix broken builds, debug developer issues, et cetera.

## What's in this PR?

This PR adds the submodule SHA for bls-signatures and rust-fil-proofs to build output.