### PR TITLE
Feat/redeem payment command 2850

### DIFF
--- a/commands/deals.go
+++ b/commands/deals.go
@@ -1,0 +1,132 @@
+package commands
+
+import (
+	"io"
+	"strconv"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-ipfs-cmdkit"
+	"github.com/ipfs/go-ipfs-cmds"
+	"github.com/pkg/errors"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+var dealsCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Manage and inspect deals made by or with this node",
+	},
+	Subcommands: map[string]*cmds.Command{
+		"redeem": dealsRedeemCmd,
+	},
+}
+
+var dealsRedeemCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Redeem vouchers for a deal",
+		ShortDescription: `
+Redeem vouchers for FIL on the storage deal specified with the given deal CID.
+`,
+	},
+	Arguments: []cmdkit.Argument{
+		cmdkit.StringArg("dealid", true, false, "CID of the deal to redeem"),
+	},
+	Options: []cmdkit.Option{
+		cmdkit.StringOption("from", "Address to send from"),
+		priceOption,
+		limitOption,
+		previewOption,
+	},
+	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+		fromAddr, err := optionalAddr(req.Options["from"])
+		if err != nil {
+			return err
+		}
+
+		gasPrice, gasLimit, preview, err := parseGasOptions(req)
+		if err != nil {
+			return err
+		}
+
+		dealCid, err := cid.Parse(req.Arguments[0])
+		if err != nil {
+			return errors.Wrap(err, "invalid cid "+req.Arguments[0])
+		}
+
+		deal, err := GetPorcelainAPI(env).DealGet(req.Context, dealCid)
+		if err != nil {
+			return err
+		}
+
+		currentBlockHeight, err := GetPorcelainAPI(env).ChainBlockHeight()
+		if err != nil {
+			return err
+		}
+
+		var voucher *types.PaymentVoucher
+		for _, v := range deal.Proposal.Payment.Vouchers {
+			if v.ValidAt.LessThan(currentBlockHeight) {
+				continue
+			}
+			if voucher != nil && v.Amount.LessThan(&voucher.Amount) {
+				continue
+			}
+			voucher = v
+		}
+
+		if voucher == nil {
+			return errors.New("no remaining redeemable vouchers found")
+		}
+
+		result := &RedeemResult{Preview: preview}
+
+		params := []interface{}{
+			voucher.Payer,
+			&voucher.Channel,
+			&voucher.Amount,
+			&voucher.ValidAt,
+			voucher.Condition,
+			[]byte(voucher.Signature),
+			[]interface{}{},
+		}
+
+		if preview {
+			result.GasUsed, err = GetPorcelainAPI(env).MessagePreview(
+				req.Context,
+				fromAddr,
+				address.PaymentBrokerAddress,
+				"redeem",
+				params...,
+			)
+		} else {
+			result.Cid, err = GetPorcelainAPI(env).MessageSendWithDefaultAddress(
+				req.Context,
+				fromAddr,
+				address.PaymentBrokerAddress,
+				types.NewAttoFILFromFIL(0),
+				gasPrice,
+				gasLimit,
+				"redeem",
+				params...,
+			)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return re.Emit(result)
+	},
+	Type: RedeemResult{},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *RedeemResult) error {
+			if res.Preview {
+				output := strconv.FormatUint(uint64(res.GasUsed), 10)
+				_, err := w.Write([]byte(output))
+				return err
+			}
+			return PrintString(w, res.Cid)
+		}),
+	},
+}

