### PR TITLE
compute proving period as a function of sector size

### DIFF
--- a/consensus/expected.go
+++ b/consensus/expected.go
@@ -69,7 +69,11 @@ const ECPrM uint64 = 100
 
 // AncestorRoundsNeeded is the number of rounds of the ancestor chain needed
 // to process all state transitions.
-const AncestorRoundsNeeded = miner.ProvingPeriodBlocks + miner.GracePeriodBlocks
+//
+// TODO: If the following PR is merged - and the network doesn't define a
+// largest sector size - this constant will need to be reconsidered.
+// https://github.com/filecoin-project/specs/pull/318
+const AncestorRoundsNeeded = miner.LargestSectorSizeProvingPeriodBlocks + miner.GracePeriodBlocks
 
 // A Processor processes all the messages in a block or tip set.
 type Processor interface {

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -727,9 +727,17 @@ func (sm *Miner) OnNewHeaviestTipSet(ts types.TipSet) {
 		return
 	}
 
+	sectorSize, err := sm.porcelainAPI.MinerGetSectorSize(ctx, sm.minerAddr)
+	if err != nil {
+		log.Errorf("failed to get miner's sector size: %s", err)
+		return
+	}
+
+	// the block height of the new heaviest tipset
 	h := types.NewBlockHeight(height)
-	provingPeriodHeight := types.NewBlockHeight(miner.LargestSectorSizeProvingPeriodBlocks)
-	provingPeriodEnd := provingPeriodStart.Add(provingPeriodHeight)
+
+	// compute the block height at which the miner's current proving period ends
+	provingPeriodEnd := provingPeriodStart.Add(types.NewBlockHeight(miner.ProvingPeriodDuration(sectorSize)))
 
 	if h.GreaterEqual(provingPeriodStart) {
 		if h.LessThan(provingPeriodEnd) {

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -728,7 +728,7 @@ func (sm *Miner) OnNewHeaviestTipSet(ts types.TipSet) {
 	}
 
 	h := types.NewBlockHeight(height)
-	provingPeriodHeight := types.NewBlockHeight(miner.ProvingPeriodBlocks)
+	provingPeriodHeight := types.NewBlockHeight(miner.LargestSectorSizeProvingPeriodBlocks)
 	provingPeriodEnd := provingPeriodStart.Add(provingPeriodHeight)
 
 	if h.GreaterEqual(provingPeriodStart) {


### PR DESCRIPTION
Fixes #2839 

## Why is this PR required?

A miner actor's proving period is a function of the miner's selected sector size. Small sectors take less time to prove than larger sectors do, so proving period blocks should be a function of sector size. This is consistent with the [spec](https://github.com/filecoin-project/specs/blob/master/actors.md#commitsector).

## What's in this PR?

Make proving period blocks a function of sector size. This is currently a constant function. Make `AncestorRoundsNeeded` rely on the maximum value which `ProvingPeriodDuration` can return. 