### PR TITLE
enable nightly prerelease cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -480,7 +480,7 @@ jobs:
           filename: "nightly-devnet.json"
       - run:
           name: cleanup nightly releases
-          command: ./tools/prerelease-tool/prerelease-tool --dry-run
+          command: ./tools/prerelease-tool/prerelease-tool
 
 
   trigger_devnet_deploy:


### PR DESCRIPTION
this is ready for showtime. I ran a test here https://circleci.com/gh/filecoin-project/go-filecoin/20271 with --dry-run flag enabled. Results are as expected.
removing --dry-run flag to enable this feature