### PR TITLE
Change chain traversal to hit tipset cache

### DIFF
--- a/chain/traversal.go
+++ b/chain/traversal.go
@@ -8,40 +8,21 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
-// BlockProvider provides blocks. This is a subset of the ReadStore interface.
-type BlockProvider interface {
-	GetBlock(ctx context.Context, cid cid.Cid) (*types.Block, error)
-}
-
-// GetParentTipSet returns the parent tipset of a tipset.
-// The result is empty if the tipset has no parents, but an error if the tipset is undefined.
-func GetParentTipSet(ctx context.Context, store BlockProvider, ts types.TipSet) (types.TipSet, error) {
-	parents, err := ts.Parents()
-	// Parents is empty (without error) for the genesis tipset, and does't produce an error here either.
-	if err != nil || parents.Len() == 0 {
-		return types.UndefTipSet, err
-	}
-	var newBlocks []*types.Block
-	for it := parents.Iter(); !it.Complete() && ctx.Err() == nil; it.Next() {
-		newBlk, err := store.GetBlock(ctx, it.Value())
-		if err != nil {
-			return types.UndefTipSet, err
-		}
-		newBlocks = append(newBlocks, newBlk)
-	}
-	return types.NewTipSet(newBlocks...)
+// TipSetProvider provides tipsets for traversal.
+type TipSetProvider interface {
+	GetTipSet(tsKey types.SortedCidSet) (types.TipSet, error)
 }
 
 // IterAncestors returns an iterator over tipset ancestors, yielding first the start tipset and
 // then its parent tipsets until (and including) the genesis tipset.
-func IterAncestors(ctx context.Context, store BlockProvider, start types.TipSet) *TipsetIterator {
+func IterAncestors(ctx context.Context, store TipSetProvider, start types.TipSet) *TipsetIterator {
 	return &TipsetIterator{ctx, store, start}
 }
 
 // TipsetIterator is an iterator over tipsets.
 type TipsetIterator struct {
 	ctx   context.Context
-	store BlockProvider
+	store TipSetProvider
 	value types.TipSet
 }
 
@@ -57,12 +38,52 @@ func (it *TipsetIterator) Complete() bool {
 
 // Next advances the iterator to the next value.
 func (it *TipsetIterator) Next() error {
-	var err error
 	select {
 	case <-it.ctx.Done():
 		return it.ctx.Err()
 	default:
-		it.value, err = GetParentTipSet(it.ctx, it.store, it.value)
+		parentKey, err := it.value.Parents()
+		// Parents is empty (without error) for the genesis tipset.
+		if err != nil || parentKey.Len() == 0 {
+			it.value = types.UndefTipSet
+		} else {
+			it.value, err = it.store.GetTipSet(parentKey)
+		}
+		return err
 	}
-	return err
+}
+
+// BlockProvider provides blocks.
+type BlockProvider interface {
+	GetBlock(ctx context.Context, cid cid.Cid) (*types.Block, error)
+}
+
+// LoadTipSetBlocks loads all the blocks for a tipset from the store.
+func LoadTipSetBlocks(ctx context.Context, store BlockProvider, key types.SortedCidSet) (types.TipSet, error) {
+	var blocks []*types.Block
+	for it := key.Iter(); !it.Complete(); it.Next() {
+		blk, err := store.GetBlock(ctx, it.Value())
+		if err != nil {
+			return types.UndefTipSet, err
+		}
+		blocks = append(blocks, blk)
+	}
+	return types.NewTipSet(blocks...)
+}
+
+type tipsetFromBlockProvider struct {
+	ctx    context.Context // Context to use when loading blocks
+	blocks BlockProvider   // Provides blocks
+}
+
+// TipSetProviderFromBlocks builds a tipset provider backed by a block provider.
+// Blocks will be loaded with the provided context, since GetTipSet does not accept a
+// context parameter. This can and should be removed when GetTipSet does take a context.
+func TipSetProviderFromBlocks(ctx context.Context, blocks BlockProvider) TipSetProvider {
+	return &tipsetFromBlockProvider{ctx, blocks}
+}
+
+// GetTipSet loads the blocks for a tipset.
+func (p *tipsetFromBlockProvider) GetTipSet(tsKey types.SortedCidSet) (types.TipSet, error) {
+	return LoadTipSetBlocks(p.ctx, p.blocks, tsKey)
 }

--- a/chain/traversal_test.go
+++ b/chain/traversal_test.go
@@ -13,43 +13,12 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
-func TestGetParentTipSet(t *testing.T) {
-	tf.UnitTest(t)
-
-	ctx := context.Background()
-	store := th.NewFakeBlockProvider()
-
-	root := store.NewBlock(0)
-	b11 := store.NewBlock(1, root)
-	b12 := store.NewBlock(2, root)
-	b21 := store.NewBlock(3, b11, b12)
-
-	t.Run("root has empty parent", func(t *testing.T) {
-		ts := requireTipset(t, root)
-		parent, e := chain.GetParentTipSet(ctx, store, ts)
-		require.NoError(t, e)
-		assert.Empty(t, parent)
-	})
-	t.Run("plural tipset", func(t *testing.T) {
-		ts := requireTipset(t, b11, b12)
-		parent, e := chain.GetParentTipSet(ctx, store, ts)
-		require.NoError(t, e)
-		assert.True(t, requireTipset(t, root).Equals(parent))
-	})
-	t.Run("plural parent", func(t *testing.T) {
-		ts := requireTipset(t, b21)
-		parent, e := chain.GetParentTipSet(ctx, store, ts)
-		require.NoError(t, e)
-		assert.True(t, requireTipset(t, b11, b12).Equals(parent))
-	})
-}
-
 func TestIterAncestors(t *testing.T) {
 	tf.UnitTest(t)
 
 	t.Run("iterates", func(t *testing.T) {
 		ctx := context.Background()
-		store := th.NewFakeBlockProvider()
+		store := th.NewFakeChainProvider()
 
 		root := store.NewBlock(0)
 		b11 := store.NewBlock(1, root)
@@ -78,7 +47,7 @@ func TestIterAncestors(t *testing.T) {
 
 	t.Run("respects context", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		store := th.NewFakeBlockProvider()
+		store := th.NewFakeChainProvider()
 
 		root := store.NewBlock(0)
 		b11 := store.NewBlock(1, root)

--- a/core/chains.go
+++ b/core/chains.go
@@ -11,7 +11,7 @@ import (
 // ancestor, collecting all blocks that are in one chain but not the other.
 // The resulting lists of blocks are ordered by decreasing height; the ordering of blocks with the same
 // height is undefined until https://github.com/filecoin-project/go-filecoin/issues/2310 is resolved.
-func CollectBlocksToCommonAncestor(ctx context.Context, store chain.BlockProvider, oldHead, newHead types.TipSet) (oldBlocks, newBlocks []*types.Block, err error) {
+func CollectBlocksToCommonAncestor(ctx context.Context, store chain.TipSetProvider, oldHead, newHead types.TipSet) (oldBlocks, newBlocks []*types.Block, err error) {
 	oldIter := chain.IterAncestors(ctx, store, oldHead)
 	newIter := chain.IterAncestors(ctx, store, newHead)
 

--- a/core/inbox_test.go
+++ b/core/inbox_test.go
@@ -5,16 +5,18 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/filecoin-project/go-filecoin/config"
-	"github.com/filecoin-project/go-filecoin/core"
-	th "github.com/filecoin-project/go-filecoin/testhelpers"
-	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
-	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-hamt-ipld"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/config"
+	"github.com/filecoin-project/go-filecoin/core"
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 func TestUpdateMessagePool(t *testing.T) {
@@ -406,6 +408,11 @@ func (p *fakeChainProvider) GetBlock(ctx context.Context, cid cid.Cid) (*types.B
 		return nil, errors.Wrapf(err, "failed to get block %s", cid)
 	}
 	return &blk, nil
+}
+
+func (p *fakeChainProvider) GetTipSet(tsKey types.SortedCidSet) (types.TipSet, error) {
+	ctx := context.TODO() // Should GetTipSet require a context everywhere?
+	return chain.LoadTipSetBlocks(ctx, p, tsKey)
 }
 
 func (p *fakeChainProvider) BlockHeight() (uint64, error) {

--- a/core/policy.go
+++ b/core/policy.go
@@ -37,14 +37,14 @@ type PolicyTarget interface {
 // ends up childless (in contrast to the message pool).
 type DefaultQueuePolicy struct {
 	// Provides blocks for chain traversal.
-	store chain.BlockProvider
+	store chain.TipSetProvider
 	// Maximum difference in message stamp from current block height before expiring an address's queue
 	maxAgeRounds uint64
 }
 
 // NewMessageQueuePolicy returns a new policy which removes mined messages from the queue and expires
 // messages older than `maxAgeTipsets` rounds.
-func NewMessageQueuePolicy(store chain.BlockProvider, maxAge uint64) *DefaultQueuePolicy {
+func NewMessageQueuePolicy(store chain.TipSetProvider, maxAge uint64) *DefaultQueuePolicy {
 	return &DefaultQueuePolicy{store, maxAge}
 }
 

--- a/core/policy_test.go
+++ b/core/policy_test.go
@@ -2,9 +2,10 @@ package core_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 
 	"github.com/filecoin-project/go-filecoin/core"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
@@ -34,7 +35,7 @@ func TestMessageQueuePolicy(t *testing.T) {
 	}
 
 	t.Run("old block does nothing", func(t *testing.T) {
-		blocks := th.NewFakeBlockProvider()
+		blocks := th.NewFakeChainProvider()
 		q := core.NewMessageQueue()
 		policy := core.NewMessageQueuePolicy(blocks, 10)
 
@@ -53,7 +54,7 @@ func TestMessageQueuePolicy(t *testing.T) {
 	})
 
 	t.Run("removes mined messages", func(t *testing.T) {
-		blocks := th.NewFakeBlockProvider()
+		blocks := th.NewFakeChainProvider()
 		q := core.NewMessageQueue()
 		policy := core.NewMessageQueuePolicy(blocks, 10)
 
@@ -98,7 +99,7 @@ func TestMessageQueuePolicy(t *testing.T) {
 	})
 
 	t.Run("expires old messages", func(t *testing.T) {
-		blocks := th.NewFakeBlockProvider()
+		blocks := th.NewFakeChainProvider()
 		q := core.NewMessageQueue()
 		policy := core.NewMessageQueuePolicy(blocks, 10)
 
@@ -132,7 +133,7 @@ func TestMessageQueuePolicy(t *testing.T) {
 	})
 
 	t.Run("fails when messages out of nonce order", func(t *testing.T) {
-		blocks := th.NewFakeBlockProvider()
+		blocks := th.NewFakeChainProvider()
 		q := core.NewMessageQueue()
 		policy := core.NewMessageQueuePolicy(blocks, 10)
 

--- a/tools/migration/migrations/repo-1-2/migration.go
+++ b/tools/migration/migrations/repo-1-2/migration.go
@@ -166,7 +166,8 @@ func (m *MetadataFormatJSONtoCBOR) convertJSONtoCBOR(ctx context.Context) error 
 		return errors.Wrap(err, "failed to add validated block to TipSet")
 	}
 
-	for iter := chain.IterAncestors(ctx, m.store, headTs); !iter.Complete(); err = iter.Next() {
+	tipsetProvider := chain.TipSetProviderFromBlocks(ctx, m.store)
+	for iter := chain.IterAncestors(ctx, tipsetProvider, headTs); !iter.Complete(); err = iter.Next() {
 		if err != nil {
 			return err
 		}
@@ -322,8 +323,8 @@ func compareChainStores(ctx context.Context, oldStore *migrationChainStore, newS
 		return errors.New("new and old head tipsets not equal")
 	}
 
-	oldIt := chain.IterAncestors(ctx, oldStore, oldHeadTs)
-	for newIt := chain.IterAncestors(ctx, newStore, newHeadTs); !newIt.Complete(); err = newIt.Next() {
+	oldIt := chain.IterAncestors(ctx, chain.TipSetProviderFromBlocks(ctx, oldStore), oldHeadTs)
+	for newIt := chain.IterAncestors(ctx, chain.TipSetProviderFromBlocks(ctx, newStore), newHeadTs); !newIt.Complete(); err = newIt.Next() {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
@ZenGround0 suggested that the chain traversals should use a TipsetProvider rather than BlockProvider so they could hit the store's tip index.

This allows most traversals to hit the in-memory tipset cache and bypass a heap of disk access and decoding. For the traversals that can't use an index, added an adaptor that builds tipsets on the fly from a block provider (i.e. the old way).