### PR TITLE
move BlockTime to plumbing add BlockClock interface

### DIFF
--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -95,7 +95,7 @@ func daemonRun(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment)
 	if err != nil {
 		return errors.Wrap(err, "Bad block time passed")
 	}
-	opts = append(opts, node.BlockTime(blockTime))
+	opts = append(opts, node.BlockClock(blockTime))
 
 	fcn, err := node.New(req.Context, opts...)
 	if err != nil {

--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -19,9 +19,9 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/config"
-	"github.com/filecoin-project/go-filecoin/mining"
 	"github.com/filecoin-project/go-filecoin/node"
 	"github.com/filecoin-project/go-filecoin/paths"
+	"github.com/filecoin-project/go-filecoin/plumbing/clock"
 	"github.com/filecoin-project/go-filecoin/repo"
 )
 
@@ -38,7 +38,7 @@ var daemonCmd = &cmds.Command{
 		cmdkit.BoolOption(OfflineMode, "start the node without networking"),
 		cmdkit.BoolOption(ELStdout),
 		cmdkit.BoolOption(IsRelay, "advertise and allow filecoin network traffic to be relayed through this node"),
-		cmdkit.StringOption(BlockTime, "time a node waits before trying to mine the next block").WithDefault(mining.DefaultBlockTime.String()),
+		cmdkit.StringOption(BlockTime, "time a node waits before trying to mine the next block").WithDefault(clock.DefaultBlockTime.String()),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		return daemonRun(req, re, env)
@@ -95,7 +95,7 @@ func daemonRun(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment)
 	if err != nil {
 		return errors.Wrap(err, "Bad block time passed")
 	}
-	opts = append(opts, node.BlockClock(blockTime))
+	opts = append(opts, node.BlockClock(clock.NewConfiguredBlockClock(blockTime)))
 
 	fcn, err := node.New(req.Context, opts...)
 	if err != nil {

--- a/consensus/block_validation.go
+++ b/consensus/block_validation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/filecoin-project/go-filecoin/plumbing/clock"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -49,16 +50,14 @@ func (ebc *DefaultBlockValidationClock) EpochSeconds() uint64 {
 
 // DefaultBlockValidator implements the BlockValidator interface.
 type DefaultBlockValidator struct {
-	clock     BlockValidationClock
-	blockTime time.Duration
+	clock clock.BlockClock
 }
 
 // NewDefaultBlockValidator returns a new DefaultBlockValidator. It uses `blkTime`
 // to validate blocks and uses the DefaultBlockValidationClock.
-func NewDefaultBlockValidator(blkTime time.Duration) *DefaultBlockValidator {
+func NewDefaultBlockValidator(c clock.BlockClock) *DefaultBlockValidator {
 	return &DefaultBlockValidator{
-		clock:     NewDefaultBlockValidationClock(),
-		blockTime: blkTime,
+		clock: c,
 	}
 }
 
@@ -83,5 +82,5 @@ func (dv *DefaultBlockValidator) ValidateSyntax(ctx context.Context, blk *types.
 // BlockTime returns the block time the DefaultBlockValidator uses to validate
 /// blocks against.
 func (dv *DefaultBlockValidator) BlockTime() time.Duration {
-	return dv.blockTime
+	return dv.clock.BlockTime()
 }

--- a/mining/worker.go
+++ b/mining/worker.go
@@ -23,10 +23,6 @@ import (
 
 var log = logging.Logger("mining")
 
-// DefaultBlockTime is the estimated proving period time.
-// We define this so that we can fake mining in the current incomplete system.
-const DefaultBlockTime = 30 * time.Second
-
 // Output is the result of a single mining run. It has either a new
 // block or an error, mimicing the golang (retVal, error) pattern.
 // If a mining run's context is canceled there is no output.

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -57,7 +57,7 @@ func Test_Mine(t *testing.T) {
 		outCh := make(chan mining.Output)
 		worker := mining.NewDefaultWorkerWithDeps(
 			pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(), mining.NewTestPowerTableView(1),
-			bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest,
+			bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewTestBlockClock(),
 			CreatePoSTFunc)
 
 		go worker.Mine(ctx, tipSet, 0, outCh)
@@ -70,7 +70,7 @@ func Test_Mine(t *testing.T) {
 		doSomeWorkCalled = false
 		ctx, cancel := context.WithCancel(context.Background())
 		worker := mining.NewDefaultWorkerWithDeps(pool, makeExplodingGetStateTree(st), getWeightTest, getAncestors, th.NewTestProcessor(),
-			mining.NewTestPowerTableView(1), bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+			mining.NewTestPowerTableView(1), bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewTestBlockClock(), CreatePoSTFunc)
 		outCh := make(chan mining.Output)
 		doSomeWorkCalled = false
 		go worker.Mine(ctx, tipSet, 0, outCh)
@@ -85,7 +85,7 @@ func Test_Mine(t *testing.T) {
 		doSomeWorkCalled = false
 		ctx, cancel := context.WithCancel(context.Background())
 		worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(),
-			mining.NewTestPowerTableView(1), bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+			mining.NewTestPowerTableView(1), bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewTestBlockClock(), CreatePoSTFunc)
 		input := types.TipSet{}
 		outCh := make(chan mining.Output)
 		go worker.Mine(ctx, input, 0, outCh)
@@ -212,7 +212,7 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 	minerOwnerAddr := addrs[3]
 
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(),
-		&th.TestView{}, bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+		&th.TestView{}, bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewTestBlockClock(), CreatePoSTFunc)
 
 	parents := types.NewSortedCidSet(newCid())
 	stateRoot := newCid()
@@ -255,7 +255,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		return nil, nil
 	}
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(),
-		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.NewTestBlockClock(), CreatePoSTFunc)
 
 	// addr3 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
 	msg1 := types.NewMessage(addrs[2], addrs[0], 0, nil, "", nil)
@@ -337,7 +337,7 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 	minerAddr := addrs[4]
 	minerOwnerAddr := addrs[3]
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(),
-		&th.TestView{}, bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+		&th.TestView{}, bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewTestBlockClock(), CreatePoSTFunc)
 
 	h := types.Uint64(100)
 	w := types.Uint64(1000)
@@ -379,7 +379,7 @@ func TestGenerateWithoutMessages(t *testing.T) {
 		return nil, nil
 	}
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(),
-		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.NewTestBlockClock(), CreatePoSTFunc)
 
 	assert.Len(t, pool.Pending(), 0)
 	baseBlock := types.Block{
@@ -413,7 +413,7 @@ func TestGenerateError(t *testing.T) {
 	}
 	worker := mining.NewDefaultWorkerWithDeps(pool, makeExplodingGetStateTree(st), getWeightTest, getAncestors,
 		consensus.NewDefaultProcessor(),
-		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.NewTestBlockClock(), CreatePoSTFunc)
 
 	// This is actually okay and should result in a receipt
 	msg := types.NewMessage(addrs[0], addrs[1], 0, nil, "", nil)

--- a/node/node.go
+++ b/node/node.go
@@ -214,9 +214,9 @@ func IsRelay() ConfigOpt {
 }
 
 // BlockClock sets the clock.
-func BlockClock(blockTime time.Duration) ConfigOpt {
+func BlockClock(clk clock.BlockClock) ConfigOpt {
 	return func(c *Config) error {
-		c.Clock = clock.NewDefaultBlockClock(blockTime)
+		c.Clock = clk
 		return nil
 	}
 }
@@ -381,7 +381,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 	// DO NOT MERGE this code smells like poo, this smell exists elsewhere,
 	// should have defaults set on it _before_ we get here?
 	if nc.Clock == nil {
-		nc.Clock = clock.NewDefaultBlockClock(mining.DefaultBlockTime)
+		nc.Clock = clock.NewDefaultBlockClock()
 	}
 
 	// setup block validation

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -198,7 +198,7 @@ func TestNodeConfig(t *testing.T) {
 	configOptions := []node.ConfigOpt{
 		repoConfig(),
 		node.VerifierConfigOption(verifier),
-		node.BlockTime(time.Duration(configBlockTime)),
+		node.BlockClock(time.Duration(configBlockTime)),
 	}
 
 	initOpts := []node.InitOpt{node.AutoSealIntervalSecondsOpt(120)}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/mining"
 	"github.com/filecoin-project/go-filecoin/node"
+	"github.com/filecoin-project/go-filecoin/plumbing/clock"
 	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/protocol/storage"
 	"github.com/filecoin-project/go-filecoin/repo"
@@ -198,7 +199,7 @@ func TestNodeConfig(t *testing.T) {
 	configOptions := []node.ConfigOpt{
 		repoConfig(),
 		node.VerifierConfigOption(verifier),
-		node.BlockClock(time.Duration(configBlockTime)),
+		node.BlockClock(clock.NewConfiguredBlockClock(time.Duration(configBlockTime))),
 	}
 
 	initOpts := []node.InitOpt{node.AutoSealIntervalSecondsOpt(120)}

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -25,6 +25,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/net"
 	"github.com/filecoin-project/go-filecoin/net/pubsub"
 	"github.com/filecoin-project/go-filecoin/plumbing/cfg"
+	"github.com/filecoin-project/go-filecoin/plumbing/clock"
 	"github.com/filecoin-project/go-filecoin/plumbing/cst"
 	"github.com/filecoin-project/go-filecoin/plumbing/dag"
 	"github.com/filecoin-project/go-filecoin/plumbing/msg"
@@ -45,6 +46,7 @@ type API struct {
 
 	bitswap      exchange.Interface
 	chain        *cst.ChainStateProvider
+	clock        clock.BlockClock
 	config       *cfg.Config
 	dag          *dag.DAG
 	msgPool      *core.MessagePool
@@ -61,6 +63,7 @@ type API struct {
 type APIDeps struct {
 	Bitswap      exchange.Interface
 	Chain        *cst.ChainStateProvider
+	Clock        clock.BlockClock
 	Config       *cfg.Config
 	DAG          *dag.DAG
 	Deals        *strgdls.Store
@@ -80,6 +83,7 @@ func New(deps *APIDeps) *API {
 
 		bitswap:      deps.Bitswap,
 		chain:        deps.Chain,
+		clock:        deps.Clock,
 		config:       deps.Config,
 		dag:          deps.DAG,
 		msgPool:      deps.MsgPool,
@@ -108,6 +112,11 @@ func (api *API) ActorGetSignature(ctx context.Context, actorAddr address.Address
 // ActorLs returns a channel with actors from the latest state on the chain
 func (api *API) ActorLs(ctx context.Context) (<-chan state.GetAllActorsResult, error) {
 	return api.chain.LsActors(ctx)
+}
+
+// BlockTime returns a duration representing the current block time.
+func (api *API) BlockTime(ctx context.Context) time.Duration {
+	return api.clock.BlockTime()
 }
 
 // ConfigSet sets the given parameters at the given path in the local config.

--- a/plumbing/clock/clock.go
+++ b/plumbing/clock/clock.go
@@ -4,6 +4,10 @@ import (
 	"time"
 )
 
+// DefaultBlockTime is the estimated proving period time.
+// We define this so that we can fake mining in the current incomplete system.
+const DefaultBlockTime = 30 * time.Second
+
 // BlockClock defines an interface for fetching the block time.
 type BlockClock interface {
 	BlockTime() time.Duration
@@ -16,10 +20,19 @@ type DefaultBlockClock struct {
 }
 
 // NewDefaultBlockClock returns a DefaultBlockClock. It can be used to
-// get the value of block time.
-func NewDefaultBlockClock(t time.Duration) *DefaultBlockClock {
+// get the value of block time. NewDefaultBlockClock uses DefaltBlockTime
+// as the block time.
+func NewDefaultBlockClock() *DefaultBlockClock {
 	return &DefaultBlockClock{
-		blockTime: t,
+		blockTime: DefaultBlockTime,
+	}
+}
+
+// NewConfiguredBlockClock returns a DefaultBlockClock with the provided
+// blockTime.
+func NewConfiguredBlockClock(blockTime time.Duration) *DefaultBlockClock {
+	return &DefaultBlockClock{
+		blockTime: blockTime,
 	}
 }
 

--- a/plumbing/clock/clock.go
+++ b/plumbing/clock/clock.go
@@ -1,0 +1,29 @@
+package clock
+
+import (
+	"time"
+)
+
+// BlockClock defines an interface for fetching the block time.
+type BlockClock interface {
+	BlockTime() time.Duration
+}
+
+// DefaultBlockClock implements BlockClock and can be used to get the
+// block time.
+type DefaultBlockClock struct {
+	blockTime time.Duration
+}
+
+// NewDefaultBlockClock returns a DefaultBlockClock. It can be used to
+// get the value of block time.
+func NewDefaultBlockClock(t time.Duration) *DefaultBlockClock {
+	return &DefaultBlockClock{
+		blockTime: t,
+	}
+}
+
+// BlockTime returns the block time DefaultBlockClock was configured to use.
+func (bc *DefaultBlockClock) BlockTime() time.Duration {
+	return bc.blockTime
+}

--- a/protocol/block/mining_api_test.go
+++ b/protocol/block/mining_api_test.go
@@ -77,7 +77,7 @@ func newAPI(t *testing.T, assert *ast.Assertions) (bapi.MiningAPI, *node.Node) {
 	nd := node.MakeNodeWithChainSeed(t, seed, configOpts,
 		node.AutoSealIntervalSecondsOpt(1),
 	)
-	bt := nd.GetBlockTime()
+	bt := nd.PorcelainAPI.BlockTime(context.Background())
 	seed.GiveKey(t, nd, 0)
 	mAddr, moAddr := seed.GiveMiner(t, nd, 0)
 	_, err := storage.NewMiner(mAddr, moAddr, nd, nd.Repo.DealsDatastore(), nd.PorcelainAPI)

--- a/protocol/retrieval/client.go
+++ b/protocol/retrieval/client.go
@@ -35,7 +35,7 @@ type Client struct {
 }
 
 // NewClient produces a new Client.
-func NewClient(host host.Host, blockTime time.Duration, api clientPorcelainAPI) *Client {
+func NewClient(host host.Host, api clientPorcelainAPI) *Client {
 	return &Client{
 		api:  api,
 		host: host,

--- a/protocol/storage/client.go
+++ b/protocol/storage/client.go
@@ -53,6 +53,7 @@ const (
 type clientPorcelainAPI interface {
 	ChainBlockHeight() (*types.BlockHeight, error)
 	CreatePayments(ctx context.Context, config porcelain.CreatePaymentsParams) (*porcelain.CreatePaymentsReturn, error)
+	BlockTime(ctx context.Context) time.Duration
 	DealGet(context.Context, cid.Cid) (*storagedeal.Deal, error)
 	DAGGetFileSize(context.Context, cid.Cid) (uint64, error)
 	DealPut(*storagedeal.Deal) error
@@ -70,17 +71,15 @@ type clientPorcelainAPI interface {
 // Client is used to make deals directly with storage miners.
 type Client struct {
 	api                 clientPorcelainAPI
-	blockTime           time.Duration
 	host                host.Host
 	log                 logging.EventLogger
 	ProtocolRequestFunc func(ctx context.Context, protocol protocol.ID, peer peer.ID, host host.Host, request interface{}, response interface{}) error
 }
 
 // NewClient creates a new storage client.
-func NewClient(blockTime time.Duration, host host.Host, api clientPorcelainAPI) *Client {
+func NewClient(host host.Host, api clientPorcelainAPI) *Client {
 	smc := &Client{
 		api:                 api,
-		blockTime:           blockTime,
 		host:                host,
 		log:                 logging.Logger("storage/client"),
 		ProtocolRequestFunc: MakeProtocolRequest,
@@ -91,7 +90,7 @@ func NewClient(blockTime time.Duration, host host.Host, api clientPorcelainAPI) 
 // ProposeDeal proposes a storage deal to a miner.  Pass allowDuplicates = true to
 // allow duplicate proposals without error.
 func (smc *Client) ProposeDeal(ctx context.Context, miner address.Address, data cid.Cid, askID uint64, duration uint64, allowDuplicates bool) (*storagedeal.Response, error) {
-	ctxSetup, cancel := context.WithTimeout(ctx, 5*smc.GetBlockTime())
+	ctxSetup, cancel := context.WithTimeout(ctx, 5*smc.api.BlockTime(ctx))
 	defer cancel()
 
 	pid, err := smc.api.MinerGetPeerID(ctxSetup, miner)
@@ -265,11 +264,6 @@ func (smc *Client) minerForProposal(ctx context.Context, c cid.Cid) (address.Add
 		return address.Undef, errors.Wrapf(err, "failed to fetch deal: %s", c)
 	}
 	return storageDeal.Miner, nil
-}
-
-// GetBlockTime returns the blocktime this node is configured with.
-func (smc *Client) GetBlockTime() time.Duration {
-	return smc.blockTime
 }
 
 // QueryDeal queries an in-progress proposal.

--- a/protocol/storage/client_test.go
+++ b/protocol/storage/client_test.go
@@ -49,7 +49,7 @@ func TestProposeDeal(t *testing.T) {
 	})
 
 	testAPI := newTestClientAPI(t)
-	client := NewClient(testNode.GetBlockTime(), th.NewFakeHost(), testAPI)
+	client := NewClient(th.NewFakeHost(), testAPI)
 	client.ProtocolRequestFunc = testNode.MakeTestProtocolRequest
 
 	dataCid := types.SomeCid()
@@ -139,7 +139,7 @@ func TestProposeDealFailsWhenADealAlreadyExists(t *testing.T) {
 	})
 
 	testAPI := newTestClientAPI(t)
-	client := NewClient(testNode.GetBlockTime(), th.NewFakeHost(), testAPI)
+	client := NewClient(th.NewFakeHost(), testAPI)
 	client.ProtocolRequestFunc = testNode.MakeTestProtocolRequest
 
 	dataCid := types.SomeCid()
@@ -259,10 +259,6 @@ func newTestClientNode(responder func(request interface{}) (interface{}, error))
 	}
 }
 
-func (tcn *testClientNode) GetBlockTime() time.Duration {
-	return 100 * time.Millisecond
-}
-
 // MakeTestProtocolRequest calls the responder set for the testClientNode to provide a test
 // response for a protocol request.
 // It ignores the host param required for the storage client interface.
@@ -274,6 +270,10 @@ func (tcn *testClientNode) MakeTestProtocolRequest(ctx context.Context, protocol
 	}
 	*dealResponse = *res.(*storagedeal.Response)
 	return nil
+}
+
+func (ctp *clientTestAPI) BlockTime(_ context.Context) time.Duration {
+	return 100 * time.Millisecond
 }
 
 func (ctp *clientTestAPI) DealClientLs(_ context.Context) (<-chan *porcelain.StorageDealLsResult, error) {

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -90,7 +90,6 @@ type minerPorcelain interface {
 // are moving off of node and into the porcelain api (see porcelainAPI). Eventually this
 // dependency on node should go away, fully replaced by the dependency on the porcelain api.
 type node interface {
-	GetBlockTime() time.Duration
 	BlockService() bserv.BlockService
 	Host() host.Host
 	SectorBuilder() sectorbuilder.SectorBuilder

--- a/testhelpers/mining.go
+++ b/testhelpers/mining.go
@@ -1,6 +1,7 @@
 package testhelpers
 
 import (
+	"context"
 	"crypto/rand"
 	"strconv"
 	"testing"
@@ -11,6 +12,24 @@ import (
 
 // BlockTimeTest is the block time used by workers during testing
 const BlockTimeTest = time.Second
+
+// TestBlockClock implement plumbing/clock.BlockClock
+type TestBlockClock struct {
+	blockTime time.Duration
+}
+
+// NewTestBlockClock returns a TestBlockClock that uses BlockTimeTest
+// as its duration
+func NewTestBlockClock() *TestBlockClock {
+	return &TestBlockClock{
+		blockTime: BlockTimeTest,
+	}
+}
+
+// BlockTime returns the block time of TestBlockClock
+func (tbc *TestBlockClock) BlockTime(ctx context.Context) time.Duration {
+	return tbc.blockTime
+}
 
 // MakeCommitment creates a random commitment.
 func MakeCommitment() []byte {

--- a/tools/fast/series/ctx_sleep_delay.go
+++ b/tools/fast/series/ctx_sleep_delay.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/filecoin-project/go-filecoin/mining"
+	"github.com/filecoin-project/go-filecoin/plumbing/clock"
 )
 
 type ctxSleepDelayKey struct{}
@@ -14,7 +14,7 @@ var (
 	sleepDelayKey = ctxSleepDelayKey{}
 
 	// Default delay
-	defaultSleepDelay = mining.DefaultBlockTime
+	defaultSleepDelay = clock.DefaultBlockTime
 )
 
 // SetCtxSleepDelay returns a context with `d` set in the context. To sleep with


### PR DESCRIPTION
### What
This PR move BlockTime to a method on the plumbing api and adds an interface called `BlockClock`. In coming PR's this interface can be extended to return the current time (`time.Now()`) so that mining may timestamp blocks. This makes progress towards implementing a soft-block dealy.