### PR TITLE
add timeout to daemon test Wait() calls

### DIFF
--- a/commands/message_daemon_test.go
+++ b/commands/message_daemon_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -104,7 +105,9 @@ func TestMessageWait(t *testing.T) {
 
 		d.RunSuccess("mining once")
 
-		wg.Wait()
+		if !th.WaitWithTimeout(&wg, time.Second*5) {
+			t.Fatal("timed out waiting for message wait command to return")
+		}
 	})
 }
 

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -143,7 +143,10 @@ func TestMinerCreate(t *testing.T) {
 
 			// ensure mining runs after the command in our goroutine
 			d1.MineAndPropagate(time.Second, d)
-			wg.Wait()
+
+			if !th.WaitWithTimeout(&wg, time.Second*5) {
+				t.Fatal("timed out waiting for miner create command to return")
+			}
 
 			// expect address to have been written in config
 			config := d.RunSuccess("config mining.minerAddress")
@@ -208,7 +211,10 @@ func TestMinerCreate(t *testing.T) {
 
 		// ensure mining runs after the command in our goroutine
 		d1.MineAndPropagate(time.Second, d)
-		wg.Wait()
+
+		if !th.WaitWithTimeout(&wg, time.Second*5) {
+			t.Fatal("timed out waiting for miner create command to return")
+		}
 	})
 }
 
@@ -250,7 +256,10 @@ func TestMinerCreateSuccess(t *testing.T) {
 	}()
 	// ensure mining runs after the command in our goroutine
 	d1.MineAndPropagate(time.Second, d)
-	wg.Wait()
+
+	if !th.WaitWithTimeout(&wg, time.Second*5) {
+		t.Fatal("timed out waiting for miner create command to return")
+	}
 }
 
 func TestMinerCreateChargesGas(t *testing.T) {
@@ -279,7 +288,10 @@ func TestMinerCreateChargesGas(t *testing.T) {
 	}()
 	// ensure mining runs after the command in our goroutine
 	d1.MineAndPropagate(time.Second, d)
-	wg.Wait()
+
+	if !th.WaitWithTimeout(&wg, time.Second*5) {
+		t.Fatal("timed out waiting for miner create command to return")
+	}
 
 	expectedBlockReward := consensus.NewDefaultBlockRewarder().BlockRewardAmount()
 	expectedPrice := types.NewAttoFILFromFIL(333)

--- a/commands/mpool_daemon_test.go
+++ b/commands/mpool_daemon_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
@@ -72,7 +73,9 @@ func TestMpoolLs(t *testing.T) {
 		assert.False(t, complete)
 		sendMessage(d, fixtures.TestAddresses[0], fixtures.TestAddresses[1])
 
-		wg.Wait()
+		if !th.WaitWithTimeout(&wg, time.Second*5) {
+			t.Fatal("timed out waiting for mpool to return")
+		}
 
 		assert.True(t, complete)
 	})


### PR DESCRIPTION
## Why is this PR needed?

The daemon tests create wait groups and schedule goroutines. If a panic happens in the goroutine (say, because `t.Require` was used), the wait group `Done()` method is never called. The test then hangs until the `go test` timeout expires.

## What's in this PR?

- add a helper function which waits a maximum amount of time for a wait group to complete
- use the helper function in the daemon tests