### PR TITLE
create subscription logger, default error level

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,17 +28,18 @@ func main() {
 
 	logging.SetAllLoggers(oldlogging.Level(n))
 
-	logging.SetLogLevel("dht", "error")          // nolint: errcheck
-	logging.SetLogLevel("bitswap", "error")      // nolint: errcheck
-	logging.SetLogLevel("heartbeat", "error")    // nolint: errcheck
-	logging.SetLogLevel("blockservice", "error") // nolint: errcheck
-	logging.SetLogLevel("peerqueue", "error")    // nolint: errcheck
-	logging.SetLogLevel("swarm", "error")        // nolint: errcheck
-	logging.SetLogLevel("swarm2", "error")       // nolint: errcheck
-	logging.SetLogLevel("basichost", "error")    // nolint: errcheck
-	logging.SetLogLevel("dht_net", "error")      // nolint: errcheck
-	logging.SetLogLevel("pubsub", "error")       // nolint: errcheck
-	logging.SetLogLevel("relay", "error")        // nolint: errcheck
+	logging.SetLogLevel("dht", "error")               // nolint: errcheck
+	logging.SetLogLevel("bitswap", "error")           // nolint: errcheck
+	logging.SetLogLevel("heartbeat", "error")         // nolint: errcheck
+	logging.SetLogLevel("blockservice", "error")      // nolint: errcheck
+	logging.SetLogLevel("peerqueue", "error")         // nolint: errcheck
+	logging.SetLogLevel("swarm", "error")             // nolint: errcheck
+	logging.SetLogLevel("swarm2", "error")            // nolint: errcheck
+	logging.SetLogLevel("basichost", "error")         // nolint: errcheck
+	logging.SetLogLevel("dht_net", "error")           // nolint: errcheck
+	logging.SetLogLevel("pubsub", "error")            // nolint: errcheck
+	logging.SetLogLevel("relay", "error")             // nolint: errcheck
+	logging.SetLogLevel("node/subscription", "error") // nolint: errcheck
 
 	// TODO implement help text like so:
 	// https://github.com/ipfs/go-ipfs/blob/master/core/commands/root.go#L91

--- a/node/node.go
+++ b/node/node.go
@@ -1021,17 +1021,19 @@ func (node *Node) miningOwnerAddress(ctx context.Context, miningAddr address.Add
 	return ownerAddr, nil
 }
 
+var subscriptionLogger = logging.Logger("node/subscription")
+
 func (node *Node) handleSubscription(ctx context.Context, f pubSubProcessorFunc, fname string, s pubsub.Subscription, sname string) {
 	for {
 		pubSubMsg, err := s.Next(ctx)
 		if err != nil {
-			log.Errorf("%s.Next(): %s", sname, err)
+			subscriptionLogger.Errorf("%s.Next(): %s", sname, err)
 			return
 		}
 
 		if err := f(ctx, pubSubMsg); err != nil {
 			if err != context.Canceled {
-				log.Errorf("%s(): %s", fname, err)
+				subscriptionLogger.Warningf("%s(): %s", fname, err)
 			}
 		}
 	}


### PR DESCRIPTION
### Wat
This PR creates a `subscriptionLogger` that `handleSubscription` uses to log warnings when its call backs (processBlock and processMessage) error. The PR then sets the default log level of the subscriptionLogger to error. 