### PR TITLE
add timestamp field to block struct

### DIFF
--- a/build/main.go
+++ b/build/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -169,20 +171,71 @@ func forceBuildFC() {
 	}...))
 }
 
+// cleanDirectory removes the child of a directly wihtout removing the directory itself, unlike `RemoveAll`.
+// There is also an additional parameter to ignore dot files which is important for directories which are normally
+// empty. Git has no concept of directories, so for a directory to automatically be created on checkout, a file must
+// exist in side of it. We use this pattern in a few places, so the need to keep the dot files around is impotant.
+func cleanDirectory(dir string, ignoredots bool) error {
+	if abs := filepath.IsAbs(dir); !abs {
+		return fmt.Errorf("Directory %s is not an absolute path, could not clean directory", dir)
+	}
+
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		fname := file.Name()
+		if ignoredots && []rune(fname)[0] == '.' {
+			continue
+		}
+
+		fpath := filepath.Join(dir, fname)
+
+		fmt.Println("Removing", fpath)
+		if err := os.RemoveAll(fpath); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func generateGenesis() {
 	log.Println("Generating genesis...")
+
+	liveFixtures, err := filepath.Abs("./fixtures/live")
+	if err != nil {
+		panic(err)
+	}
+
+	if err := cleanDirectory(liveFixtures, true); err != nil {
+		panic(err)
+	}
+
 	runCmd(cmd([]string{
 		"./gengen/gengen",
-		"--keypath", "fixtures/live",
-		"--out-car", "fixtures/live/genesis.car",
-		"--out-json", "fixtures/live/gen.json",
+		"--keypath", liveFixtures,
+		"--out-car", filepath.Join(liveFixtures, "genesis.car"),
+		"--out-json", filepath.Join(liveFixtures, "gen.json"),
 		"--config", "./fixtures/setup.json",
 	}...))
+
+	testFixtures, err := filepath.Abs("./fixtures/test")
+	if err != nil {
+		panic(err)
+	}
+
+	if err := cleanDirectory(testFixtures, true); err != nil {
+		panic(err)
+	}
+
 	runCmd(cmd([]string{
 		"./gengen/gengen",
-		"--keypath", "fixtures/test",
-		"--out-car", "fixtures/test/genesis.car",
-		"--out-json", "fixtures/test/gen.json",
+		"--keypath", testFixtures,
+		"--out-car", filepath.Join(testFixtures, "genesis.car"),
+		"--out-json", filepath.Join(testFixtures, "gen.json"),
 		"--config", "./fixtures/setup.json",
 		"--test-proofs-mode",
 	}...))

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -1058,7 +1058,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 
 	totalPower := types.NewBytesAmount(1000).Mul(types.OneKiBSectorSize)
 
-	info, err := gengen.GenGen(ctx, genCfg, cst, bs, 0)
+	info, err := gengen.GenGen(ctx, genCfg, cst, bs, 0, 0)
 	require.NoError(t, err)
 
 	var calcGenBlk types.Block

--- a/chain/power_table_view_test.go
+++ b/chain/power_table_view_test.go
@@ -69,7 +69,7 @@ func requireMinerWithNumCommittedSectors(ctx context.Context, t *testing.T, numC
 		},
 	}
 
-	info, err := gengen.GenGen(ctx, genCfg, cst, bs, 0)
+	info, err := gengen.GenGen(ctx, genCfg, cst, bs, 0, 0)
 	require.NoError(t, err)
 
 	var calcGenBlk types.Block

--- a/commands/schema/filecoin_block.schema.json
+++ b/commands/schema/filecoin_block.schema.json
@@ -64,6 +64,9 @@
             "string",
             "null"
           ]
+        },
+        "timestamp": {
+          "type": "string"
         }
       },
       "required": [
@@ -74,7 +77,8 @@
         "parents",
         "proof",
         "stateRoot",
-        "ticket"
+        "ticket",
+        "timestamp"
       ],
       "type": "object"
     },

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	mrand "math/rand"
 	"strconv"
