### PR TITLE
Moved show deal command to deals show

### DIFF
--- a/commands/show.go
+++ b/commands/show.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ipfs/go-ipfs-cmdkit"
 	"github.com/ipfs/go-ipfs-cmds"
 
-	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -19,7 +18,6 @@ var showCmd = &cmds.Command{
 	},
 	Subcommands: map[string]*cmds.Command{
 		"block": showBlockCmd,
-		"deal":  showDealCmd,
 	},
 }
 
@@ -64,57 +62,6 @@ Nonce:  %s
 				wStr,
 				strconv.FormatUint(uint64(block.Height), 10),
 				strconv.FormatUint(uint64(block.Nonce), 10),
-			)
-			return err
-		}),
-	},
-}
-
-var showDealCmd = &cmds.Command{
-	Helptext: cmdkit.HelpText{
-		Tagline: "Show deal details for CID <cid>",
-	},
-	Arguments: []cmdkit.Argument{
-		cmdkit.StringArg("cid", true, false, "CID of deal to query"),
-	},
-	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
-		propcid, err := cid.Decode(req.Arguments[0])
-		if err != nil {
-			return err
-		}
-
-		deal, err := GetPorcelainAPI(env).DealGet(req.Context, propcid)
-		if err != nil {
-			return err
-		}
-
-		if err := re.Emit(deal); err != nil {
-			return err
-		}
-		return nil
-	},
-	Type: storagedeal.Deal{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, deal *storagedeal.Deal) error {
-			emptyDeal := storagedeal.Deal{}
-			if *deal == emptyDeal {
-				return fmt.Errorf("deal not found: %s", req.Arguments[0])
-			}
-
-			_, err := fmt.Fprintf(w, `Deal details
-CID: %s
-State: %s
-Miner: %s
-Duration: %d blocks
-Size: %s bytes
-Total Price: %s FIL
-`,
-				deal.Response.ProposalCid,
-				deal.Response.State,
-				deal.Miner.String(),
-				deal.Proposal.Duration,
-				deal.Proposal.Size,
-				deal.Proposal.TotalPrice,
 			)
 			return err
 		}),

--- a/commands/show_test.go
+++ b/commands/show_test.go
@@ -1,27 +1,15 @@
 package commands_test
 
 import (
-	"context"
-	"crypto/rand"
 	"encoding/json"
-	"io"
-	"math/big"
 	"testing"
 
-	"github.com/ipfs/go-cid"
-	files "github.com/ipfs/go-ipfs-files"
-	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/fixtures"
-	"github.com/filecoin-project/go-filecoin/proofs"
-	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
-	"github.com/filecoin-project/go-filecoin/tools/fast"
-	"github.com/filecoin-project/go-filecoin/tools/fast/fastesting"
-	"github.com/filecoin-project/go-filecoin/tools/fast/series"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -66,70 +54,4 @@ func TestBlockDaemon(t *testing.T) {
 
 		requireSchemaConformance(t, []byte(blockGetLine), "filecoin_block")
 	})
-}
-
-func TestShowDeal(t *testing.T) {
-	tf.IntegrationTest(t)
-
-	fastenvOpts := fast.FilecoinOpts{}
-
-	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fastenvOpts)
-	defer func() {
-		require.NoError(t, env.Teardown(ctx))
-	}()
-
-	clientNode := env.GenesisMiner
-	require.NoError(t, clientNode.MiningStart(ctx))
-
-	minerNode := env.RequireNewNodeWithFunds(1000)
-
-	// Connect the clientNode and the minerNode
-	require.NoError(t, series.Connect(ctx, clientNode, minerNode))
-
-	// Create a minerNode
-	collateral := big.NewInt(500)           // FIL
-	price := big.NewFloat(0.000000001)      // price per byte/block
-	expiry := big.NewInt(24 * 60 * 60 / 30) // ~24 hours
-
-	ask, err := series.CreateStorageMinerWithAsk(ctx, minerNode, collateral, price, expiry)
-	require.NoError(t, err)
-
-	// Create some data that is the full sector size and make it autoseal asap
-
-	maxBytesi64 := int64(getMaxUserBytesPerStagedSector())
-	dataReader := io.LimitReader(rand.Reader, maxBytesi64)
-	_, deal, err := series.ImportAndStore(ctx, clientNode, ask, files.NewReaderFile(dataReader))
-	require.NoError(t, err)
-
-	t.Run("showDeal outputs correct information", func(t *testing.T) {
-		showDeal, err := clientNode.ShowDeal(ctx, deal.ProposalCid)
-		require.NoError(t, err)
-
-		assert.Equal(t, ask.Miner, showDeal.Miner)
-		assert.Equal(t, storagedeal.Accepted, showDeal.Response.State)
-
-		duri64 := int64(showDeal.Proposal.Duration)
-		foo := big.NewInt(duri64 * maxBytesi64)
-
-		totalPrice := ask.Price.MulBigInt(foo)
-
-		assert.Equal(t, totalPrice, showDeal.Proposal.TotalPrice)
-	})
-
-	t.Run("When deal does not exist says deal not found", func(t *testing.T) {
-		deal.ProposalCid = requireTestCID(t, []byte("anything"))
-		showDeal, err := clientNode.ShowDeal(ctx, deal.ProposalCid)
-		assert.Error(t, err, "Error: deal not found")
-		assert.Nil(t, showDeal)
-	})
-}
-
-func getMaxUserBytesPerStagedSector() uint64 {
-	return proofs.GetMaxUserBytesPerStagedSector(types.OneKiBSectorSize).Uint64()
-}
-
-func requireTestCID(t *testing.T, data []byte) cid.Cid {
-	hash, err := multihash.Sum(data, multihash.SHA2_256, -1)
-	require.NoError(t, err)
-	return cid.NewCidV1(cid.DagCBOR, hash)
 }

--- a/tools/fast/action_deals.go
+++ b/tools/fast/action_deals.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/commands"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 )
 
 // DealsList runs the `deals list` command against the filecoin process
@@ -43,4 +44,15 @@ func (f *Filecoin) DealsRedeem(ctx context.Context, dealCid cid.Cid, options ...
 	}
 
 	return out.Cid, nil
+}
+
+// DealsShow runs the `deals show` command against the filecoin process
+func (f *Filecoin) DealsShow(ctx context.Context, propCid cid.Cid) (*storagedeal.Deal, error) {
+	var out storagedeal.Deal
+
+	err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "deals", "show", propCid.String())
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
 }

--- a/tools/fast/action_show.go
+++ b/tools/fast/action_show.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ipfs/go-cid"
 
-	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -19,17 +18,5 @@ func (f *Filecoin) ShowBlock(ctx context.Context, ref cid.Cid) (*types.Block, er
 		return nil, err
 	}
 
-	return &out, nil
-}
-
-// ShowDeal runs the `show deal` command against the filecoin process
-func (f *Filecoin) ShowDeal(ctx context.Context, propCid cid.Cid) (*storagedeal.Deal, error) {
-
-	var out storagedeal.Deal
-
-	err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "show", "deal", propCid.String())
-	if err != nil {
-		return nil, err
-	}
 	return &out, nil
 }


### PR DESCRIPTION
# Problem

We want to reorganize several commands under a new `go-filecoin deals` subcommand.

# Solution

Move `go-filecoin show deal` to `go-filecoin deals show`.