### PR TITLE
Normalize `types.AttoFIL`

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -24,7 +24,7 @@ const (
 	Invalid = Type(iota)
 	// Address is a address.Address
 	Address
-	// AttoFIL is a *types.AttoFIL
+	// AttoFIL is a types.AttoFIL
 	AttoFIL
 	// BytesAmount is a *types.BytesAmount
 	BytesAmount
@@ -69,7 +69,7 @@ func (t Type) String() string {
 	case Address:
 		return "address.Address"
 	case AttoFIL:
-		return "*types.AttoFIL"
+		return "types.AttoFIL"
 	case BytesAmount:
 		return "*types.BytesAmount"
 	case ChannelID:
@@ -122,7 +122,7 @@ func (av *Value) String() string {
 	case Address:
 		return av.Val.(address.Address).String()
 	case AttoFIL:
-		return av.Val.(*types.AttoFIL).String()
+		return av.Val.(types.AttoFIL).String()
 	case BytesAmount:
 		return av.Val.(*types.BytesAmount).String()
 	case ChannelID:
@@ -183,7 +183,7 @@ func (av *Value) Serialize() ([]byte, error) {
 		}
 		return addr.Bytes(), nil
 	case AttoFIL:
-		ba, ok := av.Val.(*types.AttoFIL)
+		ba, ok := av.Val.(types.AttoFIL)
 		if !ok {
 			return nil, &typeError{types.AttoFIL{}, av.Val}
 		}
@@ -325,7 +325,7 @@ func ToValues(i []interface{}) ([]*Value, error) {
 		switch v := v.(type) {
 		case address.Address:
 			out = append(out, &Value{Type: Address, Val: v})
-		case *types.AttoFIL:
+		case types.AttoFIL:
 			out = append(out, &Value{Type: AttoFIL, Val: v})
 		case *types.BytesAmount:
 			out = append(out, &Value{Type: BytesAmount, Val: v})
@@ -524,7 +524,7 @@ func Deserialize(data []byte, t Type) (*Value, error) {
 
 var typeTable = map[Type]reflect.Type{
 	Address:        reflect.TypeOf(address.Address{}),
-	AttoFIL:        reflect.TypeOf(&types.AttoFIL{}),
+	AttoFIL:        reflect.TypeOf(types.AttoFIL{}),
 	Bytes:          reflect.TypeOf([]byte{}),
 	BytesAmount:    reflect.TypeOf(&types.BytesAmount{}),
 	ChannelID:      reflect.TypeOf(&types.ChannelID{}),

--- a/actor/actor.go
+++ b/actor/actor.go
@@ -43,11 +43,11 @@ type Actor struct {
 	// Messages are processed in strict, contiguous nonce order.
 	Nonce types.Uint64
 	// Balance is the amount of FIL in the actor's account.
-	Balance *types.AttoFIL
+	Balance types.AttoFIL
 }
 
 // NewActor constructs a new actor.
-func NewActor(code cid.Cid, balance *types.AttoFIL) *Actor {
+func NewActor(code cid.Cid, balance types.AttoFIL) *Actor {
 	return &Actor{
 		Code:    code,
 		Head:    cid.Undef,

--- a/actor/actor_test.go
+++ b/actor/actor_test.go
@@ -22,7 +22,7 @@ import (
 func TestActorCid(t *testing.T) {
 	tf.UnitTest(t)
 
-	actor1 := NewActor(types.AccountActorCodeCid, nil)
+	actor1 := NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 	actor2 := NewActor(types.AccountActorCodeCid, types.NewAttoFILFromFIL(5))
 	actor2.Head = requireCid(t, "Actor 2 State")
 	actor1.IncNonce()
@@ -111,7 +111,7 @@ func makeCtx(method string) exec.VMContext {
 	addrGetter := address.NewForTestGetter()
 
 	vmCtxParams := vm.NewContextParams{
-		Message:     types.NewMessage(addrGetter(), addrGetter(), 0, nil, method, nil),
+		Message:     types.NewMessage(addrGetter(), addrGetter(), 0, types.ZeroAttoFIL, method, nil),
 		GasTracker:  vm.NewGasTracker(),
 		BlockHeight: types.NewBlockHeight(0),
 	}

--- a/actor/builtin/account/account.go
+++ b/actor/builtin/account/account.go
@@ -20,7 +20,7 @@ type Actor struct{}
 var _ exec.ExecutableActor = (*Actor)(nil)
 
 // NewActor creates a new account actor.
-func NewActor(balance *types.AttoFIL) (*actor.Actor, error) {
+func NewActor(balance types.AttoFIL) (*actor.Actor, error) {
 	return actor.NewActor(types.AccountActorCodeCid, balance), nil
 }
 

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -114,7 +114,7 @@ type Actor struct {
 
 // Ask is a price advertisement by the miner
 type Ask struct {
-	Price  *types.AttoFIL
+	Price  types.AttoFIL
 	Expiry *types.BlockHeight
 	ID     *big.Int
 }
@@ -131,7 +131,7 @@ type State struct {
 
 	// ActiveCollateral is the amount of collateral currently committed to live
 	// storage.
-	ActiveCollateral *types.AttoFIL
+	ActiveCollateral types.AttoFIL
 
 	// Asks is the set of asks this miner has open
 	Asks      []*Ask
@@ -277,7 +277,7 @@ func (ma *Actor) Exports() exec.Exports {
 }
 
 // AddAsk adds an ask to this miners ask list
-func (ma *Actor) AddAsk(ctx exec.VMContext, price *types.AttoFIL, expiry *big.Int) (*big.Int, uint8,
+func (ma *Actor) AddAsk(ctx exec.VMContext, price types.AttoFIL, expiry *big.Int) (*big.Int, uint8,
 	error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
@@ -567,7 +567,7 @@ func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR,
 		copy(comms.CommRStar[:], commRStar)
 		state.LastUsedSectorID = sectorID
 		state.SectorCommitments[sectorIDstr] = comms
-		_, ret, err := ctx.Send(address.StorageMarketAddress, "updatePower", nil, []interface{}{inc})
+		_, ret, err := ctx.Send(address.StorageMarketAddress, "updatePower", types.ZeroAttoFIL, []interface{}{inc})
 		if err != nil {
 			return nil, err
 		}
@@ -585,7 +585,7 @@ func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR,
 
 // CollateralForSector returns the collateral required to commit a sector of the
 // given size.
-func CollateralForSector(sectorSize *types.BytesAmount) *types.AttoFIL {
+func CollateralForSector(sectorSize *types.BytesAmount) types.AttoFIL {
 	// TODO: Replace this function with the baseline pro-rata construction.
 	// https://github.com/filecoin-project/go-filecoin/issues/2866
 	return MinimumCollateralPerSector

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -172,7 +172,7 @@ func NewState(owner address.Address, key []byte, pid peer.ID, sectorSize *types.
 		Power:             types.NewBytesAmount(0),
 		NextAskID:         big.NewInt(0),
 		SectorSize:        sectorSize,
-		ActiveCollateral:  types.NewZeroAttoFIL(),
+		ActiveCollateral:  types.ZeroAttoFIL,
 	}
 }
 
@@ -827,7 +827,7 @@ func currentProvingPeriodPoStChallengeSeed(ctx exec.VMContext, state State) (typ
 // GetProofsMode returns the genesis block-configured proofs mode.
 func GetProofsMode(ctx exec.VMContext) (types.ProofsMode, error) {
 	var proofsMode types.ProofsMode
-	msgResult, _, err := ctx.Send(address.StorageMarketAddress, "getProofsMode", types.NewZeroAttoFIL(), nil)
+	msgResult, _, err := ctx.Send(address.StorageMarketAddress, "getProofsMode", types.ZeroAttoFIL, nil)
 	if err != nil {
 		return types.TestProofsMode, xerrors.Wrap(err, "'getProofsMode' message failed")
 	}

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -28,7 +28,7 @@ func createTestMiner(t *testing.T, st state.Tree, vms vm.StorageMap, minerOwnerA
 
 func createTestMinerWith(
 	pledge uint64,
-	collateral *types.AttoFIL,
+	collateral types.AttoFIL,
 	t *testing.T,
 	stateTree state.Tree,
 	vms vm.StorageMap,
@@ -60,7 +60,7 @@ func TestAskFunctions(t *testing.T) {
 
 	// make an ask, and then make sure it all looks good
 	pdata := actor.MustConvertParams(types.NewAttoFILFromFIL(5), big.NewInt(1500))
-	msg := types.NewMessage(address.TestAddress, minerAddr, 1, nil, "addAsk", pdata)
+	msg := types.NewMessage(address.TestAddress, minerAddr, 1, types.ZeroAttoFIL, "addAsk", pdata)
 
 	_, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(1))
 	assert.NoError(t, err)
@@ -92,7 +92,7 @@ func TestAskFunctions(t *testing.T) {
 
 	// make another ask!
 	pdata = actor.MustConvertParams(types.NewAttoFILFromFIL(110), big.NewInt(200))
-	msg = types.NewMessage(address.TestAddress, minerAddr, 3, nil, "addAsk", pdata)
+	msg = types.NewMessage(address.TestAddress, minerAddr, 3, types.ZeroAttoFIL, "addAsk", pdata)
 	result, err = th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(3))
 	assert.NoError(t, err)
 	assert.Equal(t, big.NewInt(1), big.NewInt(0).SetBytes(result.Receipt.Return[0]))

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -66,7 +66,7 @@ func TestAskFunctions(t *testing.T) {
 	assert.NoError(t, err)
 
 	pdata = actor.MustConvertParams(big.NewInt(0))
-	msg = types.NewMessage(address.TestAddress, minerAddr, 2, types.NewZeroAttoFIL(), "getAsk", pdata)
+	msg = types.NewMessage(address.TestAddress, minerAddr, 2, types.ZeroAttoFIL, "getAsk", pdata)
 	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(2))
 	assert.NoError(t, err)
 
@@ -85,7 +85,7 @@ func TestAskFunctions(t *testing.T) {
 
 	// Look for an ask that doesn't exist
 	pdata = actor.MustConvertParams(big.NewInt(3453))
-	msg = types.NewMessage(address.TestAddress, minerAddr, 2, types.NewZeroAttoFIL(), "getAsk", pdata)
+	msg = types.NewMessage(address.TestAddress, minerAddr, 2, types.ZeroAttoFIL, "getAsk", pdata)
 	result, err = th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(2))
 	assert.Equal(t, Errors[ErrAskNotFound], result.ExecutionError)
 	assert.NoError(t, err)
@@ -98,7 +98,7 @@ func TestAskFunctions(t *testing.T) {
 	assert.Equal(t, big.NewInt(1), big.NewInt(0).SetBytes(result.Receipt.Return[0]))
 
 	pdata = actor.MustConvertParams(big.NewInt(1))
-	msg = types.NewMessage(address.TestAddress, minerAddr, 4, types.NewZeroAttoFIL(), "getAsk", pdata)
+	msg = types.NewMessage(address.TestAddress, minerAddr, 4, types.ZeroAttoFIL, "getAsk", pdata)
 	result, err = th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(4))
 	assert.NoError(t, err)
 
@@ -108,7 +108,7 @@ func TestAskFunctions(t *testing.T) {
 	assert.Equal(t, types.NewBlockHeight(203), ask2.Expiry)
 	assert.Equal(t, uint64(1), ask2.ID.Uint64())
 
-	msg = types.NewMessage(address.TestAddress, minerAddr, 5, types.NewZeroAttoFIL(), "getAsks", nil)
+	msg = types.NewMessage(address.TestAddress, minerAddr, 5, types.ZeroAttoFIL, "getAsks", nil)
 	result, err = th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(4))
 	assert.NoError(t, err)
 	assert.NoError(t, result.ExecutionError)

--- a/actor/builtin/miner_redeem_test.go
+++ b/actor/builtin/miner_redeem_test.go
@@ -204,7 +204,7 @@ func requireGenesis(ctx context.Context, t *testing.T, targetAddresses ...addres
 	return cst, st, vms
 }
 
-func establishChannel(st state.Tree, vms vm.StorageMap, from address.Address, target address.Address, nonce uint64, amt *types.AttoFIL, eol *types.BlockHeight) *types.ChannelID {
+func establishChannel(st state.Tree, vms vm.StorageMap, from address.Address, target address.Address, nonce uint64, amt types.AttoFIL, eol *types.BlockHeight) *types.ChannelID {
 	pdata := core.MustConvertParams(target, eol)
 	msg := types.NewMessage(from, address.PaymentBrokerAddress, nonce, amt, "createChannel", pdata)
 	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -787,7 +787,7 @@ func checkCondition(vmctx exec.VMContext, channel *PaymentChannel) error {
 		return nil
 	}
 
-	_, _, err := vmctx.Send(channel.Condition.To, channel.Condition.Method, types.NewZeroAttoFIL(), channel.Condition.Params)
+	_, _, err := vmctx.Send(channel.Condition.To, channel.Condition.Method, types.ZeroAttoFIL, channel.Condition.Params)
 	if err != nil {
 		if errors.IsFault(err) {
 			return err

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -125,7 +125,7 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 
 	t.Run("Redeem should succeed if condition is met", func(t *testing.T) {
 		sys := setup(t)
-		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
 		appResult, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, condition, redeemerParams...)
@@ -136,7 +136,7 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 
 	t.Run("Redeem should fail if condition is _NOT_ met", func(t *testing.T) {
 		sys := setup(t)
-		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 		badAddressParam := address.Undef
 		badParams := []interface{}{badAddressParam, sectorIdParam}
@@ -152,7 +152,7 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 
 	t.Run("Redeem should fail if condition goes to non-existent actor", func(t *testing.T) {
 		sys := setup(t)
-		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 		badToAddress := addrGetter()
 
@@ -167,7 +167,7 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 
 	t.Run("Redeem should fail if condition goes to non-existent method", func(t *testing.T) {
 		sys := setup(t)
-		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 		badMethod := "nonexistentMethod"
 
@@ -182,7 +182,7 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 
 	t.Run("Redeem should fail if condition has the wrong number of condition parameters", func(t *testing.T) {
 		sys := setup(t)
-		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 		badParams := []interface{}{}
 
@@ -197,7 +197,7 @@ func TestPaymentBrokerRedeemWithCondition(t *testing.T) {
 
 	t.Run("Redeem should fail if condition has the wrong number of supplied parameters", func(t *testing.T) {
 		sys := setup(t)
-		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 		badRedeemerParams := []interface{}{}
 
@@ -225,7 +225,7 @@ func TestPaymentBrokerRedeemSetsConditionAndRedeemed(t *testing.T) {
 
 	t.Run("Redeem should set the redeemed flag to true on success", func(t *testing.T) {
 		sys := setup(t)
-		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 		// Expect that the redeemed flag is false on init
 		paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
@@ -246,7 +246,7 @@ func TestPaymentBrokerRedeemSetsConditionAndRedeemed(t *testing.T) {
 
 	t.Run("Redeem should set cached condition on success", func(t *testing.T) {
 		sys := setup(t)
-		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 		// Expect that the condition is nil on init
 		paymentBroker := state.MustGetActor(sys.st, address.PaymentBrokerAddress)
@@ -272,7 +272,7 @@ func TestPaymentBrokerRedeemSetsConditionAndRedeemed(t *testing.T) {
 
 	t.Run("Redeem should set cached condition back to nil when no condition is provided", func(t *testing.T) {
 		sys := setup(t)
-		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 		// Successfully redeem the payment channel with condition
 		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
@@ -300,7 +300,7 @@ func TestPaymentBrokerRedeemSetsConditionAndRedeemed(t *testing.T) {
 
 	t.Run("Redeem should update the cached condition with new params when initial redeem condition is nil", func(t *testing.T) {
 		sys := setup(t)
-		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
 
 		// Successfully redeem the payment channel with no condition
@@ -331,7 +331,7 @@ func TestPaymentBrokerRedeemSetsConditionAndRedeemed(t *testing.T) {
 
 	t.Run("Redeem should update the cached condition with new params when provided", func(t *testing.T) {
 		sys := setup(t)
-		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 		condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
 
 		// Successfully redeem the payment channel with condition
@@ -366,7 +366,7 @@ func TestPaymentBrokerRedeemSetsConditionAndRedeemed(t *testing.T) {
 
 	t.Run("Redeem uses cached condition in subsequent calls", func(t *testing.T) {
 		sys := setup(t)
-		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 		// Redeem without params expects an invalid condition error
 		condition := &types.Predicate{To: toAddress, Method: method}
@@ -621,7 +621,7 @@ func TestPaymentBrokerCloseWithCondition(t *testing.T) {
 
 	t.Run("Close should succeed if condition is met", func(t *testing.T) {
 		sys := setup(t)
-		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 		condition := &types.Predicate{To: toAddress, Method: "paramsNotZero", Params: []interface{}{addrGetter(), uint64(6)}}
 
@@ -632,7 +632,7 @@ func TestPaymentBrokerCloseWithCondition(t *testing.T) {
 
 	t.Run("Close should fail if condition is _NOT_ met", func(t *testing.T) {
 		sys := setup(t)
-		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+		require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 		condition := &types.Predicate{To: toAddress, Method: "paramsNotZero", Params: []interface{}{address.Undef, uint64(6)}}
 
@@ -656,7 +656,7 @@ func TestPaymentBrokerCloseChecksCachedConditions(t *testing.T) {
 	redeemerParams := []interface{}{blockHeightParam}
 
 	sys := setup(t)
-	require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+	require.NoError(t, sys.st.SetActor(context.TODO(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 	// Close without params and expect a panic
 	condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
@@ -838,7 +838,7 @@ func TestPaymentBrokerCancelFailsAfterSuccessfulRedeem(t *testing.T) {
 	redeemerParams := []interface{}{blockHeightParam}
 
 	sys := setup(t)
-	require.NoError(t, sys.st.SetActor(context.Background(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+	require.NoError(t, sys.st.SetActor(context.Background(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 	// Successfully redeem the payment channel with params
 	condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}
@@ -862,7 +862,7 @@ func TestPaymentBrokerCancelFailsAfterSuccessfulRedeemWithNilCondtion(t *testing
 	toAddress := addrGetter()
 
 	sys := setup(t)
-	require.NoError(t, sys.st.SetActor(context.Background(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+	require.NoError(t, sys.st.SetActor(context.Background(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 	// Successfully redeem the payment channel with params
 	result, err := sys.applySignatureMessage(sys.target, 100, types.NewBlockHeight(0), 0, "redeem", 0, nil)
@@ -890,7 +890,7 @@ func TestPaymentBrokerCancelSucceedsAfterSuccessfulRedeemButFailedConditions(t *
 	redeemerParams := []interface{}{blockHeightParam}
 
 	sys := setup(t)
-	require.NoError(t, sys.st.SetActor(context.Background(), toAddress, actor.NewActor(pbTestActorCid, types.NewZeroAttoFIL())))
+	require.NoError(t, sys.st.SetActor(context.Background(), toAddress, actor.NewActor(pbTestActorCid, types.ZeroAttoFIL)))
 
 	// Successfully redeem the payment channel with params
 	condition := &types.Predicate{To: toAddress, Method: method, Params: payerParams}

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -996,7 +996,7 @@ func TestNewPaymentBrokerVoucher(t *testing.T) {
 		// create voucher
 		voucherAmount := types.NewAttoFILFromFIL(100)
 		pdata := core.MustConvertParams(sys.channelID, voucherAmount, sys.defaultValidAt, nilCondition)
-		msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, nil, "voucher", pdata)
+		msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, types.ZeroAttoFIL, "voucher", pdata)
 		res, err := sys.ApplyMessage(msg, 9)
 		assert.NoError(t, err)
 		assert.NoError(t, res.ExecutionError)
@@ -1009,7 +1009,7 @@ func TestNewPaymentBrokerVoucher(t *testing.T) {
 		assert.Equal(t, *sys.channelID, voucher.Channel)
 		assert.Equal(t, sys.payer, voucher.Payer)
 		assert.Equal(t, sys.target, voucher.Target)
-		assert.Equal(t, *voucherAmount, voucher.Amount)
+		assert.Equal(t, voucherAmount, voucher.Amount)
 		assert.Nil(t, voucher.Condition)
 	})
 
@@ -1032,7 +1032,7 @@ func TestNewPaymentBrokerVoucher(t *testing.T) {
 		voucherAmount := types.NewAttoFILFromFIL(2000)
 		args := core.MustConvertParams(sys.channelID, voucherAmount, sys.defaultValidAt, nilCondition)
 
-		msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, nil, "voucher", args)
+		msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, types.ZeroAttoFIL, "voucher", args)
 		res, err := sys.ApplyMessage(msg, 9)
 		assert.NoError(t, err)
 		assert.NotEqual(t, uint8(0), res.Receipt.ExitCode)
@@ -1051,7 +1051,7 @@ func TestNewPaymentBrokerVoucher(t *testing.T) {
 		// create voucher
 		voucherAmount := types.NewAttoFILFromFIL(100)
 		pdata := core.MustConvertParams(sys.channelID, voucherAmount, sys.defaultValidAt, condition)
-		msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, nil, "voucher", pdata)
+		msg := types.NewMessage(sys.payer, address.PaymentBrokerAddress, 1, types.ZeroAttoFIL, "voucher", pdata)
 		res, err := sys.ApplyMessage(msg, 9)
 		assert.NoError(t, err)
 		assert.NoError(t, res.ExecutionError)
@@ -1064,7 +1064,7 @@ func TestNewPaymentBrokerVoucher(t *testing.T) {
 		assert.Equal(t, *sys.channelID, voucher.Channel)
 		assert.Equal(t, sys.payer, voucher.Payer)
 		assert.Equal(t, sys.target, voucher.Target)
-		assert.Equal(t, *voucherAmount, voucher.Amount)
+		assert.Equal(t, voucherAmount, voucher.Amount)
 	})
 }
 
@@ -1103,7 +1103,7 @@ func TestSignVoucher(t *testing.T) {
 	})
 }
 
-func establishChannel(ctx context.Context, st state.Tree, vms vm.StorageMap, from address.Address, target address.Address, nonce uint64, amt *types.AttoFIL, eol *types.BlockHeight) *types.ChannelID {
+func establishChannel(ctx context.Context, st state.Tree, vms vm.StorageMap, from address.Address, target address.Address, nonce uint64, amt types.AttoFIL, eol *types.BlockHeight) *types.ChannelID {
 	pdata := core.MustConvertParams(target, eol)
 	msg := types.NewMessage(from, address.PaymentBrokerAddress, nonce, amt, "createChannel", pdata)
 	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
@@ -1186,7 +1186,7 @@ func setup(t *testing.T) system {
 	}
 }
 
-func (sys *system) Signature(amt *types.AttoFIL, validAt *types.BlockHeight, condition *types.Predicate) ([]byte, error) {
+func (sys *system) Signature(amt types.AttoFIL, validAt *types.BlockHeight, condition *types.Predicate) ([]byte, error) {
 	sig, err := SignVoucher(sys.channelID, amt, validAt, sys.payer, condition, mockSigner)
 	if err != nil {
 		return nil, err

--- a/actor/builtin/storagemarket/storagemarket.go
+++ b/actor/builtin/storagemarket/storagemarket.go
@@ -56,7 +56,7 @@ type State struct {
 
 // NewActor returns a new storage market actor.
 func NewActor() (*actor.Actor, error) {
-	return actor.NewActor(types.StorageMarketActorCodeCid, types.NewZeroAttoFIL()), nil
+	return actor.NewActor(types.StorageMarketActorCodeCid, types.ZeroAttoFIL), nil
 }
 
 // InitializeState stores the actor's initial data structure.

--- a/actor/builtin/storagemarket/storagemarket_test.go
+++ b/actor/builtin/storagemarket/storagemarket_test.go
@@ -53,7 +53,7 @@ func TestStorageMarketCreateStorageMiner(t *testing.T) {
 	assert.Equal(t, mstor.PeerID, pid)
 }
 
-func TestStorageMarkeCreateStorageMinerDoesNotOverwriteActorBalance(t *testing.T) {
+func TestStorageMarketCreateStorageMinerDoesNotOverwriteActorBalance(t *testing.T) {
 	tf.UnitTest(t)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/commands/actor.go
+++ b/commands/actor.go
@@ -25,7 +25,7 @@ type ActorView struct {
 	Address   string          `json:"address"`
 	Code      cid.Cid         `json:"code,omitempty"`
 	Nonce     uint64          `json:"nonce"`
-	Balance   *types.AttoFIL  `json:"balance"`
+	Balance   types.AttoFIL   `json:"balance"`
 	Exports   readableExports `json:"exports"`
 	Head      cid.Cid         `json:"head,omitempty"`
 }

--- a/commands/address.go
+++ b/commands/address.go
@@ -150,7 +150,7 @@ var balanceCmd = &cmds.Command{
 	},
 	Type: &types.AttoFIL{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, b *types.AttoFIL) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, b types.AttoFIL) error {
 			return PrintString(w, b)
 		}),
 	},

--- a/commands/main.go
+++ b/commands/main.go
@@ -332,26 +332,26 @@ var previewOption = cmdkit.BoolOption("preview", "Preview the Gas cost of this c
 func parseGasOptions(req *cmds.Request) (types.AttoFIL, types.GasUnits, bool, error) {
 	priceOption := req.Options["gas-price"]
 	if priceOption == nil {
-		return types.AttoFIL{}, types.NewGasUnits(0), false, errors.New("price option is required")
+		return types.ZeroAttoFIL, types.NewGasUnits(0), false, errors.New("price option is required")
 	}
 
 	price, ok := types.NewAttoFILFromFILString(priceOption.(string))
 	if !ok {
-		return types.AttoFIL{}, types.NewGasUnits(0), false, errors.New("invalid gas price (specify FIL as a decimal number)")
+		return types.ZeroAttoFIL, types.NewGasUnits(0), false, errors.New("invalid gas price (specify FIL as a decimal number)")
 	}
 
 	limitOption := req.Options["gas-limit"]
 	if limitOption == nil {
-		return types.AttoFIL{}, types.NewGasUnits(0), false, errors.New("limit option is required")
+		return types.ZeroAttoFIL, types.NewGasUnits(0), false, errors.New("limit option is required")
 	}
 
 	gasLimitInt, ok := limitOption.(uint64)
 	if !ok {
 		msg := fmt.Sprintf("invalid gas limit: %s", limitOption)
-		return types.AttoFIL{}, types.NewGasUnits(0), false, errors.New(msg)
+		return types.ZeroAttoFIL, types.NewGasUnits(0), false, errors.New(msg)
 	}
 
 	preview, _ := req.Options["preview"].(bool)
 
-	return *price, types.NewGasUnits(gasLimitInt), preview, nil
+	return price, types.NewGasUnits(gasLimitInt), preview, nil
 }

--- a/commands/miner.go
+++ b/commands/miner.go
@@ -339,7 +339,7 @@ var minerUpdatePeerIDCmd = &cmds.Command{
 			req.Context,
 			fromAddr,
 			minerAddr,
-			nil,
+			types.ZeroAttoFIL,
 			gasPrice,
 			gasLimit,
 			"updatePeerID",

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -264,7 +264,7 @@ func TestMinerCreateChargesGas(t *testing.T) {
 	assert.Equal(t, expectedBalance.String(), newBalance.Sub(startingBalance).String())
 }
 
-func queryBalance(t *testing.T, d *th.TestDaemon, actorAddr address.Address) *types.AttoFIL {
+func queryBalance(t *testing.T, d *th.TestDaemon, actorAddr address.Address) types.AttoFIL {
 	output := d.RunSuccess("actor", "ls", "--enc", "json")
 	result := output.ReadStdoutTrimNewlines()
 	for _, line := range bytes.Split([]byte(result), []byte{'\n'}) {
@@ -276,7 +276,7 @@ func queryBalance(t *testing.T, d *th.TestDaemon, actorAddr address.Address) *ty
 		}
 	}
 	t.Fail()
-	return nil
+	return types.ZeroAttoFIL
 }
 
 func TestMinerOwner(t *testing.T) {

--- a/commands/payment_channel.go
+++ b/commands/payment_channel.go
@@ -273,7 +273,7 @@ var redeemCmd = &cmds.Command{
 		params := []interface{}{
 			voucher.Payer,
 			&voucher.Channel,
-			&voucher.Amount,
+			voucher.Amount,
 			&voucher.ValidAt,
 			voucher.Condition,
 			[]byte(voucher.Signature),
@@ -448,7 +448,7 @@ var closeCmd = &cmds.Command{
 		params := []interface{}{
 			voucher.Payer,
 			&voucher.Channel,
-			&voucher.Amount,
+			voucher.Amount,
 			&voucher.ValidAt,
 			voucher.Condition,
 			[]byte(voucher.Signature),

--- a/commands/payment_channel_daemon_test.go
+++ b/commands/payment_channel_daemon_test.go
@@ -68,7 +68,7 @@ func TestPaymentChannelLs(t *testing.T) {
 		assert.Equal(t, channelExpiry, channel.AgreedEol)
 		assert.Equal(t, channelExpiry, channel.Eol)
 		assert.Equal(t, rsrc.targetAddr, channel.Target)
-		assert.True(t, types.ZeroAttoFIL.Equal(channel.AmountRedeemed))
+		assert.Equal(t, types.ZeroAttoFIL, channel.AmountRedeemed)
 	})
 
 	t.Run("Works with specified payer", func(t *testing.T) {
@@ -98,7 +98,7 @@ func TestPaymentChannelLs(t *testing.T) {
 		assert.Equal(t, channelExpiry, channel.AgreedEol)
 		assert.Equal(t, channelExpiry, channel.Eol)
 		assert.Equal(t, rsrc.targetAddr, channel.Target)
-		assert.True(t, types.ZeroAttoFIL.Equal(channel.AmountRedeemed))
+		assert.Equal(t, types.ZeroAttoFIL, channel.AmountRedeemed)
 	})
 
 	t.Run("No results when listing with different from address", func(t *testing.T) {
@@ -239,7 +239,7 @@ func TestPaymentChannelRedeemTooEarlyFails(t *testing.T) {
 
 	channel := channels[chanid.String()]
 	assert.Equal(t, channelAmount, channel.Amount)
-	assert.True(t, types.ZeroAttoFIL.Equal(channel.AmountRedeemed))
+	assert.Equal(t, types.ZeroAttoFIL, channel.AmountRedeemed)
 }
 
 func TestPaymentChannelReclaimSuccess(t *testing.T) {
@@ -395,7 +395,7 @@ func TestPaymentChannelExtendSuccess(t *testing.T) {
 	assert.Equal(t, channelExpiry, channel.AgreedEol)
 	assert.Equal(t, channelExpiry, channel.Eol)
 	assert.Equal(t, rsrc.targetAddr, channel.Target)
-	assert.True(t, types.ZeroAttoFIL.Equal(channel.AmountRedeemed))
+	assert.Equal(t, types.ZeroAttoFIL, channel.AmountRedeemed)
 
 	extendAmount := types.NewAttoFILFromFIL(100)
 	extendExpiry := types.NewBlockHeight(100)
@@ -419,7 +419,7 @@ func TestPaymentChannelExtendSuccess(t *testing.T) {
 	assert.Equal(t, extendExpiry, channel.AgreedEol)
 	assert.Equal(t, extendExpiry, channel.Eol)
 	assert.Equal(t, rsrc.targetAddr, channel.Target)
-	assert.True(t, types.ZeroAttoFIL.Equal(channel.AmountRedeemed))
+	assert.Equal(t, types.ZeroAttoFIL, channel.AmountRedeemed)
 }
 
 func TestPaymentChannelCancelSuccess(t *testing.T) {

--- a/commands/payment_channel_daemon_test.go
+++ b/commands/payment_channel_daemon_test.go
@@ -68,7 +68,7 @@ func TestPaymentChannelLs(t *testing.T) {
 		assert.Equal(t, channelExpiry, channel.AgreedEol)
 		assert.Equal(t, channelExpiry, channel.Eol)
 		assert.Equal(t, rsrc.targetAddr, channel.Target)
-		assert.Equal(t, types.ZeroAttoFIL, channel.AmountRedeemed)
+		assert.True(t, types.ZeroAttoFIL.Equal(channel.AmountRedeemed))
 	})
 
 	t.Run("Works with specified payer", func(t *testing.T) {
@@ -98,7 +98,7 @@ func TestPaymentChannelLs(t *testing.T) {
 		assert.Equal(t, channelExpiry, channel.AgreedEol)
 		assert.Equal(t, channelExpiry, channel.Eol)
 		assert.Equal(t, rsrc.targetAddr, channel.Target)
-		assert.Equal(t, types.ZeroAttoFIL, channel.AmountRedeemed)
+		assert.True(t, types.ZeroAttoFIL.Equal(channel.AmountRedeemed))
 	})
 
 	t.Run("No results when listing with different from address", func(t *testing.T) {
@@ -157,7 +157,7 @@ func TestPaymentChannelVoucherSuccess(t *testing.T) {
 	voucher, err := types.DecodeVoucher(voucherStr)
 	require.NoError(t, err)
 
-	assert.Equal(t, voucherAmount, &voucher.Amount)
+	assert.Equal(t, voucherAmount, voucher.Amount)
 }
 
 func TestPaymentChannelRedeemSuccess(t *testing.T) {
@@ -239,7 +239,7 @@ func TestPaymentChannelRedeemTooEarlyFails(t *testing.T) {
 
 	channel := channels[chanid.String()]
 	assert.Equal(t, channelAmount, channel.Amount)
-	assert.Equal(t, types.ZeroAttoFIL, channel.AmountRedeemed)
+	assert.True(t, types.ZeroAttoFIL.Equal(channel.AmountRedeemed))
 }
 
 func TestPaymentChannelReclaimSuccess(t *testing.T) {
@@ -395,7 +395,7 @@ func TestPaymentChannelExtendSuccess(t *testing.T) {
 	assert.Equal(t, channelExpiry, channel.AgreedEol)
 	assert.Equal(t, channelExpiry, channel.Eol)
 	assert.Equal(t, rsrc.targetAddr, channel.Target)
-	assert.Equal(t, types.ZeroAttoFIL, channel.AmountRedeemed)
+	assert.True(t, types.ZeroAttoFIL.Equal(channel.AmountRedeemed))
 
 	extendAmount := types.NewAttoFILFromFIL(100)
 	extendExpiry := types.NewBlockHeight(100)
@@ -419,7 +419,7 @@ func TestPaymentChannelExtendSuccess(t *testing.T) {
 	assert.Equal(t, extendExpiry, channel.AgreedEol)
 	assert.Equal(t, extendExpiry, channel.Eol)
 	assert.Equal(t, rsrc.targetAddr, channel.Target)
-	assert.Equal(t, types.ZeroAttoFIL, channel.AmountRedeemed)
+	assert.True(t, types.ZeroAttoFIL.Equal(channel.AmountRedeemed))
 }
 
 func TestPaymentChannelCancelSuccess(t *testing.T) {
@@ -501,7 +501,7 @@ func requireNewPaychResource(ctx context.Context, t *testing.T, env *fastesting.
 	}
 }
 
-func (rsrc *paychResources) requirePaymentChannel(ctx context.Context, t *testing.T, amt *types.AttoFIL, eol *types.BlockHeight) (*types.ChannelID, *types.AttoFIL) {
+func (rsrc *paychResources) requirePaymentChannel(ctx context.Context, t *testing.T, amt types.AttoFIL, eol *types.BlockHeight) (*types.ChannelID, types.AttoFIL) {
 	mcid, err := rsrc.payer.PaychCreate(ctx, rsrc.targetAddr, amt, eol, fast.AOFromAddr(rsrc.payerAddr), fast.AOPrice(big.NewFloat(1)), fast.AOLimit(300))
 	require.NoError(t, err)
 

--- a/config/config.go
+++ b/config/config.go
@@ -113,7 +113,7 @@ func newDefaultMiningConfig() *MiningConfig {
 	return &MiningConfig{
 		MinerAddress:            address.Undef,
 		AutoSealIntervalSeconds: 120,
-		StoragePrice:            types.NewZeroAttoFIL(),
+		StoragePrice:            types.ZeroAttoFIL,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -106,7 +106,7 @@ func newDefaultBootstrapConfig() *BootstrapConfig {
 type MiningConfig struct {
 	MinerAddress            address.Address `json:"minerAddress"`
 	AutoSealIntervalSeconds uint            `json:"autoSealIntervalSeconds"`
-	StoragePrice            *types.AttoFIL  `json:"storagePrice"`
+	StoragePrice            types.AttoFIL   `json:"storagePrice"`
 }
 
 func newDefaultMiningConfig() *MiningConfig {

--- a/consensus/expected_test.go
+++ b/consensus/expected_test.go
@@ -54,13 +54,13 @@ func requireMakeBlocks(ctx context.Context, t *testing.T, pTipSet types.TipSet, 
 
 		ownerPubKeys[i] = kis[i].PublicKey()
 
-		ownerActor := th.RequireNewAccountActor(t, types.NewZeroAttoFIL())
+		ownerActor := th.RequireNewAccountActor(t, types.ZeroAttoFIL)
 		require.NoError(t, tree.SetActor(ctx, addr, ownerActor))
 
 		minerAddrs[i], err = address.NewActorAddress([]byte(fmt.Sprintf("%s%s", name, "Miner")))
 		require.NoError(t, err)
 		minerActor := th.RequireNewMinerActor(t, vms, minerAddrs[i], addr,
-			ownerPubKeys[i], 10000, th.RequireRandomPeerID(t), types.NewZeroAttoFIL())
+			ownerPubKeys[i], 10000, th.RequireRandomPeerID(t), types.ZeroAttoFIL)
 		require.NoError(t, tree.SetActor(ctx, minerAddrs[i], minerActor))
 	}
 	stateRoot, err := tree.Flush(ctx)

--- a/consensus/genesis.go
+++ b/consensus/genesis.go
@@ -223,7 +223,7 @@ func SetupDefaultActors(ctx context.Context, st state.Tree, storageMap vm.Storag
 		return err
 	}
 
-	pbAct := actor.NewActor(types.PaymentBrokerActorCodeCid, types.NewZeroAttoFIL())
+	pbAct := actor.NewActor(types.PaymentBrokerActorCodeCid, types.ZeroAttoFIL)
 	err = (&paymentbroker.Actor{}).InitializeState(storageMap.NewStorage(address.PaymentBrokerAddress, pbAct), nil)
 	if err != nil {
 		return err

--- a/consensus/genesis.go
+++ b/consensus/genesis.go
@@ -22,11 +22,11 @@ import (
 type GenesisInitFunc func(cst *hamt.CborIpldStore, bs blockstore.Blockstore) (*types.Block, error)
 
 var (
-	defaultAccounts map[address.Address]*types.AttoFIL
+	defaultAccounts map[address.Address]types.AttoFIL
 )
 
 func init() {
-	defaultAccounts = map[address.Address]*types.AttoFIL{
+	defaultAccounts = map[address.Address]types.AttoFIL{
 		address.NetworkAddress: types.NewAttoFILFromFIL(10000000000),
 		address.TestAddress:    types.NewAttoFILFromFIL(50000),
 		address.TestAddress2:   types.NewAttoFILFromFIL(60000),
@@ -35,12 +35,12 @@ func init() {
 
 type minerActorConfig struct {
 	state   *miner.State
-	balance *types.AttoFIL
+	balance types.AttoFIL
 }
 
 // Config is used to configure values in the GenesisInitFunction.
 type Config struct {
-	accounts   map[address.Address]*types.AttoFIL
+	accounts   map[address.Address]types.AttoFIL
 	nonces     map[address.Address]uint64
 	actors     map[address.Address]*actor.Actor
 	miners     map[address.Address]*minerActorConfig
@@ -51,7 +51,7 @@ type Config struct {
 type GenOption func(*Config) error
 
 // ActorAccount returns a config option that sets up an actor account.
-func ActorAccount(addr address.Address, amt *types.AttoFIL) GenOption {
+func ActorAccount(addr address.Address, amt types.AttoFIL) GenOption {
 	return func(gc *Config) error {
 		gc.accounts[addr] = amt
 		return nil
@@ -59,7 +59,7 @@ func ActorAccount(addr address.Address, amt *types.AttoFIL) GenOption {
 }
 
 // MinerActor returns a config option that sets up an miner actor account.
-func MinerActor(addr address.Address, owner address.Address, key []byte, pid peer.ID, coll *types.AttoFIL, sectorSize *types.BytesAmount) GenOption {
+func MinerActor(addr address.Address, owner address.Address, key []byte, pid peer.ID, coll types.AttoFIL, sectorSize *types.BytesAmount) GenOption {
 	return func(gc *Config) error {
 		gc.miners[addr] = &minerActorConfig{
 			state:   miner.NewState(owner, key, pid, sectorSize),
@@ -98,7 +98,7 @@ func ProofsMode(proofsMode types.ProofsMode) GenOption {
 // NewEmptyConfig inits and returns an empty config
 func NewEmptyConfig() *Config {
 	return &Config{
-		accounts:   make(map[address.Address]*types.AttoFIL),
+		accounts:   make(map[address.Address]types.AttoFIL),
 		nonces:     make(map[address.Address]uint64),
 		actors:     make(map[address.Address]*actor.Actor),
 		miners:     make(map[address.Address]*minerActorConfig),

--- a/consensus/processor.go
+++ b/consensus/processor.go
@@ -31,7 +31,7 @@ type BlockRewarder interface {
 	BlockReward(ctx context.Context, st state.Tree, minerOwnerAddr address.Address) error
 
 	// GasReward pays gas from the sender to the miner
-	GasReward(ctx context.Context, st state.Tree, minerOwnerAddr address.Address, msg *types.SignedMessage, cost *types.AttoFIL) error
+	GasReward(ctx context.Context, st state.Tree, minerOwnerAddr address.Address, msg *types.SignedMessage, cost types.AttoFIL) error
 }
 
 // ApplicationResult contains the result of successfully applying one message.
@@ -372,7 +372,7 @@ func CallQueryMethod(ctx context.Context, st state.Tree, vms vm.StorageMap, to a
 		From:   from,
 		To:     to,
 		Nonce:  0,
-		Value:  nil,
+		Value:  types.ZeroAttoFIL,
 		Method: method,
 		Params: params,
 	}
@@ -410,7 +410,7 @@ func PreviewQueryMethod(ctx context.Context, st state.Tree, vms vm.StorageMap, t
 		From:   from,
 		To:     to,
 		Nonce:  0,
-		Value:  nil,
+		Value:  types.ZeroAttoFIL,
 		Method: method,
 		Params: params,
 	}
@@ -586,7 +586,7 @@ func (br *DefaultBlockRewarder) BlockReward(ctx context.Context, st state.Tree, 
 }
 
 // GasReward transfers the gas cost reward from the sender actor to the minerOwnerAddr
-func (br *DefaultBlockRewarder) GasReward(ctx context.Context, st state.Tree, minerOwnerAddr address.Address, msg *types.SignedMessage, gas *types.AttoFIL) error {
+func (br *DefaultBlockRewarder) GasReward(ctx context.Context, st state.Tree, minerOwnerAddr address.Address, msg *types.SignedMessage, gas types.AttoFIL) error {
 	cachedTree := state.NewCachedStateTree(st)
 	if err := rewardTransfer(ctx, msg.From, minerOwnerAddr, gas, cachedTree); err != nil {
 		return errors.FaultErrorWrap(err, "Error attempting to pay gas reward")
@@ -597,12 +597,12 @@ func (br *DefaultBlockRewarder) GasReward(ctx context.Context, st state.Tree, mi
 // BlockRewardAmount returns the max FIL value miners can claim as the block reward.
 // TODO this is one of the system parameters that should be configured as part of
 // https://github.com/filecoin-project/go-filecoin/issues/884.
-func (br *DefaultBlockRewarder) BlockRewardAmount() *types.AttoFIL {
+func (br *DefaultBlockRewarder) BlockRewardAmount() types.AttoFIL {
 	return types.NewAttoFILFromFIL(1000)
 }
 
 // rewardTransfer retrieves two actors from the given addresses and attempts to transfer the given value from the balance of the first's to the second.
-func rewardTransfer(ctx context.Context, fromAddr, toAddr address.Address, value *types.AttoFIL, st *state.CachedTree) error {
+func rewardTransfer(ctx context.Context, fromAddr, toAddr address.Address, value types.AttoFIL, st *state.CachedTree) error {
 	fromActor, err := st.GetActor(ctx, fromAddr)
 	if err != nil {
 		return errors.FaultErrorWrap(err, "could not retrieve from actor for reward transfer.")

--- a/consensus/processor_test.go
+++ b/consensus/processor_test.go
@@ -346,7 +346,7 @@ func TestProcessBlockVMErrors(t *testing.T) {
 
 	stCid, miner := mustCreateStorageMiner(ctx, t, st, vms, minerAddr, minerOwnerAddr)
 
-	msg := types.NewMessage(fromAddr, toAddr, 0, nil, "returnRevertError", nil)
+	msg := types.NewMessage(fromAddr, toAddr, 0, types.ZeroAttoFIL, "returnRevertError", nil)
 	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(1), types.NewGasUnits(0))
 	require.NoError(t, err)
 	blk := &types.Block{
@@ -491,7 +491,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 	t.Run("errors when specifying a gas limit in excess of balance", func(t *testing.T) {
 		addr1, _, addr2, _, st, mockSigner := mustSetup2Actors(t, types.NewAttoFILFromFIL(1000), types.NewAttoFILFromFIL(10000))
 		msg := types.NewMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(550), "", []byte{})
-		smsg, err := types.NewSignedMessage(*msg, mockSigner, *types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
+		smsg, err := types.NewSignedMessage(*msg, mockSigner, types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
 		require.NoError(t, err)
 
 		// the maximum gas charge (10*50 = 500) is greater than the sender balance minus the message value (1000-550 = 450)
@@ -510,7 +510,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 		require.NoError(t, err)
 
 		msg := types.NewMessage(addr1, addr2, 0, types.ZeroAttoFIL, "", []byte{})
-		smsg, err := types.NewSignedMessage(*msg, mockSigner, *types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
+		smsg, err := types.NewSignedMessage(*msg, mockSigner, types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
 		require.NoError(t, err)
 
 		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
@@ -530,7 +530,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 		_, st := requireMakeStateTree(t, cst, map[address.Address]*actor.Actor{addr2: act2})
 
 		msg := types.NewMessage(addr1, addr2, 0, types.ZeroAttoFIL, "", []byte{})
-		smsg, err := types.NewSignedMessage(*msg, mockSigner, *types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
+		smsg, err := types.NewSignedMessage(*msg, mockSigner, types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
 		require.NoError(t, err)
 
 		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, addr2,
@@ -570,7 +570,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 	t.Run("errors when attempting to send to self", func(t *testing.T) {
 		addr1, _, addr2, _, st, mockSigner := mustSetup2Actors(t, types.NewAttoFILFromFIL(1000), types.NewAttoFILFromFIL(10000))
 		msg := types.NewMessage(addr1, addr1, 0, types.NewAttoFILFromFIL(550), "", []byte{})
-		smsg, err := types.NewSignedMessage(*msg, mockSigner, *types.NewAttoFILFromFIL(10), types.NewGasUnits(0))
+		smsg, err := types.NewSignedMessage(*msg, mockSigner, types.NewAttoFILFromFIL(10), types.NewGasUnits(0))
 		require.NoError(t, err)
 
 		// the maximum gas charge (10*50 = 500) is greater than the sender balance minus the message value (1000-550 = 450)
@@ -582,7 +582,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 	t.Run("errors when specifying a gas limit in excess of balance", func(t *testing.T) {
 		addr1, _, addr2, _, st, mockSigner := mustSetup2Actors(t, types.NewAttoFILFromFIL(1000), types.NewAttoFILFromFIL(10000))
 		msg := types.NewMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(550), "", []byte{})
-		smsg, err := types.NewSignedMessage(*msg, mockSigner, *types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
+		smsg, err := types.NewSignedMessage(*msg, mockSigner, types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
 		require.NoError(t, err)
 
 		// the maximum gas charge (10*50 = 500) is greater than the sender balance minus the message value (1000-550 = 450)
@@ -625,7 +625,7 @@ func TestNestedSendBalance(t *testing.T) {
 	// send 100 from addr1 -> addr2, by sending a message from addr0 to addr1
 	params1, err := abi.ToEncodedValues(addr2)
 	assert.NoError(t, err)
-	msg1 := types.NewMessage(addr0, addr1, 0, nil, "nestedBalance", params1)
+	msg1 := types.NewMessage(addr0, addr1, 0, types.ZeroAttoFIL, "nestedBalance", params1)
 
 	_, err = th.ApplyTestMessage(st, th.VMStorage(), msg1, types.NewBlockHeight(0))
 	assert.NoError(t, err)
@@ -800,7 +800,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 		gasLimit := types.NewGasUnits(200)
 
 		appResult, err := th.ApplyTestMessageWithGas(st, th.VMStorage(), msg, types.NewBlockHeight(0), mockSigner,
-			*gasPrice, gasLimit, minerAddr)
+			gasPrice, gasLimit, minerAddr)
 		assert.NoError(t, err)
 		assert.NoError(t, appResult.ExecutionError)
 
@@ -826,7 +826,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 		gasLimit := types.NewGasUnits(200)
 
 		appResult, err := th.ApplyTestMessageWithGas(st, th.VMStorage(), msg, types.NewBlockHeight(0), mockSigner,
-			*gasPrice, gasLimit, minerAddr)
+			gasPrice, gasLimit, minerAddr)
 		assert.NoError(t, err)
 		assert.EqualError(t, appResult.ExecutionError, "boom")
 
@@ -853,7 +853,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 		gasLimit := types.NewGasUnits(50)
 
 		appResult, err := th.ApplyTestMessageWithGas(st, th.VMStorage(), msg, types.NewBlockHeight(0), mockSigner,
-			*gasPrice, gasLimit, minerAddr)
+			gasPrice, gasLimit, minerAddr)
 		assert.NoError(t, err)
 		assert.EqualError(t, appResult.ExecutionError, "Insufficient gas: gas cost exceeds gas limit")
 
@@ -885,7 +885,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 		gasLimit := types.NewGasUnits(600)
 
 		appResult, err := th.ApplyTestMessageWithGas(st, th.VMStorage(), msg, types.NewBlockHeight(0), mockSigner,
-			*gasPrice, gasLimit, minerAddr)
+			gasPrice, gasLimit, minerAddr)
 		assert.NoError(t, err)
 		assert.NoError(t, appResult.ExecutionError)
 		minerActor, err := st.GetActor(ctx, minerAddr)
@@ -918,7 +918,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 		gasLimit := types.NewGasUnits(50)
 
 		appResult, err := th.ApplyTestMessageWithGas(st, th.VMStorage(), msg, types.NewBlockHeight(0), mockSigner,
-			*gasPrice, gasLimit, minerAddr)
+			gasPrice, gasLimit, minerAddr)
 		assert.NoError(t, err)
 		assert.EqualError(t, appResult.ExecutionError, "Insufficient gas: gas cost exceeds gas limit")
 
@@ -949,8 +949,8 @@ func TestBlockGasLimitBehavior(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("A single message whose gas limit is greater than the block gas limit fails permanently", func(t *testing.T) {
-		msg := types.NewMessage(sender, receiver, 0, nil, "blockLimitTestMethod", []byte{})
-		sgnedMsg, err := types.NewSignedMessage(*msg, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*2)
+		msg := types.NewMessage(sender, receiver, 0, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
+		sgnedMsg, err := types.NewSignedMessage(*msg, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*2)
 		require.NoError(t, err)
 
 		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg}, sender, types.NewBlockHeight(0), nil)
@@ -960,12 +960,12 @@ func TestBlockGasLimitBehavior(t *testing.T) {
 	})
 
 	t.Run("2 msgs both succeed when sum of limits > block limit, but 1st usage + 2nd limit < block limit", func(t *testing.T) {
-		msg1 := types.NewMessage(sender, receiver, 0, nil, "blockLimitTestMethod", []byte{})
-		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*5/8)
+		msg1 := types.NewMessage(sender, receiver, 0, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
+		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*5/8)
 		require.NoError(t, err)
 
-		msg2 := types.NewMessage(sender, receiver, 1, nil, "blockLimitTestMethod", []byte{})
-		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*5/8)
+		msg2 := types.NewMessage(sender, receiver, 1, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
+		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*5/8)
 		require.NoError(t, err)
 
 		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg1, sgnedMsg2}, sender, types.NewBlockHeight(0), nil)
@@ -976,12 +976,12 @@ func TestBlockGasLimitBehavior(t *testing.T) {
 	})
 
 	t.Run("2nd message delayed when 1st usage + 2nd limit > block limit", func(t *testing.T) {
-		msg1 := types.NewMessage(sender, receiver, 0, nil, "blockLimitTestMethod", []byte{})
-		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*3/8)
+		msg1 := types.NewMessage(sender, receiver, 0, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
+		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*3/8)
 		require.NoError(t, err)
 
-		msg2 := types.NewMessage(sender, receiver, 1, nil, "blockLimitTestMethod", []byte{})
-		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*7/8)
+		msg2 := types.NewMessage(sender, receiver, 1, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
+		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*7/8)
 		require.NoError(t, err)
 
 		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg1, sgnedMsg2}, sender, types.NewBlockHeight(0), nil)
@@ -992,16 +992,16 @@ func TestBlockGasLimitBehavior(t *testing.T) {
 	})
 
 	t.Run("message with high gas limit does not block messages with lower limits from being included in block", func(t *testing.T) {
-		msg1 := types.NewMessage(sender, receiver, 0, nil, "blockLimitTestMethod", []byte{})
-		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*3/8)
+		msg1 := types.NewMessage(sender, receiver, 0, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
+		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*3/8)
 		require.NoError(t, err)
 
-		msg2 := types.NewMessage(sender, receiver, 1, nil, "blockLimitTestMethod", []byte{})
-		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*7/8)
+		msg2 := types.NewMessage(sender, receiver, 1, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
+		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*7/8)
 		require.NoError(t, err)
 
-		msg3 := types.NewMessage(sender, receiver, 2, nil, "blockLimitTestMethod", []byte{})
-		sgnedMsg3, err := types.NewSignedMessage(*msg3, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*3/8)
+		msg3 := types.NewMessage(sender, receiver, 2, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
+		sgnedMsg3, err := types.NewSignedMessage(*msg3, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*3/8)
 		require.NoError(t, err)
 
 		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg1, sgnedMsg2, sgnedMsg3}, sender, types.NewBlockHeight(0), nil)
@@ -1052,7 +1052,7 @@ func setupActorsForGasTest(t *testing.T, vms vm.StorageMap, fakeActorCodeCid cid
 	return addresses, st, &mockSigner
 }
 
-func mustSetup2Actors(t *testing.T, balance1 *types.AttoFIL, balance2 *types.AttoFIL) (address.Address, *actor.Actor, address.Address, *actor.Actor, state.Tree, types.MockSigner) {
+func mustSetup2Actors(t *testing.T, balance1 types.AttoFIL, balance2 types.AttoFIL) (address.Address, *actor.Actor, address.Address, *actor.Actor, state.Tree, types.MockSigner) {
 	cst := hamt.NewCborStore()
 	vms := th.VMStorage()
 	mockSigner, _ := types.NewMockSignersAndKeyInfo(2)

--- a/consensus/processor_test.go
+++ b/consensus/processor_test.go
@@ -950,7 +950,7 @@ func TestBlockGasLimitBehavior(t *testing.T) {
 
 	t.Run("A single message whose gas limit is greater than the block gas limit fails permanently", func(t *testing.T) {
 		msg := types.NewMessage(sender, receiver, 0, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
-		sgnedMsg, err := types.NewSignedMessage(*msg, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*2)
+		sgnedMsg, err := types.NewSignedMessage(*msg, signer, types.ZeroAttoFIL, types.BlockGasLimit*2)
 		require.NoError(t, err)
 
 		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg}, sender, types.NewBlockHeight(0), nil)
@@ -961,11 +961,11 @@ func TestBlockGasLimitBehavior(t *testing.T) {
 
 	t.Run("2 msgs both succeed when sum of limits > block limit, but 1st usage + 2nd limit < block limit", func(t *testing.T) {
 		msg1 := types.NewMessage(sender, receiver, 0, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
-		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*5/8)
+		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, types.ZeroAttoFIL, types.BlockGasLimit*5/8)
 		require.NoError(t, err)
 
 		msg2 := types.NewMessage(sender, receiver, 1, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
-		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*5/8)
+		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, types.ZeroAttoFIL, types.BlockGasLimit*5/8)
 		require.NoError(t, err)
 
 		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg1, sgnedMsg2}, sender, types.NewBlockHeight(0), nil)
@@ -977,11 +977,11 @@ func TestBlockGasLimitBehavior(t *testing.T) {
 
 	t.Run("2nd message delayed when 1st usage + 2nd limit > block limit", func(t *testing.T) {
 		msg1 := types.NewMessage(sender, receiver, 0, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
-		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*3/8)
+		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, types.ZeroAttoFIL, types.BlockGasLimit*3/8)
 		require.NoError(t, err)
 
 		msg2 := types.NewMessage(sender, receiver, 1, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
-		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*7/8)
+		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, types.ZeroAttoFIL, types.BlockGasLimit*7/8)
 		require.NoError(t, err)
 
 		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg1, sgnedMsg2}, sender, types.NewBlockHeight(0), nil)
@@ -993,15 +993,15 @@ func TestBlockGasLimitBehavior(t *testing.T) {
 
 	t.Run("message with high gas limit does not block messages with lower limits from being included in block", func(t *testing.T) {
 		msg1 := types.NewMessage(sender, receiver, 0, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
-		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*3/8)
+		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, types.ZeroAttoFIL, types.BlockGasLimit*3/8)
 		require.NoError(t, err)
 
 		msg2 := types.NewMessage(sender, receiver, 1, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
-		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*7/8)
+		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, types.ZeroAttoFIL, types.BlockGasLimit*7/8)
 		require.NoError(t, err)
 
 		msg3 := types.NewMessage(sender, receiver, 2, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{})
-		sgnedMsg3, err := types.NewSignedMessage(*msg3, signer, types.NewZeroAttoFIL(), types.BlockGasLimit*3/8)
+		sgnedMsg3, err := types.NewSignedMessage(*msg3, signer, types.ZeroAttoFIL, types.BlockGasLimit*3/8)
 		require.NoError(t, err)
 
 		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg1, sgnedMsg2, sgnedMsg3}, sender, types.NewBlockHeight(0), nil)

--- a/consensus/testing.go
+++ b/consensus/testing.go
@@ -87,7 +87,7 @@ func (tbr *TestBlockRewarder) BlockReward(ctx context.Context, st state.Tree, mi
 }
 
 // GasReward is a noop
-func (tbr *TestBlockRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr address.Address, msg *types.SignedMessage, gas *types.AttoFIL) error {
+func (tbr *TestBlockRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr address.Address, msg *types.SignedMessage, gas types.AttoFIL) error {
 	// do nothing to keep state root the same
 	return nil
 }

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -165,7 +165,7 @@ func newMessage(t *testing.T, from, to address.Address, nonce uint64, valueAF in
 	return signed
 }
 
-func attoFil(v int) *types.AttoFIL {
+func attoFil(v int) types.AttoFIL {
 	val, _ := types.NewAttoFILFromString(fmt.Sprintf("%d", v), 10)
 	return val
 }

--- a/core/outbox.go
+++ b/core/outbox.go
@@ -73,7 +73,7 @@ func (ob *Outbox) Queue() *MessageQueue {
 }
 
 // Send marshals and sends a message, retaining it in the outbound message queue.
-func (ob *Outbox) Send(ctx context.Context, from, to address.Address, value *types.AttoFIL,
+func (ob *Outbox) Send(ctx context.Context, from, to address.Address, value types.AttoFIL,
 	gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (out cid.Cid, err error) {
 	defer func() {
 		if err != nil {

--- a/core/outbox_test.go
+++ b/core/outbox_test.go
@@ -45,7 +45,7 @@ func TestOutbox(t *testing.T) {
 
 		blk := types.NewBlockForTest(nil, 1)
 		blk.Height = 1000
-		actr, _ := account.NewActor(types.NewZeroAttoFIL())
+		actr, _ := account.NewActor(types.ZeroAttoFIL)
 		actr.Nonce = 42
 		provider.Set(t, blk, sender, actr)
 
@@ -53,7 +53,7 @@ func TestOutbox(t *testing.T) {
 		require.Empty(t, queue.List(sender))
 		require.Nil(t, publisher.message)
 
-		_, err := ob.Send(context.Background(), sender, toAddr, types.NewZeroAttoFIL(), types.NewGasPrice(0), types.NewGasUnits(0), "")
+		_, err := ob.Send(context.Background(), sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), types.NewGasUnits(0), "")
 		require.NoError(t, err)
 		assert.Equal(t, uint64(1000), queue.List(sender)[0].Stamp)
 		assert.NotNil(t, publisher.message)
@@ -75,7 +75,7 @@ func TestOutbox(t *testing.T) {
 
 		blk := types.NewBlockForTest(nil, 1)
 		blk.Height = 1000
-		actr, _ := account.NewActor(types.NewZeroAttoFIL())
+		actr, _ := account.NewActor(types.ZeroAttoFIL)
 		actr.Nonce = 42
 		provider.Set(t, blk, sender, actr)
 
@@ -85,7 +85,7 @@ func TestOutbox(t *testing.T) {
 		addTwentyMessages := func(batch int) {
 			defer wg.Done()
 			for i := 0; i < msgCount; i++ {
-				_, err := s.Send(ctx, sender, toAddr, types.NewZeroAttoFIL(), types.NewGasPrice(0), types.NewGasUnits(0), fmt.Sprintf("%d-%d", batch, i), []byte{})
+				_, err := s.Send(ctx, sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), types.NewGasUnits(0), fmt.Sprintf("%d-%d", batch, i), []byte{})
 				require.NoError(t, err)
 			}
 		}
@@ -129,7 +129,7 @@ func TestOutbox(t *testing.T) {
 
 		ob := core.NewOutbox(w, nullValidator{}, queue, publisher, nullPolicy{}, provider, provider)
 
-		_, err := ob.Send(context.Background(), sender, toAddr, types.NewZeroAttoFIL(), types.NewGasPrice(0), types.NewGasUnits(0), "")
+		_, err := ob.Send(context.Background(), sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), types.NewGasUnits(0), "")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "account or empty")
 	})

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -69,10 +69,10 @@ type FunctionSignature struct {
 type VMContext interface {
 	Message() *types.Message
 	Storage() Storage
-	Send(to address.Address, method string, value *types.AttoFIL, params []interface{}) ([][]byte, uint8, error)
+	Send(to address.Address, method string, value types.AttoFIL, params []interface{}) ([][]byte, uint8, error)
 	AddressForNewActor() (address.Address, error)
 	BlockHeight() *types.BlockHeight
-	MyBalance() *types.AttoFIL
+	MyBalance() types.AttoFIL
 	IsFromAccountActor() bool
 	Charge(cost types.GasUnits) error
 	SampleChainRandomness(sampleHeight *types.BlockHeight) ([]byte, error)

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -323,7 +323,7 @@ func GenGenesisCar(cfg *GenesisCfg, out io.Writer, seed int64) (*RenderedGenInfo
 // applyMessageDirect applies a given message directly to the given state tree and storage map and returns the result of the message.
 // This is a shortcut to allow gengen to use built-in actor functionality to alter the genesis block's state.
 // Outside genesis, direct execution of actor code is a really bad idea.
-func applyMessageDirect(ctx context.Context, st state.Tree, vms vm.StorageMap, from, to address.Address, value *types.AttoFIL, method string, params ...interface{}) ([][]byte, error) {
+func applyMessageDirect(ctx context.Context, st state.Tree, vms vm.StorageMap, from, to address.Address, value types.AttoFIL, method string, params ...interface{}) ([][]byte, error) {
 	pdata := actor.MustConvertParams(params...)
 	msg := types.NewMessage(from, to, 0, value, method, pdata)
 	// this should never fail due to lack of gas since gas doesn't have meaning here
@@ -373,7 +373,7 @@ func (gbr *blockRewarder) BlockReward(ctx context.Context, st state.Tree, minerA
 }
 
 // GasReward is a noop
-func (gbr *blockRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr address.Address, msg *types.SignedMessage, cost *types.AttoFIL) error {
+func (gbr *blockRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr address.Address, msg *types.SignedMessage, cost types.AttoFIL) error {
 	return nil
 }
 

--- a/mining/mqueue.go
+++ b/mining/mqueue.go
@@ -93,7 +93,7 @@ func (pq queueHeap) Len() int { return len(pq) }
 
 // Less implements Heap.Interface.Less to compare items on gas price and sender address.
 func (pq queueHeap) Less(i, j int) bool {
-	delta := pq[i][0].MeteredMessage.GasPrice.Sub(&pq[j][0].MeteredMessage.GasPrice)
+	delta := pq[i][0].MeteredMessage.GasPrice.Sub(pq[j][0].MeteredMessage.GasPrice)
 	if !delta.Equal(types.ZeroAttoFIL) {
 		// We want Pop to give us the highest gas price, so use GreaterThan.
 		return delta.GreaterThan(types.ZeroAttoFIL)

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -156,21 +156,21 @@ func TestApplyMessagesForSuccessTempAndPermFailures(t *testing.T) {
 	// If a given message's category changes in the future, it needs to be replaced here in tests by another so we fully
 	// exercise the categorization.
 	// addr2 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
-	msg1 := types.NewMessage(addr2, addr1, 0, nil, "", nil)
+	msg1 := types.NewMessage(addr2, addr1, 0, types.ZeroAttoFIL, "", nil)
 	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(1), types.NewGasUnits(0))
 	require.NoError(t, err)
 
 	// This is actually okay and should result in a receipt
-	msg2 := types.NewMessage(addr1, addr2, 0, nil, "", nil)
+	msg2 := types.NewMessage(addr1, addr2, 0, types.ZeroAttoFIL, "", nil)
 	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner, types.NewGasPrice(1), types.NewGasUnits(0))
 	require.NoError(t, err)
 
 	// The following two are sending to self -- errSelfSend, a permanent error.
-	msg3 := types.NewMessage(addr1, addr1, 1, nil, "", nil)
+	msg3 := types.NewMessage(addr1, addr1, 1, types.ZeroAttoFIL, "", nil)
 	smsg3, err := types.NewSignedMessage(*msg3, &mockSigner, types.NewGasPrice(1), types.NewGasUnits(0))
 	require.NoError(t, err)
 
-	msg4 := types.NewMessage(addr2, addr2, 1, nil, "", nil)
+	msg4 := types.NewMessage(addr2, addr2, 1, types.ZeroAttoFIL, "", nil)
 	smsg4, err := types.NewSignedMessage(*msg4, &mockSigner, types.NewGasPrice(1), types.NewGasUnits(0))
 	require.NoError(t, err)
 
@@ -258,21 +258,21 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
 
 	// addr3 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
-	msg1 := types.NewMessage(addrs[2], addrs[0], 0, nil, "", nil)
+	msg1 := types.NewMessage(addrs[2], addrs[0], 0, types.ZeroAttoFIL, "", nil)
 	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(1), types.NewGasUnits(0))
 	require.NoError(t, err)
 
 	// This is actually okay and should result in a receipt
-	msg2 := types.NewMessage(addrs[0], addrs[1], 0, nil, "", nil)
+	msg2 := types.NewMessage(addrs[0], addrs[1], 0, types.ZeroAttoFIL, "", nil)
 	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner, types.NewGasPrice(1), types.NewGasUnits(0))
 	require.NoError(t, err)
 
 	// add the following and then increment the actor nonce at addrs[1], nonceTooLow, a permanent error.
-	msg3 := types.NewMessage(addrs[1], addrs[0], 0, nil, "", nil)
+	msg3 := types.NewMessage(addrs[1], addrs[0], 0, types.ZeroAttoFIL, "", nil)
 	smsg3, err := types.NewSignedMessage(*msg3, &mockSigner, types.NewGasPrice(1), types.NewGasUnits(0))
 	require.NoError(t, err)
 
-	msg4 := types.NewMessage(addrs[1], addrs[2], 1, nil, "", nil)
+	msg4 := types.NewMessage(addrs[1], addrs[2], 1, types.ZeroAttoFIL, "", nil)
 	smsg4, err := types.NewSignedMessage(*msg4, &mockSigner, types.NewGasPrice(1), types.NewGasUnits(0))
 	require.NoError(t, err)
 
@@ -416,7 +416,7 @@ func TestGenerateError(t *testing.T) {
 		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
 
 	// This is actually okay and should result in a receipt
-	msg := types.NewMessage(addrs[0], addrs[1], 0, nil, "", nil)
+	msg := types.NewMessage(addrs[0], addrs[1], 0, types.ZeroAttoFIL, "", nil)
 	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(t, err)
 	_, err = pool.Add(ctx, smsg, 0)

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -139,7 +139,7 @@ func (r *ZeroRewarder) BlockReward(ctx context.Context, st state.Tree, minerAddr
 	return nil
 }
 
-func (r *ZeroRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr address.Address, msg *types.SignedMessage, cost *types.AttoFIL) error {
+func (r *ZeroRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr address.Address, msg *types.SignedMessage, cost types.AttoFIL) error {
 	return nil
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -841,7 +841,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 						node.miningCtx,
 						minerOwnerAddr,
 						minerAddr,
-						nil,
+						types.ZeroAttoFIL,
 						gasPrice,
 						gasUnits,
 						"commitSector",

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -206,7 +206,7 @@ func (api *API) MessageQuery(ctx context.Context, optFrom, to address.Address, m
 // message in the msg pool and broadcasts it to the network; it does not wait for the
 // message to go on chain. Note that no default from address is provided. If you need
 // a default address, use MessageSendWithDefaultAddress instead.
-func (api *API) MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+func (api *API) MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 	return api.outbox.Send(ctx, from, to, value, gasPrice, gasLimit, method, params...)
 }
 

--- a/plumbing/msg/sender.go
+++ b/plumbing/msg/sender.go
@@ -20,7 +20,7 @@ func NewSender(outbox *core.Outbox) *Sender {
 }
 
 // Send sends a message. See api description.
-func (s *Sender) Send(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (out cid.Cid, err error) {
+func (s *Sender) Send(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (out cid.Cid, err error) {
 	return s.outbox.Send(ctx, from, to, value, gasPrice, gasLimit, method, params...)
 
 }

--- a/plumbing/strgdls/store_test.go
+++ b/plumbing/strgdls/store_test.go
@@ -42,7 +42,7 @@ func TestDealStoreRoundTrip(t *testing.T) {
 			Channel: channelID,
 			Payer:   clientAddr,
 			Target:  minerAddr,
-			Amount:  *totalPrice,
+			Amount:  totalPrice,
 			ValidAt: *validAt,
 		}}}
 
@@ -93,6 +93,6 @@ func TestDealStoreRoundTrip(t *testing.T) {
 	assert.Equal(t, channelID, retrievedDeal.Proposal.Payment.Vouchers[0].Channel)
 	assert.Equal(t, clientAddr, retrievedDeal.Proposal.Payment.Vouchers[0].Payer)
 	assert.Equal(t, minerAddr, retrievedDeal.Proposal.Payment.Vouchers[0].Target)
-	assert.Equal(t, *totalPrice, retrievedDeal.Proposal.Payment.Vouchers[0].Amount)
+	assert.Equal(t, totalPrice, retrievedDeal.Proposal.Payment.Vouchers[0].Amount)
 	assert.Equal(t, *validAt, retrievedDeal.Proposal.Payment.Vouchers[0].ValidAt)
 }

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -86,7 +86,7 @@ func (a *API) MessageSendWithDefaultAddress(
 	ctx context.Context,
 	from,
 	to address.Address,
-	value *types.AttoFIL,
+	value types.AttoFIL,
 	gasPrice types.AttoFIL,
 	gasLimit types.GasUnits,
 	method string,
@@ -113,7 +113,7 @@ func (a *API) MinerCreate(
 	gasLimit types.GasUnits,
 	sectorSize *types.BytesAmount,
 	pid peer.ID,
-	collateral *types.AttoFIL,
+	collateral types.AttoFIL,
 ) (_ *address.Address, err error) {
 	return MinerCreate(ctx, a, accountAddr, gasPrice, gasLimit, sectorSize, pid, collateral)
 }
@@ -159,7 +159,7 @@ func (a *API) MinerGetPeerID(ctx context.Context, minerAddr address.Address) (pe
 }
 
 // MinerSetPrice configures the price of storage. See implementation for details.
-func (a *API) MinerSetPrice(ctx context.Context, from address.Address, miner address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, price *types.AttoFIL, expiry *big.Int) (MinerSetPriceResponse, error) {
+func (a *API) MinerSetPrice(ctx context.Context, from address.Address, miner address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, price types.AttoFIL, expiry *big.Int) (MinerSetPriceResponse, error) {
 	return MinerSetPrice(ctx, a, from, miner, gasPrice, gasLimit, price, expiry)
 }
 
@@ -169,7 +169,7 @@ func (a *API) MinerPreviewSetPrice(
 	ctx context.Context,
 	from address.Address,
 	miner address.Address,
-	price *types.AttoFIL,
+	price types.AttoFIL,
 	expiry *big.Int,
 ) (types.GasUnits, error) {
 	return MinerPreviewSetPrice(ctx, a, from, miner, price, expiry)
@@ -181,7 +181,7 @@ func (a *API) ProtocolParameters(ctx context.Context) (*ProtocolParams, error) {
 }
 
 // WalletBalance returns the current balance of the given wallet address.
-func (a *API) WalletBalance(ctx context.Context, address address.Address) (*types.AttoFIL, error) {
+func (a *API) WalletBalance(ctx context.Context, address address.Address) (types.AttoFIL, error) {
 	return WalletBalance(ctx, a, address)
 }
 
@@ -205,7 +205,7 @@ func (a *API) PaymentChannelVoucher(
 	ctx context.Context,
 	fromAddr address.Address,
 	channel *types.ChannelID,
-	amount *types.AttoFIL,
+	amount types.AttoFIL,
 	validAt *types.BlockHeight,
 	condition *types.Predicate,
 ) (voucher *types.PaymentVoucher, err error) {

--- a/porcelain/client.go
+++ b/porcelain/client.go
@@ -15,7 +15,7 @@ import (
 // Ask is a result of querying for an ask, it may contain an error
 type Ask struct {
 	Miner  address.Address
-	Price  *types.AttoFIL
+	Price  types.AttoFIL
 	Expiry *types.BlockHeight
 	ID     uint64
 

--- a/porcelain/message.go
+++ b/porcelain/message.go
@@ -13,7 +13,7 @@ var log = logging.Logger("porcelain") // nolint: deadcode
 
 // mswdaAPI is the subset of the plumbing.API that MessageSendWithDefaultAddress uses.
 type mswdaAPI interface {
-	MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
+	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
 	WalletDefaultAddress() (address.Address, error)
 }
 
@@ -25,7 +25,7 @@ func MessageSendWithDefaultAddress(
 	plumbing mswdaAPI,
 	from,
 	to address.Address,
-	value *types.AttoFIL,
+	value types.AttoFIL,
 	gasPrice types.AttoFIL,
 	gasLimit types.GasUnits,
 	method string,

--- a/porcelain/miner.go
+++ b/porcelain/miner.go
@@ -216,7 +216,7 @@ func MinerSetPrice(ctx context.Context, plumbing mspAPI, from address.Address, m
 	}
 
 	// create ask
-	res.AddAskCid, err = plumbing.MessageSendWithDefaultAddress(ctx, from, res.MinerAddr, types.NewZeroAttoFIL(), gasPrice, gasLimit, "addAsk", price, expiry)
+	res.AddAskCid, err = plumbing.MessageSendWithDefaultAddress(ctx, from, res.MinerAddr, types.ZeroAttoFIL, gasPrice, gasLimit, "addAsk", price, expiry)
 	if err != nil {
 		return res, errors.Wrap(err, "couldn't send message")
 	}

--- a/porcelain/miner.go
+++ b/porcelain/miner.go
@@ -25,7 +25,7 @@ import (
 type mcAPI interface {
 	ConfigGet(dottedPath string) (interface{}, error)
 	ConfigSet(dottedPath string, paramJSON string) error
-	MessageSendWithDefaultAddress(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
+	MessageSendWithDefaultAddress(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
 	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error
 	WalletDefaultAddress() (address.Address, error)
 	WalletGetPubKeyForAddress(addr address.Address) ([]byte, error)
@@ -43,7 +43,7 @@ func MinerCreate(
 	gasLimit types.GasUnits,
 	sectorSize *types.BytesAmount,
 	pid peer.ID,
-	collateral *types.AttoFIL,
+	collateral types.AttoFIL,
 ) (_ *address.Address, err error) {
 	if minerOwnerAddr == (address.Address{}) {
 		minerOwnerAddr, err = plumbing.WalletDefaultAddress()
@@ -172,7 +172,7 @@ func MinerPreviewCreate(
 type mspAPI interface {
 	ConfigGet(dottedPath string) (interface{}, error)
 	ConfigSet(dottedKey string, jsonString string) error
-	MessageSendWithDefaultAddress(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
+	MessageSendWithDefaultAddress(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
 	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error
 }
 
@@ -181,13 +181,13 @@ type MinerSetPriceResponse struct {
 	AddAskCid cid.Cid
 	BlockCid  cid.Cid
 	MinerAddr address.Address
-	Price     *types.AttoFIL
+	Price     types.AttoFIL
 }
 
 // MinerSetPrice configures the price of storage, then sends an ask advertising that price and waits for it to be mined.
 // If minerAddr is empty, the default miner will be used.
 // This method is non-transactional in the sense that it will set the price whether or not it creates the ask successfully.
-func MinerSetPrice(ctx context.Context, plumbing mspAPI, from address.Address, miner address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, price *types.AttoFIL, expiry *big.Int) (MinerSetPriceResponse, error) {
+func MinerSetPrice(ctx context.Context, plumbing mspAPI, from address.Address, miner address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, price types.AttoFIL, expiry *big.Int) (MinerSetPriceResponse, error) {
 	res := MinerSetPriceResponse{
 		Price: price,
 	}
@@ -242,7 +242,7 @@ type mpspAPI interface {
 
 // MinerPreviewSetPrice calculates the amount of Gas needed for a call to MinerSetPrice.
 // This method accepts all the same arguments as MinerSetPrice.
-func MinerPreviewSetPrice(ctx context.Context, plumbing mpspAPI, from address.Address, miner address.Address, price *types.AttoFIL, expiry *big.Int) (types.GasUnits, error) {
+func MinerPreviewSetPrice(ctx context.Context, plumbing mpspAPI, from address.Address, miner address.Address, price types.AttoFIL, expiry *big.Int) (types.GasUnits, error) {
 	// get miner address if not provided
 	if miner.Empty() {
 		minerValue, err := plumbing.ConfigGet("mining.minerAddress")

--- a/porcelain/miner_test.go
+++ b/porcelain/miner_test.go
@@ -56,7 +56,7 @@ func (mpc *minerCreate) ConfigSet(dottedPath string, paramJSON string) error {
 	return mpc.config.Set(dottedPath, paramJSON)
 }
 
-func (mpc *minerCreate) MessageSendWithDefaultAddress(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+func (mpc *minerCreate) MessageSendWithDefaultAddress(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 	if mpc.msgFail {
 		return cid.Cid{}, errors.New("Test Error")
 	}
@@ -182,7 +182,7 @@ type minerSetPricePlumbing struct {
 	failSend bool
 	failWait bool
 
-	messageSend func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
+	messageSend func(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
 }
 
 func newMinerSetPricePlumbing(t *testing.T) *minerSetPricePlumbing {
@@ -192,7 +192,7 @@ func newMinerSetPricePlumbing(t *testing.T) *minerSetPricePlumbing {
 	}
 }
 
-func (mtp *minerSetPricePlumbing) MessageSendWithDefaultAddress(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+func (mtp *minerSetPricePlumbing) MessageSendWithDefaultAddress(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 	if mtp.failSend {
 		return cid.Cid{}, errors.New("Test error in MessageSend")
 	}
@@ -302,7 +302,7 @@ func TestMinerSetPrice(t *testing.T) {
 		price := types.NewAttoFILFromFIL(50)
 		minerAddr := address.NewForTestGetter()()
 
-		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 			assert.Equal(t, minerAddr, to)
 			return types.NewCidForTestGetter()(), nil
 		}
@@ -320,7 +320,7 @@ func TestMinerSetPrice(t *testing.T) {
 		ctx := context.Background()
 		price := types.NewAttoFILFromFIL(50)
 
-		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 			assert.Equal(t, minerAddr, to)
 			return types.NewCidForTestGetter()(), nil
 		}
@@ -336,7 +336,7 @@ func TestMinerSetPrice(t *testing.T) {
 		price := types.NewAttoFILFromFIL(50)
 		expiry := big.NewInt(24)
 
-		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 			assert.Equal(t, "addAsk", method)
 			assert.Equal(t, price, params[0])
 			assert.Equal(t, expiry, params[1])
@@ -369,7 +369,7 @@ func TestMinerSetPrice(t *testing.T) {
 
 		messageCid := types.NewCidForTestGetter()()
 
-		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 			return messageCid, nil
 		}
 

--- a/porcelain/payment_channel.go
+++ b/porcelain/payment_channel.go
@@ -63,7 +63,7 @@ func PaymentChannelVoucher(
 	plumbing pcvPlumbing,
 	fromAddr address.Address,
 	channel *types.ChannelID,
-	amount *types.AttoFIL,
+	amount types.AttoFIL,
 	validAt *types.BlockHeight,
 	condition *types.Predicate,
 ) (voucher *types.PaymentVoucher, err error) {

--- a/porcelain/payment_channel_test.go
+++ b/porcelain/payment_channel_test.go
@@ -76,7 +76,7 @@ func TestPaymentChannelVoucher(t *testing.T) {
 			Channel:   *types.NewChannelID(5),
 			Payer:     address.Undef,
 			Target:    address.Undef,
-			Amount:    *types.NewAttoFILFromFIL(10),
+			Amount:    types.NewAttoFILFromFIL(10),
 			ValidAt:   *types.NewBlockHeight(0),
 			Signature: []byte{},
 			Condition: &types.Predicate{

--- a/porcelain/payments_test.go
+++ b/porcelain/payments_test.go
@@ -27,7 +27,7 @@ type paymentsTestPlumbing struct {
 	height *types.BlockHeight
 	msgCid cid.Cid
 
-	messageSend  func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
+	messageSend  func(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
 	messageWait  func(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error
 	messageQuery func(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error)
 }
@@ -41,7 +41,7 @@ func newTestCreatePaymentsPlumbing() *paymentsTestPlumbing {
 	return &paymentsTestPlumbing{
 		msgCid: msgCid,
 		height: types.NewBlockHeight(startingBlock),
-		messageSend: func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+		messageSend: func(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 			payer = from
 			target = params[0].(address.Address)
 			return msgCid, nil
@@ -58,7 +58,7 @@ func newTestCreatePaymentsPlumbing() *paymentsTestPlumbing {
 				Channel:   *channelID,
 				Payer:     payer,
 				Target:    target,
-				Amount:    *params[1].(*types.AttoFIL),
+				Amount:    params[1].(types.AttoFIL),
 				ValidAt:   *params[2].(*types.BlockHeight),
 				Condition: params[3].(*types.Predicate),
 			}
@@ -71,7 +71,7 @@ func newTestCreatePaymentsPlumbing() *paymentsTestPlumbing {
 	}
 }
 
-func (ptp *paymentsTestPlumbing) MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+func (ptp *paymentsTestPlumbing) MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 	return ptp.messageSend(ctx, from, to, value, gasPrice, gasLimit, method, params...)
 }
 
@@ -102,13 +102,13 @@ func validPaymentsConfig() CreatePaymentsParams {
 	return CreatePaymentsParams{
 		From:            from,
 		To:              to,
-		Value:           *types.NewAttoFILFromFIL(93),
+		Value:           types.NewAttoFILFromFIL(93),
 		Duration:        50,
 		MinerAddress:    minerAddress,
 		CommP:           commP,
 		PaymentInterval: paymentInterval,
 		ChannelExpiry:   *types.NewBlockHeight(500),
-		GasPrice:        *types.NewAttoFILFromFIL(3),
+		GasPrice:        types.NewAttoFILFromFIL(3),
 		GasLimit:        types.NewGasUnits(300),
 	}
 }
@@ -144,7 +144,7 @@ func TestCreatePayments(t *testing.T) {
 			assert.Equal(t, config.From, voucher.Payer)
 			assert.Equal(t, config.To, voucher.Target)
 			assert.Equal(t, *types.NewBlockHeight(startingBlock).Add(types.NewBlockHeight(config.PaymentInterval * uint64(i+1))), voucher.ValidAt)
-			assert.Equal(t, *expectedValuePerPayment.MulBigInt(big.NewInt(int64(i + 1))), voucher.Amount)
+			assert.Equal(t, expectedValuePerPayment.MulBigInt(big.NewInt(int64(i+1))), voucher.Amount)
 
 			// assert all vouchers other than the last have a valid condition
 			assert.NotNil(t, voucher.Condition)
@@ -181,7 +181,7 @@ func TestCreatePayments(t *testing.T) {
 		for i := 0; i < 9; i++ {
 			voucher := paymentResponse.Vouchers[i]
 			assert.Equal(t, *types.NewBlockHeight(startingBlock).Add(types.NewBlockHeight(config.PaymentInterval * uint64(i+1))), voucher.ValidAt)
-			assert.Equal(t, *expectedValuePerPayment.MulBigInt(big.NewInt(int64(i + 1))), voucher.Amount)
+			assert.Equal(t, expectedValuePerPayment.MulBigInt(big.NewInt(int64(i+1))), voucher.Amount)
 
 			// assert all vouchers other than the last have a valid condition
 			assert.NotNil(t, voucher.Condition)
@@ -242,7 +242,7 @@ func TestCreatePayments(t *testing.T) {
 
 	t.Run("Errors creating channel are surfaced", func(t *testing.T) {
 		plumbing := newTestCreatePaymentsPlumbing()
-		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 			return cid.Cid{}, errors.New("Error in MessageSend")
 		}
 

--- a/porcelain/wallet.go
+++ b/porcelain/wallet.go
@@ -18,7 +18,7 @@ type wbPlumbing interface {
 }
 
 // WalletBalance gets the current balance associated with an address
-func WalletBalance(ctx context.Context, plumbing wbPlumbing, addr address.Address) (*types.AttoFIL, error) {
+func WalletBalance(ctx context.Context, plumbing wbPlumbing, addr address.Address) (types.AttoFIL, error) {
 	act, err := plumbing.ActorGet(ctx, addr)
 	if err != nil {
 		if state.IsActorNotFoundError(err) {

--- a/porcelain/wallet_test.go
+++ b/porcelain/wallet_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 type wbTestPlumbing struct {
-	balance *types.AttoFIL
+	balance types.AttoFIL
 }
 
 type wdaTestPlumbing struct {

--- a/protocol/storage/client.go
+++ b/protocol/storage/client.go
@@ -176,13 +176,13 @@ func (smc *Client) ProposeDeal(ctx context.Context, miner address.Address, data 
 	cpResp, err := smc.api.CreatePayments(ctxSetup, porcelain.CreatePaymentsParams{
 		From:            fromAddress,
 		To:              minerOwner,
-		Value:           *price.MulBigInt(big.NewInt(int64(size * duration))),
+		Value:           price.MulBigInt(big.NewInt(int64(size * duration))),
 		Duration:        duration,
 		MinerAddress:    miner,
 		CommP:           commP,
 		PaymentInterval: VoucherInterval,
 		ChannelExpiry:   *chainHeight.Add(types.NewBlockHeight(duration + ChannelExpiryInterval)),
-		GasPrice:        *types.NewAttoFIL(big.NewInt(CreateChannelGasPrice)),
+		GasPrice:        types.NewAttoFIL(big.NewInt(CreateChannelGasPrice)),
 		GasLimit:        types.NewGasUnits(CreateChannelGasLimit),
 	})
 	if err != nil {

--- a/protocol/storage/client_test.go
+++ b/protocol/storage/client_test.go
@@ -99,7 +99,7 @@ func TestProposeDeal(t *testing.T) {
 			assert.Equal(t, testAPI.channelID, &voucher.Channel)
 			assert.True(t, voucher.ValidAt.GreaterThan(lastValidAt))
 			assert.Equal(t, testAPI.target, voucher.Target)
-			assert.Equal(t, testAPI.perPayment.MulBigInt(big.NewInt(int64(i+1))), &voucher.Amount)
+			assert.Equal(t, testAPI.perPayment.MulBigInt(big.NewInt(int64(i+1))), voucher.Amount)
 			assert.Equal(t, testAPI.payer, voucher.Payer)
 			assert.Equal(t, minerAddr, voucher.Condition.To)
 			assert.Equal(t, commP[:], voucher.Condition.Params[0])
@@ -158,7 +158,7 @@ type clientTestAPI struct {
 	msgCid      cid.Cid
 	payer       address.Address
 	target      address.Address
-	perPayment  *types.AttoFIL
+	perPayment  types.AttoFIL
 	testing     *testing.T
 	deals       map[cid.Cid]*storagedeal.Deal
 }
@@ -197,7 +197,7 @@ func (ctp *clientTestAPI) CreatePayments(ctx context.Context, config porcelain.C
 			Channel: *ctp.channelID,
 			Payer:   ctp.payer,
 			Target:  ctp.target,
-			Amount:  *ctp.perPayment.MulBigInt(big.NewInt(int64(i + 1))),
+			Amount:  ctp.perPayment.MulBigInt(big.NewInt(int64(i + 1))),
 			ValidAt: *ctp.blockHeight.Add(types.NewBlockHeight(uint64(i+1) * VoucherInterval)),
 			Condition: &types.Predicate{
 				To:     config.MinerAddress,

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -79,7 +79,7 @@ type minerPorcelain interface {
 	DealGet(context.Context, cid.Cid) (*storagedeal.Deal, error)
 	DealPut(*storagedeal.Deal) error
 
-	MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
+	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
 	MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error)
 	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error
 
@@ -236,7 +236,7 @@ func (sm *Miner) validateDealPayment(ctx context.Context, p *storagedeal.Proposa
 	lastValidAt := expectedFirstPayment
 	for _, v := range p.Payment.Vouchers {
 		// confirm signature is valid against expected actor and channel id
-		if !paymentbroker.VerifyVoucherSignature(p.Payment.Payer, p.Payment.Channel, &v.Amount, &v.ValidAt, v.Condition, v.Signature) {
+		if !paymentbroker.VerifyVoucherSignature(p.Payment.Payer, p.Payment.Channel, v.Amount, &v.ValidAt, v.Condition, v.Signature) {
 			return errors.New("invalid signature in voucher")
 		}
 
@@ -273,14 +273,14 @@ func (sm *Miner) validateDealPayment(ctx context.Context, p *storagedeal.Proposa
 	return nil
 }
 
-func (sm *Miner) getStoragePrice() (*types.AttoFIL, error) {
+func (sm *Miner) getStoragePrice() (types.AttoFIL, error) {
 	storagePrice, err := sm.porcelainAPI.ConfigGet("mining.storagePrice")
 	if err != nil {
-		return nil, err
+		return types.ZeroAttoFIL, err
 	}
-	storagePriceAF, ok := storagePrice.(*types.AttoFIL)
+	storagePriceAF, ok := storagePrice.(types.AttoFIL)
 	if !ok {
-		return nil, errors.New("Could not retrieve storagePrice from config")
+		return types.ZeroAttoFIL, errors.New("Could not retrieve storagePrice from config")
 	}
 	return storagePriceAF, nil
 }

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -360,7 +360,7 @@ func (mtp *minerTestPorcelain) ActorGetSignature(ctx context.Context, actorAddr 
 	return nil, nil
 }
 
-func (mtp *minerTestPorcelain) MessageSend(ctx context.Context, from, to address.Address, val *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+func (mtp *minerTestPorcelain) MessageSend(ctx context.Context, from, to address.Address, val types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 	return cid.Cid{}, nil
 }
 
@@ -479,7 +479,7 @@ func testPaymentVouchers(porcelainAPI *minerTestPorcelain, voucherInterval int, 
 			Channel:   *porcelainAPI.channelID,
 			Payer:     porcelainAPI.payerAddress,
 			Target:    porcelainAPI.targetAddress,
-			Amount:    *amount,
+			Amount:    amount,
 			ValidAt:   *validAt,
 			Signature: signature,
 		}

--- a/protocol/storage/storage_protocol_test.go
+++ b/protocol/storage/storage_protocol_test.go
@@ -27,7 +27,7 @@ func TestSerializeProposal(t *testing.T) {
 		Channel:   *types.NewChannelID(4),
 		Payer:     ag(),
 		Target:    ag(),
-		Amount:    *types.NewAttoFILFromFIL(3),
+		Amount:    types.NewAttoFILFromFIL(3),
 		ValidAt:   *types.NewBlockHeight(3),
 		Signature: types.Signature{},
 	}

--- a/protocol/storage/storagedeal/types.go
+++ b/protocol/storage/storagedeal/types.go
@@ -49,7 +49,7 @@ type Proposal struct {
 	Size *types.BytesAmount
 
 	// TotalPrice is the total price that will be paid for the entire storage operation
-	TotalPrice *types.AttoFIL
+	TotalPrice types.AttoFIL
 
 	// Duration is the number of blocks to make a deal for
 	Duration uint64

--- a/state/cached_tree_test.go
+++ b/state/cached_tree_test.go
@@ -26,11 +26,11 @@ func TestCachedStateGetCommit(t *testing.T) {
 	tree := NewCachedStateTree(underlying)
 
 	// create some actors
-	act1 := actor.NewActor(types.AccountActorCodeCid, nil)
+	act1 := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 	act1Cid := requireCid(t, "hello")
 	act1.Head = act1Cid
 	act1.IncNonce()
-	act2 := actor.NewActor(types.AccountActorCodeCid, nil)
+	act2 := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 	act2Cid := requireCid(t, "world")
 	act2.Head = act2Cid
 
@@ -92,7 +92,7 @@ func TestCachedStateGetOrCreate(t *testing.T) {
 	underlying := NewEmptyStateTree(cst)
 	tree := NewCachedStateTree(underlying)
 
-	actorToCreate := actor.NewActor(types.AccountActorCodeCid, nil)
+	actorToCreate := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 
 	// can create actor in cache
 	addr := address.NewForTestGetter()()

--- a/state/tree_test.go
+++ b/state/tree_test.go
@@ -24,9 +24,9 @@ func TestStatePutGet(t *testing.T) {
 	cst := hamt.NewCborStore()
 	tree := NewEmptyStateTree(cst)
 
-	act1 := actor.NewActor(types.AccountActorCodeCid, nil)
+	act1 := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 	act1.IncNonce()
-	act2 := actor.NewActor(types.AccountActorCodeCid, nil)
+	act2 := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 	act2.IncNonce()
 	act2.IncNonce()
 

--- a/testhelpers/consensus.go
+++ b/testhelpers/consensus.go
@@ -122,7 +122,7 @@ func (tbr *TestBlockRewarder) BlockReward(ctx context.Context, st state.Tree, mi
 }
 
 // GasReward does nothing
-func (tbr *TestBlockRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr address.Address, msg *types.SignedMessage, cost *types.AttoFIL) error {
+func (tbr *TestBlockRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr address.Address, msg *types.SignedMessage, cost types.AttoFIL) error {
 	// do nothing to keep state root the same
 	return nil
 }

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -41,13 +41,13 @@ func RequireMakeStateTree(t *testing.T, cst *hamt.CborIpldStore, acts map[addres
 
 // RequireNewEmptyActor creates a new empty actor with the given starting
 // value and requires that its steps succeed.
-func RequireNewEmptyActor(value *types.AttoFIL) *actor.Actor {
+func RequireNewEmptyActor(value types.AttoFIL) *actor.Actor {
 	return &actor.Actor{Balance: value}
 }
 
 // RequireNewAccountActor creates a new account actor with the given starting
 // value and requires that its steps succeed.
-func RequireNewAccountActor(t *testing.T, value *types.AttoFIL) *actor.Actor {
+func RequireNewAccountActor(t *testing.T, value types.AttoFIL) *actor.Actor {
 	act, err := account.NewActor(value)
 	require.NoError(t, err)
 	return act
@@ -55,7 +55,7 @@ func RequireNewAccountActor(t *testing.T, value *types.AttoFIL) *actor.Actor {
 
 // RequireNewMinerActor creates a new miner actor with the given owner, pledge, and collateral,
 // and requires that its steps succeed.
-func RequireNewMinerActor(t *testing.T, vms vm.StorageMap, addr address.Address, owner address.Address, key []byte, pledge uint64, pid peer.ID, coll *types.AttoFIL) *actor.Actor {
+func RequireNewMinerActor(t *testing.T, vms vm.StorageMap, addr address.Address, owner address.Address, key []byte, pledge uint64, pid peer.ID, coll types.AttoFIL) *actor.Actor {
 	act := actor.NewActor(types.MinerActorCodeCid, coll)
 	storage := vms.NewStorage(addr, act)
 	initializerData := miner.NewState(owner, key, pid, types.OneKiBSectorSize)
@@ -73,7 +73,7 @@ func RequireNewFakeActor(t *testing.T, vms vm.StorageMap, addr address.Address, 
 
 // RequireNewFakeActorWithTokens instantiates and returns a new fake actor and requires
 // that its steps succeed.
-func RequireNewFakeActorWithTokens(t *testing.T, vms vm.StorageMap, addr address.Address, codeCid cid.Cid, amt *types.AttoFIL) *actor.Actor {
+func RequireNewFakeActorWithTokens(t *testing.T, vms vm.StorageMap, addr address.Address, codeCid cid.Cid, amt types.AttoFIL) *actor.Actor {
 	act := actor.NewActor(codeCid, amt)
 	store := vms.NewStorage(addr, act)
 	err := (&actor.FakeActor{}).InitializeState(store, &actor.FakeActorStorage{})

--- a/tools/fast/action_paych.go
+++ b/tools/fast/action_paych.go
@@ -13,7 +13,7 @@ import (
 
 // PaychCreate runs the `paych create` command against the filecoin process.
 func (f *Filecoin) PaychCreate(ctx context.Context,
-	target address.Address, amount *types.AttoFIL, eol *types.BlockHeight,
+	target address.Address, amount types.AttoFIL, eol *types.BlockHeight,
 	options ...ActionOption) (cid.Cid, error) {
 
 	var out commands.CreateChannelResult
@@ -49,7 +49,7 @@ func (f *Filecoin) PaychClose(ctx context.Context, voucher string, options ...Ac
 
 // PaychExtend runs the `paych extend` command against the filecoin process.
 func (f *Filecoin) PaychExtend(ctx context.Context,
-	channel *types.ChannelID, amount *types.AttoFIL, eol *types.BlockHeight,
+	channel *types.ChannelID, amount types.AttoFIL, eol *types.BlockHeight,
 	options ...ActionOption) (cid.Cid, error) {
 
 	var out commands.ExtendResult
@@ -133,7 +133,7 @@ func (f *Filecoin) PaychRedeem(ctx context.Context, voucher string, options ...A
 }
 
 // PaychVoucher runs the `paych voucher` command against the filecoin process.
-func (f *Filecoin) PaychVoucher(ctx context.Context, channel *types.ChannelID, amount *types.AttoFIL, options ...ActionOption) (string, error) {
+func (f *Filecoin) PaychVoucher(ctx context.Context, channel *types.ChannelID, amount types.AttoFIL, options ...ActionOption) (string, error) {
 	var out string
 
 	args := []string{"go-filecoin", "paych", "voucher", channel.String(), amount.String()}

--- a/tools/fast/action_wallet.go
+++ b/tools/fast/action_wallet.go
@@ -12,10 +12,10 @@ import (
 )
 
 // WalletBalance run the wallet balance command against the filecoin process.
-func (f *Filecoin) WalletBalance(ctx context.Context, addr address.Address) (*types.AttoFIL, error) {
-	var balance *types.AttoFIL
+func (f *Filecoin) WalletBalance(ctx context.Context, addr address.Address) (types.AttoFIL, error) {
+	var balance types.AttoFIL
 	if err := f.RunCmdJSONWithStdin(ctx, nil, &balance, "go-filecoin", "wallet", "balance", addr.String()); err != nil {
-		return nil, err
+		return types.ZeroAttoFIL, err
 	}
 	return balance, nil
 }

--- a/types/atto_fil.go
+++ b/types/atto_fil.go
@@ -13,28 +13,15 @@ import (
 	"github.com/polydawn/refmt/obj/atlas"
 )
 
-// NOTE -- ALL *AttoFIL methods must call ensureZeroAmounts with refs to every user-supplied value before use.
-
 func init() {
 	cbor.RegisterCborType(attoFILAtlasEntry)
 }
 
 var attoPower = 18
 var tenToTheEighteen = big.NewInt(10).Exp(big.NewInt(10), big.NewInt(18), nil)
-var zero big.Int
 
-// ZeroAttoFIL represents an AttoFIL quantity of 0
+// ZeroAttoFIL is the zero value for an AttoFIL, exported for consistency in construction of AttoFILs
 var ZeroAttoFIL AttoFIL
-
-// ensureZeroAmounts takes a variable number of refs -- variables holding *AttoFIL --
-// and sets their values to the ZeroAttoFIL (the zero value for the type) if their values are nil.
-func ensureZeroAmounts(refs ...*AttoFIL) {
-	//for _, ref := range refs {
-	//	if ref.val == nil {
-	//		ref.val = &zero
-	//	}
-	//}
-}
 
 var attoFILAtlasEntry = atlas.BuildEntry(AttoFIL{}).Transform().
 	TransformMarshal(atlas.MakeMarshalTransformFunc(
@@ -78,12 +65,6 @@ func NewAttoFIL(x *big.Int) AttoFIL {
 	return AttoFIL{val: *big.NewInt(0).Set(x)}
 }
 
-// NewZeroAttoFIL returns a new zero quantity of attofilecoin. It is
-// different from ZeroAttoFIL in that this value may be used/mutated.
-func NewZeroAttoFIL() AttoFIL {
-	return AttoFIL{}
-}
-
 // NewAttoFILFromFIL returns a new AttoFIL representing a quantity
 // of attofilecoin equal to x filecoin.
 func NewAttoFILFromFIL(x uint64) AttoFIL {
@@ -122,14 +103,13 @@ func NewAttoFILFromFILString(s string) (AttoFIL, bool) {
 // NewAttoFILFromString allocates a new AttoFIL set to the value of s attofilecoin,
 // interpreted in the given base, and returns it and a boolean indicating success.
 func NewAttoFILFromString(s string, base int) (AttoFIL, bool) {
-	af := NewZeroAttoFIL()
+	af := AttoFIL{}
 	_, ok := af.val.SetString(s, base)
 	return af, ok
 }
 
 // Add sets z to the sum x+y and returns z.
 func (z AttoFIL) Add(y AttoFIL) AttoFIL {
-	ensureZeroAmounts(&z, &y)
 	newZ := AttoFIL{}
 	newZ.val.Add(&z.val, &y.val)
 	return newZ
@@ -137,7 +117,6 @@ func (z AttoFIL) Add(y AttoFIL) AttoFIL {
 
 // Sub sets z to the difference x-y and returns z.
 func (z AttoFIL) Sub(y AttoFIL) AttoFIL {
-	ensureZeroAmounts(&z, &y)
 	newZ := AttoFIL{}
 	newZ.val.Sub(&z.val, &y.val)
 	return newZ
@@ -166,60 +145,50 @@ func (z AttoFIL) DivCeil(y AttoFIL) AttoFIL {
 
 // Equal returns true if z = y
 func (z AttoFIL) Equal(y AttoFIL) bool {
-	ensureZeroAmounts(&z, &y)
 	return z.val.Cmp(&y.val) == 0
 }
 
 // LessThan returns true if z < y
 func (z AttoFIL) LessThan(y AttoFIL) bool {
-	ensureZeroAmounts(&z, &y)
 	return z.val.Cmp(&y.val) < 0
 }
 
 // GreaterThan returns true if z > y
 func (z AttoFIL) GreaterThan(y AttoFIL) bool {
-	ensureZeroAmounts(&z, &y)
 	return z.val.Cmp(&y.val) > 0
 }
 
 // LessEqual returns true if z <= y
 func (z AttoFIL) LessEqual(y AttoFIL) bool {
-	ensureZeroAmounts(&z, &y)
 	return z.val.Cmp(&y.val) <= 0
 }
 
 // GreaterEqual returns true if z >= y
 func (z AttoFIL) GreaterEqual(y AttoFIL) bool {
-	ensureZeroAmounts(&z, &y)
 	return z.val.Cmp(&y.val) >= 0
 }
 
 // IsPositive returns true if z is greater than zero.
 func (z AttoFIL) IsPositive() bool {
-	ensureZeroAmounts(&z)
 	return z.GreaterThan(ZeroAttoFIL)
 }
 
 // IsNegative returns true if z is less than zero.
 func (z AttoFIL) IsNegative() bool {
-	ensureZeroAmounts(&z)
 	return z.LessThan(ZeroAttoFIL)
 }
 
 // IsZero returns true if z equals zero.
 func (z AttoFIL) IsZero() bool {
-	ensureZeroAmounts(&z)
 	return z.Equal(ZeroAttoFIL)
 }
 
 // Bytes returns the absolute value of x as a big-endian byte slice.
 func (z AttoFIL) Bytes() []byte {
-	ensureZeroAmounts(&z)
 	return leb128.FromBigInt(&z.val)
 }
 
 func (z AttoFIL) String() string {
-	ensureZeroAmounts(&z)
 	attoPadLength := strconv.Itoa(attoPower + 1)
 	paddedStr := fmt.Sprintf("%0"+attoPadLength+"d", &z.val)
 	decimaledStr := fmt.Sprintf("%s.%s", paddedStr[:len(paddedStr)-attoPower], paddedStr[len(paddedStr)-attoPower:])
@@ -229,7 +198,6 @@ func (z AttoFIL) String() string {
 
 // CalculatePrice treats z as a price in AttoFIL/Byte and applies it to numBytes to calculate a total price.
 func (z AttoFIL) CalculatePrice(numBytes *BytesAmount) AttoFIL {
-	ensureZeroAmounts(&z)
 	ensureBytesAmounts(&numBytes)
 	unitPrice := z
 

--- a/types/atto_fil.go
+++ b/types/atto_fil.go
@@ -17,23 +17,23 @@ import (
 
 func init() {
 	cbor.RegisterCborType(attoFILAtlasEntry)
-	ZeroAttoFIL = NewZeroAttoFIL()
 }
 
 var attoPower = 18
 var tenToTheEighteen = big.NewInt(10).Exp(big.NewInt(10), big.NewInt(18), nil)
+var zero big.Int
 
 // ZeroAttoFIL represents an AttoFIL quantity of 0
-var ZeroAttoFIL *AttoFIL
+var ZeroAttoFIL AttoFIL
 
 // ensureZeroAmounts takes a variable number of refs -- variables holding *AttoFIL --
 // and sets their values to the ZeroAttoFIL (the zero value for the type) if their values are nil.
-func ensureZeroAmounts(refs ...**AttoFIL) {
-	for _, ref := range refs {
-		if *ref == nil {
-			*ref = ZeroAttoFIL
-		}
-	}
+func ensureZeroAmounts(refs ...*AttoFIL) {
+	//for _, ref := range refs {
+	//	if ref.val == nil {
+	//		ref.val = &zero
+	//	}
+	//}
 }
 
 var attoFILAtlasEntry = atlas.BuildEntry(AttoFIL{}).Transform().
@@ -43,7 +43,7 @@ var attoFILAtlasEntry = atlas.BuildEntry(AttoFIL{}).Transform().
 		})).
 	TransformUnmarshal(atlas.MakeUnmarshalTransformFunc(
 		func(x []byte) (AttoFIL, error) {
-			return *NewAttoFILFromBytes(x), nil
+			return NewAttoFILFromBytes(x), nil
 		})).
 	Complete()
 
@@ -53,12 +53,12 @@ func (z *AttoFIL) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	token, ok := NewAttoFILFromFILString(s)
+	af, ok := NewAttoFILFromFILString(s)
 	if !ok {
 		return errors.New("cannot convert string to token amount")
 	}
 
-	*z = *token
+	z.val = af.val
 
 	return nil
 }
@@ -71,37 +71,35 @@ func (z AttoFIL) MarshalJSON() ([]byte, error) {
 // AttoFIL represents a signed multi-precision integer quantity of
 // attofilecoin (atto is metric for 10**-18). The zero value for
 // AttoFIL represents the value 0.
-type AttoFIL struct{ val *big.Int }
+type AttoFIL struct{ val big.Int }
 
 // NewAttoFIL allocates and returns a new AttoFIL set to x.
-func NewAttoFIL(x *big.Int) *AttoFIL {
-	return &AttoFIL{val: big.NewInt(0).Set(x)}
+func NewAttoFIL(x *big.Int) AttoFIL {
+	return AttoFIL{val: *big.NewInt(0).Set(x)}
 }
 
 // NewZeroAttoFIL returns a new zero quantity of attofilecoin. It is
 // different from ZeroAttoFIL in that this value may be used/mutated.
-func NewZeroAttoFIL() *AttoFIL {
-	return NewAttoFIL(big.NewInt(0))
+func NewZeroAttoFIL() AttoFIL {
+	return AttoFIL{}
 }
 
 // NewAttoFILFromFIL returns a new AttoFIL representing a quantity
 // of attofilecoin equal to x filecoin.
-func NewAttoFILFromFIL(x uint64) *AttoFIL {
+func NewAttoFILFromFIL(x uint64) AttoFIL {
 	xAsBigInt := big.NewInt(0).SetUint64(x)
 	return NewAttoFIL(xAsBigInt.Mul(xAsBigInt, tenToTheEighteen))
 }
 
 // NewAttoFILFromBytes allocates and returns a new AttoFIL set
 // to the value of buf as the bytes of a big-endian unsigned integer.
-func NewAttoFILFromBytes(buf []byte) *AttoFIL {
-	af := NewZeroAttoFIL()
-	af.val = leb128.ToBigInt(buf)
-	return af
+func NewAttoFILFromBytes(buf []byte) AttoFIL {
+	return NewAttoFIL(leb128.ToBigInt(buf))
 }
 
 // NewAttoFILFromFILString allocates a new AttoFIL set to the value of s filecoin,
 // interpreted as a decimal in base 10, and returns it and a boolean indicating success.
-func NewAttoFILFromFILString(s string) (*AttoFIL, bool) {
+func NewAttoFILFromFILString(s string) (AttoFIL, bool) {
 	splitNumber := strings.Split(s, ".")
 	// If '.' is absent from string, add an empty string to become the decimal part
 	if len(splitNumber) == 1 {
@@ -111,7 +109,7 @@ func NewAttoFILFromFILString(s string) (*AttoFIL, bool) {
 	decPart := splitNumber[1]
 	// A decimal part longer than 18 digits should be an error
 	if len(decPart) > attoPower || len(splitNumber) > 2 {
-		return nil, false
+		return ZeroAttoFIL, false
 	}
 	// The decimal is right padded with 0's if it less than 18 digits long
 	for len(decPart) < attoPower {
@@ -123,43 +121,41 @@ func NewAttoFILFromFILString(s string) (*AttoFIL, bool) {
 
 // NewAttoFILFromString allocates a new AttoFIL set to the value of s attofilecoin,
 // interpreted in the given base, and returns it and a boolean indicating success.
-func NewAttoFILFromString(s string, base int) (*AttoFIL, bool) {
+func NewAttoFILFromString(s string, base int) (AttoFIL, bool) {
 	af := NewZeroAttoFIL()
 	_, ok := af.val.SetString(s, base)
 	return af, ok
 }
 
 // Add sets z to the sum x+y and returns z.
-func (z *AttoFIL) Add(y *AttoFIL) *AttoFIL {
+func (z AttoFIL) Add(y AttoFIL) AttoFIL {
 	ensureZeroAmounts(&z, &y)
-	newVal := big.NewInt(0)
-	newVal.Add(z.val, y.val)
-	newZ := AttoFIL{val: newVal}
-	return &newZ
+	newZ := AttoFIL{}
+	newZ.val.Add(&z.val, &y.val)
+	return newZ
 }
 
 // Sub sets z to the difference x-y and returns z.
-func (z *AttoFIL) Sub(y *AttoFIL) *AttoFIL {
+func (z AttoFIL) Sub(y AttoFIL) AttoFIL {
 	ensureZeroAmounts(&z, &y)
-	newVal := big.NewInt(0)
-	newVal.Sub(z.val, y.val)
-	newZ := AttoFIL{val: newVal}
-	return &newZ
+	newZ := AttoFIL{}
+	newZ.val.Sub(&z.val, &y.val)
+	return newZ
 }
 
 // MulBigInt multiplies attoFIL by a given big int
-func (z *AttoFIL) MulBigInt(x *big.Int) *AttoFIL {
-	newVal := big.NewInt(0)
-	newVal.Mul(z.val, x)
-	return &AttoFIL{val: newVal}
+func (z AttoFIL) MulBigInt(x *big.Int) AttoFIL {
+	newZ := AttoFIL{}
+	newZ.val.Mul(&z.val, x)
+	return newZ
 }
 
 // DivCeil returns the minimum number of times this value can be divided into smaller amounts
 // such that none of the smaller amounts are greater than the given divisor.
 // Equal to ceil(z/y) if AttoFIL could be fractional.
 // If y is zero a panic will occur.
-func (z *AttoFIL) DivCeil(y *AttoFIL) *AttoFIL {
-	value, remainder := big.NewInt(0).DivMod(z.val, y.val, big.NewInt(0))
+func (z AttoFIL) DivCeil(y AttoFIL) AttoFIL {
+	value, remainder := big.NewInt(0).DivMod(&z.val, &y.val, big.NewInt(0))
 
 	if remainder.Cmp(big.NewInt(0)) == 0 {
 		return NewAttoFIL(value)
@@ -169,76 +165,76 @@ func (z *AttoFIL) DivCeil(y *AttoFIL) *AttoFIL {
 }
 
 // Equal returns true if z = y
-func (z *AttoFIL) Equal(y *AttoFIL) bool {
+func (z AttoFIL) Equal(y AttoFIL) bool {
 	ensureZeroAmounts(&z, &y)
-	return z.val.Cmp(y.val) == 0
+	return z.val.Cmp(&y.val) == 0
 }
 
 // LessThan returns true if z < y
-func (z *AttoFIL) LessThan(y *AttoFIL) bool {
+func (z AttoFIL) LessThan(y AttoFIL) bool {
 	ensureZeroAmounts(&z, &y)
-	return z.val.Cmp(y.val) < 0
+	return z.val.Cmp(&y.val) < 0
 }
 
 // GreaterThan returns true if z > y
-func (z *AttoFIL) GreaterThan(y *AttoFIL) bool {
+func (z AttoFIL) GreaterThan(y AttoFIL) bool {
 	ensureZeroAmounts(&z, &y)
-	return z.val.Cmp(y.val) > 0
+	return z.val.Cmp(&y.val) > 0
 }
 
 // LessEqual returns true if z <= y
-func (z *AttoFIL) LessEqual(y *AttoFIL) bool {
+func (z AttoFIL) LessEqual(y AttoFIL) bool {
 	ensureZeroAmounts(&z, &y)
-	return z.val.Cmp(y.val) <= 0
+	return z.val.Cmp(&y.val) <= 0
 }
 
 // GreaterEqual returns true if z >= y
-func (z *AttoFIL) GreaterEqual(y *AttoFIL) bool {
+func (z AttoFIL) GreaterEqual(y AttoFIL) bool {
 	ensureZeroAmounts(&z, &y)
-	return z.val.Cmp(y.val) >= 0
+	return z.val.Cmp(&y.val) >= 0
 }
 
 // IsPositive returns true if z is greater than zero.
-func (z *AttoFIL) IsPositive() bool {
+func (z AttoFIL) IsPositive() bool {
 	ensureZeroAmounts(&z)
 	return z.GreaterThan(ZeroAttoFIL)
 }
 
 // IsNegative returns true if z is less than zero.
-func (z *AttoFIL) IsNegative() bool {
+func (z AttoFIL) IsNegative() bool {
 	ensureZeroAmounts(&z)
 	return z.LessThan(ZeroAttoFIL)
 }
 
 // IsZero returns true if z equals zero.
-func (z *AttoFIL) IsZero() bool {
+func (z AttoFIL) IsZero() bool {
 	ensureZeroAmounts(&z)
 	return z.Equal(ZeroAttoFIL)
 }
 
 // Bytes returns the absolute value of x as a big-endian byte slice.
-func (z *AttoFIL) Bytes() []byte {
+func (z AttoFIL) Bytes() []byte {
 	ensureZeroAmounts(&z)
-	return leb128.FromBigInt(z.val)
+	return leb128.FromBigInt(&z.val)
 }
 
-func (z *AttoFIL) String() string {
+func (z AttoFIL) String() string {
 	ensureZeroAmounts(&z)
 	attoPadLength := strconv.Itoa(attoPower + 1)
-	paddedStr := fmt.Sprintf("%0"+attoPadLength+"d", z.val)
+	paddedStr := fmt.Sprintf("%0"+attoPadLength+"d", &z.val)
 	decimaledStr := fmt.Sprintf("%s.%s", paddedStr[:len(paddedStr)-attoPower], paddedStr[len(paddedStr)-attoPower:])
 	noTrailZeroStr := strings.TrimRight(decimaledStr, "0")
 	return strings.TrimRight(noTrailZeroStr, ".")
 }
 
 // CalculatePrice treats z as a price in AttoFIL/Byte and applies it to numBytes to calculate a total price.
-func (z *AttoFIL) CalculatePrice(numBytes *BytesAmount) *AttoFIL {
+func (z AttoFIL) CalculatePrice(numBytes *BytesAmount) AttoFIL {
 	ensureZeroAmounts(&z)
 	ensureBytesAmounts(&numBytes)
 	unitPrice := z
 
 	newVal := big.NewInt(0)
-	newVal.Mul(unitPrice.val, numBytes.val)
+	newVal.Mul(&unitPrice.val, numBytes.val)
 
-	return &AttoFIL{val: newVal}
+	return AttoFIL{val: *newVal}
 }

--- a/types/atto_fil_test.go
+++ b/types/atto_fil_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func BigIntFromString(s string) *big.Int {
+func BigIntFromString(s string) big.Int {
 	bigInt, _ := new(big.Int).SetString(s, 10)
-	return bigInt
+	return *bigInt
 }
 
 func TestFILToAttoFIL(t *testing.T) {
@@ -32,7 +32,7 @@ func TestAttoFILCreation(t *testing.T) {
 	tf.UnitTest(t)
 
 	a := NewAttoFILFromFIL(123)
-	assert.IsType(t, &AttoFIL{}, a)
+	assert.IsType(t, AttoFIL{}, a)
 
 	ab := a.Bytes()
 	b := NewAttoFILFromBytes(ab)
@@ -56,9 +56,8 @@ func TestZeroAttoFIL(t *testing.T) {
 
 	z := NewAttoFILFromFIL(0)
 
-	assert.Equal(t, z, ZeroAttoFIL)
-	assert.True(t, z.Equal(nil))
-	assert.True(t, ZeroAttoFIL.Equal(nil))
+	assert.True(t, z.Equal(AttoFIL{}))
+	assert.True(t, ZeroAttoFIL.Equal(AttoFIL{}))
 }
 
 func TestAttoFILComparison(t *testing.T) {
@@ -83,16 +82,16 @@ func TestAttoFILComparison(t *testing.T) {
 		assert.True(t, a.LessEqual(b))
 	})
 
-	t.Run("treats nil pointers as zero", func(t *testing.T) {
+	t.Run("treats zero values as zero", func(t *testing.T) {
 		d := ZeroAttoFIL.Sub(a)
-		var np *AttoFIL
+		var zeroValue AttoFIL
 
-		assert.True(t, np.Equal(ZeroAttoFIL))
-		assert.True(t, ZeroAttoFIL.Equal(np))
-		assert.True(t, d.LessThan(np))
-		assert.True(t, np.GreaterThan(d))
-		assert.True(t, c.GreaterThan(np))
-		assert.True(t, np.LessThan(c))
+		assert.True(t, zeroValue.Equal(ZeroAttoFIL))
+		assert.True(t, ZeroAttoFIL.Equal(zeroValue))
+		assert.True(t, d.LessThan(zeroValue))
+		assert.True(t, zeroValue.GreaterThan(d))
+		assert.True(t, c.GreaterThan(zeroValue))
+		assert.True(t, zeroValue.LessThan(c))
 	})
 }
 
@@ -118,14 +117,14 @@ func TestAttoFILAddition(t *testing.T) {
 		assert.Equal(t, bStr, b.String())
 	})
 
-	t.Run("treats nil pointers as zero", func(t *testing.T) {
-		var x, z *AttoFIL
+	t.Run("treats zero values as zero", func(t *testing.T) {
+		var x, z AttoFIL
 
 		assert.True(t, z.Add(a).Equal(a))
 		assert.True(t, a.Add(z).Equal(a))
-		assert.True(t, a.Add(nil).Equal(a))
-		assert.True(t, z.Add(x).Equal(nil))
-		assert.True(t, z.Add(nil).Equal(x))
+		assert.True(t, a.Add(AttoFIL{}).Equal(a))
+		assert.True(t, z.Add(x).Equal(AttoFIL{}))
+		assert.True(t, z.Add(AttoFIL{}).Equal(x))
 	})
 }
 
@@ -151,13 +150,13 @@ func TestAttoFILSubtraction(t *testing.T) {
 		assert.Equal(t, bStr, b.String())
 	})
 
-	t.Run("treats nil pointers as zero", func(t *testing.T) {
-		var z *AttoFIL
+	t.Run("treats zero values as zero", func(t *testing.T) {
+		var z AttoFIL
 
 		assert.True(t, a.Sub(z).Equal(a))
-		assert.True(t, a.Sub(nil).Equal(a))
+		assert.True(t, a.Sub(AttoFIL{}).Equal(a))
 		assert.True(t, z.Sub(z).Equal(z))
-		assert.True(t, z.Sub(nil).Equal(nil))
+		assert.True(t, z.Sub(AttoFIL{}).Equal(AttoFIL{}))
 	})
 }
 
@@ -165,26 +164,26 @@ func TestMulInt(t *testing.T) {
 	tf.UnitTest(t)
 
 	multiplier := big.NewInt(25)
-	attoFIL := AttoFIL{val: big.NewInt(1000)}
+	attoFIL := NewAttoFIL(big.NewInt(1000))
 
 	t.Run("correctly multiplies the values and returns an AttoFIL", func(t *testing.T) {
-		expected := AttoFIL{val: big.NewInt(25000)}
-		assert.Equal(t, attoFIL.MulBigInt(multiplier), &expected)
+		expected := NewAttoFIL(big.NewInt(25000))
+		assert.Equal(t, attoFIL.MulBigInt(multiplier), expected)
 	})
 }
 
 func TestDivCeil(t *testing.T) {
 	tf.UnitTest(t)
 
-	x := AttoFIL{val: big.NewInt(200)}
+	x := NewAttoFIL(big.NewInt(200))
 
 	t.Run("returns exactly the dividend when y divides x", func(t *testing.T) {
-		actual := x.DivCeil(&AttoFIL{val: big.NewInt(10)})
+		actual := x.DivCeil(NewAttoFIL(big.NewInt(10)))
 		assert.Equal(t, NewAttoFIL(big.NewInt(20)), actual)
 	})
 
 	t.Run("rounds up when y does not divide x", func(t *testing.T) {
-		actual := x.DivCeil(&AttoFIL{val: big.NewInt(9)})
+		actual := x.DivCeil(NewAttoFIL(big.NewInt(9)))
 		assert.Equal(t, NewAttoFIL(big.NewInt(23)), actual)
 	})
 }
@@ -211,14 +210,14 @@ func TestPriceCalculation(t *testing.T) {
 		assert.Equal(t, numBytesStr, numBytes.String())
 	})
 
-	t.Run("treats nil pointers as zero", func(t *testing.T) {
-		var nt *AttoFIL
+	t.Run("treats zero values as zero", func(t *testing.T) {
+		var nt AttoFIL
 		var nb *BytesAmount
 
-		assert.Equal(t, price.CalculatePrice(nil), ZeroAttoFIL)
-		assert.Equal(t, nt.CalculatePrice(numBytes), ZeroAttoFIL)
-		assert.Equal(t, price.CalculatePrice(nb), ZeroAttoFIL)
-		assert.Equal(t, nt.CalculatePrice(nb), ZeroAttoFIL)
+		assert.True(t, price.CalculatePrice(nil).Equal(ZeroAttoFIL))
+		assert.True(t, nt.CalculatePrice(numBytes).Equal(ZeroAttoFIL))
+		assert.True(t, price.CalculatePrice(nb).Equal(ZeroAttoFIL))
+		assert.True(t, nt.CalculatePrice(nb).Equal(ZeroAttoFIL))
 	})
 }
 
@@ -238,7 +237,7 @@ func TestAttoFILCborMarshaling(t *testing.T) {
 			err = cbor.DecodeInto(out, &postDecode)
 			assert.NoError(t, err)
 
-			assert.True(t, preEncode.Equal(&postDecode), "pre: %s post: %s", preEncode.String(), postDecode.String())
+			assert.True(t, preEncode.Equal(postDecode), "pre: %s post: %s", preEncode.String(), postDecode.String())
 		}
 	})
 	t.Run("cannot CBOR encode nil as *AttoFIL", func(t *testing.T) {
@@ -270,7 +269,7 @@ func TestAttoFILJsonMarshaling(t *testing.T) {
 			err = json.Unmarshal(marshaled, &unmarshaled)
 			assert.NoError(t, err)
 
-			assert.True(t, toBeMarshaled.Equal(&unmarshaled), "should be equal - toBeMarshaled: %s unmarshaled: %s)", toBeMarshaled.String(), unmarshaled.String())
+			assert.True(t, toBeMarshaled.Equal(unmarshaled), "should be equal - toBeMarshaled: %s unmarshaled: %s)", toBeMarshaled.String(), unmarshaled.String())
 		}
 	})
 
@@ -284,7 +283,7 @@ func TestAttoFILJsonMarshaling(t *testing.T) {
 		err = json.Unmarshal(marshaled, &unmarshaled)
 		assert.NoError(t, err)
 
-		assert.True(t, toBeMarshaled.Equal(&unmarshaled), "should be equal - toBeMarshaled: %s unmarshaled: %s)", toBeMarshaled.String(), unmarshaled.String())
+		assert.True(t, toBeMarshaled.Equal(unmarshaled), "should be equal - toBeMarshaled: %s unmarshaled: %s)", toBeMarshaled.String(), unmarshaled.String())
 	})
 
 	t.Run("cannot JSON marshall nil as *AttoFIL", func(t *testing.T) {
@@ -306,11 +305,11 @@ func TestAttoFILIsPositive(t *testing.T) {
 	p := NewAttoFILFromFIL(100)      // positive
 	z := NewAttoFILFromFIL(0)        // zero
 	n := NewAttoFILFromFIL(0).Sub(p) // negative
-	var np *AttoFIL
+	var zeroValue AttoFIL
 
 	t.Run("returns false if zero", func(t *testing.T) {
 		assert.False(t, z.IsPositive())
-		assert.False(t, np.IsPositive())
+		assert.False(t, zeroValue.IsPositive())
 	})
 
 	t.Run("returns true if greater than zero", func(t *testing.T) {
@@ -328,11 +327,11 @@ func TestAttoFILIsNegative(t *testing.T) {
 	p := NewAttoFILFromFIL(100)      // positive
 	z := NewAttoFILFromFIL(0)        // zero
 	n := NewAttoFILFromFIL(0).Sub(p) // negative
-	var np *AttoFIL
+	var zeroValue AttoFIL
 
 	t.Run("returns false if zero", func(t *testing.T) {
 		assert.False(t, z.IsNegative())
-		assert.False(t, np.IsNegative())
+		assert.False(t, zeroValue.IsNegative())
 	})
 
 	t.Run("returns false if greater than zero", func(t *testing.T) {
@@ -350,11 +349,11 @@ func TestAttoFILIsZero(t *testing.T) {
 	p := NewAttoFILFromFIL(100)      // positive
 	z := NewAttoFILFromFIL(0)        // zero
 	n := NewAttoFILFromFIL(0).Sub(p) // negative
-	var np *AttoFIL
+	var zeroValue AttoFIL
 
 	t.Run("returns true if zero token", func(t *testing.T) {
 		assert.True(t, z.IsZero())
-		assert.True(t, np.IsZero())
+		assert.True(t, zeroValue.IsZero())
 	})
 
 	t.Run("returns false if greater than zero token", func(t *testing.T) {

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -236,6 +236,7 @@ func TestBlockJsonMarshal(t *testing.T) {
 	e2 := json.Unmarshal(marshalled, &unmarshalled)
 	assert.NoError(t, e2)
 
+	assert.Equal(t, child, unmarshalled)
 	AssertHaveSameCid(t, &child, &unmarshalled)
 	assert.True(t, child.Equals(&unmarshalled))
 

--- a/types/message.go
+++ b/types/message.go
@@ -34,7 +34,7 @@ type Message struct {
 	// This prevents replay attacks.
 	Nonce Uint64 `json:"nonce"`
 
-	Value *AttoFIL `json:"value"`
+	Value AttoFIL `json:"value"`
 
 	Method string `json:"method"`
 	Params []byte `json:"params"`
@@ -42,7 +42,7 @@ type Message struct {
 }
 
 // NewMessage creates a new message.
-func NewMessage(from, to address.Address, nonce uint64, value *AttoFIL, method string, params []byte) *Message {
+func NewMessage(from, to address.Address, nonce uint64, value AttoFIL, method string, params []byte) *Message {
 	return &Message{
 		From:   from,
 		To:     to,

--- a/types/message_receipt.go
+++ b/types/message_receipt.go
@@ -19,5 +19,5 @@ type MessageReceipt struct {
 	Return [][]byte `json:"return"`
 
 	// GasAttoFIL Charge is the actual amount of FIL transferred from the sender to the miner for processing the message
-	GasAttoFIL *AttoFIL `json:"gasAttoFIL"`
+	GasAttoFIL AttoFIL `json:"gasAttoFIL"`
 }

--- a/types/message_receipt_test.go
+++ b/types/message_receipt_test.go
@@ -31,6 +31,8 @@ func TestMessageReceiptMarshal(t *testing.T) {
 		err = cbor.DecodeInto(bytes, &actual)
 
 		assert.NoError(t, err)
-		assert.Equal(t, expected, actual)
+		assert.Equal(t, expected.ExitCode, actual.ExitCode)
+		assert.Equal(t, expected.Return, actual.Return)
+		assert.True(t, expected.GasAttoFIL.Equal(actual.GasAttoFIL))
 	}
 }

--- a/types/metered_message.go
+++ b/types/metered_message.go
@@ -46,7 +46,7 @@ func (msg *MeteredMessage) Marshal() ([]byte, error) {
 
 // NewGasPrice constructs a gas price (in AttoFIL) from the given number.
 func NewGasPrice(price int64) AttoFIL {
-	return *NewAttoFIL(big.NewInt(price))
+	return NewAttoFIL(big.NewInt(price))
 }
 
 // NewGasUnits constructs a new GasUnits from the given number.
@@ -57,6 +57,6 @@ func NewGasUnits(cost uint64) GasUnits {
 // Equals tests whether two metered messages are equal
 func (msg *MeteredMessage) Equals(other *MeteredMessage) bool {
 	return msg.Message.Equals(&other.Message) &&
-		msg.GasPrice.Equal(&other.GasPrice) &&
+		msg.GasPrice.Equal(other.GasPrice) &&
 		msg.GasLimit == other.GasLimit
 }

--- a/types/metered_message_test.go
+++ b/types/metered_message_test.go
@@ -26,7 +26,7 @@ func TestMeteredMessageMessage(t *testing.T) {
 			[]byte("foobar"),
 		)
 
-		mmsg := NewMeteredMessage(*inner, *NewAttoFILFromFIL(2), NewGasUnits(300))
+		mmsg := NewMeteredMessage(*inner, NewAttoFILFromFIL(2), NewGasUnits(300))
 
 		// This check requests that you add a non-zero value for new fields above,
 		// then update the field count below.

--- a/types/payment_voucher_test.go
+++ b/types/payment_voucher_test.go
@@ -24,7 +24,7 @@ func TestPaymentVoucherEncodingRoundTrip(t *testing.T) {
 		Channel:   *NewChannelID(5),
 		Payer:     addr1,
 		Target:    addr2,
-		Amount:    *NewAttoFILFromFIL(100),
+		Amount:    NewAttoFILFromFIL(100),
 		ValidAt:   *NewBlockHeight(25),
 		Condition: condition,
 	}

--- a/types/testing.go
+++ b/types/testing.go
@@ -133,7 +133,7 @@ func NewSignedMessageForTestGetter(ms MockSigner) func() *SignedMessage {
 			ms.Addresses[0], // from needs to be an address from the signer
 			newAddr,
 			0,
-			NewAttoFILFromFIL(0),
+			ZeroAttoFIL,
 			s,
 			[]byte("params"))
 		smsg, err := NewSignedMessage(*msg, &ms, NewGasPrice(0), NewGasUnits(0))
@@ -187,7 +187,7 @@ func NewMessageForTestGetter() func() *Message {
 			from,
 			to,
 			0,
-			nil,
+			ZeroAttoFIL,
 			s,
 			nil)
 	}

--- a/types/testing_messages.go
+++ b/types/testing_messages.go
@@ -28,7 +28,7 @@ func NewMessageMaker(t *testing.T, keys []KeyInfo) *MessageMaker {
 		addresses[i] = addr
 	}
 
-	return &MessageMaker{*ZeroAttoFIL, NewGasUnits(0), &signer, 0, t}
+	return &MessageMaker{ZeroAttoFIL, NewGasUnits(0), &signer, 0, t}
 }
 
 // Addresses returns the addresses for which this maker can sign messages.
@@ -51,7 +51,7 @@ func (mm *MessageMaker) NewSignedMessage(from address.Address, nonce uint64) *Si
 		from,
 		to,
 		nonce,
-		NewAttoFILFromFIL(0),
+		ZeroAttoFIL,
 		"method"+fmt.Sprintf("%d", seq),
 		[]byte("params"))
 	signed, err := NewSignedMessage(*msg, mm.signer, mm.DefaultGasPrice, mm.DefaultGasUnits)

--- a/types/tipset_test.go
+++ b/types/tipset_test.go
@@ -149,13 +149,14 @@ func TestTipSet(t *testing.T) {
 		assert.Equal(t, []*Block{b1, b2, b3}, ts.ToSlice()) // tipset is immutable
 	})
 
-	//t.Run("string", func(t *testing.T) {
-	//	// String shouldn't really need testing, but some existing code uses the string as a
-	//	// datastore key and depends on the format exactly.
-	//	assert.Equal(t, "{ "+b1.Cid().String()+" }", RequireNewTipSet(t, b1).String())
-	//	assert.Equal(t, "{ "+b1.Cid().String()+" "+b2.Cid().String()+" "+b3.Cid().String()+" }",
-	//		RequireNewTipSet(t, b3, b2, b1).String())
-	//})
+	t.Run("string", func(t *testing.T) {
+		// String shouldn't really need testing, but some existing code uses the string as a
+		// datastore key and depends on the format exactly.
+		assert.Equal(t, "{ "+b1.Cid().String()+" }", RequireNewTipSet(t, b1).String())
+
+		expected := NewSortedCidSet(b1.Cid(), b2.Cid(), b3.Cid()).String()
+		assert.Equal(t, expected, RequireNewTipSet(t, b3, b2, b1).String())
+	})
 
 	t.Run("empty new tipset fails", func(t *testing.T) {
 		_, err := NewTipSet()

--- a/types/tipset_test.go
+++ b/types/tipset_test.go
@@ -149,13 +149,13 @@ func TestTipSet(t *testing.T) {
 		assert.Equal(t, []*Block{b1, b2, b3}, ts.ToSlice()) // tipset is immutable
 	})
 
-	t.Run("string", func(t *testing.T) {
-		// String shouldn't really need testing, but some existing code uses the string as a
-		// datastore key and depends on the format exactly.
-		assert.Equal(t, "{ "+b1.Cid().String()+" }", RequireNewTipSet(t, b1).String())
-		assert.Equal(t, "{ "+b1.Cid().String()+" "+b2.Cid().String()+" "+b3.Cid().String()+" }",
-			RequireNewTipSet(t, b3, b2, b1).String())
-	})
+	//t.Run("string", func(t *testing.T) {
+	//	// String shouldn't really need testing, but some existing code uses the string as a
+	//	// datastore key and depends on the format exactly.
+	//	assert.Equal(t, "{ "+b1.Cid().String()+" }", RequireNewTipSet(t, b1).String())
+	//	assert.Equal(t, "{ "+b1.Cid().String()+" "+b2.Cid().String()+" "+b3.Cid().String()+" }",
+	//		RequireNewTipSet(t, b3, b2, b1).String())
+	//})
 
 	t.Run("empty new tipset fails", func(t *testing.T) {
 		_, err := NewTipSet()

--- a/vm/context.go
+++ b/vm/context.go
@@ -124,7 +124,7 @@ func (ctx *Context) BlockHeight() *types.BlockHeight {
 }
 
 // MyBalance returns the balance of the associated actor.
-func (ctx *Context) MyBalance() *types.AttoFIL {
+func (ctx *Context) MyBalance() types.AttoFIL {
 	return ctx.to.Balance
 }
 
@@ -135,7 +135,7 @@ func (ctx *Context) IsFromAccountActor() bool {
 
 // Send sends a message to another actor.
 // This method assumes to be called from inside the `to` actor.
-func (ctx *Context) Send(to address.Address, method string, value *types.AttoFIL, params []interface{}) ([][]byte, uint8, error) {
+func (ctx *Context) Send(to address.Address, method string, value types.AttoFIL, params []interface{}) ([][]byte, uint8, error) {
 	deps := ctx.deps
 
 	// the message sender is the `to` actor, so this is what we set as `from` in the new message

--- a/vm/context_test.go
+++ b/vm/context_test.go
@@ -40,12 +40,12 @@ func TestVMContextStorage(t *testing.T) {
 	bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
 	vms := NewStorageMap(bs)
 
-	toActor, err := account.NewActor(nil)
+	toActor, err := account.NewActor(types.ZeroAttoFIL)
 	assert.NoError(t, err)
 	toAddr := addrGetter()
 
 	assert.NoError(t, st.SetActor(ctx, toAddr, toActor))
-	msg := types.NewMessage(addrGetter(), toAddr, 0, nil, "hello", nil)
+	msg := types.NewMessage(addrGetter(), toAddr, 0, types.ZeroAttoFIL, "hello", nil)
 
 	to, err := cstate.GetActor(ctx, toAddr)
 	assert.NoError(t, err)
@@ -114,7 +114,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		ctx := NewVMContext(vmCtxParams)
 		ctx.deps = deps
 
-		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
+		_, code, err := ctx.Send(newAddress(), "foo", types.ZeroAttoFIL, []interface{}{})
 
 		assert.Error(t, err)
 		assert.Equal(t, 1, int(code))
@@ -138,7 +138,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		ctx := NewVMContext(vmCtxParams)
 		ctx.deps = deps
 
-		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
+		_, code, err := ctx.Send(newAddress(), "foo", types.ZeroAttoFIL, []interface{}{})
 
 		assert.Error(t, err)
 		assert.Equal(t, 1, int(code))
@@ -167,7 +167,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		ctx := NewVMContext(vmCtxParams)
 		ctx.deps = deps
 
-		_, code, err := ctx.Send(to, "foo", nil, []interface{}{})
+		_, code, err := ctx.Send(to, "foo", types.ZeroAttoFIL, []interface{}{})
 
 		assert.Error(t, err)
 		assert.Equal(t, 1, int(code))
@@ -197,7 +197,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		ctx := NewVMContext(vmCtxParams)
 		ctx.deps = deps
 
-		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
+		_, code, err := ctx.Send(newAddress(), "foo", types.ZeroAttoFIL, []interface{}{})
 
 		assert.Error(t, err)
 		assert.Equal(t, 1, int(code))
@@ -231,7 +231,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		ctx := NewVMContext(vmCtxParams)
 		ctx.deps = deps
 
-		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
+		_, code, err := ctx.Send(newAddress(), "foo", types.ZeroAttoFIL, []interface{}{})
 
 		assert.Error(t, err)
 		assert.Equal(t, 123, int(code))

--- a/vm/storage_test.go
+++ b/vm/storage_test.go
@@ -21,7 +21,7 @@ func TestGetAndPutWithEmptyStorage(t *testing.T) {
 
 	bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
 	vms := NewStorageMap(bs)
-	testActor := actor.NewActor(types.AccountActorCodeCid, types.NewZeroAttoFIL())
+	testActor := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 
 	t.Run("Put adds to storage", func(t *testing.T) {
 		as := vms.NewStorage(address.TestAddress, testActor)
@@ -100,7 +100,7 @@ func TestGetAndPutWithEmptyStorage(t *testing.T) {
 func TestGetAndPutWithDataInStorage(t *testing.T) {
 	tf.UnitTest(t)
 
-	testActor := actor.NewActor(types.AccountActorCodeCid, types.NewZeroAttoFIL())
+	testActor := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 
 	bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
 	vms := NewStorageMap(bs)
@@ -147,7 +147,7 @@ func TestStorageHeadAndCommit(t *testing.T) {
 	bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
 
 	t.Run("Committing changes head", func(t *testing.T) {
-		testActor := actor.NewActor(types.AccountActorCodeCid, types.NewZeroAttoFIL())
+		testActor := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 
 		stage := NewStorageMap(bs).NewStorage(address.TestAddress, testActor)
 
@@ -166,7 +166,7 @@ func TestStorageHeadAndCommit(t *testing.T) {
 	})
 
 	t.Run("Committing a non existent chunk is an error", func(t *testing.T) {
-		testActor := actor.NewActor(types.AccountActorCodeCid, types.NewZeroAttoFIL())
+		testActor := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 
 		stage := NewStorageMap(bs).NewStorage(address.TestAddress, testActor)
 
@@ -178,7 +178,7 @@ func TestStorageHeadAndCommit(t *testing.T) {
 	})
 
 	t.Run("Committing out of sequence is an error", func(t *testing.T) {
-		testActor := actor.NewActor(types.AccountActorCodeCid, types.NewZeroAttoFIL())
+		testActor := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 
 		stage := NewStorageMap(bs).NewStorage(address.TestAddress, testActor)
 
@@ -214,7 +214,7 @@ func TestDatastoreBacking(t *testing.T) {
 		// add a value to underlying datastore
 		require.NoError(t, bs.Put(memory2))
 
-		testActor := actor.NewActor(types.AccountActorCodeCid, types.NewZeroAttoFIL())
+		testActor := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 		stage := NewStorageMap(bs).NewStorage(address.TestAddress, testActor)
 
 		chunk, err := stage.Get(memory2.Cid())
@@ -225,7 +225,7 @@ func TestDatastoreBacking(t *testing.T) {
 	t.Run("Flush adds chunks to underlying store", func(t *testing.T) {
 		bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
 
-		testActor := actor.NewActor(types.AccountActorCodeCid, types.NewZeroAttoFIL())
+		testActor := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 		storage := NewStorageMap(bs)
 		stage := storage.NewStorage(address.TestAddress, testActor)
 
@@ -249,7 +249,7 @@ func TestDatastoreBacking(t *testing.T) {
 	t.Run("Flush ignores chunks not referenced through head", func(t *testing.T) {
 		bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
 
-		testActor := actor.NewActor(types.AccountActorCodeCid, types.NewZeroAttoFIL())
+		testActor := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 		storage := NewStorageMap(bs)
 		stage := storage.NewStorage(address.TestAddress, testActor)
 
@@ -279,7 +279,7 @@ func TestDatastoreBacking(t *testing.T) {
 	t.Run("Flush includes non-head chunks that are referenced in node", func(t *testing.T) {
 		bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
 
-		testActor := actor.NewActor(types.AccountActorCodeCid, types.NewZeroAttoFIL())
+		testActor := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 		storage := NewStorageMap(bs)
 		stage := storage.NewStorage(address.TestAddress, testActor)
 
@@ -317,7 +317,7 @@ func TestValidationAndPruning(t *testing.T) {
 	t.Run("Linking to a non-existent cid fails in Commit", func(t *testing.T) {
 		bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
 
-		testActor := actor.NewActor(types.AccountActorCodeCid, types.NewZeroAttoFIL())
+		testActor := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 		storage := NewStorageMap(bs)
 		stage := storage.NewStorage(address.TestAddress, testActor)
 
@@ -337,7 +337,7 @@ func TestValidationAndPruning(t *testing.T) {
 	t.Run("Prune removes unlinked chunks from stage", func(t *testing.T) {
 		bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
 
-		testActor := actor.NewActor(types.AccountActorCodeCid, types.NewZeroAttoFIL())
+		testActor := actor.NewActor(types.AccountActorCodeCid, types.ZeroAttoFIL)
 		storage := NewStorageMap(bs)
 		stage := storage.NewStorage(address.TestAddress, testActor)
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -22,12 +22,12 @@ func Send(ctx context.Context, vmCtx *Context) ([][]byte, uint8, error) {
 }
 
 type sendDeps struct {
-	transfer func(*actor.Actor, *actor.Actor, *types.AttoFIL) error
+	transfer func(*actor.Actor, *actor.Actor, types.AttoFIL) error
 }
 
 // send executes a message pass inside the VM. It exists alongside Send so that we can inject its dependencies during test.
 func send(ctx context.Context, deps sendDeps, vmCtx *Context) ([][]byte, uint8, error) {
-	if vmCtx.message.Value != nil {
+	if !vmCtx.message.Value.Equal(types.ZeroAttoFIL) {
 		if err := deps.transfer(vmCtx.from, vmCtx.to, vmCtx.message.Value); err != nil {
 			if errors.ShouldRevert(err) {
 				return nil, err.(*errors.RevertError).Code(), err
@@ -64,7 +64,7 @@ func send(ctx context.Context, deps sendDeps, vmCtx *Context) ([][]byte, uint8, 
 }
 
 // Transfer transfers the given value between two actors.
-func Transfer(fromActor, toActor *actor.Actor, value *types.AttoFIL) error {
+func Transfer(fromActor, toActor *actor.Actor, value types.AttoFIL) error {
 	if value.IsNegative() {
 		return errors.Errors[errors.ErrCannotTransferNegativeValue]
 	}
@@ -73,9 +73,9 @@ func Transfer(fromActor, toActor *actor.Actor, value *types.AttoFIL) error {
 		return errors.Errors[errors.ErrInsufficientBalance]
 	}
 
-	if toActor.Balance == nil {
-		toActor.Balance = types.NewZeroAttoFIL()
-	}
+	//if toActor.Balance == nil {
+	//	toActor.Balance = types.NewZeroAttoFIL()
+	//}
 	fromActor.Balance = fromActor.Balance.Sub(value)
 	toActor.Balance = toActor.Balance.Add(value)
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -73,9 +73,6 @@ func Transfer(fromActor, toActor *actor.Actor, value types.AttoFIL) error {
 		return errors.Errors[errors.ErrInsufficientBalance]
 	}
 
-	//if toActor.Balance == nil {
-	//	toActor.Balance = types.ZeroAttoFIL
-	//}
 	fromActor.Balance = fromActor.Balance.Sub(value)
 	toActor.Balance = toActor.Balance.Add(value)
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -74,7 +74,7 @@ func Transfer(fromActor, toActor *actor.Actor, value types.AttoFIL) error {
 	}
 
 	//if toActor.Balance == nil {
-	//	toActor.Balance = types.NewZeroAttoFIL()
+	//	toActor.Balance = types.ZeroAttoFIL
 	//}
 	fromActor.Balance = fromActor.Balance.Sub(value)
 	toActor.Balance = toActor.Balance.Add(value)

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -24,7 +24,7 @@ func TestTransfer(t *testing.T) {
 
 	actor1 := actor.NewActor(cid.Undef, types.NewAttoFILFromFIL(100))
 	actor2 := actor.NewActor(cid.Undef, types.NewAttoFILFromFIL(50))
-	actor3 := actor.NewActor(cid.Undef, nil)
+	actor3 := actor.NewActor(cid.Undef, types.ZeroAttoFIL)
 
 	t.Run("success", func(t *testing.T) {
 		assert.NoError(t, Transfer(actor1, actor2, types.NewAttoFILFromFIL(10)))
@@ -60,7 +60,7 @@ func TestSendErrorHandling(t *testing.T) {
 		msg.Value = types.NewAttoFILFromFIL(1) // exact value doesn't matter - needs to be non-nil
 
 		deps := sendDeps{
-			transfer: func(_ *actor.Actor, _ *actor.Actor, _ *types.AttoFIL) error {
+			transfer: func(_ *actor.Actor, _ *actor.Actor, _ types.AttoFIL) error {
 				return transferErr
 			},
 		}
@@ -85,7 +85,7 @@ func TestSendErrorHandling(t *testing.T) {
 
 	t.Run("returns right exit code and a revert error if we can't load the recipient actor's code", func(t *testing.T) {
 		msg := newMsg()
-		msg.Value = nil // such that we don't transfer
+		msg.Value = types.ZeroAttoFIL // such that we don't transfer
 
 		deps := sendDeps{}
 
@@ -109,7 +109,7 @@ func TestSendErrorHandling(t *testing.T) {
 
 	t.Run("returns exit code 1 and a revert error if code doesn't export a matching method", func(t *testing.T) {
 		msg := newMsg()
-		msg.Value = nil // such that we don't transfer
+		msg.Value = types.ZeroAttoFIL // such that we don't transfer
 		msg.Method = "bar"
 
 		assert.False(t, actor.FakeActorExports.Has(msg.Method))

--- a/wallet/signature_test.go
+++ b/wallet/signature_test.go
@@ -110,7 +110,7 @@ func TestSignMessageOk(t *testing.T) {
 
 	fs, addr := requireSignerAddr(t)
 
-	msg := types.NewMessage(addr, addr, 1, nil, "", nil)
+	msg := types.NewMessage(addr, addr, 1, types.ZeroAttoFIL, "", nil)
 	smsg, err := types.NewSignedMessage(*msg, fs, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(t, err)
 
@@ -125,7 +125,7 @@ func TestBadFrom(t *testing.T) {
 	addr2, err := fs.NewAddress()
 	require.NoError(t, err)
 
-	msg := types.NewMessage(addr, addr, 1, nil, "", nil)
+	msg := types.NewMessage(addr, addr, 1, types.ZeroAttoFIL, "", nil)
 	meteredMsg := types.NewMeteredMessage(*msg, types.NewGasPrice(0), types.NewGasUnits(0))
 	// Can't use NewSignedMessage constructor as it always signs with msg.From.
 	bmsg, err := meteredMsg.Marshal()
@@ -145,7 +145,7 @@ func TestSignedMessageBadSignature(t *testing.T) {
 	tf.UnitTest(t)
 
 	fs, addr := requireSignerAddr(t)
-	msg := types.NewMessage(addr, addr, 1, nil, "", nil)
+	msg := types.NewMessage(addr, addr, 1, types.ZeroAttoFIL, "", nil)
 	smsg, err := types.NewSignedMessage(*msg, fs, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(t, err)
 
@@ -159,7 +159,7 @@ func TestSignedMessageCorrupted(t *testing.T) {
 
 	fs, addr := requireSignerAddr(t)
 
-	msg := types.NewMessage(addr, addr, 1, nil, "", nil)
+	msg := types.NewMessage(addr, addr, 1, types.ZeroAttoFIL, "", nil)
 	smsg, err := types.NewSignedMessage(*msg, fs, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Problem
`AttoFIL` is a struct wrapping a pointer to a [`big.Int`](https://golang.org/pkg/math/big/#Int).  Its usage in the code base is confusing and inconsistent.  In most cases, it is passed as as a pointer to its methods, and the methods are defined on a pointer receiver, even though the receiver is never modified and usually the parameters aren't either.

Additionally, an `AttoFIL` with a value of `0` has 3 representations:
1. `AttoFIL{}` (The zero value of an `AttoFIL`)
1. `AttoFIL{val: &big.Int{}}` (With a pointer to the zero value of a `big.Int`)
1. `AttoFIL{val: big.NewInt(0)}` (With a pointer to a zero-valued `big.Int`)

This can cause some serialization/deserialization asymmetry.

## Solution
Pass `AttoFIL`s by value always; they can be treated as immutable values.

Also, embed a `big.Int` in the `AttoFIL` instead of wrapping just a `*big.Int`.  This is the most questionable part of this PR.  It increases the size of the struct from just a pointer to a pointer, a bool, and a slice.  However, this has some nice benefits:

1. We don't have [check for `nil`](https://github.com/filecoin-project/go-filecoin/blob/742c9836f43479de8a14bdd5c5b5e27ca34b0870/types/atto_fil.go#L173) in every method that does calculations.
1. Serialization "symmetry" when serializing `AttoFIL{}`.