### PR TITLE
Add built-in burnt funds account actor to genesis

### DIFF
--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -104,6 +104,11 @@ type PaymentChannel struct {
 // channel's creator.
 type Actor struct{}
 
+// NewActor returns a new payment broker actor.
+func NewActor() *actor.Actor {
+	return actor.NewActor(types.PaymentBrokerActorCodeCid, types.ZeroAttoFIL)
+}
+
 // InitializeState stores the actor's initial data structure.
 func (pb *Actor) InitializeState(storage exec.Storage, initializerData interface{}) error {
 	// pb's default state is an empty lookup, so this method is a no-op

--- a/actor/builtin/storagemarket/storagemarket.go
+++ b/actor/builtin/storagemarket/storagemarket.go
@@ -55,8 +55,8 @@ type State struct {
 }
 
 // NewActor returns a new storage market actor.
-func NewActor() (*actor.Actor, error) {
-	return actor.NewActor(types.StorageMarketActorCodeCid, types.ZeroAttoFIL), nil
+func NewActor() *actor.Actor {
+	return actor.NewActor(types.StorageMarketActorCodeCid, types.ZeroAttoFIL)
 }
 
 // InitializeState stores the actor's initial data structure.

--- a/address/constants.go
+++ b/address/constants.go
@@ -21,17 +21,22 @@ func init() {
 		panic(err)
 	}
 
-	NetworkAddress, err = NewActorAddress([]byte("filecoin"))
+	NetworkAddress, err = NewIDAddress(1)
 	if err != nil {
 		panic(err)
 	}
 
-	StorageMarketAddress, err = NewActorAddress([]byte("storage"))
+	StorageMarketAddress, err = NewIDAddress(2)
 	if err != nil {
 		panic(err)
 	}
 
-	PaymentBrokerAddress, err = NewActorAddress([]byte("payments"))
+	PaymentBrokerAddress, err = NewIDAddress(3)
+	if err != nil {
+		panic(err)
+	}
+
+	BurntFundsAddress, err = NewIDAddress(99)
 	if err != nil {
 		panic(err)
 	}
@@ -43,12 +48,14 @@ var (
 	// TestAddress2 is an account with some initial funds in it.
 	TestAddress2 Address
 
-	// NetworkAddress is the filecoin network.
+	// NetworkAddress is the filecoin network treasury.
 	NetworkAddress Address
-	// StorageMarketAddress is the hard-coded address of the filecoin storage market.
+	// StorageMarketAddress is the hard-coded address of the filecoin storage market actor.
 	StorageMarketAddress Address
-	// PaymentBrokerAddress is the hard-coded address of the filecoin payment broker.
+	// PaymentBrokerAddress is the hard-coded address of the filecoin payment broker actor.
 	PaymentBrokerAddress Address
+	// BurntFundsAddress is the hard-coded address of the burnt funds account actor.
+	BurntFundsAddress Address
 )
 
 var (

--- a/consensus/genesis.go
+++ b/consensus/genesis.go
@@ -27,9 +27,10 @@ var (
 
 func init() {
 	defaultAccounts = map[address.Address]types.AttoFIL{
-		address.NetworkAddress: types.NewAttoFILFromFIL(10000000000),
-		address.TestAddress:    types.NewAttoFILFromFIL(50000),
-		address.TestAddress2:   types.NewAttoFILFromFIL(60000),
+		address.NetworkAddress:    types.NewAttoFILFromFIL(10000000000),
+		address.BurntFundsAddress: types.NewAttoFILFromFIL(0),
+		address.TestAddress:       types.NewAttoFILFromFIL(50000),
+		address.TestAddress2:      types.NewAttoFILFromFIL(60000),
 	}
 }
 
@@ -210,12 +211,8 @@ func SetupDefaultActors(ctx context.Context, st state.Tree, storageMap vm.Storag
 		}
 	}
 
-	stAct, err := storagemarket.NewActor()
-	if err != nil {
-		return err
-	}
-
-	err = (&storagemarket.Actor{}).InitializeState(storageMap.NewStorage(address.StorageMarketAddress, stAct), storeType)
+	stAct := storagemarket.NewActor()
+	err := (&storagemarket.Actor{}).InitializeState(storageMap.NewStorage(address.StorageMarketAddress, stAct), storeType)
 	if err != nil {
 		return err
 	}
@@ -223,13 +220,10 @@ func SetupDefaultActors(ctx context.Context, st state.Tree, storageMap vm.Storag
 		return err
 	}
 
-	pbAct := actor.NewActor(types.PaymentBrokerActorCodeCid, types.ZeroAttoFIL)
+	pbAct := paymentbroker.NewActor()
 	err = (&paymentbroker.Actor{}).InitializeState(storageMap.NewStorage(address.PaymentBrokerAddress, pbAct), nil)
 	if err != nil {
 		return err
 	}
-
-	pbAct.Balance = types.NewAttoFILFromFIL(0)
-
 	return st.SetActor(ctx, address.PaymentBrokerAddress, pbAct)
 }

--- a/core/outbox_test.go
+++ b/core/outbox_test.go
@@ -124,7 +124,7 @@ func TestOutbox(t *testing.T) {
 		provider := &fakeProvider{}
 
 		blk := types.NewBlockForTest(nil, 1)
-		actr, _ := storagemarket.NewActor() // Not an account actor
+		actr := storagemarket.NewActor() // Not an account actor
 		provider.Set(t, blk, sender, actr)
 
 		ob := core.NewOutbox(w, nullValidator{}, queue, publisher, nullPolicy{}, provider, provider)


### PR DESCRIPTION
As [specified](https://github.com/filecoin-project/specs/blob/master/actors.md#built-in-actors)

Also updated the other built-in actors to have ID-style addresses.