### PR TITLE
StorageMiner.SubmitPoSt actor method charges late fees.

### DIFF
--- a/types/atto_fil.go
+++ b/types/atto_fil.go
@@ -183,6 +183,13 @@ func (z AttoFIL) IsZero() bool {
 	return z.Equal(ZeroAttoFIL)
 }
 
+// AsBigInt returns the value as a big.Int
+func (z AttoFIL) AsBigInt() (out *big.Int) {
+	out = &big.Int{}
+	out.Set(&z.val)
+	return
+}
+
 // Bytes returns the absolute value of x as a big-endian byte slice.
 func (z AttoFIL) Bytes() []byte {
 	return leb128.FromBigInt(&z.val)

--- a/types/block_height.go
+++ b/types/block_height.go
@@ -118,6 +118,8 @@ func (z *BlockHeight) Sub(y *BlockHeight) *BlockHeight {
 }
 
 // AsBigInt returns the blockheight as a big.Int
-func (z *BlockHeight) AsBigInt() *big.Int {
-	return z.val
+func (z *BlockHeight) AsBigInt() (out *big.Int) {
+	out = &big.Int{}
+	out.Set(z.val)
+	return
 }


### PR DESCRIPTION
The fee is a proportion of pledge collateral equal to the lateness as a fraction of the maximum allowable lateness. Proofs after the generation attack threshold are rejected (the miner actor can expect to be slashed).

The worker doesn't yet compute and attach any required fee, so late proofs will continue to be rejected. Part of the work for #2942.