### PR TITLE
Add a timer for syncer.SyncOne, the duration to validate a tipset

### DIFF
--- a/consensus/processor.go
+++ b/consensus/processor.go
@@ -21,8 +21,8 @@ var pbTimer *metrics.Float64Timer
 var amTimer *metrics.Float64Timer
 
 func init() {
-	amTimer = metrics.NewTimer("consensus/apply_message", "Duration of message application in milliseconds")
-	pbTimer = metrics.NewTimer("consensus/process_block", "Duration of block processing in milliseconds")
+	amTimer = metrics.NewTimerMs("consensus/apply_message", "Duration of message application in milliseconds")
+	pbTimer = metrics.NewTimerMs("consensus/process_block", "Duration of block processing in milliseconds")
 }
 
 // BlockRewarder applies all rewards due to the miner's owner for processing a block including block reward and gas

--- a/metrics/timer_test.go
+++ b/metrics/timer_test.go
@@ -14,7 +14,7 @@ func TestTimerSimple(t *testing.T) {
 
 	ctx := context.Background()
 
-	testTimer := NewTimer("testName", "testDesc")
+	testTimer := NewTimerMs("testName", "testDesc")
 	// some view state is kept around after tests exit, doing this to clean that up.
 	// e.g. view will remain registered after a test exits.
 	defer view.Unregister(testTimer.view)
@@ -40,8 +40,8 @@ func TestDuplicateTimersPanics(t *testing.T) {
 		// we pass
 	}()
 
-	NewTimer("testName", "testDesc")
-	testTimer := NewTimer("testName", "testDesc")
+	NewTimerMs("testName", "testDesc")
+	testTimer := NewTimerMs("testName", "testDesc")
 	assert.Equal(t, "testName", testTimer.view.Name)
 	assert.Equal(t, "testDesc", testTimer.view.Description)
 
@@ -57,8 +57,8 @@ func TestMultipleTimers(t *testing.T) {
 	ctx1 := context.Background()
 	ctx2 := context.Background()
 
-	tt1 := NewTimer("tt1", "ttd1")
-	tt2 := NewTimer("tt2", "ttd2")
+	tt1 := NewTimerMs("tt1", "ttd1")
+	tt2 := NewTimerMs("tt2", "ttd2")
 
 	sw1 := tt1.Start(ctx1)
 	sw2 := tt2.Start(ctx2)


### PR DESCRIPTION
This is complementary to the existing timers for consensus block and message processing. This new timer captures the cost to load up all the context for that processing, in particular traversing ancestors. I expect #2879 to make a difference here.