### PR TITLE
Add IntSet implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
+	github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259
 	github.com/golang/mock v1.2.0 // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/golangci/golangci-lint v1.15.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
-	github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259
 	github.com/golang/mock v1.2.0 // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/golangci/golangci-lint v1.15.0
@@ -77,7 +76,6 @@ require (
 	github.com/multiformats/go-multistream v0.0.1
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/openzipkin/zipkin-go v0.1.6 // indirect
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 // indirect
 	github.com/pkg/errors v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.4.12 // indirect
+	github.com/Workiva/go-datastructures v1.0.50
 	github.com/cskr/pubsub v1.0.2
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v0.7.3-0.20190315170154-87d593639c77

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259 h1:ZHJ7+IGpuOXtVf6Zk/a3WuHQgkC+vXwaqfUBDFwahtI=
+github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259/go.mod h1:9Qcha0gTWLw//0VNka1Cbnjvg3pNKGFdAm7E9sBabxE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -696,6 +698,7 @@ google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMt
 google.golang.org/api v0.3.2 h1:iTp+3yyl/KOtxa/d1/JUE0GGSoR6FuW5udver22iwpw=
 google.golang.org/api v0.3.2/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b h1:lohp5blsw53GBXtLyLNaTXPXS9pJ1tiTw61ZHUoE9Qw=

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/Stebalien/go-bitfield v0.0.0-20180330043415-076a62f9ce6e h1:2Z+EBRrOJsA3psnUPcEWMIH2EIga1xHflQcr/EZslx8=
 github.com/Stebalien/go-bitfield v0.0.0-20180330043415-076a62f9ce6e/go.mod h1:3oM7gXIttpYDAJXpVNnSCiUMYBLIZ6cb1t+Ip982MRo=
+github.com/Workiva/go-datastructures v1.0.50 h1:slDmfW6KCHcC7U+LP3DDBbm4fqTwZGn1beOFPfGaLvo=
+github.com/Workiva/go-datastructures v1.0.50/go.mod h1:Z+F2Rca0qCsVYDS8z7bAGm8f3UkzuWYS/oBZz5a7VVA=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ contrib.go.opencensus.io/exporter/jaeger v0.1.0 h1:WNc9HbA38xEQmsI40Tjd/MNU/g8by
 contrib.go.opencensus.io/exporter/jaeger v0.1.0/go.mod h1:VYianECmuFPwU37O699Vc1GOcy+y8kOsfaxHRImmjbA=
 contrib.go.opencensus.io/exporter/prometheus v0.1.0 h1:SByaIoWwNgMdPSgl5sMqM2KDE5H/ukPWBRo314xiDvg=
 contrib.go.opencensus.io/exporter/prometheus v0.1.0/go.mod h1:cGFniUXGZlKRjzOyuZJ6mgB+PgBcCIa79kEKR8YCW+A=
-git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7 h1:PqzgE6kAMi81xWQA2QIVxjWkFHptGgC547vchpUbtFo=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
@@ -109,8 +108,6 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259 h1:ZHJ7+IGpuOXtVf6Zk/a3WuHQgkC+vXwaqfUBDFwahtI=
-github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259/go.mod h1:9Qcha0gTWLw//0VNka1Cbnjvg3pNKGFdAm7E9sBabxE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -364,12 +361,8 @@ github.com/libp2p/go-libp2p-interface-connmgr v0.0.1 h1:Q9EkNSLAOF+u90L88qmE9z/f
 github.com/libp2p/go-libp2p-interface-connmgr v0.0.1/go.mod h1:GarlRLH0LdeWcLnYM/SaBykKFl9U5JFnbBGruAk/D5k=
 github.com/libp2p/go-libp2p-interface-pnet v0.0.1 h1:7GnzRrBTJHEsofi1ahFdPN9Si6skwXQE9UqR2S+Pkh8=
 github.com/libp2p/go-libp2p-interface-pnet v0.0.1/go.mod h1:el9jHpQAXK5dnTpKA4yfCNBZXvrzdOU75zz+C6ryp3k=
-github.com/libp2p/go-libp2p-kad-dht v0.0.4 h1:Z+6l5pCD8xXQmqmKKO+OTa4+7Or1uyPTmu49rXNf4oo=
-github.com/libp2p/go-libp2p-kad-dht v0.0.4/go.mod h1:oaBflOQcuC8H+SVV0YN26H6AS+wcUEJyjUGV66vXuSY=
 github.com/libp2p/go-libp2p-kad-dht v0.0.8 h1:oUnAqkCAWYvAoF5TmnDIf4k1fIcipMAFec6sQlTXGKE=
 github.com/libp2p/go-libp2p-kad-dht v0.0.8/go.mod h1:fGQfSQWWOxQFB97kETE09lYRLPRKaZZdguIq98fE5PI=
-github.com/libp2p/go-libp2p-kad-dht v0.0.10 h1:3B8yv3QSdL4M2RRP5biK7YQEngxf2/wdNIQtVBHu6hA=
-github.com/libp2p/go-libp2p-kad-dht v0.0.10/go.mod h1:RVllrB76xoaayqqBkLmXT8iIkMRNfLWSBuqAggP7W00=
 github.com/libp2p/go-libp2p-kbucket v0.0.1 h1:7H5hM851hkEpLOFjrVNSrrxo6J4bWrUQxxv+z1JW9xk=
 github.com/libp2p/go-libp2p-kbucket v0.0.1/go.mod h1:Y0iQDHRTk/ZgM8PC4jExoF+E4j+yXWwRkdldkMa5Xm4=
 github.com/libp2p/go-libp2p-kbucket v0.1.1 h1:ZrvW3qCM+lAuv7nrNts/zfEiClq+GZe8OIzX4Vb3Dwo=
@@ -621,8 +614,6 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v1.1.0 h1:ngVtJC9TY/lg0AA/1k48FYhBrhRoFlEmWzsehpNAaZg=
 github.com/xeipuuv/gojsonschema v1.1.0/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
-go.opencensus.io v0.20.2 h1:NAfh7zF0/3/HqtMvJNZ/RFrSlCE6ZTlHmKfhL/Dm1Jk=
-go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go4.org v0.0.0-20190218023631-ce4c26f7be8e h1:m9LfARr2VIOW0vsV19kEKp/sWQvZnGobA8JHui/XJoY=

--- a/types/intset.go
+++ b/types/intset.go
@@ -11,31 +11,30 @@ type IntSet struct {
 
 // NewIntSet returns a new IntSet, optionally initialized with integers
 func NewIntSet(ints ...uint64) IntSet {
+	// We are ignoring errors from SetBit, GetBit since SparseBitArrays never return errors for those methods
 	out := IntSet{ba: bitarray.NewSparseBitArray()}
 	for _, i := range ints {
-		out.Add(i)
+		_ = out.ba.SetBit(i)
 	}
 	return out
 }
 
-// Add adds an integer to this IntSet
-func (is IntSet) Add(i uint64) {
-	// Ignoring errors as we are using SparseBitArrays, which never return errors
-	_ = is.ba.SetBit(i)
-}
-
-// Contains returns whether an integer exists in this IntSet
-func (is IntSet) Contains(i uint64) bool {
-	// Ignoring errors as we are using SparseBitArrays, which never return errors
+// Has returns whether an integer exists in this IntSet
+func (is IntSet) Has(i uint64) bool {
 	isSet, _ := is.ba.GetBit(i)
 	return isSet
 }
 
-// IsSubset returns true if every element in other is also in the receiver
-func (is IntSet) IsSubset(other IntSet) bool {
+// HasSubset returns true if every element in other is also in the receiver
+func (is IntSet) HasSubset(other IntSet) bool {
 	// The method we're calling here seems weird, but in bitarray (https://github.com/Workiva/go-datastructures/blob/f07cbe3f82ca2fd6e5ab94afce65fe43319f675f/bitarray/block.go#L97)
 	// "intersect" means, "wholly contained within"
 	return is.ba.Intersects(other.ba)
+}
+
+// Add returns a new IntSet, the result of adding i to the receiver
+func (is IntSet) Add(i uint64) IntSet {
+	return is.Union(NewIntSet(i))
 }
 
 // Union returns a new IntSet, the result of a set union of the receiver and other
@@ -53,8 +52,8 @@ func (is IntSet) Difference(other IntSet) IntSet {
 	out := NewIntSet()
 
 	for _, i := range is.ba.ToNums() {
-		if !other.Contains(i) {
-			out.Add(i)
+		if !other.Has(i) {
+			_ = out.ba.SetBit(i)
 		}
 	}
 

--- a/types/intset.go
+++ b/types/intset.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"github.com/golang-collections/go-datastructures/bitarray"
+	"github.com/Workiva/go-datastructures/bitarray"
 )
 
 // IntSet is a space-efficient set of uint64
@@ -9,7 +9,7 @@ type IntSet struct {
 	ba bitarray.BitArray
 }
 
-// NewIntSet returns an new IntSet, optionally initialized with integers
+// NewIntSet returns a new IntSet, optionally initialized with integers
 func NewIntSet(ints ...uint64) IntSet {
 	out := IntSet{ba: bitarray.NewSparseBitArray()}
 	for _, i := range ints {
@@ -29,6 +29,13 @@ func (is IntSet) Contains(i uint64) bool {
 	// Ignoring errors as we are using SparseBitArrays, which never return errors
 	isSet, _ := is.ba.GetBit(i)
 	return isSet
+}
+
+// IsSubset returns true if every element in other is also in the receiver
+func (is IntSet) IsSubset(other IntSet) bool {
+	// The method we're calling here seems weird, but in bitarray (https://github.com/Workiva/go-datastructures/blob/f07cbe3f82ca2fd6e5ab94afce65fe43319f675f/bitarray/block.go#L97)
+	// "intersect" means, "wholly contained within"
+	return is.ba.Intersects(other.ba)
 }
 
 // Union returns a new IntSet, the result of a set union of the receiver and other

--- a/types/intset.go
+++ b/types/intset.go
@@ -61,7 +61,7 @@ func (is IntSet) Difference(other IntSet) IntSet {
 	return out
 }
 
-// Integers returns a slice with all integers in this IntSet
-func (is IntSet) Integers() []uint64 {
+// Values returns a slice with all integers in this IntSet
+func (is IntSet) Values() []uint64 {
 	return is.ba.ToNums()
 }

--- a/types/intset.go
+++ b/types/intset.go
@@ -1,0 +1,60 @@
+package types
+
+import (
+	"github.com/golang-collections/go-datastructures/bitarray"
+)
+
+// IntSet is a space-efficient set of uint64
+type IntSet struct {
+	ba bitarray.BitArray
+}
+
+// NewIntSet returns an new IntSet, optionally initialized with integers
+func NewIntSet(ints ...uint64) IntSet {
+	out := IntSet{ba: bitarray.NewSparseBitArray()}
+	for _, i := range ints {
+		out.Add(i)
+	}
+	return out
+}
+
+// Add adds an integer to this IntSet
+func (is IntSet) Add(i uint64) {
+	// Ignoring errors as we are using SparseBitArrays, which never return errors
+	_ = is.ba.SetBit(i)
+}
+
+// Contains returns whether an integer exists in this IntSet
+func (is IntSet) Contains(i uint64) bool {
+	// Ignoring errors as we are using SparseBitArrays, which never return errors
+	isSet, _ := is.ba.GetBit(i)
+	return isSet
+}
+
+// Union returns a new IntSet, the result of a set union of the receiver and other
+func (is IntSet) Union(other IntSet) IntSet {
+	return IntSet{ba: is.ba.Or(other.ba)}
+}
+
+// Intersection returns a new IntSet, which is the intersection of the receiver and other
+func (is IntSet) Intersection(other IntSet) IntSet {
+	return IntSet{ba: is.ba.And(other.ba)}
+}
+
+// Difference returns a new IntSet, containing values in the receiver that are not in other
+func (is IntSet) Difference(other IntSet) IntSet {
+	out := NewIntSet()
+
+	for _, i := range is.ba.ToNums() {
+		if !other.Contains(i) {
+			out.Add(i)
+		}
+	}
+
+	return out
+}
+
+// Integers returns a slice with all integers in this IntSet
+func (is IntSet) Integers() []uint64 {
+	return is.ba.ToNums()
+}

--- a/types/intset_test.go
+++ b/types/intset_test.go
@@ -1,0 +1,61 @@
+package types_test
+
+import (
+	"testing"
+
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntSet(t *testing.T) {
+	tf.UnitTest(t)
+
+	t.Run("Add and Contains", func(t *testing.T) {
+		is := types.NewIntSet()
+		is.Add(1)
+		is.Add(0xffffffffffff)
+
+		assert.True(t, is.Contains(1))
+		assert.True(t, is.Contains(0xffffffffffff))
+		assert.False(t, is.Contains(2))
+	})
+
+	t.Run("Union", func(t *testing.T) {
+		is0 := types.NewIntSet(1)
+		is1 := types.NewIntSet(2)
+
+		result := is0.Union(is1)
+
+		assert.True(t, result.Contains(1))
+		assert.True(t, result.Contains(2))
+	})
+
+	t.Run("Intersection", func(t *testing.T) {
+		is0 := types.NewIntSet(1, 2)
+		is1 := types.NewIntSet(2, 3)
+
+		result := is0.Intersection(is1)
+
+		assert.True(t, result.Contains(2))
+		assert.False(t, result.Contains(1))
+		assert.False(t, result.Contains(3))
+	})
+
+	t.Run("Difference", func(t *testing.T) {
+		is0 := types.NewIntSet(1, 2, 3)
+		is1 := types.NewIntSet(3, 4, 5)
+
+		result := is0.Difference(is1)
+
+		assert.True(t, result.Contains(1))
+		assert.True(t, result.Contains(2))
+		assert.False(t, result.Contains(3))
+	})
+
+	t.Run("Integers", func(t *testing.T) {
+		is0 := types.NewIntSet(1, 2, 3)
+
+		assert.Equal(t, is0.Integers(), []uint64{1, 2, 3})
+	})
+}

--- a/types/intset_test.go
+++ b/types/intset_test.go
@@ -1,6 +1,8 @@
 package types_test
 
 import (
+	"math/rand"
+	"sort"
 	"testing"
 
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
@@ -72,9 +74,17 @@ func TestIntSet(t *testing.T) {
 		assert.False(t, result.Contains(3))
 	})
 
-	t.Run("Integers", func(t *testing.T) {
-		is0 := types.NewIntSet(1, 2, 3)
+	t.Run("Values", func(t *testing.T) {
+		ints := make([]uint64, 1024)
+		for idx := range ints {
+			ints[idx] = rand.Uint64()
+		}
 
-		assert.Equal(t, is0.Integers(), []uint64{1, 2, 3})
+		result := types.NewIntSet(ints...).Values()
+
+		sort.Slice(ints, func(i, j int) bool { return ints[i] < ints[j] })
+		sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
+
+		assert.Equal(t, ints, result)
 	})
 }

--- a/types/intset_test.go
+++ b/types/intset_test.go
@@ -13,33 +13,35 @@ import (
 func TestIntSet(t *testing.T) {
 	tf.UnitTest(t)
 
-	t.Run("Add and Contains", func(t *testing.T) {
-		is := types.NewIntSet()
-		is.Add(1)
-		is.Add(0xffffffffffff)
+	t.Run("Add", func(t *testing.T) {
+		empty := types.NewIntSet()
+		is := empty.Add(1).Add(0xffffffffffff)
 
-		assert.True(t, is.Contains(1))
-		assert.True(t, is.Contains(0xffffffffffff))
-		assert.False(t, is.Contains(2))
+		// doesn't mutate receivers
+		assert.Equal(t, 0, len(empty.Values()))
+
+		assert.True(t, is.Has(1))
+		assert.True(t, is.Has(0xffffffffffff))
+		assert.False(t, is.Has(2))
 	})
 
-	t.Run("IsSubset", func(t *testing.T) {
+	t.Run("HasSubset()", func(t *testing.T) {
 		is0 := types.NewIntSet(1, 2, 3)
 		is1 := types.NewIntSet()
 
 		// {} ⊆ {1, 2, 3}
-		assert.True(t, is0.IsSubset(is1))
-		assert.False(t, is1.IsSubset(is0))
+		assert.True(t, is0.HasSubset(is1))
+		assert.False(t, is1.HasSubset(is0))
 
 		// {3} ⊆ {1, 2, 3}
-		is1.Add(3)
-		assert.True(t, is0.IsSubset(is1))
-		assert.False(t, is1.IsSubset(is0))
+		is1 = is1.Add(3)
+		assert.True(t, is0.HasSubset(is1))
+		assert.False(t, is1.HasSubset(is0))
 
 		// {3, 4} ⊈ {1, 2, 3}
-		is1.Add(4)
-		assert.False(t, is0.IsSubset(is1))
-		assert.False(t, is1.IsSubset(is0))
+		is1 = is1.Add(4)
+		assert.False(t, is0.HasSubset(is1))
+		assert.False(t, is1.HasSubset(is0))
 	})
 
 	t.Run("Union", func(t *testing.T) {
@@ -48,8 +50,8 @@ func TestIntSet(t *testing.T) {
 
 		result := is0.Union(is1)
 
-		assert.True(t, result.Contains(1))
-		assert.True(t, result.Contains(2))
+		assert.True(t, result.Has(1))
+		assert.True(t, result.Has(2))
 	})
 
 	t.Run("Intersection", func(t *testing.T) {
@@ -58,9 +60,9 @@ func TestIntSet(t *testing.T) {
 
 		result := is0.Intersection(is1)
 
-		assert.True(t, result.Contains(2))
-		assert.False(t, result.Contains(1))
-		assert.False(t, result.Contains(3))
+		assert.True(t, result.Has(2))
+		assert.False(t, result.Has(1))
+		assert.False(t, result.Has(3))
 	})
 
 	t.Run("Difference", func(t *testing.T) {
@@ -69,9 +71,9 @@ func TestIntSet(t *testing.T) {
 
 		result := is0.Difference(is1)
 
-		assert.True(t, result.Contains(1))
-		assert.True(t, result.Contains(2))
-		assert.False(t, result.Contains(3))
+		assert.True(t, result.Has(1))
+		assert.True(t, result.Has(2))
+		assert.False(t, result.Has(3))
 	})
 
 	t.Run("Values", func(t *testing.T) {

--- a/types/intset_test.go
+++ b/types/intset_test.go
@@ -21,6 +21,25 @@ func TestIntSet(t *testing.T) {
 		assert.False(t, is.Contains(2))
 	})
 
+	t.Run("IsSubset", func(t *testing.T) {
+		is0 := types.NewIntSet(1, 2, 3)
+		is1 := types.NewIntSet()
+
+		// {} ⊆ {1, 2, 3}
+		assert.True(t, is0.IsSubset(is1))
+		assert.False(t, is1.IsSubset(is0))
+
+		// {3} ⊆ {1, 2, 3}
+		is1.Add(3)
+		assert.True(t, is0.IsSubset(is1))
+		assert.False(t, is1.IsSubset(is0))
+
+		// {3, 4} ⊈ {1, 2, 3}
+		is1.Add(4)
+		assert.False(t, is0.IsSubset(is1))
+		assert.False(t, is1.IsSubset(is0))
+	})
+
 	t.Run("Union", func(t *testing.T) {
 		is0 := types.NewIntSet(1)
 		is1 := types.NewIntSet(2)


### PR DESCRIPTION
## Summary
`IntSet` implementation, primarily intended for manipulating and passing around groups of Sector Ids.

Supports the basic set operations: Union, Difference, and Intersection, which should take care of most of our uses cases.

This implementation pretty much follows the [design document](https://docs.google.com/document/d/1aE5a-QZojprMkig6IyYkwV1SrMDDLOnNBqNdnwpu9tk), the relevant part quoted here:
> Proposed data structure: use a golang-collections bitarray.  Don’t worry too much about efficient construction and set difference.  Most operations are fairly trivial.  We will KISS and not avoid iterating over members of the set.  We won’t do any clever run or range based operations.  This will of course change if this is seen to be a state machine processing bottleneck.