### PR TITLE
[part 2] parameterize CreateStorageMiner with a sector size

### DIFF
--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -36,7 +36,7 @@ func createTestMinerWith(
 	key []byte,
 	peerId peer.ID,
 ) address.Address {
-	pdata := actor.MustConvertParams(key, peerId)
+	pdata := actor.MustConvertParams(key, types.OneKiBSectorSize, peerId)
 	nonce := core.MustGetNonce(stateTree, address.TestAddress)
 	msg := types.NewMessage(minerOwnerAddr, address.StorageMarketAddress, nonce, collateral, "createStorageMiner", pdata)
 

--- a/actor/builtin/storagemarket/storagemarket_test.go
+++ b/actor/builtin/storagemarket/storagemarket_test.go
@@ -28,7 +28,7 @@ func TestStorageMarketCreateStorageMiner(t *testing.T) {
 	st, vms := core.CreateStorages(ctx, t)
 
 	pid := th.RequireRandomPeerID(t)
-	pdata := actor.MustConvertParams([]byte{}, pid)
+	pdata := actor.MustConvertParams([]byte{}, types.OneKiBSectorSize, pid)
 	msg := types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(100), "createStorageMiner", pdata)
 	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 	require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestStorageMarkeCreateStorageMinerDoesNotOverwriteActorBalance(t *testing.T
 	require.NoError(t, err)
 	require.Equal(t, uint8(0), result.Receipt.ExitCode)
 
-	pdata := actor.MustConvertParams([]byte{}, th.RequireRandomPeerID(t))
+	pdata := actor.MustConvertParams([]byte{}, types.OneKiBSectorSize, th.RequireRandomPeerID(t))
 	msg = types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(200), "createStorageMiner", pdata)
 	result, err = th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 	require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestStorageMarkeCreateStorageMinerErrorsOnInvalidKey(t *testing.T) {
 	st, vms := core.CreateStorages(ctx, t)
 
 	publicKey := []byte("012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567")
-	pdata := actor.MustConvertParams(publicKey, th.RequireRandomPeerID(t))
+	pdata := actor.MustConvertParams(publicKey, types.OneKiBSectorSize, th.RequireRandomPeerID(t))
 
 	msg := types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(200), "createStorageMiner", pdata)
 	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -1034,19 +1034,24 @@ func TestTipSetWeightDeep(t *testing.T) {
 
 	// set up dstP.genesis block with power
 	genCfg := &gengen.GenesisCfg{
-		Keys: 4,
-		Miners: []gengen.Miner{
+		ProofsMode: types.TestProofsMode,
+		Keys:       4,
+		Miners: []*gengen.CreateStorageMinerConfig{
 			{
 				NumCommittedSectors: 0,
+				SectorSize:          types.OneKiBSectorSize.Uint64(),
 			},
 			{
 				NumCommittedSectors: 10,
+				SectorSize:          types.OneKiBSectorSize.Uint64(),
 			},
 			{
 				NumCommittedSectors: 10,
+				SectorSize:          types.OneKiBSectorSize.Uint64(),
 			},
 			{
 				NumCommittedSectors: 980,
+				SectorSize:          types.OneKiBSectorSize.Uint64(),
 			},
 		},
 	}

--- a/chain/power_table_view_test.go
+++ b/chain/power_table_view_test.go
@@ -59,10 +59,12 @@ func requireMinerWithNumCommittedSectors(ctx context.Context, t *testing.T, numC
 
 	// set up genesis block containing some miners with non-zero power
 	genCfg := &gengen.GenesisCfg{
-		Keys: 1,
-		Miners: []gengen.Miner{
+		ProofsMode: types.TestProofsMode,
+		Keys:       1,
+		Miners: []*gengen.CreateStorageMinerConfig{
 			{
 				NumCommittedSectors: numCommittedSectors,
+				SectorSize:          types.OneKiBSectorSize.Uint64(),
 			},
 		},
 	}

--- a/commands/miner.go
+++ b/commands/miner.go
@@ -62,6 +62,25 @@ additional sectors.`,
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		var err error
 
+		pp, err := GetPorcelainAPI(env).ProtocolParameters(env.Context())
+		if err != nil {
+			return err
+		}
+
+		// TODO: Modify this command to accept a sector size as an argument,
+		// ensuring that the provided sector size is supported by the network.
+		// https://github.com/filecoin-project/go-filecoin/issues/2530
+		//
+		// TODO: It may become the case that the protocol does not specify an
+		// enumeration of supported sector sizes, but rather that any sector
+		// size for which a miner has Groth parameters and a verifying key is
+		// supported.
+		// https://github.com/filecoin-project/specs/pull/318
+		sectorSize := types.OneKiBSectorSize
+		if pp.ProofsMode == types.LiveProofsMode {
+			sectorSize = types.TwoHundredFiftySixMiBSectorSize
+		}
+
 		fromAddr, err := optionalAddr(req.Options["from"])
 		if err != nil {
 			return err
@@ -93,6 +112,7 @@ additional sectors.`,
 			usedGas, err := GetPorcelainAPI(env).MinerPreviewCreate(
 				req.Context,
 				fromAddr,
+				sectorSize,
 				pid,
 			)
 			if err != nil {
@@ -110,6 +130,7 @@ additional sectors.`,
 			fromAddr,
 			gasPrice,
 			gasLimit,
+			sectorSize,
 			pid,
 			collateral,
 		)

--- a/commands/miner.go
+++ b/commands/miner.go
@@ -50,7 +50,7 @@ miner's collateral drops below 0.001FIL, the miner will not be able to commit
 additional sectors.`,
 	},
 	Arguments: []cmdkit.Argument{
-		cmdkit.StringArg("collateral", true, false, "The amount of collateral in FIL to be sent (minimum 0.001 FIL per sector)"),
+		cmdkit.StringArg("collateral", true, false, "The amount of collateral, in FIL"),
 	},
 	Options: []cmdkit.Option{
 		cmdkit.StringOption("from", "Address to send from"),

--- a/commands/miner.go
+++ b/commands/miner.go
@@ -50,7 +50,7 @@ miner's collateral drops below 0.001FIL, the miner will not be able to commit
 additional sectors.`,
 	},
 	Arguments: []cmdkit.Argument{
-		cmdkit.StringArg("collateral", true, false, "The amount of collateral, in FIL"),
+		cmdkit.StringArg("collateral", true, false, "The amount of collateral in FIL to be sent (minimum 0.001 FIL per sector)"),
 	},
 	Options: []cmdkit.Option{
 		cmdkit.StringOption("from", "Address to send from"),

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -341,19 +341,22 @@ func TestMinerPower(t *testing.T) {
 }
 
 var testConfig = &gengen.GenesisCfg{
-	Keys: 4,
+	ProofsMode: types.TestProofsMode,
+	Keys:       4,
 	PreAlloc: []string{
 		"10",
 		"50",
 	},
-	Miners: []gengen.Miner{
+	Miners: []*gengen.CreateStorageMinerConfig{
 		{
 			Owner:               0,
 			NumCommittedSectors: 3,
+			SectorSize:          types.OneKiBSectorSize.Uint64(),
 		},
 		{
 			Owner:               1,
 			NumCommittedSectors: 3,
+			SectorSize:          types.OneKiBSectorSize.Uint64(),
 		},
 	},
 }

--- a/gengen/main.go
+++ b/gengen/main.go
@@ -69,7 +69,7 @@ func main() {
 	var defaultSeed = time.Now().Unix()
 
 	jsonout := flag.Bool("json", false, "sets output to be json")
-	testProofsMode := flag.Bool("test-proofs-mode", false, "change sealing, sector packing, PoSt, etc. to be compatible with test environments")
+	testProofsMode := flag.Bool("test-proofs-mode", false, "change sealing, sector packing, PoSt, etc. to be compatible with test environments (overrides proofs mode read from JSON)")
 	keypath := flag.String("keypath", ".", "sets location to write key files to")
 	outJSON := flag.String("out-json", "", "enables json output and writes it to the given file")
 	outCar := flag.String("out-car", "", "writes the generated car file to the give path, instead of stdout")
@@ -86,6 +86,8 @@ func main() {
 		panic(err)
 	}
 
+	gengen.ApplyProofsModeDefaults(cfg, !*testProofsMode, isFlagPassed("test-proofs-mode"))
+
 	outfile := os.Stdout
 	if *outCar != "" {
 		f, err := os.Create(*outCar)
@@ -94,10 +96,7 @@ func main() {
 		}
 		outfile = f
 	}
-	cfg.ProofsMode = types.LiveProofsMode
-	if *testProofsMode {
-		cfg.ProofsMode = types.TestProofsMode
-	}
+
 	info, err := gengen.GenGenesisCar(cfg, outfile, *seed)
 	if err != nil {
 		fmt.Println("ERROR", err)
@@ -153,4 +152,17 @@ func readConfig(filePath string) (*gengen.GenesisCfg, error) {
 	}
 
 	return &cfg, nil
+}
+
+// isFlagPassed returns true if a flag with the given name was provided by the
+// caller.
+func isFlagPassed(name string) bool {
+	found := false
+	flag.Visit(func(f *flg.Flag) {
+		if f.Name == name {
+			found = true
+		}
+	})
+
+	return found
 }

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -30,8 +30,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Miner is
-type Miner struct {
+// CreateStorageMinerConfig holds configuration options used to create a storage
+// miner in the genesis block. Note: Instances of this struct can be created
+// from the contents of fixtures/setup.json, which means that a JSON
+// encoder/decoder must exist for any of the struct's fields' types.
+type CreateStorageMinerConfig struct {
 	// Owner is the name of the key that owns this miner
 	// It must be a name of a key from the configs 'Keys' list
 	Owner int
@@ -41,19 +44,14 @@ type Miner struct {
 
 	// NumCommittedSectors is the number of sectors that this miner has
 	// committed to the network.
-	//
-	// TODO: This struct needs a field which represents the size of sectors
-	// that this miner has committed. For now, sector size is configured by
-	// the StorageMarketActor's ProofsMode. We should add this field as part of:
-	//
-	// https://github.com/filecoin-project/go-filecoin/issues/2530
-	//
-	// TODO: this will get more complicated when we actually have to
-	// prove real files.
 	NumCommittedSectors uint64
+
+	// SectorSize is the size of the sectors that this miner commits, in bytes.
+	SectorSize uint64
 }
 
-// GenesisCfg is
+// GenesisCfg is the top level configuration struct used to create a genesis
+// block.
 type GenesisCfg struct {
 	// Keys is an array of names of keys. A random key will be generated
 	// for each name here.
@@ -64,7 +62,7 @@ type GenesisCfg struct {
 	PreAlloc []string
 
 	// Miners is a list of miners that should be set up at the start of the network
-	Miners []Miner
+	Miners []*CreateStorageMinerConfig
 
 	// ProofsMode affects sealing, sector packing, PoSt, etc. in the proofs library
 	ProofsMode types.ProofsMode
@@ -117,7 +115,7 @@ func GenGen(ctx context.Context, cfg *GenesisCfg, cst *hamt.CborIpldStore, bs bl
 		return nil, err
 	}
 
-	miners, err := setupMiners(st, storageMap, keys, cfg.Miners, cfg.ProofsMode, pnrg)
+	miners, err := setupMiners(st, storageMap, keys, cfg.Miners, pnrg)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +216,7 @@ func setupPrealloc(st state.Tree, keys []*types.KeyInfo, prealloc []string) erro
 	return st.SetActor(context.Background(), address.NetworkAddress, netact)
 }
 
-func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners []Miner, proofsMode types.ProofsMode, pnrg io.Reader) ([]RenderedMinerInfo, error) {
+func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners []*CreateStorageMinerConfig, pnrg io.Reader) ([]RenderedMinerInfo, error) {
 	var minfos []RenderedMinerInfo
 	ctx := context.Background()
 
@@ -253,7 +251,7 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 		// create miner
 		pubkey := keys[m.Owner].PublicKey()
 
-		ret, err := applyMessageDirect(ctx, st, sm, addr, address.StorageMarketAddress, types.NewAttoFILFromFIL(100000), "createStorageMiner", pubkey[:], pid)
+		ret, err := applyMessageDirect(ctx, st, sm, addr, address.StorageMarketAddress, types.NewAttoFILFromFIL(100000), "createStorageMiner", pubkey[:], types.NewBytesAmount(m.SectorSize), pid)
 		if err != nil {
 			return nil, err
 		}
@@ -264,20 +262,10 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 			return nil, err
 		}
 
-		// Sector size will ultimately become an argument to the createStorageMiner
-		// method. For now, sector size is a function of the storage market
-		// actor's proofs mode.
-		sectorSize := types.OneKiBSectorSize
-		if proofsMode == types.LiveProofsMode {
-			sectorSize = types.TwoHundredFiftySixMiBSectorSize
-		}
-
-		power := types.NewBytesAmount(sectorSize.Uint64() * m.NumCommittedSectors)
-
 		minfos = append(minfos, RenderedMinerInfo{
 			Address: maddr,
 			Owner:   m.Owner,
-			Power:   power,
+			Power:   types.NewBytesAmount(m.SectorSize * m.NumCommittedSectors),
 		})
 
 		// commit sector to add power
@@ -396,4 +384,28 @@ var _ types.Signer = (*signer)(nil)
 
 func (ggs *signer) SignBytes(data []byte, addr address.Address) (types.Signature, error) {
 	return nil, nil
+}
+
+// ApplyProofsModeDefaults mutates the given genesis configuration, setting the
+// appropriate proofs mode and corresponding storage miner sector size. If
+// force is true, proofs mode and sector size-values will be overridden with the
+// appropriate defaults for the selected proofs mode.
+func ApplyProofsModeDefaults(cfg *GenesisCfg, useLiveProofsMode bool, force bool) {
+	mode := types.TestProofsMode
+	sectorSize := types.OneKiBSectorSize
+
+	if useLiveProofsMode {
+		mode = types.LiveProofsMode
+		sectorSize = types.TwoHundredFiftySixMiBSectorSize
+	}
+
+	if cfg.ProofsMode == types.UnsetProofsMode || force {
+		cfg.ProofsMode = mode
+	}
+
+	for _, m := range cfg.Miners {
+		if m.SectorSize == 0 || force {
+			m.SectorSize = sectorSize.Uint64()
+		}
+	}
 }

--- a/gengen/util/gengen_test.go
+++ b/gengen/util/gengen_test.go
@@ -14,21 +14,25 @@ import (
 	. "github.com/filecoin-project/go-filecoin/gengen/util"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/types"
 
 	"github.com/stretchr/testify/assert"
 )
 
 var testConfig = &GenesisCfg{
-	Keys:     4,
-	PreAlloc: []string{"10", "50"},
-	Miners: []Miner{
+	ProofsMode: types.TestProofsMode,
+	Keys:       4,
+	PreAlloc:   []string{"10", "50"},
+	Miners: []*CreateStorageMinerConfig{
 		{
 			Owner:               0,
 			NumCommittedSectors: 50,
+			SectorSize:          types.OneKiBSectorSize.Uint64(),
 		},
 		{
 			Owner:               1,
 			NumCommittedSectors: 10,
+			SectorSize:          types.OneKiBSectorSize.Uint64(),
 		},
 	},
 }

--- a/node/testing.go
+++ b/node/testing.go
@@ -226,12 +226,14 @@ var PeerKeys = []crypto.PrivKey{
 
 // TestGenCfg is a genesis configuration used for tests.
 var TestGenCfg = &gengen.GenesisCfg{
-	Keys: 2,
-	Miners: []gengen.Miner{
+	ProofsMode: types.TestProofsMode,
+	Keys:       2,
+	Miners: []*gengen.CreateStorageMinerConfig{
 		{
 			Owner:               0,
 			NumCommittedSectors: 100,
 			PeerID:              mustPeerID(PeerKeys[0]).Pretty(),
+			SectorSize:          types.OneKiBSectorSize.Uint64(),
 		},
 	},
 	PreAlloc: []string{

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -111,19 +111,21 @@ func (a *API) MinerCreate(
 	accountAddr address.Address,
 	gasPrice types.AttoFIL,
 	gasLimit types.GasUnits,
+	sectorSize *types.BytesAmount,
 	pid peer.ID,
 	collateral *types.AttoFIL,
 ) (_ *address.Address, err error) {
-	return MinerCreate(ctx, a, accountAddr, gasPrice, gasLimit, pid, collateral)
+	return MinerCreate(ctx, a, accountAddr, gasPrice, gasLimit, sectorSize, pid, collateral)
 }
 
 // MinerPreviewCreate previews the Gas cost of creating a miner
 func (a *API) MinerPreviewCreate(
 	ctx context.Context,
 	fromAddr address.Address,
+	sectorSize *types.BytesAmount,
 	pid peer.ID,
 ) (usedGas types.GasUnits, err error) {
-	return MinerPreviewCreate(ctx, a, fromAddr, pid)
+	return MinerPreviewCreate(ctx, a, fromAddr, sectorSize, pid)
 }
 
 // MinerGetAsk queries for an ask of the given miner

--- a/porcelain/miner.go
+++ b/porcelain/miner.go
@@ -41,6 +41,7 @@ func MinerCreate(
 	minerOwnerAddr address.Address,
 	gasPrice types.AttoFIL,
 	gasLimit types.GasUnits,
+	sectorSize *types.BytesAmount,
 	pid peer.ID,
 	collateral *types.AttoFIL,
 ) (_ *address.Address, err error) {
@@ -78,6 +79,7 @@ func MinerCreate(
 		gasLimit,
 		"createStorageMiner",
 		pubKey,
+		sectorSize,
 		pid,
 	)
 	if err != nil {
@@ -117,6 +119,7 @@ func MinerPreviewCreate(
 	ctx context.Context,
 	plumbing mpcAPI,
 	fromAddr address.Address,
+	sectorSize *types.BytesAmount,
 	pid peer.ID,
 ) (usedGas types.GasUnits, err error) {
 	if fromAddr.Empty() {
@@ -155,6 +158,7 @@ func MinerPreviewCreate(
 		address.StorageMarketAddress,
 		"createStorageMiner",
 		pubkey,
+		sectorSize,
 		pid,
 	)
 	if err != nil {

--- a/porcelain/miner_test.go
+++ b/porcelain/miner_test.go
@@ -96,6 +96,7 @@ func TestMinerCreate(t *testing.T) {
 			address.Address{},
 			types.NewGasPrice(0),
 			types.NewGasUnits(100),
+			types.OneKiBSectorSize,
 			"",
 			collateral,
 		)
@@ -114,6 +115,7 @@ func TestMinerCreate(t *testing.T) {
 			address.Address{},
 			types.NewGasPrice(0),
 			types.NewGasUnits(100),
+			types.OneKiBSectorSize,
 			"",
 			collateral,
 		)
@@ -162,7 +164,7 @@ func TestMinerPreviewCreate(t *testing.T) {
 		ctx := context.Background()
 		plumbing := newMinerPreviewCreate(t)
 
-		usedGas, err := MinerPreviewCreate(ctx, plumbing, address.Undef, "")
+		usedGas, err := MinerPreviewCreate(ctx, plumbing, address.Undef, types.OneKiBSectorSize, "")
 		require.NoError(t, err)
 		assert.Equal(t, usedGas, types.NewGasUnits(5))
 	})

--- a/testhelpers/iptbtester/genesis.go
+++ b/testhelpers/iptbtester/genesis.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/commands"
 	"github.com/filecoin-project/go-filecoin/gengen/util"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 // GenesisInfo chains require information to start a single node with funds
@@ -29,14 +30,16 @@ type idResult struct {
 func MustGenerateGenesis(t *testing.T, funds int64, dir string) *GenesisInfo {
 	// Setup, generate a genesis and key file
 	cfg := &gengen.GenesisCfg{
-		Keys: 1,
+		ProofsMode: types.TestProofsMode,
+		Keys:       1,
 		PreAlloc: []string{
 			strconv.FormatInt(funds, 10),
 		},
-		Miners: []gengen.Miner{
+		Miners: []*gengen.CreateStorageMinerConfig{
 			{
 				Owner:               0,
 				NumCommittedSectors: 1,
+				SectorSize:          types.OneKiBSectorSize.Uint64(),
 			},
 		},
 	}

--- a/tools/fast/environment_memory_genesis.go
+++ b/tools/fast/environment_memory_genesis.go
@@ -217,7 +217,7 @@ func (e *EnvironmentMemoryGenesis) buildGenesis(funds *big.Int) error {
 		PreAlloc: []string{
 			funds.String(),
 		},
-		Miners: []gengen.Miner{
+		Miners: []*gengen.CreateStorageMinerConfig{
 			{
 				Owner:               0,
 				NumCommittedSectors: 1,
@@ -225,6 +225,10 @@ func (e *EnvironmentMemoryGenesis) buildGenesis(funds *big.Int) error {
 		},
 		ProofsMode: e.proofsMode,
 	}
+
+	// ensure miners' sector size is set appropriately for the configured
+	// proofs mode
+	gengen.ApplyProofsModeDefaults(cfg, e.proofsMode == types.LiveProofsMode, true)
 
 	var genbuffer bytes.Buffer
 

--- a/types/proofs_mode.go
+++ b/types/proofs_mode.go
@@ -6,8 +6,10 @@ package types
 type ProofsMode int
 
 const (
+	// UnsetProofsMode is the default
+	UnsetProofsMode = ProofsMode(iota)
 	// TestProofsMode changes sealing, sector packing, PoSt, etc. to be compatible with test environments
-	TestProofsMode = ProofsMode(iota)
+	TestProofsMode
 	// LiveProofsMode changes sealing, sector packing, PoSt, etc. to be compatible with non-test environments
 	LiveProofsMode
 )


### PR DESCRIPTION
This PR makes incremental progress on #2530.

Note that this PR is branched off of #2871. Once the upstream PR is merged, this PR will need to be rebased onto `master`. 

## Why does this PR exist?

The specification shows that the `CreateStorageMiner` method should accept a sector size, and that the created storage miner actor must be forever pinned to that sector size.

## What's in this PR?

This PR modifies the implementation to select, based on the storage market actor's proofs mode, a sector size to be passed in the `createStorageMiner` message.

## What's next?

I need to modify the `miner create` command (and corresponding wiki docs) to accept a sector size as input.