### PR TITLE
Disable flaky assertion in TestDealsRedeem FAST test

### DIFF
--- a/commands/deals_daemon_test.go
+++ b/commands/deals_daemon_test.go
@@ -28,6 +28,12 @@ import (
 )
 
 func TestDealsRedeem(t *testing.T) {
+	// DISABLED: this test has nondeterministic rounding errors
+	// https://github.com/filecoin-project/go-filecoin/issues/2960
+	// It also takes many minutes due to waiting for real sector sealing. This is unacceptable
+	// for an integration test (possibly ok for a functional test).
+	// https://github.com/filecoin-project/go-filecoin/issues/2965
+	t.Skipf("Flaky and slow: #2960, #2965")
 	tf.IntegrationTest(t)
 
 	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{})


### PR DESCRIPTION
We don't know the cause of this yet. It's a significant problem (#2960) but meanwhile this flaky test prevents us from merging PRs. Leaving it disabled is a louder warning that we have a problem than relaxing it to accept a rounding error.