### PR TITLE
remove unspecified GetPledge method

### DIFF
--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -230,10 +230,6 @@ var minerExports = exec.Exports{
 		Params: []abi.Type{abi.PeerID},
 		Return: []abi.Type{},
 	},
-	"getPledge": &exec.FunctionSignature{
-		Params: []abi.Type{},
-		Return: []abi.Type{abi.Integer},
-	},
 	"getPower": &exec.FunctionSignature{
 		Params: []abi.Type{},
 		Return: []abi.Type{abi.BytesAmount},
@@ -677,28 +673,6 @@ func (ma *Actor) UpdatePeerID(ctx exec.VMContext, pid peer.ID) (uint8, error) {
 	}
 
 	return 0, nil
-}
-
-// GetPledge returns the number of pledged sectors
-func (ma *Actor) GetPledge(ctx exec.VMContext) (*big.Int, uint8, error) {
-	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
-		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
-	}
-
-	var state State
-	ret, err := actor.WithState(ctx, &state, func() (interface{}, error) {
-		return state.PledgeSectors, nil
-	})
-	if err != nil {
-		return nil, errors.CodeError(err), err
-	}
-
-	pledgeSectors, ok := ret.(*big.Int)
-	if !ok {
-		return nil, 1, errors.NewFaultError("Failed to retrieve pledge sectors")
-	}
-
-	return pledgeSectors, 0, nil
 }
 
 // GetPower returns the amount of proven sectors for this miner.

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -206,25 +206,6 @@ func TestPeerIdGetterAndSetter(t *testing.T) {
 	})
 }
 
-func TestMinerGetPledge(t *testing.T) {
-	tf.UnitTest(t)
-
-	t.Run("GetPledge returns pledged sectors, 0, nil when successful", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		st, vms := core.CreateStorages(ctx, t)
-
-		minerAddr := createTestMinerWith(120, 240, t, st, vms, address.TestAddress,
-			[]byte("my public key"), th.RequireRandomPeerID(t))
-
-		// retrieve power (trivial result for no proven sectors)
-		result := callQueryMethodSuccess("getPledge", ctx, t, st, vms, address.TestAddress, minerAddr)[0][0]
-
-		require.Equal(t, 120, int(result))
-	})
-}
-
 func TestMinerGetPower(t *testing.T) {
 	tf.UnitTest(t)
 

--- a/commands/miner.go
+++ b/commands/miner.go
@@ -24,42 +24,9 @@ var minerCmd = &cmds.Command{
 	Subcommands: map[string]*cmds.Command{
 		"create":        minerCreateCmd,
 		"owner":         minerOwnerCmd,
-		"pledge":        minerPledgeCmd,
 		"power":         minerPowerCmd,
 		"set-price":     minerSetPriceCmd,
 		"update-peerid": minerUpdatePeerIDCmd,
-	},
-}
-
-var minerPledgeCmd = &cmds.Command{
-	Helptext: cmdkit.HelpText{
-		Tagline:          "View number of pledged sectors for <miner>",
-		ShortDescription: `Shows the number of pledged sectors for the given miner address`,
-	},
-	Arguments: []cmdkit.Argument{
-		cmdkit.StringArg("miner", true, false, "The miner address"),
-	},
-	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
-		var err error
-
-		minerAddr, err := optionalAddr(req.Arguments[0])
-		if err != nil {
-			return err
-		}
-
-		bytes, err := GetPorcelainAPI(env).MessageQuery(
-			req.Context,
-			address.Undef,
-			minerAddr,
-			"getPledge",
-		)
-		if err != nil {
-			return err
-		}
-		pledgeSectors := big.NewInt(0).SetBytes(bytes[0])
-
-		str := fmt.Sprintf("%d", pledgeSectors) // nolint: govet
-		return re.Emit(str)
 	},
 }
 

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -35,7 +35,6 @@ func TestMinerHelp(t *testing.T) {
 		expected := []string{
 			"miner create <pledge> <collateral>      - Create a new file miner with <pledge> sectors and <collateral> FIL",
 			"miner owner <miner>                     - Show the actor address of <miner>",
-			"miner pledge <miner>                    - View number of pledged sectors for <miner>",
 			"miner power <miner>                     - Get the power of a miner versus the total storage market power",
 			"miner set-price <storageprice> <expiry> - Set the minimum price for storage",
 			"miner update-peerid <address> <peerid>  - Change the libp2p identity that a miner is operating",

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -46,12 +46,6 @@ func TestMinerHelp(t *testing.T) {
 		}
 	})
 
