### PR TITLE
rename some deal states

### DIFF
--- a/commands/deals_daemon_test.go
+++ b/commands/deals_daemon_test.go
@@ -68,7 +68,7 @@ func TestDealsRedeem(t *testing.T) {
 	dealResponse, err := clientDaemon.ClientProposeStorageDeal(ctx, dataCid, minerAddress, 0, 1, true)
 	require.NoError(t, err)
 
-	err = series.WaitForDealState(ctx, clientDaemon, dealResponse, storagedeal.Posted)
+	err = series.WaitForDealState(ctx, clientDaemon, dealResponse, storagedeal.Complete)
 	require.NoError(t, err)
 
 	// Stop mining to guarantee the miner doesn't receive any block rewards

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -540,7 +540,7 @@ func (sm *Miner) onCommitSuccess(ctx context.Context, dealCid cid.Cid, sector *s
 
 	// update response
 	err = sm.updateDealResponse(ctx, dealCid, func(resp *storagedeal.Response) {
-		resp.State = storagedeal.Posted
+		resp.State = storagedeal.Complete
 		resp.ProofInfo = &storagedeal.ProofInfo{
 			SectorID:          sector.SectorID,
 			CommitmentMessage: commitMessageCid,
@@ -550,7 +550,7 @@ func (sm *Miner) onCommitSuccess(ctx context.Context, dealCid cid.Cid, sector *s
 		}
 	})
 	if err != nil {
-		log.Errorf("commit succeeded but could not update to deal 'Posted' state: %s", err)
+		log.Errorf("commit succeeded but could not update to deal 'Complete' state: %s", err)
 	}
 }
 

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -273,7 +273,7 @@ func TestOnCommitmentAddedToChain(t *testing.T) {
 		// retrieve deal response
 		dealResponse := miner.Query(context.Background(), proposal.Proposal.PieceRef)
 
-		assert.Equal(t, storagedeal.Complete, dealResponse.State, "deal should be in posted state")
+		assert.Equal(t, storagedeal.Complete, dealResponse.State, "deal should be in complete state")
 		require.NotNil(t, dealResponse.ProofInfo, "deal should have proof info")
 		assert.Equal(t, sector.SectorID, dealResponse.ProofInfo.SectorID, "sector id should match committed sector")
 		assert.Equal(t, msgCid, dealResponse.ProofInfo.CommitmentMessage, "CommitmentMessage should be cid of commitSector messsage")
@@ -290,7 +290,7 @@ func TestOnCommitmentAddedToChain(t *testing.T) {
 		// retrieve deal response
 		dealResponse := miner.Query(context.Background(), proposal.Proposal.PieceRef)
 
-		assert.Equal(t, storagedeal.Complete, dealResponse.State, "deal should be in posted state")
+		assert.Equal(t, storagedeal.Complete, dealResponse.State, "deal should be in complete state")
 
 		// expect proof to be nil because it wasn't provided
 		assert.Nil(t, dealResponse.ProofInfo.PieceInclusionProof)

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -273,7 +273,7 @@ func TestOnCommitmentAddedToChain(t *testing.T) {
 		// retrieve deal response
 		dealResponse := miner.Query(context.Background(), proposal.Proposal.PieceRef)
 
-		assert.Equal(t, storagedeal.Posted, dealResponse.State, "deal should be in posted state")
+		assert.Equal(t, storagedeal.Complete, dealResponse.State, "deal should be in posted state")
 		require.NotNil(t, dealResponse.ProofInfo, "deal should have proof info")
 		assert.Equal(t, sector.SectorID, dealResponse.ProofInfo.SectorID, "sector id should match committed sector")
 		assert.Equal(t, msgCid, dealResponse.ProofInfo.CommitmentMessage, "CommitmentMessage should be cid of commitSector messsage")
@@ -290,7 +290,7 @@ func TestOnCommitmentAddedToChain(t *testing.T) {
 		// retrieve deal response
 		dealResponse := miner.Query(context.Background(), proposal.Proposal.PieceRef)
 
-		assert.Equal(t, storagedeal.Posted, dealResponse.State, "deal should be in posted state")
+		assert.Equal(t, storagedeal.Complete, dealResponse.State, "deal should be in posted state")
 
 		// expect proof to be nil because it wasn't provided
 		assert.Nil(t, dealResponse.ProofInfo.PieceInclusionProof)

--- a/protocol/storage/storagedeal/state.go
+++ b/protocol/storage/storagedeal/state.go
@@ -8,7 +8,7 @@ import (
 type State int
 
 const (
-	// This implies a programmer error and should never appear in an actual message.
+	// Unset indicates a programmer error and should never appear in an actual message.
 	Unset = State(iota)
 
 	// Unknown signifies an unknown negotiation
@@ -26,10 +26,10 @@ const (
 	// Failed means the deal has failed for some reason
 	Failed
 
-	// The data has been received and staged into a sector, but is not sealed yet.
+	// Staged means that data has been received and staged into a sector, but is not sealed yet.
 	Staged
 
-	// Deal is complete, and the sector that the deal is contained in has been sealed and its commitment posted on chain.
+	// Complete means that the sector that the deal is contained in has been sealed and its commitment posted on chain.
 	Complete
 )
 

--- a/protocol/storage/storagedeal/state.go
+++ b/protocol/storage/storagedeal/state.go
@@ -8,8 +8,11 @@ import (
 type State int
 
 const (
+	// This implies a programmer error and should never appear in an actual message.
+	Unset = State(iota)
+
 	// Unknown signifies an unknown negotiation
-	Unknown = State(iota)
+	Unknown
 
 	// Rejected means the deal was rejected for some reason
 	Rejected
@@ -23,19 +26,17 @@ const (
 	// Failed means the deal has failed for some reason
 	Failed
 
-	// Posted means the deal has been posted to the blockchain
-	Posted
-
-	// Complete means the deal is complete
-	// TODO: distinguish this from 'Posted'
-	Complete
-
-	// Staged means that the data in the deal has been staged into a sector
+	// The data has been received and staged into a sector, but is not sealed yet.
 	Staged
+
+	// Deal is complete, and the sector that the deal is contained in has been sealed and its commitment posted on chain.
+	Complete
 )
 
 func (s State) String() string {
 	switch s {
+	case Unset:
+		return "unset"
 	case Unknown:
 		return "unknown"
 	case Rejected:
@@ -46,12 +47,10 @@ func (s State) String() string {
 		return "started"
 	case Failed:
 		return "failed"
-	case Posted:
-		return "posted"
-	case Complete:
-		return "complete"
 	case Staged:
 		return "staged"
+	case Complete:
+		return "posted"
 	default:
 		return fmt.Sprintf("<unrecognized %d>", s)
 	}

--- a/protocol/storage/storagedeal/state.go
+++ b/protocol/storage/storagedeal/state.go
@@ -50,7 +50,7 @@ func (s State) String() string {
 	case Staged:
 		return "staged"
 	case Complete:
-		return "posted"
+		return "complete"
 	default:
 		return fmt.Sprintf("<unrecognized %d>", s)
 	}

--- a/tools/fast/bin/localnet/main.go
+++ b/tools/fast/bin/localnet/main.go
@@ -250,7 +250,7 @@ func main() {
 	// 8. Genesis proposes a storage deal with miner
 	//
 	// WaitForDealState
-	// 9. Query deal till posted
+	// 9. Query deal till complete
 
 	var deals []*storagedeal.Response
 

--- a/tools/fast/bin/localnet/main.go
+++ b/tools/fast/bin/localnet/main.go
@@ -292,7 +292,7 @@ func main() {
 	}
 
 	for _, deal := range deals {
-		err = series.WaitForDealState(ctx, genesis, deal, storagedeal.Posted)
+		err = series.WaitForDealState(ctx, genesis, deal, storagedeal.Complete)
 		if err != nil {
 			exitcode = handleError(err, "failed series.WaitForDealState;")
 			return

--- a/tools/fast/tests/retrieval_test.go
+++ b/tools/fast/tests/retrieval_test.go
@@ -211,7 +211,7 @@ func RunRetrievalTest(ctx context.Context, t *testing.T, miner, client *fast.Fil
 	require.NoError(t, err)
 
 	// Wait for the deal to be posted
-	err = series.WaitForDealState(ctx, client, deal, storagedeal.Posted)
+	err = series.WaitForDealState(ctx, client, deal, storagedeal.Complete)
 	require.NoError(t, err)
 
 	// Retrieve the stored piece of data

--- a/tools/fast/tests/retrieval_test.go
+++ b/tools/fast/tests/retrieval_test.go
@@ -210,7 +210,7 @@ func RunRetrievalTest(ctx context.Context, t *testing.T, miner, client *fast.Fil
 	dcid, deal, err := series.ImportAndStore(ctx, client, ask, files.NewReaderFile(dataReader))
 	require.NoError(t, err)
 
-	// Wait for the deal to be posted
+	// Wait for the deal to be complete
 	err = series.WaitForDealState(ctx, client, deal, storagedeal.Complete)
 	require.NoError(t, err)
 


### PR DESCRIPTION
closes #2806

### Problem

The names we use for deal states are inconsistent with [the spec](https://github.com/filecoin-project/specs/blob/ed6f64914edc4fef47fc287a68305b7cd1e7afb8/network-protocols.md#deal-state-values)

### Solution

1. Add `Unset` state to distinguish unknown deals from deals with their state unset
2. Rename `Posted` to `Complete`.
3. Sync comments.