### PR TITLE
Show more information by '--messages' flag when show block

### DIFF
--- a/commands/show.go
+++ b/commands/show.go
@@ -31,6 +31,9 @@ all other block properties will be included as well.`,
 	Arguments: []cmdkit.Argument{
 		cmdkit.StringArg("cid", true, false, "CID of block to show"),
 	},
+	Options: []cmdkit.Option{
+		cmdkit.BoolOption("messages", "m", "show messages in block"),
+	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		cid, err := cid.Decode(req.Arguments[0])
 		if err != nil {
@@ -57,12 +60,22 @@ Miner:  %s
 Weight: %s
 Height: %s
 Nonce:  %s
+Timestamp:  %s
 `,
 				block.Miner,
 				wStr,
 				strconv.FormatUint(uint64(block.Height), 10),
 				strconv.FormatUint(uint64(block.Nonce), 10),
+				strconv.FormatUint(uint64(block.Timestamp), 10),
 			)
+			if err != nil {
+				return err
+			}
+
+			showMessages, _ := req.Options["messages"].(bool)
+			if showMessages == true {
+				_, err = fmt.Fprintf(w, `Messages:  %s`+"\n", block.Messages)
+			}
 			return err
 		}),
 	},

--- a/commands/show_test.go
+++ b/commands/show_test.go
@@ -30,6 +30,25 @@ func TestBlockDaemon(t *testing.T) {
 		assert.Contains(t, output, "Weight: 0")
 		assert.Contains(t, output, "Height: 1")
 		assert.Contains(t, output, "Nonce:  0")
+		assert.Contains(t, output, "Timestamp:  ")
+	})
+
+	t.Run("show block --messages <cid-of-genesis-block> returns human readable output for the filecoin block including messages", func(t *testing.T) {
+		d := makeTestDaemonWithMinerAndStart(t)
+		defer d.ShutdownSuccess()
+
+		// mine a block and get its CID
+		minedBlockCidStr := th.RunSuccessFirstLine(d, "mining", "once")
+
+		// get the mined block by its CID
+		output := d.RunSuccess("show", "block", "--messages", minedBlockCidStr).ReadStdoutTrimNewlines()
+
+		assert.Contains(t, output, "Block Details")
+		assert.Contains(t, output, "Weight: 0")
+		assert.Contains(t, output, "Height: 1")
+		assert.Contains(t, output, "Nonce:  0")
+		assert.Contains(t, output, "Timestamp:  ")
+		assert.Contains(t, output, "Messages:  ")
 	})
 
 	t.Run("show block <cid-of-genesis-block> --enc json returns JSON for a filecoin block", func(t *testing.T) {


### PR DESCRIPTION
I think we should show messages in block when run 'go-filecoin show block', then we can know the history messages, including transaction and other messages.

 
```
waynewyang:go-filecoin waynewyang$ ./go-filecoin show block zDPWYqFCwxAV66BT3jnYZMVWNZvayYf95EjjK6f8n46n9AVsReSD
Block Details
Miner:  t2ej7i72xtkglfpbo7nc56pqg2fsdzlspqe63vnoq
Weight: 0.000
Height: 1
Nonce:  0
Timestamp:  0
Message:  [SignedMessage cid=[zDPWYqFCz3f9sTvKp5W1u6Vo57u2xH4T7Nicv2Xx8jz1zoQ1UL1v]: {
  "meteredMessage": {
    "message": {
      "to": "t2ej7i72xtkglfpbo7nc56pqg2fsdzlspqe63vnoq",
      "from": "t1strybge3p4daa6qgtz5jsfxalzg4mr6bix5s2ti",
      "nonce": "2",
      "value": "0",
      "method": "updatePeerID",
      "params": "gVgiEiDbXbBmGs1XgNWvOhNU42yekJfMBSr7U4fZYPsDbHxqFQ=="
    },
    "gasPrice": "0.000000001",
    "gasLimit": "300"
  },
  "signature": "mpnLn2DQ2kbObOrG2z0nfihYHUUnEUl8E85NjZ6Ok6RCgucH2cUSOppN2f96uYc3By+L0S/rSrVwyxeKgZofcAE="
} SignedMessage cid=[zDPWYqFCyU6B4qiJCBQ1k8pDP16KJDueJUMm1jtM7QAGEEkvYc3u]: {
  "meteredMessage": {
    "message": {
      "to": "t1cgp7xhkvsarve2mm32jidxnlbxuxgqjqcvya2qa",
      "from": "t1strybge3p4daa6qgtz5jsfxalzg4mr6bix5s2ti",
      "nonce": "3",
      "value": "100",
      "method": "",
      "params": null
    },
    "gasPrice": "0.000000001",
    "gasLimit": "300"
  },
  "signature": "Djb6b8K8tmwZAPBrlaLqkC0aaLfCoXLqyYV+YafAy09R/skyGm0tFIzOTLflt0ppmHi5cQWB3l64f0IEDkI9TgE="
}]
```