+	"time"
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
@@ -97,7 +98,7 @@ type RenderedMinerInfo struct {
 // the final genesis block.
 //
 // WARNING: Do not use maps in this code, they will make this code non deterministic.
-func GenGen(ctx context.Context, cfg *GenesisCfg, cst *hamt.CborIpldStore, bs blockstore.Blockstore, seed int64) (*RenderedGenInfo, error) {
+func GenGen(ctx context.Context, cfg *GenesisCfg, cst *hamt.CborIpldStore, bs blockstore.Blockstore, seed, timestamp int64) (*RenderedGenInfo, error) {
 	pnrg := mrand.New(mrand.NewSource(seed))
 	keys, err := genKeys(cfg.Keys, pnrg)
 	if err != nil {
@@ -148,6 +149,7 @@ func GenGen(ctx context.Context, cfg *GenesisCfg, cst *hamt.CborIpldStore, bs bl
 
 	geneblk := &types.Block{
 		StateRoot: stateRoot,
+		Timestamp: types.Uint64(timestamp),
 	}
 
 	c, err := cst.Put(ctx, geneblk)
@@ -312,7 +314,7 @@ func GenGenesisCar(cfg *GenesisCfg, out io.Writer, seed int64) (*RenderedGenInfo
 
 	ctx := context.Background()
 
-	info, err := GenGen(ctx, cfg, cst, bstore, seed)
+	info, err := GenGen(ctx, cfg, cst, bstore, seed, time.Now().Unix())
 	if err != nil {
 		return nil, err
 	}

--- a/gengen/util/gengen_test.go
+++ b/gengen/util/gengen_test.go
@@ -70,7 +70,7 @@ func TestGenGenDeterministicBetweenBuilds(t *testing.T) {
 
 		ctx := context.Background()
 
-		inf, err := GenGen(ctx, testConfig, cst, bstore, 0)
+		inf, err := GenGen(ctx, testConfig, cst, bstore, 0, 0)
 		assert.NoError(t, err)
 		if info == nil {
 			info = inf

--- a/mining/block_generate.go
+++ b/mining/block_generate.go
@@ -86,6 +86,8 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 		Proof:           proof,
 		StateRoot:       newStateTreeCid,
 		Ticket:          ticket,
+		// TODO user BlockClock interface from #2894 while completing #2886
+		Timestamp: 0,
 	}
 
 	for i, msg := range res.PermanentFailures {

--- a/node/testing.go
+++ b/node/testing.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"testing"
+	"time"
 
 	bserv "github.com/ipfs/go-blockservice"
 	ds "github.com/ipfs/go-datastore"
@@ -54,7 +55,7 @@ func MakeChainSeed(t *testing.T, cfg *gengen.GenesisCfg) *ChainSeed {
 	blkserv := bserv.New(bstore, offl)
 	cst := &hamt.CborIpldStore{Blocks: blkserv}
 
-	info, err := gengen.GenGen(context.TODO(), cfg, cst, bstore, 0)
+	info, err := gengen.GenGen(context.TODO(), cfg, cst, bstore, 0, time.Now().Unix())
 	require.NoError(t, err)
 
 	return &ChainSeed{

--- a/types/block.go
+++ b/types/block.go
@@ -52,6 +52,9 @@ type Block struct {
 	// a challenge
 	Proof PoStProof `json:"proof"`
 
+	// The timestamp, in seconds since the Unix epoch, at which this block was created.
+	Timestamp Uint64 `json:"timestamp"`
+
 	cachedCid cid.Cid
 
 	cachedBytes []byte

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -72,11 +72,12 @@ func TestTriangleEncoding(t *testing.T) {
 			ParentWeight:    Uint64(1000),
 			Proof:           NewTestPoSt(),
 			StateRoot:       SomeCid(),
+			Timestamp:       Uint64(1),
 		}
 		s := reflect.TypeOf(*b)
 		// This check is here to request that you add a non-zero value for new fields
 		// to the above (and update the field count below).
-		require.Equal(t, 12, s.NumField()) // Note: this also counts private fields
+		require.Equal(t, 13, s.NumField()) // Note: this also counts private fields
 		testRoundTrip(t, b)
 	})
 }

--- a/types/tipset_test.go
+++ b/types/tipset_test.go
@@ -28,7 +28,7 @@ func init() {
 	mockSignerForTest, _ = NewMockSignersAndKeyInfo(2)
 }
 
-func block(t *testing.T, ticket []byte, height int, parentCid cid.Cid, parentWeight uint64, msg string) *Block {
+func block(t *testing.T, ticket []byte, height int, parentCid cid.Cid, parentWeight, timestamp uint64, msg string) *Block {
 	addrGetter := address.NewForTestGetter()
 
 	m1 := NewMessage(mockSignerForTest.Addresses[0], addrGetter(), 0, NewAttoFILFromFIL(10), "hello", []byte(msg))
@@ -45,6 +45,7 @@ func block(t *testing.T, ticket []byte, height int, parentCid cid.Cid, parentWei
 		Messages:        []*SignedMessage{sm1},
 		StateRoot:       SomeCid(),
 		MessageReceipts: []*MessageReceipt{{ExitCode: 1, Return: [][]byte{ret}}},
+		Timestamp:       Uint64(timestamp),
 	}
 }
 
@@ -68,8 +69,8 @@ func TestTipSet(t *testing.T) {
 	})
 
 	t.Run("order breaks ties with CID", func(t *testing.T) {
-		b1 := block(t, []byte{1}, 1, cid1, parentWeight, "1")
-		b2 := block(t, []byte{1}, 1, cid1, parentWeight, "2")
+		b1 := block(t, []byte{1}, 1, cid1, parentWeight, 1, "1")
+		b2 := block(t, []byte{1}, 1, cid1, parentWeight, 2, "2")
 
 		ts := RequireNewTipSet(t, b1, b2)
 		if bytes.Compare(b1.Cid().Bytes(), b2.Cid().Bytes()) < 0 {
@@ -153,7 +154,7 @@ func TestTipSet(t *testing.T) {
 		// String shouldn't really need testing, but some existing code uses the string as a
 		// datastore key and depends on the format exactly.
 		assert.Equal(t, "{ "+b1.Cid().String()+" }", RequireNewTipSet(t, b1).String())
-		assert.Equal(t, "{ "+b1.Cid().String()+" "+b2.Cid().String()+" "+b3.Cid().String()+" }",
+		assert.Equal(t, "{ "+b2.Cid().String()+" "+b1.Cid().String()+" "+b3.Cid().String()+" }",
 			RequireNewTipSet(t, b3, b2, b1).String())
 	})
 
@@ -197,8 +198,8 @@ func TestTipSet(t *testing.T) {
 
 // Test methods: String, ToSortedCidSet, ToSlice, MinTicket, Height, NewTipSet, Equals
 func makeTestBlocks(t *testing.T) (*Block, *Block, *Block) {
-	b1 := block(t, []byte{1}, 1, cid1, parentWeight, "1")
-	b2 := block(t, []byte{2}, 1, cid1, parentWeight, "2")
-	b3 := block(t, []byte{3}, 1, cid1, parentWeight, "3")
+	b1 := block(t, []byte{1}, 1, cid1, parentWeight, 1, "1")
+	b2 := block(t, []byte{2}, 1, cid1, parentWeight, 2, "2")
+	b3 := block(t, []byte{3}, 1, cid1, parentWeight, 3, "3")
 	return b1, b2, b3
 }


### PR DESCRIPTION
### What
This PR adds a timestamp to block, currently these timestamps are set to `0`. This will be updated to use the `BlockClock` interface defined in #2894 once it merges. These updates will be made while completing #2886.