### PR TITLE
[part 3] "miner create" command must accept "sectorsize" flag

### DIFF
--- a/commands/miner.go
+++ b/commands/miner.go
@@ -50,7 +50,7 @@ miner's collateral drops below 0.001FIL, the miner will not be able to commit
 additional sectors.`,
 	},
 	Arguments: []cmdkit.Argument{
-		cmdkit.StringArg("collateral", true, false, "The amount of collateral in FIL to be sent (minimum 0.001 FIL per sector)"),
+		cmdkit.StringArg("collateral", true, false, "The amount of collateral, in FIL"),
 	},
 	Options: []cmdkit.Option{
 		cmdkit.StringOption("from", "Address to send from"),

--- a/commands/miner.go
+++ b/commands/miner.go
@@ -50,7 +50,7 @@ miner's collateral drops below 0.001FIL, the miner will not be able to commit
 additional sectors.`,
 	},
 	Arguments: []cmdkit.Argument{
-		cmdkit.StringArg("collateral", true, false, "The amount of collateral, in FIL"),
+		cmdkit.StringArg("collateral", true, false, "The amount of collateral in FIL to be sent (minimum 0.001 FIL per sector)"),
 	},
 	Options: []cmdkit.Option{
 		cmdkit.StringOption("from", "Address to send from"),

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -149,6 +149,18 @@ func TestMinerCreate(t *testing.T) {
 		tf(testAddr, th.RequireRandomPeerID(t))
 	})
 
+	t.Run("unsupported sector size", func(t *testing.T) {
+		d := th.NewDaemon(t).Start()
+		defer d.ShutdownSuccess()
+
+		d.CreateAddress()
+
+		d.RunFail("unsupported sector size",
+			"miner", "create", "20",
+			"--sectorsize", "42",
+		)
+	})
+
 	t.Run("validation failure", func(t *testing.T) {
 
 		d := th.NewDaemon(t).Start()
@@ -156,6 +168,10 @@ func TestMinerCreate(t *testing.T) {
 
 		d.CreateAddress()
 
+		d.RunFail("invalid sector size",
+			"miner", "create", "20",
+			"--sectorsize", "ninetybillion",
+		)
 		d.RunFail("invalid peer id",
 			"miner", "create",
 			"--from", testAddr.String(), "--gas-price", "1", "--gas-limit", "300", "--peerid", "flarp", "20",

--- a/commands/opt_sector_size.go
+++ b/commands/opt_sector_size.go
@@ -1,0 +1,21 @@
+package commands
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+func optionalSectorSizeWithDefault(o interface{}, def *types.BytesAmount) (*types.BytesAmount, error) {
+	if o != nil {
+		n, err := strconv.ParseUint(o.(string), 10, 64)
+		if err != nil || n == 0 {
+			return nil, fmt.Errorf("invalid sector size: %s", o.(string))
+		}
+
+		return types.NewBytesAmount(n), nil
+	}
+
+	return def, nil
+}

--- a/porcelain/protocol_test.go
+++ b/porcelain/protocol_test.go
@@ -38,8 +38,9 @@ func TestProtocolParams(t *testing.T) {
 		}
 
 		expected := &porcelain.ProtocolParams{
-			AutoSealInterval: 120,
-			ProofsMode:       types.TestProofsMode,
+			AutoSealInterval:     120,
+			ProofsMode:           types.TestProofsMode,
+			SupportedSectorSizes: []*types.BytesAmount{types.OneKiBSectorSize},
 		}
 
 		out, err := porcelain.ProtocolParameters(context.TODO(), plumbing)


### PR DESCRIPTION
Fixes #2530.

Note that this PR is based off of #2873. Once that PR is merged, this PR will need to be rebased onto `master`.

## Why does this PR exist?

We need to give an operator a command option which lets them pick the size of the sectors which their newly-created storage miner actor will commit.

## What's in this PR?

- modify `miner create` to accept an optional `sectorsize` flag
- default to whatever sector size is supported by the proofs mode

## Usage

### Invalid `sectorsize`

```
$ ./go-filecoin miner create 1 --sectorsize=woot
Error: invalid sector size: woot
```

### Unsupported `sectorsize`

```
$ ./go-filecoin miner create 1 --sectorsize=12
Error: unsupported sector size: 12 (supported sizes: 268435456)
```