### PR TITLE
move blocktime onto consensus and plumb

### DIFF
--- a/chain/default_store_test.go
+++ b/chain/default_store_test.go
@@ -26,7 +26,7 @@ func initStoreTest(ctx context.Context, t *testing.T, dstP *DefaultSyncerTestPar
 	r := repo.NewInMemoryRepo()
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := hamt.NewCborStore()
-	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), powerTable, dstP.genCid, proofs.NewFakeVerifier(true, nil))
+	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), powerTable, dstP.genCid, proofs.NewFakeVerifier(true, nil), th.BlockTimeTest)
 	initGenesisWrapper := func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
 		return initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs)
 	}

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -195,7 +195,7 @@ func loadSyncerFromRepo(t *testing.T, r repo.Repo, dstP *DefaultSyncerTestParams
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := hamt.NewCborStore()
 	verifier := proofs.NewFakeVerifier(true, nil)
-	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), powerTable, dstP.genCid, verifier)
+	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), powerTable, dstP.genCid, verifier, th.BlockTimeTest)
 
 	calcGenBlk, err := initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs) // flushes state
 	require.NoError(t, err)
@@ -221,7 +221,7 @@ func initSyncTestDefault(t *testing.T, dstP *DefaultSyncerTestParams) (*chain.De
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := hamt.NewCborStore()
 	verifier := proofs.NewFakeVerifier(true, nil)
-	con := consensus.NewExpected(cst, bs, processor, th.NewFakeBlockValidator(), powerTable, dstP.genCid, verifier)
+	con := consensus.NewExpected(cst, bs, processor, th.NewFakeBlockValidator(), powerTable, dstP.genCid, verifier, th.BlockTimeTest)
 	requireSetTestChain(t, con, false, dstP)
 	initGenesisWrapper := func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
 		return initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs)
@@ -240,7 +240,7 @@ func initSyncTestWithMode(t *testing.T, dstP *DefaultSyncerTestParams, syncMode 
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := hamt.NewCborStore()
 	verifier := proofs.NewFakeVerifier(true, nil)
-	con := consensus.NewExpected(cst, bs, processor, th.NewFakeBlockValidator(), powerTable, dstP.genCid, verifier)
+	con := consensus.NewExpected(cst, bs, processor, th.NewFakeBlockValidator(), powerTable, dstP.genCid, verifier, th.BlockTimeTest)
 	requireSetTestChain(t, con, false, dstP)
 	initGenesisWrapper := func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
 		return initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs)
@@ -257,7 +257,7 @@ func initSyncTestWithPowerTable(t *testing.T, powerTable consensus.PowerTableVie
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := hamt.NewCborStore()
 	verifier := proofs.NewFakeVerifier(true, nil)
-	con := consensus.NewExpected(cst, bs, processor, th.NewFakeBlockValidator(), powerTable, dstP.genCid, verifier)
+	con := consensus.NewExpected(cst, bs, processor, th.NewFakeBlockValidator(), powerTable, dstP.genCid, verifier, th.BlockTimeTest)
 	requireSetTestChain(t, con, false, dstP)
 	initGenesisWrapper := func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
 		return initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs)
@@ -1067,7 +1067,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 	chainStore := chain.NewStore(r.ChainDatastore(), calcGenBlk.Cid())
 
 	verifier := proofs.NewFakeVerifier(true, nil)
-	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &th.TestView{}, calcGenBlk.Cid(), verifier)
+	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &th.TestView{}, calcGenBlk.Cid(), verifier, th.BlockTimeTest)
 
 	// Initialize stores to contain dstP.genesis block and state
 	calcGenTS := th.RequireNewTipSet(t, &calcGenBlk)
@@ -1086,7 +1086,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 
 	// Now sync the chainStore with consensus using a MarketView.
 	verifier = proofs.NewFakeVerifier(true, nil)
-	con = consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &consensus.MarketView{}, calcGenBlk.Cid(), verifier)
+	con = consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &consensus.MarketView{}, calcGenBlk.Cid(), verifier, th.BlockTimeTest)
 	syncer := chain.NewDefaultSyncer(cst, con, chainStore, blockSource, chain.Syncing)
 	baseTS := requireHeadTipset(t, chainStore) // this is the last block of the bootstrapping chain creating miners
 	require.Equal(t, 1, baseTS.Len())

