### PR TITLE
Make show deal test use FAST.  Increase default FAST block time to 50 ms

### DIFF
--- a/commands/show_test.go
+++ b/commands/show_test.go
@@ -1,7 +1,6 @@
 package commands_test
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/json"
@@ -85,8 +84,7 @@ func TestShowDeal(t *testing.T) {
 	minerNode := env.RequireNewNodeWithFunds(1000)
 
 	// Connect the clientNode and the minerNode
-	err := series.Connect(ctx, clientNode, minerNode)
-	require.NoError(t, err)
+	require.NoError(t, series.Connect(ctx, clientNode, minerNode))
 
 	// Create a minerNode
 	collateral := big.NewInt(500)           // FIL
@@ -97,11 +95,9 @@ func TestShowDeal(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create some data that is the full sector size and make it autoseal asap
-	var data bytes.Buffer
 
 	maxBytesi64 := int64(getMaxUserBytesPerStagedSector())
 	dataReader := io.LimitReader(rand.Reader, maxBytesi64)
-	dataReader = io.TeeReader(dataReader, &data)
 	_, deal, err := series.ImportAndStore(ctx, clientNode, ask, files.NewReaderFile(dataReader))
 	require.NoError(t, err)
 

--- a/commands/show_test.go
+++ b/commands/show_test.go
@@ -68,7 +68,7 @@ func TestBlockDaemon(t *testing.T) {
 	})
 }
 
-func TestShowDeal2(t *testing.T) {
+func TestShowDeal(t *testing.T) {
 	tf.IntegrationTest(t)
 
 	fastenvOpts := fast.EnvironmentOpts{

--- a/tools/fast/action_show.go
+++ b/tools/fast/action_show.go
@@ -23,11 +23,11 @@ func (f *Filecoin) ShowBlock(ctx context.Context, ref cid.Cid) (*types.Block, er
 }
 
 // ShowDeal runs the `show deal` command against the filecoin process
-func (f *Filecoin) ShowDeal(ctx context.Context, ref cid.Cid) (*storagedeal.Deal, error) {
-	var out storagedeal.Deal
-	sRef := ref.String()
+func (f *Filecoin) ShowDeal(ctx context.Context, dealResp *storagedeal.Response) (*storagedeal.Deal, error) {
 
-	err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "show", "deal", sRef)
+	var out storagedeal.Deal
+
+	err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "show", "deal", dealResp.ProposalCid.String())
 	if err != nil {
 		return nil, err
 	}

--- a/tools/fast/action_show.go
+++ b/tools/fast/action_show.go
@@ -23,11 +23,11 @@ func (f *Filecoin) ShowBlock(ctx context.Context, ref cid.Cid) (*types.Block, er
 }
 
 // ShowDeal runs the `show deal` command against the filecoin process
-func (f *Filecoin) ShowDeal(ctx context.Context, dealResp *storagedeal.Response) (*storagedeal.Deal, error) {
+func (f *Filecoin) ShowDeal(ctx context.Context, propCid cid.Cid) (*storagedeal.Deal, error) {
 
 	var out storagedeal.Deal
 
-	err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "show", "deal", dealResp.ProposalCid.String())
+	err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "show", "deal", propCid.String())
 	if err != nil {
 		return nil, err
 	}

--- a/tools/fast/fastesting/basic.go
+++ b/tools/fast/fastesting/basic.go
@@ -60,7 +60,7 @@ func NewTestEnvironment(ctx context.Context, t *testing.T, fastenvOpts fast.Envi
 
 	fastenvOpts = fast.EnvironmentOpts{
 		InitOpts:   append([]fast.ProcessInitOption{fast.POGenesisFile(genesisURI)}, fastenvOpts.InitOpts...),
-		DaemonOpts: append([]fast.ProcessDaemonOption{fast.POBlockTime(time.Millisecond)}, fastenvOpts.DaemonOpts...),
+		DaemonOpts: append([]fast.ProcessDaemonOption{fast.POBlockTime(time.Second)}, fastenvOpts.DaemonOpts...),
 	}
 
 	// Setup the first node which is used to help coordinate the other nodes by providing

--- a/tools/fast/fastesting/basic.go
+++ b/tools/fast/fastesting/basic.go
@@ -60,7 +60,7 @@ func NewTestEnvironment(ctx context.Context, t *testing.T, fastenvOpts fast.Envi
 
 	fastenvOpts = fast.EnvironmentOpts{
 		InitOpts:   append([]fast.ProcessInitOption{fast.POGenesisFile(genesisURI)}, fastenvOpts.InitOpts...),
-		DaemonOpts: append([]fast.ProcessDaemonOption{fast.POBlockTime(time.Second)}, fastenvOpts.DaemonOpts...),
+		DaemonOpts: append([]fast.ProcessDaemonOption{fast.POBlockTime(50 * time.Millisecond)}, fastenvOpts.DaemonOpts...),
 	}
 
 	// Setup the first node which is used to help coordinate the other nodes by providing


### PR DESCRIPTION
1. converts a daemon tests to FAST tests for the `show deal` command.  
1. changes the interface of the FAST `ShowDeal` function to take a deal instead of a CID
1. increases the default block time from 1ms to 50ms because this was needed to get the tests passing; otherwise there wasn't enough time to accept the deal.

The reason for changing the default time was that  I ran into a bug which, when you pass a DaemonOpt to the NewEnvironment function, for some reason the repo/api file is never created. I spent just a little time trying to figure out why but then I figured out a workaround, so for this PR I am using the workaround, as it's basically harmless anyway.  I filed an issue against this here: #2900 