--- a/commands/deals_daemon_test.go
+++ b/commands/deals_daemon_test.go
@@ -51,6 +51,9 @@ func TestDealsRedeem(t *testing.T) {
 	err = series.WaitForDealState(ctx, clientDaemon, dealResponse, storagedeal.Posted)
 	require.NoError(t, err)
 
+	// Stop mining to guarantee the miner doesn't receive any block rewards
+	require.NoError(t, minerDaemon.MiningStop(ctx))
+
 	minerOwnerAddresses, err := minerDaemon.AddressLs(ctx)
 	require.NoError(t, err)
 	minerOwnerAddress := minerOwnerAddresses[0]
@@ -67,6 +70,6 @@ func TestDealsRedeem(t *testing.T) {
 	newWalletBalance, err := minerDaemon.WalletBalance(ctx, minerOwnerAddress)
 	require.NoError(t, err)
 
-	actualBalanceDiff := newWalletBalance.Sub(oldWalletBalance).String()
-	assert.Equal(t, "11.8999999999999998", actualBalanceDiff)
+	actualBalanceDiff := newWalletBalance.Sub(oldWalletBalance)
+	assert.Equal(t, "11.9", actualBalanceDiff.String())
 }

--- a/commands/deals_daemon_test.go
+++ b/commands/deals_daemon_test.go
@@ -26,26 +26,19 @@ func TestDealsRedeem(t *testing.T) {
 		require.NoError(t, env.Teardown(ctx))
 	}()
 
-	require.NoError(t, env.GenesisMiner.MiningStart(ctx))
-
-	clientDaemon := env.RequireNewNodeWithFunds(10000)
+	clientDaemon := env.GenesisMiner
 	minerDaemon := env.RequireNewNodeWithFunds(10000)
 
+	require.NoError(t, clientDaemon.MiningStart(ctx))
+
 	collateral := big.NewInt(int64(1))
-	price := big.NewFloat(float64(0.001))
+	price := big.NewFloat(float64(1))
 	expiry := big.NewInt(int64(10000))
 	_, err := series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, price, expiry)
 	require.NoError(t, err)
 
 	f := files.NewBytesFile([]byte("HODLHODLHODL"))
 	dataCid, err := clientDaemon.ClientImport(ctx, f)
-	require.NoError(t, err)
-
-	minerOwnerAddresses, err := minerDaemon.AddressLs(ctx)
-	require.NoError(t, err)
-	minerOwnerAddress := minerOwnerAddresses[0]
-
-	oldWalletBalance, err := minerDaemon.WalletBalance(ctx, minerOwnerAddress)
 	require.NoError(t, err)
 
 	var minerAddress address.Address
@@ -58,6 +51,13 @@ func TestDealsRedeem(t *testing.T) {
 	err = series.WaitForDealState(ctx, clientDaemon, dealResponse, storagedeal.Posted)
 	require.NoError(t, err)
 
+	minerOwnerAddresses, err := minerDaemon.AddressLs(ctx)
+	require.NoError(t, err)
+	minerOwnerAddress := minerOwnerAddresses[0]
+
+	oldWalletBalance, err := minerDaemon.WalletBalance(ctx, minerOwnerAddress)
+	require.NoError(t, err)
+
 	redeemCid, err := minerDaemon.DealsRedeem(ctx, dealResponse.ProposalCid, fast.AOPrice(big.NewFloat(0.001)), fast.AOLimit(100))
 	require.NoError(t, err)
 
@@ -68,5 +68,5 @@ func TestDealsRedeem(t *testing.T) {
 	require.NoError(t, err)
 
 	actualBalanceDiff := newWalletBalance.Sub(oldWalletBalance).String()
-	assert.Equal(t, "1000.0119999999999998", actualBalanceDiff)
+	assert.Equal(t, "11.8999999999999998", actualBalanceDiff)
 }

--- a/commands/deals_daemon_test.go
+++ b/commands/deals_daemon_test.go
@@ -1,0 +1,59 @@
+package commands_test
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/fixtures"
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+)
+
+func TestDealsRedeem(t *testing.T) {
+	tf.IntegrationTest(t)
+
+	clientDaemon := th.NewDaemon(t,
+		th.KeyFile(fixtures.KeyFilePaths()[1]),
+		th.DefaultAddress(fixtures.TestAddresses[1]),
+	).Start()
+	defer clientDaemon.ShutdownSuccess()
+
+	minerDaemon := th.NewDaemon(t,
+		th.WithMiner(fixtures.TestMiners[0]),
+		th.KeyFile(fixtures.KeyFilePaths()[0]),
+		th.DefaultAddress(fixtures.TestAddresses[0]),
+		th.AutoSealInterval("1"),
+	).Start()
+	defer minerDaemon.ShutdownSuccess()
+
+	minerDaemon.RunSuccess("mining", "start")
+	minerDaemon.UpdatePeerID()
+
+	minerDaemon.ConnectSuccess(clientDaemon)
+
+	addAskCid := minerDaemon.MinerSetPrice(fixtures.TestMiners[0], fixtures.TestAddresses[0], "20", "10")
+	clientDaemon.WaitForMessageRequireSuccess(addAskCid)
+	dataCid := clientDaemon.RunWithStdin(strings.NewReader("HODLHODLHODL"), "client", "import").ReadStdoutTrimNewlines()
+
+	proposeDealOutput := clientDaemon.RunSuccess("client", "propose-storage-deal", fixtures.TestMiners[0], dataCid, "0", "5").ReadStdoutTrimNewlines()
+
+	splitOnSpace := strings.Split(proposeDealOutput, " ")
+	dealCid := splitOnSpace[len(splitOnSpace)-1]
+
+	walletBalanceOutput := minerDaemon.RunSuccess("wallet", "balance", fixtures.TestAddresses[0]).ReadStdoutTrimNewlines()
+	oldWalletBalance, err := strconv.ParseFloat(walletBalanceOutput, 64)
+	require.NoError(t, err)
+
+	redeemCid := minerDaemon.RunSuccess("deals", "redeem", dealCid, "--gas-price", "1", "--gas-limit", "100").ReadStdoutTrimNewlines()
+	minerDaemon.RunSuccess("message", "wait", redeemCid)
+
+	walletBalanceOutput = minerDaemon.RunSuccess("wallet", "balance", fixtures.TestAddresses[0]).ReadStdoutTrimNewlines()
+	newWalletBalance, err := strconv.ParseFloat(walletBalanceOutput, 64)
+	require.NoError(t, err)
+
+	assert.Equal(t, float64(1000), (newWalletBalance - oldWalletBalance))
+}