--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/config"
-	"github.com/filecoin-project/go-filecoin/mining"
+	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/node"
 	"github.com/filecoin-project/go-filecoin/paths"
 	"github.com/filecoin-project/go-filecoin/repo"
@@ -38,7 +38,7 @@ var daemonCmd = &cmds.Command{
 		cmdkit.BoolOption(OfflineMode, "start the node without networking"),
 		cmdkit.BoolOption(ELStdout),
 		cmdkit.BoolOption(IsRelay, "advertise and allow filecoin network traffic to be relayed through this node"),
-		cmdkit.StringOption(BlockTime, "time a node waits before trying to mine the next block").WithDefault(mining.DefaultBlockTime.String()),
+		cmdkit.StringOption(BlockTime, "time a node waits before trying to mine the next block").WithDefault(consensus.DefaultBlockTime.String()),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		return daemonRun(req, re, env)

--- a/consensus/expected_test.go
+++ b/consensus/expected_test.go
@@ -33,7 +33,7 @@ func TestNewExpected(t *testing.T) {
 	t.Run("a new Expected can be created", func(t *testing.T) {
 		cst, bstore, verifier := setupCborBlockstoreProofs()
 		ptv := th.NewTestPowerTableView(types.NewBytesAmount(1), types.NewBytesAmount(5))
-		exp := consensus.NewExpected(cst, bstore, consensus.NewDefaultProcessor(), th.NewFakeBlockValidator(), ptv, types.SomeCid(), verifier)
+		exp := consensus.NewExpected(cst, bstore, consensus.NewDefaultProcessor(), th.NewFakeBlockValidator(), ptv, types.SomeCid(), verifier, th.BlockTimeTest)
 		assert.NotNil(t, exp)
 	})
 }
@@ -93,7 +93,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		totalPower := types.NewBytesAmount(1)
 
 		ptv := th.NewTestPowerTableView(minerPower, totalPower)
-		exp := consensus.NewExpected(cistore, bstore, th.NewTestProcessor(), th.NewFakeBlockValidator(), ptv, genesisBlock.Cid(), verifier)
+		exp := consensus.NewExpected(cistore, bstore, th.NewTestProcessor(), th.NewFakeBlockValidator(), ptv, genesisBlock.Cid(), verifier, th.BlockTimeTest)
 
 		pTipSet := types.RequireNewTipSet(t, genesisBlock)
 
@@ -112,7 +112,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 	t.Run("returns nil + mining error when IsWinningTicket fails due to miner power error", func(t *testing.T) {
 
 		ptv := NewFailingMinerTestPowerTableView(types.NewBytesAmount(1), types.NewBytesAmount(5))
-		exp := consensus.NewExpected(cistore, bstore, consensus.NewDefaultProcessor(), th.NewFakeBlockValidator(), ptv, types.SomeCid(), verifier)
+		exp := consensus.NewExpected(cistore, bstore, consensus.NewDefaultProcessor(), th.NewFakeBlockValidator(), ptv, types.SomeCid(), verifier, th.BlockTimeTest)
 
 		pTipSet := types.RequireNewTipSet(t, genesisBlock)
 

--- a/consensus/protocol.go
+++ b/consensus/protocol.go
@@ -11,6 +11,7 @@ package consensus
 // except for errors in the case the stores do not have a mapping.
 import (
 	"context"
+	"time"
 
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
@@ -38,4 +39,7 @@ type Protocol interface {
 
 	// ValidateSemantic validates a block is correctly derived from its parent.
 	ValidateSemantic(ctx context.Context, child *types.Block, parents *types.TipSet) error
+
+	// BlockTime returns the block time used by the consensus protocol.
+	BlockTime() time.Duration
 }

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -57,7 +57,7 @@ func Test_Mine(t *testing.T) {
 		outCh := make(chan mining.Output)
 		worker := mining.NewDefaultWorkerWithDeps(
 			pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(), mining.NewTestPowerTableView(1),
-			bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest,
+			bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(),
 			CreatePoSTFunc)
 
 		go worker.Mine(ctx, tipSet, 0, outCh)
@@ -70,7 +70,7 @@ func Test_Mine(t *testing.T) {
 		doSomeWorkCalled = false
 		ctx, cancel := context.WithCancel(context.Background())
 		worker := mining.NewDefaultWorkerWithDeps(pool, makeExplodingGetStateTree(st), getWeightTest, getAncestors, th.NewTestProcessor(),
-			mining.NewTestPowerTableView(1), bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+			mining.NewTestPowerTableView(1), bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
 		outCh := make(chan mining.Output)
 		doSomeWorkCalled = false
 		go worker.Mine(ctx, tipSet, 0, outCh)
@@ -85,7 +85,7 @@ func Test_Mine(t *testing.T) {
 		doSomeWorkCalled = false
 		ctx, cancel := context.WithCancel(context.Background())
 		worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(),
-			mining.NewTestPowerTableView(1), bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+			mining.NewTestPowerTableView(1), bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
 		input := types.TipSet{}
 		outCh := make(chan mining.Output)
 		go worker.Mine(ctx, input, 0, outCh)
@@ -212,7 +212,7 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 	minerOwnerAddr := addrs[3]
 
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(),
-		&th.TestView{}, bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+		&th.TestView{}, bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
 
 	parents := types.NewSortedCidSet(newCid())
 	stateRoot := newCid()
@@ -255,7 +255,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		return nil, nil
 	}
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(),
-		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
 
 	// addr3 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
 	msg1 := types.NewMessage(addrs[2], addrs[0], 0, types.ZeroAttoFIL, "", nil)
@@ -337,7 +337,7 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 	minerAddr := addrs[4]
 	minerOwnerAddr := addrs[3]
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(),
-		&th.TestView{}, bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+		&th.TestView{}, bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
 
 	h := types.Uint64(100)
 	w := types.Uint64(1000)
@@ -379,7 +379,7 @@ func TestGenerateWithoutMessages(t *testing.T) {
 		return nil, nil
 	}
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(),
-		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
 
 	assert.Len(t, pool.Pending(), 0)
 	baseBlock := types.Block{
@@ -413,7 +413,7 @@ func TestGenerateError(t *testing.T) {
 	}
 	worker := mining.NewDefaultWorkerWithDeps(pool, makeExplodingGetStateTree(st), getWeightTest, getAncestors,
 		consensus.NewDefaultProcessor(),
-		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.BlockTimeTest, CreatePoSTFunc)
+		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
 
 	// This is actually okay and should result in a receipt
 	msg := types.NewMessage(addrs[0], addrs[1], 0, types.ZeroAttoFIL, "", nil)

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/core"
 	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/net"
@@ -47,6 +48,7 @@ type API struct {
 	chain        *cst.ChainStateProvider
 	config       *cfg.Config
 	dag          *dag.DAG
+	expected     consensus.Protocol
 	msgPool      *core.MessagePool
 	msgPreviewer *msg.Previewer
 	msgQueryer   *msg.Queryer
@@ -64,6 +66,7 @@ type APIDeps struct {
 	Config       *cfg.Config
 	DAG          *dag.DAG
 	Deals        *strgdls.Store
+	Expected     consensus.Protocol
 	MsgPool      *core.MessagePool
 	MsgPreviewer *msg.Previewer
 	MsgQueryer   *msg.Queryer
@@ -82,6 +85,7 @@ func New(deps *APIDeps) *API {
 		chain:        deps.Chain,
 		config:       deps.Config,
 		dag:          deps.DAG,
+		expected:     deps.Expected,
 		msgPool:      deps.MsgPool,
 		msgPreviewer: deps.MsgPreviewer,
 		msgQueryer:   deps.MsgQueryer,
@@ -108,6 +112,11 @@ func (api *API) ActorGetSignature(ctx context.Context, actorAddr address.Address
 // ActorLs returns a channel with actors from the latest state on the chain
 func (api *API) ActorLs(ctx context.Context) (<-chan state.GetAllActorsResult, error) {
 	return api.chain.LsActors(ctx)
+}
+
+// BlockTime returns the block time used by the consensus protocol.
+func (api *API) BlockTime() time.Duration {
+	return api.expected.BlockTime()
 }
 
 // ConfigSet sets the given parameters at the given path in the local config.

--- a/porcelain/protocol.go
+++ b/porcelain/protocol.go
@@ -2,6 +2,7 @@ package porcelain
 
 import (
 	"context"
+	"time"
 
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/pkg/errors"
@@ -10,9 +11,10 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
-// ProtocolParams TODO(rosa)
+// ProtocolParams contains parameters that modify the filecoin nodes protocol
 type ProtocolParams struct {
 	AutoSealInterval     uint
+	BlockTime            time.Duration
 	ProofsMode           types.ProofsMode
 	SupportedSectorSizes []*types.BytesAmount
 }
@@ -20,6 +22,7 @@ type ProtocolParams struct {
 type protocolParamsPlumbing interface {
 	ConfigGet(string) (interface{}, error)
 	MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error)
+	BlockTime() time.Duration
 }
 
 // ProtocolParameters TODO(rosa)
@@ -46,6 +49,7 @@ func ProtocolParameters(ctx context.Context, plumbing protocolParamsPlumbing) (*
 
 	return &ProtocolParams{
 		AutoSealInterval:     autoSealInterval,
+		BlockTime:            plumbing.BlockTime(),
 		ProofsMode:           proofsMode,
 		SupportedSectorSizes: supportedSectorSizes,
 	}, nil

--- a/porcelain/protocol_test.go
+++ b/porcelain/protocol_test.go
@@ -2,6 +2,7 @@ package porcelain_test
 
 import (
 	"context"
+	"time"
 
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/porcelain"
@@ -11,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"testing"
 )
+
+const protocolTestParamBlockTime = time.Second
 
 type testProtocolParamsPlumbing struct {
 	testing          *testing.T
@@ -24,6 +27,10 @@ func (tppp *testProtocolParamsPlumbing) ConfigGet(path string) (interface{}, err
 
 func (tppp *testProtocolParamsPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error) {
 	return [][]byte{{byte(types.TestProofsMode)}}, nil
+}
+
+func (tppp *testProtocolParamsPlumbing) BlockTime() time.Duration {
+	return protocolTestParamBlockTime
 }
 
 func TestProtocolParams(t *testing.T) {
@@ -41,6 +48,7 @@ func TestProtocolParams(t *testing.T) {
 			AutoSealInterval:     120,
 			ProofsMode:           types.TestProofsMode,
 			SupportedSectorSizes: []*types.BytesAmount{types.OneKiBSectorSize},
+			BlockTime:            protocolTestParamBlockTime,
 		}
 
 		out, err := porcelain.ProtocolParameters(context.TODO(), plumbing)

--- a/protocol/block/mining_api_test.go
+++ b/protocol/block/mining_api_test.go
@@ -77,7 +77,7 @@ func newAPI(t *testing.T, assert *ast.Assertions) (bapi.MiningAPI, *node.Node) {
 	nd := node.MakeNodeWithChainSeed(t, seed, configOpts,
 		node.AutoSealIntervalSecondsOpt(1),
 	)
-	bt := nd.GetBlockTime()
+	bt := nd.PorcelainAPI.BlockTime()
 	seed.GiveKey(t, nd, 0)
 	mAddr, moAddr := seed.GiveMiner(t, nd, 0)
 	_, err := storage.NewMiner(mAddr, moAddr, nd, nd.Repo.DealsDatastore(), nd.PorcelainAPI)

--- a/protocol/retrieval/client.go
+++ b/protocol/retrieval/client.go
@@ -35,7 +35,7 @@ type Client struct {
 }
 
 // NewClient produces a new Client.
-func NewClient(host host.Host, blockTime time.Duration, api clientPorcelainAPI) *Client {
+func NewClient(host host.Host, api clientPorcelainAPI) *Client {
 	return &Client{
 		api:  api,
 		host: host,

--- a/protocol/storage/client_test.go
+++ b/protocol/storage/client_test.go
@@ -49,7 +49,7 @@ func TestProposeDeal(t *testing.T) {
 	})
 
 	testAPI := newTestClientAPI(t)
-	client := NewClient(testNode.GetBlockTime(), th.NewFakeHost(), testAPI)
+	client := NewClient(th.NewFakeHost(), testAPI)
 	client.ProtocolRequestFunc = testNode.MakeTestProtocolRequest
 
 	dataCid := types.SomeCid()
@@ -139,7 +139,7 @@ func TestProposeDealFailsWhenADealAlreadyExists(t *testing.T) {
 	})
 
 	testAPI := newTestClientAPI(t)
-	client := NewClient(testNode.GetBlockTime(), th.NewFakeHost(), testAPI)
+	client := NewClient(th.NewFakeHost(), testAPI)
 	client.ProtocolRequestFunc = testNode.MakeTestProtocolRequest
 
 	dataCid := types.SomeCid()
@@ -177,6 +177,10 @@ func newTestClientAPI(t *testing.T) *clientTestAPI {
 		testing:     t,
 		deals:       make(map[cid.Cid]*storagedeal.Deal),
 	}
+}
+
+func (ctp *clientTestAPI) BlockTime() time.Duration {
+	return 100 * time.Millisecond
 }
 
 func (ctp *clientTestAPI) ChainBlockHeight() (*types.BlockHeight, error) {
@@ -257,10 +261,6 @@ func newTestClientNode(responder func(request interface{}) (interface{}, error))
 	return &testClientNode{
 		responder: responder,
 	}
-}
-
-func (tcn *testClientNode) GetBlockTime() time.Duration {
-	return 100 * time.Millisecond
 }
 
 // MakeTestProtocolRequest calls the responder set for the testClientNode to provide a test

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -90,7 +90,6 @@ type minerPorcelain interface {
 // are moving off of node and into the porcelain api (see porcelainAPI). Eventually this
 // dependency on node should go away, fully replaced by the dependency on the porcelain api.
 type node interface {
-	GetBlockTime() time.Duration
 	BlockService() bserv.BlockService
 	Host() host.Host
 	SectorBuilder() sectorbuilder.SectorBuilder

--- a/testhelpers/chain.go
+++ b/testhelpers/chain.go
@@ -58,7 +58,8 @@ func MkFakeChild(params FakeChildParams) (*types.Block, error) {
 		NewFakeBlockValidator(),
 		powerTableView,
 		params.GenesisCid,
-		proofs.NewFakeVerifier(true, nil))
+		proofs.NewFakeVerifier(true, nil),
+		BlockTimeTest)
 	params.Consensus = con
 	return MkFakeChildWithCon(params)
 }

--- a/testhelpers/mining.go
+++ b/testhelpers/mining.go
@@ -9,8 +9,23 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
-// BlockTimeTest is the block time used by workers during testing
+// BlockTimeTest is the block time used by workers during testing.
 const BlockTimeTest = time.Second
+
+// TestWorkerPorcelainAPI implements the WorkerPorcelainAPI>
+type TestWorkerPorcelainAPI struct {
+	blockTime time.Duration
+}
+
+// NewDefaultTestWorkerPorcelainAPI returns a TestWrokerPorcelainAPI.
+func NewDefaultTestWorkerPorcelainAPI() *TestWorkerPorcelainAPI {
+	return &TestWorkerPorcelainAPI{blockTime: BlockTimeTest}
+}
+
+// BlockTime returns the blocktime TestWrokerPorcelainAPI si configured with.
+func (t *TestWorkerPorcelainAPI) BlockTime() time.Duration {
+	return t.blockTime
+}
 
 // MakeCommitment creates a random commitment.
 func MakeCommitment() []byte {

--- a/tools/fast/series/ctx_sleep_delay.go
+++ b/tools/fast/series/ctx_sleep_delay.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/filecoin-project/go-filecoin/mining"
+	"github.com/filecoin-project/go-filecoin/consensus"
 )
 
 type ctxSleepDelayKey struct{}
@@ -14,7 +14,7 @@ var (
 	sleepDelayKey = ctxSleepDelayKey{}
 
 	// Default delay
-	defaultSleepDelay = mining.DefaultBlockTime
+	defaultSleepDelay = consensus.DefaultBlockTime
 )
 
 // SetCtxSleepDelay returns a context with `d` set in the context. To sleep with


### PR DESCRIPTION
- This commit moves the blocktime default to the consensus package and
adds plumbing and porcelain cals to access it.