### PR TITLE
Iterate messages in canonical tipset order when removing from outbox

### DIFF
--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -17,8 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var seed = types.GenerateKeyInfoSeed()
-var keys = types.MustGenerateKeyInfo(2, seed)
+var keys = types.MustGenerateKeyInfo(2, 42)
 var signer = types.NewMockSigner(keys)
 var addresses = make([]address.Address, len(keys))
 

--- a/core/chains.go
+++ b/core/chains.go
@@ -7,11 +7,10 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
-// CollectBlocksToCommonAncestor traverses chains from two tipsets (called old and new) until their common
-// ancestor, collecting all blocks that are in one chain but not the other.
-// The resulting lists of blocks are ordered by decreasing height; the ordering of blocks with the same
-// height is undefined until https://github.com/filecoin-project/go-filecoin/issues/2310 is resolved.
-func CollectBlocksToCommonAncestor(ctx context.Context, store chain.TipSetProvider, oldHead, newHead types.TipSet) (oldBlocks, newBlocks []*types.Block, err error) {
+// CollectTipsToCommonAncestor traverses chains from two tipsets (called old and new) until their common
+// ancestor, collecting all tipsets that are in one chain but not the other.
+// The resulting lists of tipsets are ordered by decreasing height.
+func CollectTipsToCommonAncestor(ctx context.Context, store chain.TipSetProvider, oldHead, newHead types.TipSet) (oldTips, newTips []types.TipSet, err error) {
 	oldIter := chain.IterAncestors(ctx, store, oldHead)
 	newIter := chain.IterAncestors(ctx, store, newHead)
 
@@ -30,19 +29,10 @@ func CollectBlocksToCommonAncestor(ctx context.Context, store chain.TipSetProvid
 
 	// Add 1 to the height argument so that the common ancestor is not
 	// included in the outputs.
-	oldTipsets, err := chain.CollectTipSetsOfHeightAtLeast(ctx, oldIter, types.NewBlockHeight(commonHeight+uint64(1)))
+	oldTips, err = chain.CollectTipSetsOfHeightAtLeast(ctx, oldIter, types.NewBlockHeight(commonHeight+uint64(1)))
 	if err != nil {
 		return
 	}
-	for _, ts := range oldTipsets {
-		oldBlocks = append(oldBlocks, ts.ToSlice()...)
-	}
-	newTipsets, err := chain.CollectTipSetsOfHeightAtLeast(ctx, newIter, types.NewBlockHeight(commonHeight+uint64(1)))
-	for _, ts := range newTipsets {
-		newBlocks = append(newBlocks, ts.ToSlice()...)
-	}
-	if err != nil {
-		return
-	}
+	newTips, err = chain.CollectTipSetsOfHeightAtLeast(ctx, newIter, types.NewBlockHeight(commonHeight+uint64(1)))
 	return
 }

--- a/core/message_queue_test.go
+++ b/core/message_queue_test.go
@@ -18,7 +18,7 @@ func TestMessageQueue(t *testing.T) {
 	tf.UnitTest(t)
 
 	// Individual tests share a MessageMaker so not parallel (but quick)
-	keys := types.MustGenerateKeyInfo(2, types.GenerateKeyInfoSeed())
+	keys := types.MustGenerateKeyInfo(2, 42)
 	mm := types.NewMessageMaker(t, keys)
 
 	alice := mm.Addresses()[0]

--- a/core/policy.go
+++ b/core/policy.go
@@ -50,28 +50,27 @@ func NewMessageQueuePolicy(store chain.TipSetProvider, maxAge uint64) *DefaultQu
 
 // HandleNewHead updates the policy target in response to a new head tipset.
 func (p *DefaultQueuePolicy) HandleNewHead(ctx context.Context, target PolicyTarget, oldHead, newHead types.TipSet) error {
-	_, newBlocks, err := CollectBlocksToCommonAncestor(ctx, p.store, oldHead, newHead)
+	_, newTips, err := CollectTipsToCommonAncestor(ctx, p.store, oldHead, newHead)
 	if err != nil {
 		return err
 	}
 
 	// Remove from the queue all messages that have now been mined in new blocks.
-
-	// Rearrange the blocks in increasing height order so messages are discovered in order.
-	// Note: this is imperfect until CollectBlocksToCommonAncestor is updated to return blocks
-	// at the same height in canonical (ticket) order.
-	reverse(newBlocks)
-	for _, block := range newBlocks {
-		for _, minedMsg := range block.Messages {
-			removed, found, err := target.RemoveNext(ctx, minedMsg.From, uint64(minedMsg.Nonce))
-			if err != nil {
-				return err
+	// Rearrange the tipsets into increasing height order so messages are discovered in nonce order.
+	reverse(newTips)
+	for _, tipset := range newTips {
+		for i := 0; i < tipset.Len(); i++ {
+			for _, minedMsg := range tipset.At(i).Messages {
+				removed, found, err := target.RemoveNext(ctx, minedMsg.From, uint64(minedMsg.Nonce))
+				if err != nil {
+					return err
+				}
+				if found && !minedMsg.Equals(removed) {
+					log.Errorf("Queued message %v differs from mined message %v with same sender & nonce", removed, minedMsg)
+				}
+				// Else if not found, the message was not sent by this node, or has already been removed
+				// from the queue (e.g. a blockchain re-org).
 			}
-			if found && !minedMsg.Equals(removed) {
-				log.Errorf("Queued message %v differs from mined message %v with same sender & nonce", removed, minedMsg)
-			}
-			// Else if not found, the message was not sent by this node, or has already been removed
-			// from the queue (e.g. a blockchain re-org).
 		}
 	}
 
@@ -89,7 +88,7 @@ func (p *DefaultQueuePolicy) HandleNewHead(ctx context.Context, target PolicyTar
 	return nil
 }
 
-func reverse(list []*types.Block) {
+func reverse(list []types.TipSet) {
 	// https://github.com/golang/go/wiki/SliceTricks#reversing
 	for i := len(list)/2 - 1; i >= 0; i-- {
 		opp := len(list) - 1 - i

--- a/core/policy_test.go
+++ b/core/policy_test.go
@@ -1,6 +1,7 @@
 package core_test
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -22,7 +23,7 @@ func TestMessageQueuePolicy(t *testing.T) {
 	// Individual tests share a MessageMaker so not parallel (but quick)
 	ctx := context.Background()
 
-	keys := types.MustGenerateKeyInfo(2, types.GenerateKeyInfoSeed())
+	keys := types.MustGenerateKeyInfo(2, 42)
 	mm := types.NewMessageMaker(t, keys)
 
 	alice := mm.Addresses()[0]
@@ -148,6 +149,47 @@ func TestMessageQueuePolicy(t *testing.T) {
 
 		b1 := blocks.NewBlockWithMessages(1, []*types.SignedMessage{msgs[1]}, root)
 		err := policy.HandleNewHead(ctx, q, requireTipset(t, root), requireTipset(t, b1))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nonce 1, expected 2")
+	})
+
+	t.Run("removes sequential messages in peer blocks", func(t *testing.T) {
+		blocks := th.NewFakeChainProvider()
+		q := core.NewMessageQueue()
+		policy := core.NewMessageQueuePolicy(blocks, 10)
+
+		msgs := []*types.SignedMessage{
+			requireEnqueue(q, mm.NewSignedMessage(alice, 1), 100),
+			requireEnqueue(q, mm.NewSignedMessage(alice, 2), 101),
+		}
+
+		root := blocks.NewBlock(0)
+		root.Height = 100
+
+		// Construct two blocks at the same height, each with one message. The messages must
+		// have been mined in nonce order. The canonical tipset block ordering
+		// is given by block ticket, which hence must match this nonce order.
+		// These blocks are constructed so that their CIDs would order them
+		// in the *opposite* order (blocks used to be ordered by CID).
+		b1 := blocks.NewBlockWithMessages(1, []*types.SignedMessage{msgs[0]}, root)
+		b2 := blocks.NewBlockWithMessages(1, []*types.SignedMessage{msgs[1]}, root)
+		b1.Ticket = []byte{0}
+		b2.Ticket = []byte{1}
+		b2.Timestamp = 0 // Tweak to force CID ordering to be opposite to ticket ordering.
+		assert.True(t, bytes.Compare(b1.Cid().Bytes(), b2.Cid().Bytes()) > 0)
+
+		// With blocks ordered [b1, b2], everything is ok.
+		err := policy.HandleNewHead(ctx, q, requireTipset(t, root), requireTipset(t, b1, b2))
+		require.NoError(t, err)
+		assert.Empty(t, q.List(alice))
+
+		// With blocks ordered [b2, b1], this fails. This demonstrates that the policy is
+		// processing the blocks in canonical (ticket) order.
+		requireEnqueue(q, msgs[0], 200)
+		requireEnqueue(q, msgs[1], 201)
+		b1.Ticket = []byte{1}
+		b2.Ticket = []byte{0}
+		err = policy.HandleNewHead(ctx, q, requireTipset(t, root), requireTipset(t, b1, b2))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "nonce 1, expected 2")
 	})

--- a/mining/mqueue_test.go
+++ b/mining/mqueue_test.go
@@ -13,8 +13,7 @@ import (
 func TestMessageQueueOrder(t *testing.T) {
 	tf.UnitTest(t)
 
-	var seed = types.GenerateKeyInfoSeed()
-	var ki = types.MustGenerateKeyInfo(10, seed)
+	var ki = types.MustGenerateKeyInfo(10, 42)
 	var mockSigner = types.NewMockSigner(ki)
 
 	a0 := mockSigner.Addresses[0]

--- a/node/message_propagate_test.go
+++ b/node/message_propagate_test.go
@@ -25,7 +25,7 @@ func TestMessagePropagation(t *testing.T) {
 	defer cancel()
 
 	// Generate a key and install an account actor at genesis which will be able to send messages.
-	ki := types.MustGenerateKeyInfo(1, types.GenerateKeyInfoSeed())[0]
+	ki := types.MustGenerateKeyInfo(1, 42)[0]
 	senderAddress, err := ki.Address()
 	require.NoError(t, err)
 	genesis := consensus.MakeGenesisFunc(

--- a/porcelain/mpool_test.go
+++ b/porcelain/mpool_test.go
@@ -43,7 +43,7 @@ func (plumbing *fakeMpoolWaitPlumbing) PubSubSubscribe(topic string) (pubsub.Sub
 func TestMessagePoolWait(t *testing.T) {
 	tf.UnitTest(t)
 
-	ki := types.MustGenerateKeyInfo(1, types.GenerateKeyInfoSeed())
+	ki := types.MustGenerateKeyInfo(1, 42)
 	signer := types.NewMockSigner(ki)
 
 	t.Run("empty", func(t *testing.T) {

--- a/types/helpers.go
+++ b/types/helpers.go
@@ -1,39 +1,6 @@
 package types
 
-import (
-	"bytes"
-	"io"
-	"math/rand"
-
-	"github.com/filecoin-project/go-filecoin/crypto"
-)
-
 const (
 	// SECP256K1 is a curve used to compute private keys
 	SECP256K1 = "secp256k1"
 )
-
-// MustGenerateKeyInfo generates a slice of KeyInfo size `n` with seed `seed`
-func MustGenerateKeyInfo(n int, seed io.Reader) []KeyInfo {
-	var keyinfos []KeyInfo
-	for i := 0; i < n; i++ {
-		prv, err := crypto.GenerateKeyFromSeed(seed)
-		if err != nil {
-			panic(err)
-		}
-
-		ki := &KeyInfo{
-			PrivateKey: prv,
-			Curve:      SECP256K1,
-		}
-		keyinfos = append(keyinfos, *ki)
-	}
-	return keyinfos
-}
-
-// GenerateKeyInfoSeed returns a random to be passed to MustGenerateKeyInfo
-func GenerateKeyInfoSeed() io.Reader {
-	token := make([]byte, 512)
-	rand.Read(token)
-	return bytes.NewReader(token)
-}

--- a/types/signed_message_test.go
+++ b/types/signed_message_test.go
@@ -11,7 +11,7 @@ import (
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 )
 
-var mockSigner = NewMockSigner(MustGenerateKeyInfo(1, GenerateKeyInfoSeed()))
+var mockSigner = NewMockSigner(MustGenerateKeyInfo(1, 42))
 
 func TestSignedMessageString(t *testing.T) {
 	tf.UnitTest(t)

--- a/types/testing.go
+++ b/types/testing.go
@@ -60,9 +60,30 @@ func NewMockSigner(kis []KeyInfo) MockSigner {
 // NewMockSignersAndKeyInfo is a convenience function to generate a mock
 // signers with some keys.
 func NewMockSignersAndKeyInfo(numSigners int) (MockSigner, []KeyInfo) {
-	ki := MustGenerateKeyInfo(numSigners, GenerateKeyInfoSeed())
+	ki := MustGenerateKeyInfo(numSigners, 42)
 	signer := NewMockSigner(ki)
 	return signer, ki
+}
+
+// MustGenerateKeyInfo generates `n` distinct keyinfos using seed `seed`.
+// The result is deterministic (for stable tests), don't use this for real keys!
+func MustGenerateKeyInfo(n int, seed byte) []KeyInfo {
+	token := bytes.Repeat([]byte{seed}, 512)
+	var keyinfos []KeyInfo
+	for i := 0; i < n; i++ {
+		token[0] = byte(i)
+		prv, err := crypto.GenerateKeyFromSeed(bytes.NewReader(token))
+		if err != nil {
+			panic(err)
+		}
+
+		ki := &KeyInfo{
+			PrivateKey: prv,
+			Curve:      SECP256K1,
+		}
+		keyinfos = append(keyinfos, *ki)
+	}
+	return keyinfos
 }
 
 // SignBytes cryptographically signs `data` using the Address `addr`.


### PR DESCRIPTION
This is the last item in #2310, ensuring that messages are removed from the outbox in the order they were mined (i.e. correct nonce order).

Closes #2310