-	t.Run("pledge --help shows pledge help", func(t *testing.T) {
-
-		result := runHelpSuccess(t, "miner", "pledge", "--help")
-		assert.Contains(t, result, "Shows the number of pledged sectors for the given miner address")
-	})
-
 	t.Run("update-peerid --help shows update-peerid help", func(t *testing.T) {
 
 		result := runHelpSuccess(t, "miner", "update-peerid", "--help")
@@ -62,18 +56,6 @@ func TestMinerHelp(t *testing.T) {
 
 		result := runHelpSuccess(t, "miner", "owner", "--help")
 		assert.Contains(t, result, "Given <miner> miner address, output the address of the actor that owns the miner.")
-	})
-
-	t.Run("power --help shows power help", func(t *testing.T) {
-
-		result := runHelpSuccess(t, "miner", "power", "--help")
-		expected := []string{
-			"Check the current power of a given miner and total power of the storage market.",
-			"Values will be output as a ratio where the first number is the miner power and second is the total market power.",
-		}
-		for _, elem := range expected {
-			assert.Contains(t, result, elem)
-		}
 	})
 
 	t.Run("create --help shows create help", func(t *testing.T) {
@@ -108,52 +90,6 @@ func runHelpSuccess(t *testing.T, args ...string) string {
 
 	op := d.RunSuccess(args...)
 	return op.ReadStdoutTrimNewlines()
-}
-
-func TestMinerPledge(t *testing.T) {
-	tf.IntegrationTest(t)
-
-	fi, err := ioutil.TempFile("", "gengentest")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err = gengen.GenGenesisCar(testConfig, fi, 0); err != nil {
-		t.Fatal(err)
-	}
-
-	_ = fi.Close()
-
-	t.Run("shows error with no miner address", func(t *testing.T) {
-
-		d := th.NewDaemon(t, th.GenesisFile(fi.Name())).Start()
-		defer d.ShutdownSuccess()
-
-		d.RunFail("argument \"miner\" is required", "miner", "pledge")
-	})
-
-	t.Run("shows pledge amount for miner", func(t *testing.T) {
-
-		d := th.NewDaemon(t, th.GenesisFile(fi.Name())).Start()
-		defer d.ShutdownSuccess()
-
-		// get Miner address
-		actorLsOutput := d.RunSuccess("actor", "ls")
-		scanner := bufio.NewScanner(strings.NewReader(actorLsOutput.ReadStdout()))
-		var addressStruct struct{ Address string }
-		for scanner.Scan() {
-			line := scanner.Text()
-			if strings.Contains(line, "MinerActor") {
-				err := json.Unmarshal([]byte(line), &addressStruct)
-				assert.NoError(t, err)
-				break
-			}
-		}
-
-		op1 := d.RunSuccess("miner", "pledge", addressStruct.Address)
-		result1 := op1.ReadStdoutTrimNewlines()
-		assert.Contains(t, result1, "10000")
-	})
 }
 
 func TestMinerCreate(t *testing.T) {

--- a/tools/fast/action_miner.go
+++ b/tools/fast/action_miner.go
@@ -67,19 +67,6 @@ func (f *Filecoin) MinerOwner(ctx context.Context, minerAddr address.Address) (a
 	return out, nil
 }
 
-// MinerPledge runs the `miner pledge` command against the filecoin process
-func (f *Filecoin) MinerPledge(ctx context.Context, minerAddr address.Address) (*big.Int, error) {
-	var out big.Int
-
-	sMinerAddr := minerAddr.String()
-
-	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "miner", "pledge", sMinerAddr); err != nil {
-		return big.NewInt(0), err
-	}
-
-	return &out, nil
-}
-
 // MinerPower runs the `miner power` command against the filecoin process
 func (f *Filecoin) MinerPower(ctx context.Context, minerAddr address.Address) (*big.Int, error) {
 	var out big.Int


### PR DESCRIPTION
Makes incremental progress towards #2530.

## Why does this PR exist?

The `GetPledge` method does [not exist in the spec](https://github.com/filecoin-project/specs/blob/master/actors.md#code-cid-3), and is used only in tests.

## What's in this PR?

This PR deletes the `GetPledge` method and corresponding CLI command.