### PR TITLE
generation attack threshold is a function of sector size

### DIFF
--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -355,9 +355,9 @@ func TestMinerSubmitPoSt(t *testing.T) {
 	require.NoError(t, res.ExecutionError)
 	require.Equal(t, types.NewBlockHeightFromBytes(res.Receipt.Return[0]), types.NewBlockHeight(20003))
 
-	// fail to submit inside the proving period
+	// fail to submit inside the proving period (plus generation attack threshold)
 	proof = th.MakeRandomPoStProofForTest()
-	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 40008, "submitPoSt", ancestors, []types.PoStProof{proof})
+	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 40108, "submitPoSt", ancestors, []types.PoStProof{proof})
 	require.NoError(t, err)
 	require.EqualError(t, res.ExecutionError, "submitted PoSt late, need to pay a fee")
 }

--- a/consensus/expected.go
+++ b/consensus/expected.go
@@ -73,7 +73,7 @@ const ECPrM uint64 = 100
 // TODO: If the following PR is merged - and the network doesn't define a
 // largest sector size - this constant will need to be reconsidered.
 // https://github.com/filecoin-project/specs/pull/318
-const AncestorRoundsNeeded = miner.LargestSectorSizeProvingPeriodBlocks + miner.GracePeriodBlocks
+const AncestorRoundsNeeded = miner.LargestSectorSizeProvingPeriodBlocks + miner.LargestSectorGenerationAttackThresholdBlocks
 
 // A Processor processes all the messages in a block or tip set.
 type Processor interface {


### PR DESCRIPTION
Fixes #2840 

## Why is this PR needed?

The specification shows, in pseudocode, that generate attack threshold is a function of sector size.

## What's in this PR?

Introduce `GenerationAttackTime` (constant) function which returns, for the largest sector size, the number of blocks after a proving period P ends after which a delinquent miner (i.e. they haven't yet posted a `submitPoSt` message for P) is subject to storage fault slashing.