### PR TITLE
Added prerelease tool to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tools/faucet/faucet
 tools/aggregator/aggregator
 tools/genesis-file-server/genesis-file-server
 tools/migration/go-filecoin-migrate
+tools/prerelease-tool/prerelease-tool
 proofs/misc/parameters.json
 proofs/bin/paramcache
 proofs/bin/paramfetch


### PR DESCRIPTION
No issue for this one. I just noticed this file was created every time after running `go run ./build build`, and it was bugging me, so I gitignored it. If you want me to add an issue for it, just let me know.