### PR TITLE
Codecov requires a base report before posting a GH comment.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,10 +9,10 @@ coverage:
     changes: off
 
 comment:
-  layout: "reach, diff, flags, files"
+  layout: "diff, flags, files"
   behavior: default
   require_changes: false  # if true: only post the comment if coverage changes
-  require_base: no        # [yes :: must have a base report to post]
+  require_base: yes       # [yes :: must have a base report to post]
   require_head: yes       # [yes :: must have a head report to post]
   branches: null          # branch names that can post comment
 


### PR DESCRIPTION
This improves the quality of the coverage diffs, though I'm not 100% sure it's right yet.

We do have a small amount of nondeterministic coverage in node.go and hello.go, but on the order of <10 lines. 
The coverage report can be confusing while the Circle build is still running: it shows partial results when only some of the jobs have uploaded their coverage reports. It's necessary to wait until the build is finished and then reload the PR page to see a sensible report.