--- a/commands/main.go
+++ b/commands/main.go
@@ -106,6 +106,7 @@ MINE
 VIEW DATA STRUCTURES
   go-filecoin chain                  - Inspect the filecoin blockchain
   go-filecoin dag                    - Interact with IPLD DAG objects
+  go-filecoin deals                  - Manage deals made by or with this node
   go-filecoin show                   - Get human-readable representations of filecoin objects
 
 NETWORK COMMANDS
@@ -164,6 +165,7 @@ var rootSubcmdsDaemon = map[string]*cmds.Command{
 	"config":           configCmd,
 	"client":           clientCmd,
 	"dag":              dagCmd,
+	"deals":            dealsCmd,
 	"dht":              dhtCmd,
 	"id":               idCmd,
 	"inspect":          inspectCmd,

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -64,6 +64,18 @@ func (a *API) DealGet(ctx context.Context, proposalCid cid.Cid) (*storagedeal.De
 	return DealGet(ctx, a, proposalCid)
 }
 
+// DealRedeem redeems a voucher for the deal with the given cid and returns
+// either the cid of the created redeem message or an error
+func (a *API) DealRedeem(ctx context.Context, fromAddr address.Address, dealCid cid.Cid, gasPrice types.AttoFIL, gasLimit types.GasUnits) (cid.Cid, error) {
+	return DealRedeem(ctx, a, fromAddr, dealCid, gasPrice, gasLimit)
+}
+
+// DealRedeemPreview previews the redeem method for a deal and returns the
+// expected gas used
+func (a *API) DealRedeemPreview(ctx context.Context, fromAddr address.Address, dealCid cid.Cid) (types.GasUnits, error) {
+	return DealRedeemPreview(ctx, a, fromAddr, dealCid)
+}
+
 // DealsLs returns a channel with all deals
 func (a *API) DealsLs(ctx context.Context) (<-chan *StorageDealLsResult, error) {
 	return DealsLs(ctx, a)

--- a/porcelain/storagedeals.go
+++ b/porcelain/storagedeals.go
@@ -147,7 +147,7 @@ type dealRedeemPlumbing interface {
 	ChainBlockHeight() (*types.BlockHeight, error)
 	DealGet(context.Context, cid.Cid) (*storagedeal.Deal, error)
 	MessagePreview(context.Context, address.Address, address.Address, string, ...interface{}) (types.GasUnits, error)
-	MessageSendWithDefaultAddress(context.Context, address.Address, address.Address, *types.AttoFIL, types.AttoFIL, types.GasUnits, string, ...interface{}) (cid.Cid, error)
+	MessageSendWithDefaultAddress(context.Context, address.Address, address.Address, types.AttoFIL, types.AttoFIL, types.GasUnits, string, ...interface{}) (cid.Cid, error)
 }
 
 // DealRedeem redeems a voucher for the deal with the given cid and returns
@@ -203,7 +203,7 @@ func buildDealRedeemParams(ctx context.Context, plumbing dealRedeemPlumbing, dea
 		if currentBlockHeight.LessThan(&v.ValidAt) {
 			continue
 		}
-		if voucher != nil && v.Amount.LessThan(&voucher.Amount) {
+		if voucher != nil && v.Amount.LessThan(voucher.Amount) {
 			continue
 		}
 		voucher = v
@@ -216,7 +216,7 @@ func buildDealRedeemParams(ctx context.Context, plumbing dealRedeemPlumbing, dea
 	return []interface{}{
 		voucher.Payer,
 		&voucher.Channel,
-		&voucher.Amount,
+		voucher.Amount,
 		&voucher.ValidAt,
 		voucher.Condition,
 		[]byte(voucher.Signature),

--- a/porcelain/storagedeals.go
+++ b/porcelain/storagedeals.go
@@ -8,7 +8,9 @@ import (
 	cbor "github.com/ipfs/go-ipld-cbor"
 	errors "github.com/pkg/errors"
 
+	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 var (
@@ -139,4 +141,85 @@ func filterDealChannel(dealCh <-chan *StorageDealLsResult, filterFunc func(*stor
 	}()
 
 	return outCh
+}
+
+type dealRedeemPlumbing interface {
+	ChainBlockHeight() (*types.BlockHeight, error)
+	DealGet(context.Context, cid.Cid) (*storagedeal.Deal, error)
+	MessagePreview(context.Context, address.Address, address.Address, string, ...interface{}) (types.GasUnits, error)
+	MessageSendWithDefaultAddress(context.Context, address.Address, address.Address, *types.AttoFIL, types.AttoFIL, types.GasUnits, string, ...interface{}) (cid.Cid, error)
+}
+
+// DealRedeem redeems a voucher for the deal with the given cid and returns
+// either the cid of the created redeem message or an error
+func DealRedeem(ctx context.Context, plumbing dealRedeemPlumbing, fromAddr address.Address, dealCid cid.Cid, gasPrice types.AttoFIL, gasLimit types.GasUnits) (cid.Cid, error) {
+	params, err := buildDealRedeemParams(ctx, plumbing, dealCid)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	return plumbing.MessageSendWithDefaultAddress(
+		ctx,
+		fromAddr,
+		address.PaymentBrokerAddress,
+		types.NewAttoFILFromFIL(0),
+		gasPrice,
+		gasLimit,
+		"redeem",
+		params...,
+	)
+}
+
+// DealRedeemPreview previews the redeem method for a deal and returns the
+// expected gas used
+func DealRedeemPreview(ctx context.Context, plumbing dealRedeemPlumbing, fromAddr address.Address, dealCid cid.Cid) (types.GasUnits, error) {
+	params, err := buildDealRedeemParams(ctx, plumbing, dealCid)
+	if err != nil {
+		return types.NewGasUnits(0), err
+	}
+
+	return plumbing.MessagePreview(
+		ctx,
+		fromAddr,
+		address.PaymentBrokerAddress,
+		"redeem",
+		params...,
+	)
+}
+
+func buildDealRedeemParams(ctx context.Context, plumbing dealRedeemPlumbing, dealCid cid.Cid) ([]interface{}, error) {
+	deal, err := plumbing.DealGet(ctx, dealCid)
+	if err != nil {
+		return []interface{}{}, err
+	}
+
+	currentBlockHeight, err := plumbing.ChainBlockHeight()
+	if err != nil {
+		return []interface{}{}, err
+	}
+
+	var voucher *types.PaymentVoucher
+	for _, v := range deal.Proposal.Payment.Vouchers {
+		if currentBlockHeight.LessThan(&v.ValidAt) {
+			continue
+		}
+		if voucher != nil && v.Amount.LessThan(&voucher.Amount) {
+			continue
+		}
+		voucher = v
+	}
+
+	if voucher == nil {
+		return []interface{}{}, errors.New("no remaining redeemable vouchers found")
+	}
+
+	return []interface{}{
+		voucher.Payer,
+		&voucher.Channel,
+		&voucher.Amount,
+		&voucher.ValidAt,
+		voucher.Condition,
+		[]byte(voucher.Signature),
+		[]interface{}{},
+	}, nil
 }

--- a/porcelain/storagedeals_test.go
+++ b/porcelain/storagedeals_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -138,4 +139,163 @@ func TestDealMinerLs(t *testing.T) {
 	}
 	assert.NotContains(t, results, clientDeal)
 	assert.Contains(t, results, minerDeal)
+}
+
+type testRedeemPlumbing struct {
+	t *testing.T
+
+	blockHeight     *types.BlockHeight
+	dealCid         cid.Cid
+	expectedVoucher *types.PaymentVoucher
+	fromAddr        address.Address
+	gasPrice        types.GasUnits
+	messageCid      cid.Cid
+	vouchers        []*types.PaymentVoucher
+}
+
+func (trp *testRedeemPlumbing) ChainBlockHeight() (*types.BlockHeight, error) {
+	return trp.blockHeight, nil
+}
+
+func (trp *testRedeemPlumbing) DealGet(_ context.Context, c cid.Cid) (*storagedeal.Deal, error) {
+	require.Equal(trp.t, trp.dealCid, c)
+
+	deal := &storagedeal.Deal{
+		Proposal: &storagedeal.Proposal{
+			Payment: storagedeal.PaymentInfo{
+				Vouchers: trp.vouchers,
+			},
+		},
+	}
+
+	return deal, nil
+}
+
+func (trp *testRedeemPlumbing) MessagePreview(_ context.Context, fromAddr address.Address, actorAddr address.Address, method string, params ...interface{}) (types.GasUnits, error) {
+	require.Equal(trp.t, trp.fromAddr, fromAddr)
+	require.Equal(trp.t, address.PaymentBrokerAddress, actorAddr)
+	require.Equal(trp.t, "redeem", method)
+	require.Equal(trp.t, []interface{}{
+		trp.expectedVoucher.Payer,
+		&trp.expectedVoucher.Channel,
+		&trp.expectedVoucher.Amount,
+		&trp.expectedVoucher.ValidAt,
+		trp.expectedVoucher.Condition,
+		[]byte(trp.expectedVoucher.Signature),
+		[]interface{}{},
+	}, params)
+	return trp.gasPrice, nil
+}
+
+func (trp *testRedeemPlumbing) MessageSendWithDefaultAddress(_ context.Context, fromAddr address.Address, actorAddr address.Address, _ *types.AttoFIL, _ types.AttoFIL, _ types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+	require.Equal(trp.t, trp.fromAddr, fromAddr)
+	require.Equal(trp.t, address.PaymentBrokerAddress, actorAddr)
+	require.Equal(trp.t, "redeem", method)
+	require.Equal(trp.t, []interface{}{
+		trp.expectedVoucher.Payer,
+		&trp.expectedVoucher.Channel,
+		&trp.expectedVoucher.Amount,
+		&trp.expectedVoucher.ValidAt,
+		trp.expectedVoucher.Condition,
+		[]byte(trp.expectedVoucher.Signature),
+		[]interface{}{},
+	}, params)
+	return trp.messageCid, nil
+}
+
+func TestDealRedeem(t *testing.T) {
+	tf.UnitTest(t)
+
+	addressGetter := address.NewForTestGetter()
+	cidGetter := types.NewCidForTestGetter()
+	dealCid := cidGetter()
+	messageCid := cidGetter()
+	fromAddr := addressGetter()
+	payerAddr := addressGetter()
+	channelID := *types.NewChannelID(0)
+	tooSmallVoucher := &types.PaymentVoucher{
+		Payer:   payerAddr,
+		Channel: channelID,
+		Amount:  *types.NewAttoFILFromFIL(1),
+		ValidAt: *types.NewBlockHeight(10),
+	}
+	expectedVoucher := &types.PaymentVoucher{
+		Payer:   payerAddr,
+		Channel: channelID,
+		Amount:  *types.NewAttoFILFromFIL(2),
+		ValidAt: *types.NewBlockHeight(20),
+	}
+	notYetValidVoucher := &types.PaymentVoucher{
+		Payer:   payerAddr,
+		Channel: channelID,
+		Amount:  *types.NewAttoFILFromFIL(3),
+		ValidAt: *types.NewBlockHeight(30),
+	}
+	vouchers := []*types.PaymentVoucher{
+		tooSmallVoucher,
+		expectedVoucher,
+		notYetValidVoucher,
+	}
+	plumbing := &testRedeemPlumbing{
+		t:               t,
+		blockHeight:     types.NewBlockHeight(25),
+		dealCid:         dealCid,
+		expectedVoucher: expectedVoucher,
+		fromAddr:        fromAddr,
+		messageCid:      messageCid,
+		vouchers:        vouchers,
+	}
+
+	resultCid, err := porcelain.DealRedeem(context.Background(), plumbing, fromAddr, dealCid, *types.NewAttoFILFromFIL(0), types.NewGasUnits(0))
+	require.NoError(t, err)
+
+	assert.Equal(t, messageCid, resultCid)
+}
+
+func TestDealRedeemPreview(t *testing.T) {
+	tf.UnitTest(t)
+
+	addressGetter := address.NewForTestGetter()
+	cidGetter := types.NewCidForTestGetter()
+	dealCid := cidGetter()
+	fromAddr := addressGetter()
+	payerAddr := addressGetter()
+	channelID := *types.NewChannelID(0)
+	tooSmallVoucher := &types.PaymentVoucher{
+		Payer:   payerAddr,
+		Channel: channelID,
+		Amount:  *types.NewAttoFILFromFIL(1),
+		ValidAt: *types.NewBlockHeight(10),
+	}
+	expectedVoucher := &types.PaymentVoucher{
+		Payer:   payerAddr,
+		Channel: channelID,
+		Amount:  *types.NewAttoFILFromFIL(2),
+		ValidAt: *types.NewBlockHeight(20),
+	}
+	notYetValidVoucher := &types.PaymentVoucher{
+		Payer:   payerAddr,
+		Channel: channelID,
+		Amount:  *types.NewAttoFILFromFIL(3),
+		ValidAt: *types.NewBlockHeight(30),
+	}
+	vouchers := []*types.PaymentVoucher{
+		tooSmallVoucher,
+		expectedVoucher,
+		notYetValidVoucher,
+	}
+	plumbing := &testRedeemPlumbing{
+		t:               t,
+		blockHeight:     types.NewBlockHeight(25),
+		dealCid:         dealCid,
+		expectedVoucher: expectedVoucher,
+		fromAddr:        fromAddr,
+		gasPrice:        types.NewGasUnits(42),
+		vouchers:        vouchers,
+	}
+
+	resultGasPrice, err := porcelain.DealRedeemPreview(context.Background(), plumbing, fromAddr, dealCid)
+	require.NoError(t, err)
+
+	assert.Equal(t, types.NewGasUnits(42), resultGasPrice)
 }

--- a/porcelain/storagedeals_test.go
+++ b/porcelain/storagedeals_test.go
@@ -178,7 +178,7 @@ func (trp *testRedeemPlumbing) MessagePreview(_ context.Context, fromAddr addres
 	require.Equal(trp.t, []interface{}{
 		trp.expectedVoucher.Payer,
 		&trp.expectedVoucher.Channel,
-		&trp.expectedVoucher.Amount,
+		trp.expectedVoucher.Amount,
 		&trp.expectedVoucher.ValidAt,
 		trp.expectedVoucher.Condition,
 		[]byte(trp.expectedVoucher.Signature),
@@ -187,14 +187,14 @@ func (trp *testRedeemPlumbing) MessagePreview(_ context.Context, fromAddr addres
 	return trp.gasPrice, nil
 }
 
-func (trp *testRedeemPlumbing) MessageSendWithDefaultAddress(_ context.Context, fromAddr address.Address, actorAddr address.Address, _ *types.AttoFIL, _ types.AttoFIL, _ types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+func (trp *testRedeemPlumbing) MessageSendWithDefaultAddress(_ context.Context, fromAddr address.Address, actorAddr address.Address, _ types.AttoFIL, _ types.AttoFIL, _ types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 	require.Equal(trp.t, trp.fromAddr, fromAddr)
 	require.Equal(trp.t, address.PaymentBrokerAddress, actorAddr)
 	require.Equal(trp.t, "redeem", method)
 	require.Equal(trp.t, []interface{}{
 		trp.expectedVoucher.Payer,
 		&trp.expectedVoucher.Channel,
-		&trp.expectedVoucher.Amount,
+		trp.expectedVoucher.Amount,
 		&trp.expectedVoucher.ValidAt,
 		trp.expectedVoucher.Condition,
 		[]byte(trp.expectedVoucher.Signature),
@@ -216,19 +216,19 @@ func TestDealRedeem(t *testing.T) {
 	tooSmallVoucher := &types.PaymentVoucher{
 		Payer:   payerAddr,
 		Channel: channelID,
-		Amount:  *types.NewAttoFILFromFIL(1),
+		Amount:  types.NewAttoFILFromFIL(1),
 		ValidAt: *types.NewBlockHeight(10),
 	}
 	expectedVoucher := &types.PaymentVoucher{
 		Payer:   payerAddr,
 		Channel: channelID,
-		Amount:  *types.NewAttoFILFromFIL(2),
+		Amount:  types.NewAttoFILFromFIL(2),
 		ValidAt: *types.NewBlockHeight(20),
 	}
 	notYetValidVoucher := &types.PaymentVoucher{
 		Payer:   payerAddr,
 		Channel: channelID,
-		Amount:  *types.NewAttoFILFromFIL(3),
+		Amount:  types.NewAttoFILFromFIL(3),
 		ValidAt: *types.NewBlockHeight(30),
 	}
 	vouchers := []*types.PaymentVoucher{
@@ -246,7 +246,7 @@ func TestDealRedeem(t *testing.T) {
 		vouchers:        vouchers,
 	}
 
-	resultCid, err := porcelain.DealRedeem(context.Background(), plumbing, fromAddr, dealCid, *types.NewAttoFILFromFIL(0), types.NewGasUnits(0))
+	resultCid, err := porcelain.DealRedeem(context.Background(), plumbing, fromAddr, dealCid, types.NewAttoFILFromFIL(0), types.NewGasUnits(0))
 	require.NoError(t, err)
 
 	assert.Equal(t, messageCid, resultCid)
@@ -264,19 +264,19 @@ func TestDealRedeemPreview(t *testing.T) {
 	tooSmallVoucher := &types.PaymentVoucher{
 		Payer:   payerAddr,
 		Channel: channelID,
-		Amount:  *types.NewAttoFILFromFIL(1),
+		Amount:  types.NewAttoFILFromFIL(1),
 		ValidAt: *types.NewBlockHeight(10),
 	}
 	expectedVoucher := &types.PaymentVoucher{
 		Payer:   payerAddr,
 		Channel: channelID,
-		Amount:  *types.NewAttoFILFromFIL(2),
+		Amount:  types.NewAttoFILFromFIL(2),
 		ValidAt: *types.NewBlockHeight(20),
 	}
 	notYetValidVoucher := &types.PaymentVoucher{
 		Payer:   payerAddr,
 		Channel: channelID,
-		Amount:  *types.NewAttoFILFromFIL(3),
+		Amount:  types.NewAttoFILFromFIL(3),
 		ValidAt: *types.NewBlockHeight(30),
 	}
 	vouchers := []*types.PaymentVoucher{

--- a/tools/fast/action_deals.go
+++ b/tools/fast/action_deals.go
@@ -9,9 +9,9 @@ import (
 )
 
 // DealsRedeem runs the `deals redeem` command against the filecoin process.
-func (f *Filecoin) DealsRedeem(ctx context.Context, dealCid string, options ...ActionOption) (cid.Cid, error) {
+func (f *Filecoin) DealsRedeem(ctx context.Context, dealCid cid.Cid, options ...ActionOption) (cid.Cid, error) {
 	var out commands.RedeemResult
-	args := []string{"go-filecoin", "deals", "redeem", dealCid}
+	args := []string{"go-filecoin", "deals", "redeem", dealCid.String()}
 
 	for _, option := range options {
 		args = append(args, option()...)

--- a/tools/fast/action_deals.go
+++ b/tools/fast/action_deals.go
@@ -1,0 +1,25 @@
+package fast
+
+import (
+	"context"
+
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/go-filecoin/commands"
+)
+
+// DealsRedeem runs the `deals redeem` command against the filecoin process.
+func (f *Filecoin) DealsRedeem(ctx context.Context, dealCid string, options ...ActionOption) (cid.Cid, error) {
+	var out commands.RedeemResult
+	args := []string{"go-filecoin", "deals", "redeem", dealCid}
+
+	for _, option := range options {
+		args = append(args, option()...)
+	}
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
+		return cid.Undef, err
+	}
+
+	return out.Cid, nil
+}


### PR DESCRIPTION
# Problem

We don't have a simple way for users to redeem vouchers for a given storage deal.

# Solution

Create a `go-filecoin deals redeem` command for redeeming the first valid voucher on a given deal.

Resolves #2850 