### PR TITLE
RLE+ encoding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,5 +92,5 @@ require (
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
-	gotest.tools v2.2.0+incompatible // indirect
+	gotest.tools v2.2.0+incompatible
 )

--- a/rleplus/internal/bitvector.go
+++ b/rleplus/internal/bitvector.go
@@ -36,8 +36,7 @@ type BitVector struct {
 
 // NewBitVector constructs a new BitVector from a slice of bytes.
 //
-// The bytePacking parameter is required to know how to interpret the
-// bit ordering within the bytes.
+// The bytePacking parameter is required to know how to interpret the bit ordering within the bytes.
 func NewBitVector(buf []byte, bytePacking BitNumbering) *BitVector {
 	return &BitVector{
 		BytePacking: bytePacking,
@@ -48,8 +47,7 @@ func NewBitVector(buf []byte, bytePacking BitNumbering) *BitVector {
 
 // Push adds a single bit to the BitVector.
 //
-// Although it takes a byte, only the low-order
-// bit is used, so just use 0 or 1.
+// Although it takes a byte, only the low-order bit is used, so just use 0 or 1.
 func (v *BitVector) Push(val byte) {
 	if v.Len%8 == 0 {
 		v.Buf = append(v.Buf, 0)
@@ -66,7 +64,7 @@ func (v *BitVector) Push(val byte) {
 	v.Len++
 }
 
-// Get returns byte either 0, 1
+// Get returns a single bit as a byte -- either 0 or 1
 func (v *BitVector) Get(idx int) (byte, error) {
 	if idx >= v.Len {
 		return 0, ErrOutOfRange
@@ -84,8 +82,8 @@ func (v *BitVector) Get(idx int) (byte, error) {
 // Extend adds up to 8 bits to the receiver
 //
 // Given a byte b == 0b11010101
-// v.Extend(b, 4, LSB0) would add <1, 0, 1, 0>
-// v.Extend(b, 4, MSB0) would add <1, 1, 0, 1>
+// v.Extend(b, 4, LSB0) would add < 1, 0, 1, 0 >
+// v.Extend(b, 4, MSB0) would add < 1, 1, 0, 1 >
 func (v *BitVector) Extend(val byte, count uint, order BitNumbering) {
 	if count > 8 {
 		count = 8

--- a/rleplus/internal/bitvector.go
+++ b/rleplus/internal/bitvector.go
@@ -29,9 +29,14 @@ const (
 
 // BitVector is used to manipulate ordered collections of bits
 type BitVector struct {
+	Buf []byte
+
+	// BytePacking is the bit ordering within bytes
 	BytePacking BitNumbering
-	Buf         []byte
-	Len         int
+
+	// Len is the logical number of bits in the vector.
+	// The last byte in Buf may have undefined bits if Len is not a multiple of 8
+	Len int
 }
 
 // NewBitVector constructs a new BitVector from a slice of bytes.

--- a/rleplus/internal/bitvector.go
+++ b/rleplus/internal/bitvector.go
@@ -1,0 +1,187 @@
+package bitvector
+
+import "errors"
+
+var (
+	// ErrOutOfRange - the index passed is out of range for the BitVector
+	ErrOutOfRange = errors.New("index out of range")
+)
+
+// BitNumbering indicates the ordering of bits, either
+// least-significant bit in position 0, or most-significant bit
+// in position 0.
+//
+// It it used in 3 ways with BitVector:
+// 1. Ordering of bits within the Buf []byte structure
+// 2. What order to add bits when using Extend()
+// 3. What order to read bits when using Take()
+//
+// https://en.wikipedia.org/wiki/Bit_numbering
+type BitNumbering int
+
+const (
+	// LSB0 - bit ordering starts with the low-order bit
+	LSB0 BitNumbering = iota
+
+	// MSB0 - bit ordering starts with the high-order bit
+	MSB0
+)
+
+// BitVector is used to manipulate ordered collections of bits
+type BitVector struct {
+	BytePacking BitNumbering
+	Buf         []byte
+	Len         int
+}
+
+// NewBitVector constructs a new BitVector from a slice of bytes.
+//
+// The bytePacking parameter is required to know how to interpret the
+// bit ordering within the bytes.
+func NewBitVector(buf []byte, bytePacking BitNumbering) *BitVector {
+	return &BitVector{
+		BytePacking: bytePacking,
+		Buf:         buf,
+		Len:         len(buf) * 8,
+	}
+}
+
+// Push adds a single bit to the BitVector.
+//
+// Although it takes a byte, only the low-order
+// bit is used, so just use 0 or 1.
+func (v *BitVector) Push(val byte) {
+	if v.Len%8 == 0 {
+		v.Buf = append(v.Buf, 0)
+	}
+
+	switch v.BytePacking {
+	case LSB0:
+		v.pushLSB0(val)
+	default:
+		v.pushMSB0(val)
+	}
+
+	v.Len++
+}
+
+// Get returns byte either 0, 1
+func (v *BitVector) Get(idx int) (byte, error) {
+	if idx >= v.Len {
+		return 0, ErrOutOfRange
+	}
+
+	switch v.BytePacking {
+	case LSB0:
+		return v.getLSB0(idx), nil
+	default:
+		return v.getMSB0(idx), nil
+	}
+}
+
+// Extend adds up to 8 bits to the receiver, in the order indicated
+//
+// Given a byte b == 0b11010101
+// v.Extend(b, 4, LSB0) would add <1, 0, 1, 0>
+// v.Extend(b, 4, MSB0) would add <1, 1, 0, 1>
+func (v *BitVector) Extend(val byte, count uint, order BitNumbering) {
+	if count > 8 {
+		count = 8
+	}
+
+	switch order {
+	case LSB0:
+		v.extendLSB0(val, count)
+	default:
+		v.extendMSB0(val, count)
+	}
+}
+
+// Take reads up to 8 bits at the given index, and returns them in a byte.
+// The byte packing is determined by the order parameter.
+//
+// Given a BitVector < 1, 1, 0, 1, 0, 1, 0, 1 >
+// v.Take(1, 4, LSB0) would return 0b00001011
+// v.Take(1, 4, MSB0) would return 0b00001101
+func (v *BitVector) Take(index int, count int, order BitNumbering) byte {
+	if count > 8 {
+		count = 8
+	}
+
+	switch order {
+	case LSB0:
+		return v.takeLSB0(index, count)
+	default:
+		return v.takeMSB0(index, count)
+	}
+}
+
+// Iterator returns a function, which when invokes, returns the number
+// of bits passed, and increments an internal cursor.
+//
+// When the end of the BitVector is reached, it returns zeroes indefinitely
+func (v *BitVector) Iterator(order BitNumbering) func(int) byte {
+	cursor := 0
+	return func(count int) (out byte) {
+		out = v.Take(cursor, count, order)
+		cursor += count
+		return
+	}
+}
+
+func (v *BitVector) getLSB0(idx int) byte {
+	blockIdx := idx / 8
+	return v.Buf[blockIdx] >> uint(idx%8) & 1
+}
+
+func (v *BitVector) getMSB0(idx int) byte {
+	blockIdx := idx / 8
+	return v.Buf[blockIdx] >> uint(7-idx%8) & 1
+}
+
+func (v *BitVector) pushLSB0(val byte) {
+	lastIdx := v.Len / 8
+	v.Buf[lastIdx] |= (val & 1) << uint(v.Len%8)
+}
+
+func (v *BitVector) pushMSB0(val byte) {
+	lastIdx := v.Len / 8
+	v.Buf[lastIdx] |= (val & 1) << uint(7-(v.Len%8))
+}
+
+// extendLSB0 pushes bits onto the BitVector, low-order bit first
+// e.g. v.extendLSB0(171, 4) // adds <...., 1, 1, 0, 1> since 171 == 0b10101011
+func (v *BitVector) extendLSB0(val byte, count uint) {
+	for i := uint(0); i < count; i++ {
+		v.Push((val >> i) & 1)
+	}
+}
+
+// takeLSB0 fetches up to 8 bits and returns it as a byte, low-order bit first
+// e.g. BitVector <1, 1, 0, 1, 0, 1, 0, 1 >, v.takeLSB0(1, 4) returns 0b00001011
+func (v *BitVector) takeLSB0(index int, count int) (out byte) {
+	for i := 0; i < count; i++ {
+		val, _ := v.Get(index + i)
+		out |= val << uint(i)
+	}
+	return
+}
+
+// extendMSB0 pushes up to 8 bits onto the BitVector, high-order bit first
+// e.g. v.extendMSB0(171, 4) // adds <...., 1, 0, 1, 0> since 171 == 0b10101011
+func (v *BitVector) extendMSB0(val byte, count uint) {
+	for i := uint(0); i < count; i++ {
+		v.Push((val >> (7 - i)) & 1)
+	}
+}
+
+// takeMSB0 fetches up to 8 bits and returns it as a byte, high-order bit first
+// e.g. BitVector <1, 1, 0, 1, 0, 1, 0, 1 >, v.takeMSB0(1, 4) returns 0b00001101
+func (v *BitVector) takeMSB0(index int, count int) (out byte) {
+	for i := 0; i < count; i++ {
+		// 3, 2, 1, 0
+		val, _ := v.Get(index + i)
+		out |= val << uint(count-i-1)
+	}
+	return
+}

--- a/rleplus/internal/bitvector.go
+++ b/rleplus/internal/bitvector.go
@@ -64,9 +64,9 @@ func (v *BitVector) Push(val byte) {
 
 	switch v.BytePacking {
 	case LSB0:
-		v.Buf[lastIdx] |= (val & 1) << uint(v.Len%8)
+		v.Buf[lastIdx] |= (val & 1) << (v.Len % 8)
 	default:
-		v.Buf[lastIdx] |= (val & 1) << uint(7-(v.Len%8))
+		v.Buf[lastIdx] |= (val & 1) << (7 - (v.Len % 8))
 	}
 
 	v.Len++
@@ -81,9 +81,9 @@ func (v *BitVector) Get(idx uint) (byte, error) {
 
 	switch v.BytePacking {
 	case LSB0:
-		return v.Buf[blockIdx] >> uint(idx%8) & 1, nil
+		return v.Buf[blockIdx] >> (idx % 8) & 1, nil
 	default:
-		return v.Buf[blockIdx] >> uint(7-idx%8) & 1, nil
+		return v.Buf[blockIdx] >> (7 - idx%8) & 1, nil
 	}
 }
 
@@ -126,9 +126,9 @@ func (v *BitVector) Take(index uint, count uint, order BitNumbering) (out byte) 
 
 		switch order {
 		case LSB0:
-			out |= val << uint(i)
+			out |= val << i
 		default:
-			out |= val << uint(7-i)
+			out |= val << (7 - i)
 		}
 	}
 	return

--- a/rleplus/internal/bitvector.go
+++ b/rleplus/internal/bitvector.go
@@ -54,12 +54,13 @@ func (v *BitVector) Push(val byte) {
 	if v.Len%8 == 0 {
 		v.Buf = append(v.Buf, 0)
 	}
+	lastIdx := v.Len / 8
 
 	switch v.BytePacking {
 	case LSB0:
-		v.pushLSB0(val)
+		v.Buf[lastIdx] |= (val & 1) << uint(v.Len%8)
 	default:
-		v.pushMSB0(val)
+		v.Buf[lastIdx] |= (val & 1) << uint(7-(v.Len%8))
 	}
 
 	v.Len++
@@ -70,16 +71,17 @@ func (v *BitVector) Get(idx int) (byte, error) {
 	if idx >= v.Len {
 		return 0, ErrOutOfRange
 	}
+	blockIdx := idx / 8
 
 	switch v.BytePacking {
 	case LSB0:
-		return v.getLSB0(idx), nil
+		return v.Buf[blockIdx] >> uint(idx%8) & 1, nil
 	default:
-		return v.getMSB0(idx), nil
+		return v.Buf[blockIdx] >> uint(7-idx%8) & 1, nil
 	}
 }
 
-// Extend adds up to 8 bits to the receiver, in the order indicated
+// Extend adds up to 8 bits to the receiver
 //
 // Given a byte b == 0b11010101
 // v.Extend(b, 4, LSB0) would add <1, 0, 1, 0>
@@ -89,35 +91,41 @@ func (v *BitVector) Extend(val byte, count uint, order BitNumbering) {
 		count = 8
 	}
 
-	switch order {
-	case LSB0:
-		v.extendLSB0(val, count)
-	default:
-		v.extendMSB0(val, count)
+	for i := uint(0); i < count; i++ {
+		switch order {
+		case LSB0:
+			v.Push((val >> i) & 1)
+		default:
+			v.Push((val >> (7 - i)) & 1)
+		}
 	}
 }
 
-// Take reads up to 8 bits at the given index, and returns them in a byte.
-// The byte packing is determined by the order parameter.
+// Take reads up to 8 bits at the given index.
 //
 // Given a BitVector < 1, 1, 0, 1, 0, 1, 0, 1 >
-// v.Take(1, 4, LSB0) would return 0b00001011
-// v.Take(1, 4, MSB0) would return 0b00001101
-func (v *BitVector) Take(index int, count int, order BitNumbering) byte {
+// v.Take(0, 4, LSB0) would return 0b00001011
+// v.Take(0, 4, MSB0) would return 0b11010000
+func (v *BitVector) Take(index int, count int, order BitNumbering) (out byte) {
 	if count > 8 {
 		count = 8
 	}
 
-	switch order {
-	case LSB0:
-		return v.takeLSB0(index, count)
-	default:
-		return v.takeMSB0(index, count)
+	for i := 0; i < count; i++ {
+		val, _ := v.Get(index + i)
+
+		switch order {
+		case LSB0:
+			out |= val << uint(i)
+		default:
+			out |= val << uint(7-i)
+		}
 	}
+	return
 }
 
-// Iterator returns a function, which when invokes, returns the number
-// of bits passed, and increments an internal cursor.
+// Iterator returns a function, which when invoked, returns the number
+// of bits requested, and increments an internal cursor.
 //
 // When the end of the BitVector is reached, it returns zeroes indefinitely
 func (v *BitVector) Iterator(order BitNumbering) func(int) byte {
@@ -127,61 +135,4 @@ func (v *BitVector) Iterator(order BitNumbering) func(int) byte {
 		cursor += count
 		return
 	}
-}
-
-func (v *BitVector) getLSB0(idx int) byte {
-	blockIdx := idx / 8
-	return v.Buf[blockIdx] >> uint(idx%8) & 1
-}
-
-func (v *BitVector) getMSB0(idx int) byte {
-	blockIdx := idx / 8
-	return v.Buf[blockIdx] >> uint(7-idx%8) & 1
-}
-
-func (v *BitVector) pushLSB0(val byte) {
-	lastIdx := v.Len / 8
-	v.Buf[lastIdx] |= (val & 1) << uint(v.Len%8)
-}
-
-func (v *BitVector) pushMSB0(val byte) {
-	lastIdx := v.Len / 8
-	v.Buf[lastIdx] |= (val & 1) << uint(7-(v.Len%8))
-}
-
-// extendLSB0 pushes bits onto the BitVector, low-order bit first
-// e.g. v.extendLSB0(171, 4) // adds <...., 1, 1, 0, 1> since 171 == 0b10101011
-func (v *BitVector) extendLSB0(val byte, count uint) {
-	for i := uint(0); i < count; i++ {
-		v.Push((val >> i) & 1)
-	}
-}
-
-// takeLSB0 fetches up to 8 bits and returns it as a byte, low-order bit first
-// e.g. BitVector <1, 1, 0, 1, 0, 1, 0, 1 >, v.takeLSB0(1, 4) returns 0b00001011
-func (v *BitVector) takeLSB0(index int, count int) (out byte) {
-	for i := 0; i < count; i++ {
-		val, _ := v.Get(index + i)
-		out |= val << uint(i)
-	}
-	return
-}
-
-// extendMSB0 pushes up to 8 bits onto the BitVector, high-order bit first
-// e.g. v.extendMSB0(171, 4) // adds <...., 1, 0, 1, 0> since 171 == 0b10101011
-func (v *BitVector) extendMSB0(val byte, count uint) {
-	for i := uint(0); i < count; i++ {
-		v.Push((val >> (7 - i)) & 1)
-	}
-}
-
-// takeMSB0 fetches up to 8 bits and returns it as a byte, high-order bit first
-// e.g. BitVector <1, 1, 0, 1, 0, 1, 0, 1 >, v.takeMSB0(1, 4) returns 0b00001101
-func (v *BitVector) takeMSB0(index int, count int) (out byte) {
-	for i := 0; i < count; i++ {
-		// 3, 2, 1, 0
-		val, _ := v.Get(index + i)
-		out |= val << uint(count-i-1)
-	}
-	return
 }

--- a/rleplus/internal/bitvector_test.go
+++ b/rleplus/internal/bitvector_test.go
@@ -1,0 +1,124 @@
+package bitvector_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/filecoin-project/go-filecoin/rleplus/internal"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"gotest.tools/assert"
+)
+
+func assertBitVector(t *testing.T, expected []byte, actual bitvector.BitVector) {
+	assert.Equal(t, len(expected), actual.Len)
+
+	for idx, bit := range expected {
+		actualBit, err := actual.Get(idx)
+		assert.NilError(t, err)
+		assert.Equal(t, bit, actualBit)
+	}
+}
+
+func TestBitVector(t *testing.T) {
+	tf.UnitTest(t)
+
+	t.Run("Zero Value", func(t *testing.T) {
+		var v bitvector.BitVector
+
+		assert.Equal(t, bitvector.LSB0, v.BytePacking)
+	})
+
+	t.Run("Push", func(t *testing.T) {
+		// MSB0 bit numbering
+		v := bitvector.BitVector{BytePacking: bitvector.MSB0}
+		v.Push(1)
+		v.Push(0)
+		v.Push(1)
+		v.Push(1)
+
+		assert.Equal(t, byte(176), v.Buf[0])
+
+		// LSB0 bit numbering
+		v = bitvector.BitVector{BytePacking: bitvector.LSB0}
+		v.Push(1)
+		v.Push(0)
+		v.Push(1)
+		v.Push(1)
+
+		assert.Equal(t, byte(13), v.Buf[0])
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		bits := []byte{1, 0, 1, 1, 0, 0, 1, 0}
+
+		for _, numbering := range []bitvector.BitNumbering{bitvector.MSB0, bitvector.LSB0} {
+			v := bitvector.BitVector{BytePacking: numbering}
+
+			for _, bit := range bits {
+				v.Push(bit)
+			}
+
+			for idx, expected := range bits {
+				actual, _ := v.Get(idx)
+				assert.Equal(t, expected, actual)
+			}
+		}
+	})
+
+	t.Run("Extend", func(t *testing.T) {
+		val := byte(171) // 0b10101011
+
+		var v bitvector.BitVector
+
+		// MSB0 bit numbering
+		v = bitvector.BitVector{}
+		v.Extend(val, 4, bitvector.MSB0)
+		assertBitVector(t, []byte{1, 0, 1, 0}, v)
+		v.Extend(val, 5, bitvector.MSB0)
+		assertBitVector(t, []byte{1, 0, 1, 0, 1, 0, 1, 0, 1}, v)
+
+		// LSB0 bit numbering
+		v = bitvector.BitVector{}
+		v.Extend(val, 4, bitvector.LSB0)
+		assertBitVector(t, []byte{1, 1, 0, 1}, v)
+		v.Extend(val, 5, bitvector.LSB0)
+		assertBitVector(t, []byte{1, 1, 0, 1, 1, 1, 0, 1, 0}, v)
+	})
+
+	t.Run("Take", func(t *testing.T) {
+		var v bitvector.BitVector
+
+		bits := []byte{1, 0, 1, 0, 1, 0, 1, 1}
+		for _, bit := range bits {
+			v.Push(bit)
+		}
+
+		assert.Equal(t, byte(11), v.Take(4, 4, bitvector.MSB0))
+		assert.Equal(t, byte(13), v.Take(4, 4, bitvector.LSB0))
+	})
+
+	t.Run("Iterator", func(t *testing.T) {
+		var v bitvector.BitVector
+
+		for i := 0; i < 256; i++ {
+			v.Push(byte(rand.Int() & 1))
+		}
+
+		next := v.Iterator(bitvector.LSB0)
+
+		// compare to Get()
+		for i := 0; i < v.Len; i++ {
+			expected, _ := v.Get(i)
+			assert.Equal(t, expected, next(1))
+		}
+
+		// out of range should return zero
+		assert.Equal(t, byte(0), next(1))
+		assert.Equal(t, byte(0), next(8))
+
+		// compare to Take()
+		next = v.Iterator(bitvector.LSB0)
+		assert.Equal(t, next(5), v.Take(0, 5, bitvector.LSB0))
+		assert.Equal(t, next(8), v.Take(5, 8, bitvector.LSB0))
+	})
+}

--- a/rleplus/internal/bitvector_test.go
+++ b/rleplus/internal/bitvector_test.go
@@ -1,7 +1,6 @@
 package bitvector_test
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/filecoin-project/go-filecoin/rleplus/internal"
@@ -9,21 +8,10 @@ import (
 	"gotest.tools/assert"
 )
 
-// Note: When using this helper assertion, expectedBits should *only* be 0s and 1s.
-func assertBitVector(t *testing.T, expectedBits []byte, actual bitvector.BitVector) {
-	assert.Equal(t, len(expectedBits), actual.Len)
-
-	for idx, bit := range expectedBits {
-		actualBit, err := actual.Get(idx)
-		assert.NilError(t, err)
-		assert.Equal(t, bit, actualBit)
-	}
-}
-
 func TestBitVector(t *testing.T) {
 	tf.UnitTest(t)
 
-	t.Run("Zero Value", func(t *testing.T) {
+	t.Run("zero value", func(t *testing.T) {
 		var v bitvector.BitVector
 
 		assert.Equal(t, bitvector.LSB0, v.BytePacking)
@@ -99,11 +87,14 @@ func TestBitVector(t *testing.T) {
 	})
 
 	t.Run("Iterator", func(t *testing.T) {
-		var v bitvector.BitVector
+		var buf []byte
 
-		for i := 0; i < 256; i++ {
-			v.Push(byte(rand.Int() & 1))
+		// make a bitvector of 256 sample bits
+		for i := 0; i < 32; i++ {
+			buf = append(buf, 128+32)
 		}
+
+		v := bitvector.NewBitVector(buf, bitvector.LSB0)
 
 		next := v.Iterator(bitvector.LSB0)
 
@@ -122,4 +113,15 @@ func TestBitVector(t *testing.T) {
 		assert.Equal(t, next(5), v.Take(0, 5, bitvector.LSB0))
 		assert.Equal(t, next(8), v.Take(5, 8, bitvector.LSB0))
 	})
+}
+
+// Note: When using this helper assertion, expectedBits should *only* be 0s and 1s.
+func assertBitVector(t *testing.T, expectedBits []byte, actual bitvector.BitVector) {
+	assert.Equal(t, len(expectedBits), actual.Len)
+
+	for idx, bit := range expectedBits {
+		actualBit, err := actual.Get(idx)
+		assert.NilError(t, err)
+		assert.Equal(t, bit, actualBit)
+	}
 }

--- a/rleplus/internal/bitvector_test.go
+++ b/rleplus/internal/bitvector_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/rleplus/internal"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBitVector(t *testing.T) {
@@ -48,7 +48,7 @@ func TestBitVector(t *testing.T) {
 			}
 
 			for idx, expected := range bits {
-				actual, _ := v.Get(idx)
+				actual, _ := v.Get(uint(idx))
 				assert.Equal(t, expected, actual)
 			}
 		}
@@ -72,6 +72,17 @@ func TestBitVector(t *testing.T) {
 		assertBitVector(t, []byte{1, 1, 0, 1}, v)
 		v.Extend(val, 5, bitvector.LSB0)
 		assertBitVector(t, []byte{1, 1, 0, 1, 1, 1, 0, 1, 0}, v)
+	})
+
+	t.Run("invalid counts to Take/Extend/Iterator cause panics", func(t *testing.T) {
+		v := bitvector.BitVector{BytePacking: bitvector.LSB0}
+
+		assert.Panics(t, func() { v.Extend(0xff, 9, bitvector.LSB0) })
+
+		assert.Panics(t, func() { v.Take(0, 9, bitvector.LSB0) })
+
+		next := v.Iterator(bitvector.LSB0)
+		assert.Panics(t, func() { next(9) })
 	})
 
 	t.Run("Take", func(t *testing.T) {
@@ -99,8 +110,8 @@ func TestBitVector(t *testing.T) {
 		next := v.Iterator(bitvector.LSB0)
 
 		// compare to Get()
-		for i := 0; i < v.Len; i++ {
-			expected, _ := v.Get(i)
+		for i := uint(0); i < v.Len; i++ {
+			expected, _ := v.Get(uint(i))
 			assert.Equal(t, expected, next(1))
 		}
 
@@ -117,11 +128,11 @@ func TestBitVector(t *testing.T) {
 
 // Note: When using this helper assertion, expectedBits should *only* be 0s and 1s.
 func assertBitVector(t *testing.T, expectedBits []byte, actual bitvector.BitVector) {
-	assert.Equal(t, len(expectedBits), actual.Len)
+	assert.Equal(t, uint(len(expectedBits)), actual.Len)
 
 	for idx, bit := range expectedBits {
-		actualBit, err := actual.Get(idx)
-		assert.NilError(t, err)
+		actualBit, err := actual.Get(uint(idx))
+		assert.NoError(t, err)
 		assert.Equal(t, bit, actualBit)
 	}
 }

--- a/rleplus/internal/bitvector_test.go
+++ b/rleplus/internal/bitvector_test.go
@@ -9,10 +9,11 @@ import (
 	"gotest.tools/assert"
 )
 
-func assertBitVector(t *testing.T, expected []byte, actual bitvector.BitVector) {
-	assert.Equal(t, len(expected), actual.Len)
+// Note: When using this helper assertion, expectedBits should *only* be 0s and 1s.
+func assertBitVector(t *testing.T, expectedBits []byte, actual bitvector.BitVector) {
+	assert.Equal(t, len(expectedBits), actual.Len)
 
-	for idx, bit := range expected {
+	for idx, bit := range expectedBits {
 		actualBit, err := actual.Get(idx)
 		assert.NilError(t, err)
 		assert.Equal(t, bit, actualBit)
@@ -93,7 +94,7 @@ func TestBitVector(t *testing.T) {
 			v.Push(bit)
 		}
 
-		assert.Equal(t, byte(11), v.Take(4, 4, bitvector.MSB0))
+		assert.Equal(t, byte(176), v.Take(4, 4, bitvector.MSB0))
 		assert.Equal(t, byte(13), v.Take(4, 4, bitvector.LSB0))
 	})
 

--- a/rleplus/internal/bitvector_test.go
+++ b/rleplus/internal/bitvector_test.go
@@ -111,7 +111,7 @@ func TestBitVector(t *testing.T) {
 
 		// compare to Get()
 		for i := uint(0); i < v.Len; i++ {
-			expected, _ := v.Get(uint(i))
+			expected, _ := v.Get(i)
 			assert.Equal(t, expected, next(1))
 		}
 

--- a/rleplus/rleplus.go
+++ b/rleplus/rleplus.go
@@ -1,0 +1,164 @@
+package rleplus
+
+import (
+	"encoding/binary"
+	"sort"
+
+	"github.com/filecoin-project/go-filecoin/rleplus/internal"
+)
+
+// Encode returns the RLE+ representation of the provided integers.
+// Also returned is the number of bits required by this encoding,
+// which is not necessarily on a byte boundary.
+//
+// The RLE+ spec is here: https://github.com/filecoin-project/specs/blob/master/data-structures.md#rle-bitset-encoding
+// and is described by the BNF Grammar:
+//
+//    <encoding> ::= <header> <blocks>
+//    <header> ::= <version> <bit>
+//    <version> ::= "00"
+//    <blocks> ::= <block> <blocks> | ""
+//    <block> ::= <block_single> | <block_short> | <block_long>
+//    <block_single> ::= "1"
+//    <block_short> ::= "01" <bit> <bit> <bit> <bit>
+//    <block_long> ::= "00" <unsigned_varint>
+//    <bit> ::= "0" | "1"
+//
+// The specification omits the byte packing order, which inferred from the reference implementation, is low-order bit first.
+func Encode(ints []uint64) ([]byte, int) {
+	v := bitvector.BitVector{BytePacking: bitvector.LSB0}
+	firstBit, runs := RunLengths(ints)
+
+	v.Push(firstBit)
+
+	for _, run := range runs {
+		switch {
+		case run == 1:
+			v.Push(1)
+		case run < 16:
+			v.Push(0)
+			v.Push(1)
+			v.Extend(byte(run), 4, bitvector.LSB0)
+		case run >= 16:
+			v.Push(0)
+			v.Push(0)
+			buf := make([]byte, 10)
+			numBytes := binary.PutUvarint(buf, run)
+			for i := 0; i < numBytes; i++ {
+				v.Extend(buf[i], 8, bitvector.LSB0)
+			}
+		}
+	}
+
+	return v.Buf, v.Len
+}
+
+// Decode returns integers represented by the given RLE+ encoding
+//
+// The length of the encoding is not specified.  It is inferred by
+// reading zeroes from the (possibly empty) BitVector, by virtue
+// of the behavior of BitVector.Take returning 0 when the end of
+// the BitVector has been reached. This has the downside of not
+// being able to detect corrupt encodings.
+func Decode(buf []byte) (ints []uint64) {
+	if len(buf) == 0 {
+		return
+	}
+
+	v := bitvector.NewBitVector(buf, bitvector.LSB0)
+	take := v.Iterator(bitvector.LSB0)
+
+	curIdx := uint64(0)
+	curBit := take(1)
+	var runLength int
+	done := false
+
+	for done == false {
+		y := take(1)
+		switch y {
+		case 1:
+			runLength = 1
+		case 0:
+			val := take(1)
+
+			if val == 1 {
+				// short block
+				runLength = int(take(4))
+			} else {
+				// long block
+				var buf []byte
+				for {
+					b := take(8)
+					buf = append(buf, b)
+					if b&0x80 == 0 {
+						break
+					}
+				}
+				x, _ := binary.Uvarint(buf)
+
+				if x == 0 {
+					done = true
+				}
+				runLength = int(x)
+			}
+		}
+
+		if curBit == 1 {
+			for j := 0; j < runLength; j++ {
+				ints = append(ints, curIdx+uint64(j))
+			}
+		}
+		curIdx += uint64(runLength)
+		curBit = 1 - curBit
+	}
+
+	return
+}
+
+// RunLengths transforms integers into its bit-set-run-length representation.
+//
+// A set of unsigned integers { 0, 2, 4, 5, 6 } can be thought of as
+// indices into a bitset { 1, 0, 1, 0, 1, 1, 1 } where bitset[index] == 1.
+//
+// The bit set run lengths of this set would then be { 1, 1, 1, 1, 3 },
+// representing lengths of runs alternating between 1 and 0, starting
+// with a first bit of 1.
+//
+// This is a helper function for Encode()
+func RunLengths(ints []uint64) (firstBit byte, runs []uint64) {
+	if len(ints) == 0 {
+		return
+	}
+
+	// Sort our incoming numbers
+	sort.Slice(ints, func(i, j int) bool { return ints[i] < ints[j] })
+
+	last := ints[0]
+
+	// Initialize our return value
+	if last == 0 {
+		firstBit = 1
+	}
+
+	if firstBit == 0 {
+		// first run of zeroes
+		runs = append(runs, last)
+	}
+	runs = append(runs, 1)
+
+	for _, cur := range ints[1:] {
+		delta := cur - last
+		switch {
+		case delta == 1:
+			runs[len(runs)-1]++
+		case delta > 1:
+			// add run of zeroes if there is a gap
+			runs = append(runs, delta-1)
+			runs = append(runs, 1)
+		default:
+			// repeated number?
+		}
+		last = cur
+	}
+	return
+}

--- a/rleplus/rleplus.go
+++ b/rleplus/rleplus.go
@@ -43,7 +43,7 @@ var (
 // Filecoin specific:
 // The encoding is returned as a []byte, each byte packed starting with the low-order bit (LSB0)
 // The max unsigned_varint that can be encoded is 2^14 - 1
-func Encode(ints []uint64) ([]byte, int, error) {
+func Encode(ints []uint64) ([]byte, uint, error) {
 	v := bitvector.BitVector{BytePacking: bitvector.LSB0}
 	firstBit, runs := RunLengths(ints)
 

--- a/rleplus/rleplus.go
+++ b/rleplus/rleplus.go
@@ -24,14 +24,14 @@ import (
 //    <block_long> ::= "00" <unsigned_varint>
 //    <bit> ::= "0" | "1"
 //
-// The specification omits the byte packing order, which inferred from the reference implementation, is low-order bit first.
+// The encoding is returned as a []byte, each byte packed starting with the low-order bit (LSB0)
 func Encode(ints []uint64) ([]byte, int) {
 	v := bitvector.BitVector{BytePacking: bitvector.LSB0}
 	firstBit, runs := RunLengths(ints)
 
 	// Add version
-	//v.Push(0)
-	//v.Push(0)
+	v.Push(0)
+	v.Push(0)
 
 	v.Push(firstBit)
 
@@ -64,6 +64,8 @@ func Encode(ints []uint64) ([]byte, int) {
 // of the behavior of BitVector.Take returning 0 when the end of
 // the BitVector has been reached. This has the downside of not
 // being able to detect corrupt encodings.
+//
+// The passed []byte should be packed in LSB0 bit numbering
 func Decode(buf []byte) (ints []uint64) {
 	if len(buf) == 0 {
 		return
@@ -73,8 +75,8 @@ func Decode(buf []byte) (ints []uint64) {
 	take := v.Iterator(bitvector.LSB0)
 
 	// Read version and discard
-	//take(1)
-	//take(1)
+	take(1)
+	take(1)
 
 	curIdx := uint64(0)
 	curBit := take(1)

--- a/rleplus/rleplus.go
+++ b/rleplus/rleplus.go
@@ -9,7 +9,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/rleplus/internal"
 )
 
-// Version is 0 <= version < 4
+// Version is the 2 lowest bits of this constant
 const Version = 0
 
 var (

--- a/rleplus/rleplus.go
+++ b/rleplus/rleplus.go
@@ -29,6 +29,10 @@ func Encode(ints []uint64) ([]byte, int) {
 	v := bitvector.BitVector{BytePacking: bitvector.LSB0}
 	firstBit, runs := RunLengths(ints)
 
+	// Add version
+	//v.Push(0)
+	//v.Push(0)
+
 	v.Push(firstBit)
 
 	for _, run := range runs {
@@ -67,6 +71,10 @@ func Decode(buf []byte) (ints []uint64) {
 
 	v := bitvector.NewBitVector(buf, bitvector.LSB0)
 	take := v.Iterator(bitvector.LSB0)
+
+	// Read version and discard
+	//take(1)
+	//take(1)
 
 	curIdx := uint64(0)
 	curBit := take(1)

--- a/rleplus/rleplus_test.go
+++ b/rleplus/rleplus_test.go
@@ -31,6 +31,7 @@ func TestRleplus(t *testing.T) {
 		}
 
 		expectedBits := []byte{
+			//0, 0, // version
 			1,                // first bit
 			1,                // run of 1
 			1,                // gap of 1

--- a/rleplus/rleplus_test.go
+++ b/rleplus/rleplus_test.go
@@ -1,0 +1,153 @@
+package rleplus_test
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/filecoin-project/go-filecoin/rleplus"
+	"github.com/filecoin-project/go-filecoin/rleplus/internal"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"gotest.tools/assert"
+)
+
+func TestRleplus(t *testing.T) {
+	tf.UnitTest(t)
+
+	t.Run("Encode", func(t *testing.T) {
+		// Encode an intset
+		ints := []uint64{
+			// run of 1
+			0,
+			// gap of 1
+			// run of 1
+			2,
+			// gap of 1
+			// run of 3
+			4, 5, 6,
+			// gap of 4
+			// run of 17
+			11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+		}
+
+		expectedBits := []byte{
+			1,                // first bit
+			1,                // run of 1
+			1,                // gap of 1
+			1,                // run of 1
+			1,                // gap of 1
+			0, 1, 1, 1, 0, 0, // run of 3
+			0, 1, 0, 0, 1, 0, // gap of 4
+
+			// run of 17 < 0 0 (varint) >
+			0, 0,
+			1, 0, 0, 0, 1, 0, 0, 0,
+		}
+
+		v := bitvector.BitVector{}
+		for _, bit := range expectedBits {
+			v.Push(bit)
+		}
+		actualBytes, _ := rleplus.Encode(ints)
+
+		for idx, expected := range v.Buf {
+			assert.Equal(
+				t,
+				fmt.Sprintf("%08b", expected),
+				fmt.Sprintf("%08b", actualBytes[idx]),
+			)
+		}
+	})
+
+	t.Run("Encode Decode Symmetry", func(t *testing.T) {
+		testCases := [][]uint64{
+			{},
+			{1},
+			{0},
+			{0, 1, 2, 3},
+			{
+				// run of 1
+				0,
+				// gap of 1
+				// run of 1
+				2,
+				// gap of 1
+				// run of 3
+				4, 5, 6,
+				// gap of 4
+				// run of 17
+				11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+			},
+		}
+
+		for _, tc := range testCases {
+			encoded, _ := rleplus.Encode(tc)
+			result := rleplus.Decode(encoded)
+
+			sort.Slice(tc, func(i, j int) bool { return tc[i] < tc[j] })
+			sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
+
+			assert.Equal(t, len(tc), len(result))
+
+			for idx, expected := range tc {
+				assert.Equal(t, expected, result[idx])
+			}
+		}
+	})
+
+	t.Run("Outputs same as reference implementation", func(t *testing.T) {
+		// Encoding bitvec![LittleEndian; 1, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+		// in the Rust reference implementation gives an encoding of [223, 145, 136, 0]
+		// The bit vector is equivalent to the integer set { 0, 2, 4, 5, 6, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27 }
+		referenceEncoding := []byte{223, 145, 136, 0}
+		expectedNumbers := []uint64{0, 2, 4, 5, 6, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27}
+
+		encoded, _ := rleplus.Encode(expectedNumbers)
+
+		// Our encoded bytes are the same as the ref bytes
+		assert.Equal(t, len(referenceEncoding), len(encoded))
+		for idx, expected := range referenceEncoding {
+			assert.Equal(t, expected, encoded[idx])
+		}
+
+		decoded := rleplus.Decode(referenceEncoding)
+
+		// Our decoded integers are the same as expected
+		sort.Slice(decoded, func(i, j int) bool { return decoded[i] < decoded[j] })
+		assert.Equal(t, len(expectedNumbers), len(decoded))
+		for idx, expected := range expectedNumbers {
+			assert.Equal(t, expected, decoded[idx])
+		}
+	})
+
+	t.Run("RunLengths", func(t *testing.T) {
+		testCases := []struct {
+			ints  []uint64
+			first byte
+			runs  []uint64
+		}{
+			// empty
+			{},
+
+			// leading with ones
+			{[]uint64{0}, 1, []uint64{1}},
+			{[]uint64{0, 1}, 1, []uint64{2}},
+			{[]uint64{0, 0xffffffff, 0xffffffff + 1}, 1, []uint64{1, 0xffffffff - 1, 2}},
+
+			// leading with zeroes
+			{[]uint64{1}, 0, []uint64{1, 1}},
+			{[]uint64{2}, 0, []uint64{2, 1}},
+			{[]uint64{10, 11, 13, 20}, 0, []uint64{10, 2, 1, 1, 6, 1}},
+			{[]uint64{10, 11, 11, 13, 20, 10, 11, 13, 20}, 0, []uint64{10, 2, 1, 1, 6, 1}},
+		}
+
+		for _, testCase := range testCases {
+			first, runs := rleplus.RunLengths(testCase.ints)
+			assert.Equal(t, testCase.first, first)
+			assert.Equal(t, len(testCase.runs), len(runs))
+			for idx, runLength := range testCase.runs {
+				assert.Equal(t, runLength, runs[idx])
+			}
+		}
+	})
+}

--- a/rleplus/rleplus_test.go
+++ b/rleplus/rleplus_test.go
@@ -31,7 +31,7 @@ func TestRleplus(t *testing.T) {
 		}
 
 		expectedBits := []byte{
-			//0, 0, // version
+			0, 0, // version
 			1,                // first bit
 			1,                // run of 1
 			1,                // gap of 1
@@ -98,9 +98,12 @@ func TestRleplus(t *testing.T) {
 
 	t.Run("Outputs same as reference implementation", func(t *testing.T) {
 		// Encoding bitvec![LittleEndian; 1, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-		// in the Rust reference implementation gives an encoding of [223, 145, 136, 0]
+		// in the Rust reference implementation gives an encoding of [223, 145, 136, 0] (without version field)
 		// The bit vector is equivalent to the integer set { 0, 2, 4, 5, 6, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27 }
-		referenceEncoding := []byte{223, 145, 136, 0}
+
+		// This is the above reference output with a version header "00" manually added
+		referenceEncoding := []byte{124, 71, 34, 2}
+
 		expectedNumbers := []uint64{0, 2, 4, 5, 6, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27}
 
 		encoded, _ := rleplus.Encode(expectedNumbers)


### PR DESCRIPTION
## Problem
We need a compact representation of `IntSet` for network transmission and storage.

## Solution
Implementation of [RLE+](https://github.com/filecoin-project/specs/blob/master/data-structures.md#rle-bitset-encoding) encoding.

The encoding happens in [`rleplus.go`](https://github.com/filecoin-project/go-filecoin/blob/c526b748d24c062a9caa922b533db5512d76acbc/rleplus/rleplus.go) via the `Encode()` and `Decode()` functions, with an internal helper `BitVector` class.

Resolves #2868

## TODO
- [x] Determine where this package finally lives
- [x] Find out if the version string is real or not
- [x] Determine where byte-packing order (and network transmission) is part of this story