### PR TITLE
Refactor/extract config from plumbing 2928

### DIFF
--- a/plumbing/cfg/config.go
+++ b/plumbing/cfg/config.go
@@ -2,13 +2,11 @@ package cfg
 
 import (
 	"github.com/filecoin-project/go-filecoin/repo"
-	"sync"
 )
 
 // Config is plumbing implementation for setting and retrieving values from local config.
 type Config struct {
 	repo repo.Repo
-	lock sync.Mutex
 }
 
 // NewConfig returns a new Config.
@@ -18,9 +16,6 @@ func NewConfig(repo repo.Repo) *Config {
 
 // Set sets a value in config
 func (s *Config) Set(dottedKey string, jsonString string) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	cfg := s.repo.Config()
 	if err := cfg.Set(dottedKey, jsonString); err != nil {
 		return err


### PR DESCRIPTION
# Problem

We don't want config logic in plumbing. It should be thin wrappers.

# Solution

Extract `plumbing/cfg` logic to `config` and `repo` and remove the package.

Resolves #2928 