### PR TITLE
Miner worker calculates and pays late fees when submitting PoSt

### DIFF
--- a/actor/builtin/miner/miner_internal_test.go
+++ b/actor/builtin/miner/miner_internal_test.go
@@ -1,0 +1,48 @@
+package miner
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/go-filecoin/types"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+)
+
+func TestLatePoStFee(t *testing.T) {
+	tf.UnitTest(t)
+	pledgeCollateral := af(1000)
+
+	t.Run("on time charges no fee", func(t *testing.T) {
+		assert.True(t, types.ZeroAttoFIL.Equal(latePoStFee(pledgeCollateral, bh(1000), bh(999), bh(100))))
+		assert.True(t, types.ZeroAttoFIL.Equal(latePoStFee(pledgeCollateral, bh(1000), bh(1000), bh(100))))
+	})
+
+	t.Run("fee proportional to lateness", func(t *testing.T) {
+		// 1 block late is 1% of 100 allowable
+		assert.True(t, af(10).Equal(latePoStFee(pledgeCollateral, bh(1000), bh(1001), bh(100))))
+		// 5 blocks late of 100 allowable
+		assert.True(t, af(50).Equal(latePoStFee(pledgeCollateral, bh(1000), bh(1005), bh(100))))
+
+		// 2 blocks late of 10000 allowable, fee rounds down to zero
+		assert.True(t, af(0).Equal(latePoStFee(pledgeCollateral, bh(1000), bh(1002), bh(10000))))
+		// 9 blocks late of 10000 allowable, fee rounds down to zero
+		assert.True(t, af(0).Equal(latePoStFee(pledgeCollateral, bh(1000), bh(1009), bh(10000))))
+		// 10 blocks late of 10000 allowable is 1/1000
+		assert.True(t, af(1).Equal(latePoStFee(pledgeCollateral, bh(1000), bh(1010), bh(10000))))
+	})
+
+	t.Run("fee capped at total pledge", func(t *testing.T) {
+		assert.True(t, pledgeCollateral.Equal(latePoStFee(pledgeCollateral, bh(1000), bh(1100), bh(100))))
+		assert.True(t, pledgeCollateral.Equal(latePoStFee(pledgeCollateral, bh(1000), bh(2000), bh(100))))
+	})
+}
+
+func af(h int64) types.AttoFIL {
+	return types.NewAttoFIL(big.NewInt(h))
+}
+
+func bh(h uint64) *types.BlockHeight {
+	return types.NewBlockHeight(uint64(h))
+}

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -2,9 +2,10 @@ package miner_test
 
 import (
 	"context"
-	"github.com/filecoin-project/go-filecoin/exec"
 	"math/big"
 	"testing"
+
+	"github.com/filecoin-project/go-filecoin/exec"
 
 	"github.com/libp2p/go-libp2p-peer"
 	"github.com/stretchr/testify/assert"
@@ -62,8 +63,8 @@ func TestAskFunctions(t *testing.T) {
 	pdata = actor.MustConvertParams(big.NewInt(3453))
 	msg = types.NewMessage(address.TestAddress, minerAddr, 2, types.ZeroAttoFIL, "getAsk", pdata)
 	result, err = th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(2))
-	assert.Equal(t, Errors[ErrAskNotFound], result.ExecutionError)
 	assert.NoError(t, err)
+	assert.Equal(t, Errors[ErrAskNotFound], result.ExecutionError)
 
 	// make another ask!
 	pdata = actor.MustConvertParams(types.NewAttoFILFromFIL(110), big.NewInt(200))
@@ -287,7 +288,7 @@ func TestPeerIdGetterAndSetter(t *testing.T) {
 
 		// update peer ID
 		newPid := th.RequireRandomPeerID(t)
-		updatePeerIdSuccess(ctx, t, st, vms, address.TestAddress, minerAddr, newPid)
+		updatePeerIdSuccess(t, st, vms, address.TestAddress, minerAddr, newPid)
 
 		// retrieve peer ID
 		resultB := callQueryMethodSuccess("getPeerID", ctx, t, st, vms, address.TestAddress, minerAddr)
@@ -404,7 +405,7 @@ func TestMinerGetProvingPeriod(t *testing.T) {
 	})
 }
 
-func updatePeerIdSuccess(ctx context.Context, t *testing.T, st state.Tree, vms vm.StorageMap, fromAddr address.Address, minerAddr address.Address, newPid peer.ID) {
+func updatePeerIdSuccess(t *testing.T, st state.Tree, vms vm.StorageMap, fromAddr address.Address, minerAddr address.Address, newPid peer.ID) {
 	updatePeerIdMsg := types.NewMessage(
 		fromAddr,
 		minerAddr,
@@ -493,12 +494,6 @@ func TestMinerCommitSector(t *testing.T) {
 
 		// blockheight was 3
 		require.Equal(t, types.NewBlockHeight(3+provingPeriod), types.NewBlockHeightFromBytes(res.Receipt.Return[1]))
-
-		// check that the collateral requirement as expected
-		res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 3, "getPledgeCollateralRequirement", nil)
-		require.NoError(t, err)
-		require.NoError(t, res.ExecutionError)
-		require.Equal(t, MinimumCollateralPerSector.String(), types.NewAttoFILFromBytes(res.Receipt.Return[0]).String())
 
 		// fail because commR already exists
 		res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 4, "commitSector", nil, uint64(1), commD, commR, commRStar, th.MakeRandomBytes(types.TwoPoRepProofPartitions.ProofLen()))
@@ -922,14 +917,17 @@ func TestMinerSubmitPoSt(t *testing.T) {
 		assert.Error(t, res.ExecutionError)
 
 		// Accepted on the deadline with a fee
+		// Must calculate fee before submitting the PoSt, since submission will reset the proving period.
+		res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, lastPossibleSubmission, "calculateLateFee", ancestors, lastPossibleSubmission)
+		fee := types.NewAttoFILFromBytes(res.Receipt.Return[0])
+		require.False(t, fee.IsZero())
+
 		res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 1, lastPossibleSubmission, "submitPoSt", ancestors, []types.PoStProof{proof}, doneDefault)
 		assert.NoError(t, err)
 		assert.NoError(t, res.ExecutionError)
 		assert.Equal(t, uint8(0), res.Receipt.ExitCode)
 
 		// Check miner's balance unchanged (because it's topped up from message value then fee burnt).
-		postedCollateral := MinimumCollateralPerSector.Add(MinimumCollateralPerSector) // 2 sectors
-		fee := LatePoStFee(postedCollateral, bh(secondProvingPeriodStart+LargestSectorSizeProvingPeriodBlocks), bh(lastPossibleSubmission), bh(LargestSectorGenerationAttackThresholdBlocks))
 		miner := state.MustGetActor(st, minerAddr)
 		assert.Equal(t, minerBalance.String(), miner.Balance.String())
 
@@ -1093,34 +1091,6 @@ func TestGetProofsMode(t *testing.T) {
 	})
 }
 
-func TestLatePoStFee(t *testing.T) {
-	pledgeCollateral := af(1000)
-
-	t.Run("on time charges no fee", func(t *testing.T) {
-		assert.True(t, types.ZeroAttoFIL.Equal(LatePoStFee(pledgeCollateral, bh(1000), bh(999), bh(100))))
-		assert.True(t, types.ZeroAttoFIL.Equal(LatePoStFee(pledgeCollateral, bh(1000), bh(1000), bh(100))))
-	})
-
-	t.Run("fee proportional to lateness", func(t *testing.T) {
-		// 1 block late is 1% of 100 allowable
-		assert.True(t, af(10).Equal(LatePoStFee(pledgeCollateral, bh(1000), bh(1001), bh(100))))
-		// 5 blocks late of 100 allowable
-		assert.True(t, af(50).Equal(LatePoStFee(pledgeCollateral, bh(1000), bh(1005), bh(100))))
-
-		// 2 blocks late of 10000 allowable, fee rounds down to zero
-		assert.True(t, af(0).Equal(LatePoStFee(pledgeCollateral, bh(1000), bh(1002), bh(10000))))
-		// 9 blocks late of 10000 allowable, fee rounds down to zero
-		assert.True(t, af(0).Equal(LatePoStFee(pledgeCollateral, bh(1000), bh(1009), bh(10000))))
-		// 10 blocks late of 10000 allowable is 1/1000
-		assert.True(t, af(1).Equal(LatePoStFee(pledgeCollateral, bh(1000), bh(1010), bh(10000))))
-	})
-
-	t.Run("fee capped at total pledge", func(t *testing.T) {
-		assert.True(t, pledgeCollateral.Equal(LatePoStFee(pledgeCollateral, bh(1000), bh(1100), bh(100))))
-		assert.True(t, pledgeCollateral.Equal(LatePoStFee(pledgeCollateral, bh(1000), bh(2000), bh(100))))
-	})
-}
-
 func TestMinerGetPoStState(t *testing.T) {
 	tf.UnitTest(t)
 
@@ -1173,9 +1143,6 @@ func mustDeserializeAddress(t *testing.T, result [][]byte) address.Address {
 	return addr
 }
 
-func af(h int64) types.AttoFIL {
-	return types.NewAttoFIL(big.NewInt(h))
-}
 
 func bh(h uint64) *types.BlockHeight {
 	return types.NewBlockHeight(uint64(h))

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -494,6 +494,12 @@ func TestMinerCommitSector(t *testing.T) {
 		// blockheight was 3
 		require.Equal(t, types.NewBlockHeight(3+provingPeriod), types.NewBlockHeightFromBytes(res.Receipt.Return[1]))
 
+		// check that the collateral requirement as expected
+		res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 3, "getPledgeCollateralRequirement", nil)
+		require.NoError(t, err)
+		require.NoError(t, res.ExecutionError)
+		require.Equal(t, MinimumCollateralPerSector.String(), types.NewAttoFILFromBytes(res.Receipt.Return[0]).String())
+
 		// fail because commR already exists
 		res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 4, "commitSector", nil, uint64(1), commD, commR, commRStar, th.MakeRandomBytes(types.TwoPoRepProofPartitions.ProofLen()))
 		require.NoError(t, err)

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -153,8 +153,8 @@ func makeNodes(t *testing.T, numNodes int) (address.Address, []*Node) {
 		AutoSealIntervalSecondsOpt(1),
 	)
 	seed.GiveKey(t, minerNode, 0)
-	mineraddr, minerOwnerAddr := seed.GiveMiner(t, minerNode, 0)
-	_, err := storage.NewMiner(mineraddr, minerOwnerAddr, minerNode, minerNode.Repo.DealsDatastore(), minerNode.PorcelainAPI)
+	mineraddr, ownerAddr := seed.GiveMiner(t, minerNode, 0)
+	_, err := storage.NewMiner(mineraddr, ownerAddr, ownerAddr, minerNode, minerNode.Repo.DealsDatastore(), minerNode.PorcelainAPI)
 	assert.NoError(t, err)
 
 	nodes := []*Node{minerNode}

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -154,7 +154,7 @@ func makeNodes(t *testing.T, numNodes int) (address.Address, []*Node) {
 	)
 	seed.GiveKey(t, minerNode, 0)
 	mineraddr, ownerAddr := seed.GiveMiner(t, minerNode, 0)
-	_, err := storage.NewMiner(mineraddr, ownerAddr, ownerAddr, minerNode, minerNode.Repo.DealsDatastore(), minerNode.PorcelainAPI)
+	_, err := storage.NewMiner(mineraddr, ownerAddr, ownerAddr, &storage.FakeProver{}, types.OneKiBSectorSize, minerNode, minerNode.Repo.DealsDatastore(), minerNode.PorcelainAPI)
 	assert.NoError(t, err)
 
 	nodes := []*Node{minerNode}

--- a/node/node.go
+++ b/node/node.go
@@ -943,12 +943,13 @@ func initStorageMinerForNode(ctx context.Context, node *Node) (*storage.Miner, e
 		return nil, errors.Wrap(err, "failed to get node's mining address")
 	}
 
-	miningOwnerAddr, err := node.miningOwnerAddress(ctx, minerAddr)
+	ownerAddress, err := node.miningOwnerAddress(ctx, minerAddr)
 	if err != nil {
 		return nil, errors.Wrap(err, "no mining owner available, skipping storage miner setup")
 	}
+	workerAddress := ownerAddress
 
-	miner, err := storage.NewMiner(minerAddr, miningOwnerAddr, node, node.Repo.DealsDatastore(), node.PorcelainAPI)
+	miner, err := storage.NewMiner(minerAddr, ownerAddress, workerAddress, node, node.Repo.DealsDatastore(), node.PorcelainAPI)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to instantiate storage miner")
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -437,22 +437,6 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 	msgPublisher := newDefaultMessagePublisher(pubsub.NewPublisher(fsub), net.MessageTopic, msgPool)
 	outbox := core.NewOutbox(fcWallet, consensus.NewOutboundMessageValidator(), msgQueue, msgPublisher, outboxPolicy, chainStore, chainState)
 
-	PorcelainAPI := porcelain.New(plumbing.New(&plumbing.APIDeps{
-		Bitswap:      bswap,
-		Chain:        chainState,
-		Config:       cfg.NewConfig(nc.Repo),
-		DAG:          dag.NewDAG(merkledag.NewDAGService(bservice)),
-		Deals:        strgdls.New(nc.Repo.DealsDatastore()),
-		Expected:     nodeConsensus,
-		MsgPool:      msgPool,
-		MsgPreviewer: msg.NewPreviewer(chainStore, &cstOffline, bs),
-		MsgQueryer:   msg.NewQueryer(chainStore, &cstOffline, bs),
-		MsgWaiter:    msg.NewWaiter(chainStore, bs, &cstOffline),
-		Network:      net.New(peerHost, pubsub.NewPublisher(fsub), pubsub.NewSubscriber(fsub), net.NewRouter(router), bandwidthTracker, net.NewPinger(peerHost, pingService)),
-		Outbox:       outbox,
-		Wallet:       fcWallet,
-	}))
-
 	nd := &Node{
 		blockservice: bservice,
 		Blockstore:   bs,
@@ -461,7 +445,6 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 		ChainReader:  chainStore,
 		Syncer:       chainSyncer,
 		PowerTable:   powerTable,
-		PorcelainAPI: PorcelainAPI,
 		Fetcher:      fetcher,
 		Exchange:     bswap,
 		host:         peerHost,
@@ -473,6 +456,23 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 		Wallet:       fcWallet,
 		Router:       router,
 	}
+
+	nd.PorcelainAPI = porcelain.New(plumbing.New(&plumbing.APIDeps{
+		Bitswap:       bswap,
+		Chain:         chainState,
+		Config:        cfg.NewConfig(nc.Repo),
+		DAG:           dag.NewDAG(merkledag.NewDAGService(bservice)),
+		Deals:         strgdls.New(nc.Repo.DealsDatastore()),
+		Expected:      nodeConsensus,
+		MsgPool:       msgPool,
+		MsgPreviewer:  msg.NewPreviewer(chainStore, &cstOffline, bs),
+		MsgQueryer:    msg.NewQueryer(chainStore, &cstOffline, bs),
+		MsgWaiter:     msg.NewWaiter(chainStore, bs, &cstOffline),
+		Network:       net.New(peerHost, pubsub.NewPublisher(fsub), pubsub.NewSubscriber(fsub), net.NewRouter(router), bandwidthTracker, net.NewPinger(peerHost, pingService)),
+		Outbox:        outbox,
+		SectorBuilder: nd.SectorBuilder,
+		Wallet:        fcWallet,
+	}))
 
 	// Bootstrapping network peers.
 	periodStr := nd.Repo.Config().Bootstrap.Period
@@ -779,7 +779,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 		}
 	}
 
-	minerOwnerAddr, err := node.miningOwnerAddress(ctx, minerAddr)
+	minerOwnerAddr, err := node.PorcelainAPI.MinerGetOwnerAddress(ctx, minerAddr)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get mining owner address for miner %s", minerAddr)
 	}
@@ -943,13 +943,19 @@ func initStorageMinerForNode(ctx context.Context, node *Node) (*storage.Miner, e
 		return nil, errors.Wrap(err, "failed to get node's mining address")
 	}
 
-	ownerAddress, err := node.miningOwnerAddress(ctx, minerAddr)
+	ownerAddress, err := node.PorcelainAPI.MinerGetOwnerAddress(ctx, minerAddr)
 	if err != nil {
 		return nil, errors.Wrap(err, "no mining owner available, skipping storage miner setup")
 	}
 	workerAddress := ownerAddress
 
-	miner, err := storage.NewMiner(minerAddr, ownerAddress, workerAddress, node, node.Repo.DealsDatastore(), node.PorcelainAPI)
+	sectorSize, err := node.PorcelainAPI.MinerGetSectorSize(ctx, minerAddr)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch miner's sector size")
+	}
+
+	prover := storage.NewProver(minerAddr, workerAddress, sectorSize, node.PorcelainAPI, node.PorcelainAPI)
+	miner, err := storage.NewMiner(minerAddr, ownerAddress, workerAddress, prover, sectorSize, node, node.Repo.DealsDatastore(), node.PorcelainAPI)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to instantiate storage miner")
 	}
@@ -970,21 +976,6 @@ func (node *Node) StopMining(ctx context.Context) {
 	}
 
 	// TODO: stop node.StorageMiner
-}
-
-// NewAddress creates a new account address on the default wallet backend.
-func (node *Node) NewAddress() (address.Address, error) {
-	return wallet.NewAddress(node.Wallet)
-}
-
-// miningOwnerAddress returns the owner of miningAddr.
-// TODO: find a better home for this method
-func (node *Node) miningOwnerAddress(ctx context.Context, miningAddr address.Address) (address.Address, error) {
-	ownerAddr, err := node.PorcelainAPI.MinerGetOwnerAddress(ctx, miningAddr)
-	if err != nil {
-		return address.Undef, errors.Wrap(err, "failed to get miner owner address")
-	}
-	return ownerAddr, nil
 }
 
 func (node *Node) handleSubscription(ctx context.Context, f pubSubProcessorFunc, fname string, s pubsub.Subscription, sname string) {
@@ -1046,7 +1037,7 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (mining.Worker, error)
 		return nil, errors.Wrap(err, "could not get key from miner actor")
 	}
 
-	minerOwnerAddr, err := node.miningOwnerAddress(ctx, minerAddr)
+	minerOwnerAddr, err := node.PorcelainAPI.MinerGetOwnerAddress(ctx, minerAddr)
 	if err != nil {
 		log.Errorf("could not get owner address of miner actor")
 		return nil, err

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -138,8 +138,8 @@ func TestNodeStartMining(t *testing.T) {
 	minerNode := node.MakeNodeWithChainSeed(t, seed, []node.ConfigOpt{}, node.PeerKeyOpt(node.PeerKeys[0]), node.AutoSealIntervalSecondsOpt(1))
 
 	seed.GiveKey(t, minerNode, 0)
-	mineraddr, minerOwnerAddr := seed.GiveMiner(t, minerNode, 0)
-	_, err := storage.NewMiner(mineraddr, minerOwnerAddr, minerNode, minerNode.Repo.DealsDatastore(), nil)
+	mineraddr, ownerAddr := seed.GiveMiner(t, minerNode, 0)
+	_, err := storage.NewMiner(mineraddr, ownerAddr, ownerAddr, minerNode, minerNode.Repo.DealsDatastore(), nil)
 	assert.NoError(t, err)
 
 	assert.NoError(t, minerNode.Start(ctx))

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/proofs/verification"
 	"github.com/filecoin-project/go-filecoin/protocol/storage"
 	"github.com/filecoin-project/go-filecoin/repo"
+	"github.com/filecoin-project/go-filecoin/types"
 
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/libp2p/go-libp2p-peerstore"
@@ -139,7 +140,7 @@ func TestNodeStartMining(t *testing.T) {
 
 	seed.GiveKey(t, minerNode, 0)
 	mineraddr, ownerAddr := seed.GiveMiner(t, minerNode, 0)
-	_, err := storage.NewMiner(mineraddr, ownerAddr, ownerAddr, minerNode, minerNode.Repo.DealsDatastore(), nil)
+	_, err := storage.NewMiner(mineraddr, ownerAddr, ownerAddr, &storage.FakeProver{}, types.OneKiBSectorSize, minerNode, minerNode.Repo.DealsDatastore(), nil)
 	assert.NoError(t, err)
 
 	assert.NoError(t, minerNode.Start(ctx))

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/plumbing"
+	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/types"
 )
@@ -120,9 +121,9 @@ func (a *API) MinerGetSectorSize(ctx context.Context, minerAddr address.Address)
 	return MinerGetSectorSize(ctx, a, minerAddr)
 }
 
-// MinerGetPledgeCollateralRequirement queries for the required pledge collateral to be posted by a miner.
-func (a *API) MinerGetPledgeCollateralRequirement(ctx context.Context, minerAddr address.Address) (types.AttoFIL, error) {
-	return MinerGetPledgeCollateralRequirement(ctx, a, minerAddr)
+// MinerCalculateLateFee queries for the fee required for a PoSt submitted at some height.
+func (a *API) MinerCalculateLateFee(ctx context.Context, minerAddr address.Address, height *types.BlockHeight) (types.AttoFIL, error) {
+	return MinerCalculateLateFee(ctx, a, minerAddr, height)
 }
 
 // MinerGetLastCommittedSectorID queries for the sector size of the given miner.
@@ -197,6 +198,11 @@ func (a *API) PaymentChannelVoucher(
 // ClientListAsks returns a channel with asks from the latest chain state
 func (a *API) ClientListAsks(ctx context.Context) <-chan Ask {
 	return ClientListAsks(ctx, a)
+}
+
+// CalculatePoSt invokes the sector builder to calculate a proof-of-spacetime.
+func (a *API) CalculatePoSt(ctx context.Context, sortedCommRs proofs.SortedCommRs, seed types.PoStChallengeSeed) ([]types.PoStProof, []uint64, error) {
+	return CalculatePoSt(ctx, a, sortedCommRs, seed)
 }
 
 // PingMinerWithTimeout pings a storage or retrieval miner, waiting the given

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -120,6 +120,11 @@ func (a *API) MinerGetSectorSize(ctx context.Context, minerAddr address.Address)
 	return MinerGetSectorSize(ctx, a, minerAddr)
 }
 
+// MinerGetPledgeCollateralRequirement queries for the required pledge collateral to be posted by a miner.
+func (a *API) MinerGetPledgeCollateralRequirement(ctx context.Context, minerAddr address.Address) (types.AttoFIL, error) {
+	return MinerGetPledgeCollateralRequirement(ctx, a, minerAddr)
+}
+
 // MinerGetLastCommittedSectorID queries for the sector size of the given miner.
 func (a *API) MinerGetLastCommittedSectorID(ctx context.Context, minerAddr address.Address) (uint64, error) {
 	return MinerGetLastCommittedSectorID(ctx, a, minerAddr)

--- a/porcelain/miner.go
+++ b/porcelain/miner.go
@@ -318,9 +318,9 @@ func MinerGetSectorSize(ctx context.Context, plumbing minerQueryAndDeserialize, 
 	return sectorSize, nil
 }
 
-// MinerGetPledgeCollateralRequirement queries for the pledge collateral requirement for a miner.
-func MinerGetPledgeCollateralRequirement(ctx context.Context, plumbing minerQueryAndDeserialize, minerAddr address.Address) (types.AttoFIL, error) {
-	abiVal, err := queryAndDeserialize(ctx, plumbing, minerAddr, "getPledgeCollateralRequirement")
+// MinerCalculateLateFee calculates the fee due if a miner's PoSt were to be mined at `height`.
+func MinerCalculateLateFee(ctx context.Context, plumbing minerQueryAndDeserialize, minerAddr address.Address, height *types.BlockHeight) (types.AttoFIL, error) {
+	abiVal, err := queryAndDeserialize(ctx, plumbing, minerAddr, "calculateLateFee", height)
 	if err != nil {
 		return types.ZeroAttoFIL, errors.Wrap(err, "query and deserialize failed")
 	}

--- a/porcelain/miner.go
+++ b/porcelain/miner.go
@@ -318,6 +318,21 @@ func MinerGetSectorSize(ctx context.Context, plumbing minerQueryAndDeserialize, 
 	return sectorSize, nil
 }
 
+// MinerGetPledgeCollateralRequirement queries for the pledge collateral requirement for a miner.
+func MinerGetPledgeCollateralRequirement(ctx context.Context, plumbing minerQueryAndDeserialize, minerAddr address.Address) (types.AttoFIL, error) {
+	abiVal, err := queryAndDeserialize(ctx, plumbing, minerAddr, "getPledgeCollateralRequirement")
+	if err != nil {
+		return types.ZeroAttoFIL, errors.Wrap(err, "query and deserialize failed")
+	}
+
+	coll, ok := abiVal.Val.(types.AttoFIL)
+	if !ok {
+		return types.ZeroAttoFIL, errors.New("failed to convert returned ABI value")
+	}
+
+	return coll, nil
+}
+
 // MinerGetLastCommittedSectorID queries for the id of the last sector committed
 // by the given miner.
 func MinerGetLastCommittedSectorID(ctx context.Context, plumbing minerQueryAndDeserialize, minerAddr address.Address) (uint64, error) {

--- a/porcelain/sectorbuilder.go
+++ b/porcelain/sectorbuilder.go
@@ -1,0 +1,31 @@
+package porcelain
+
+import (
+	"context"
+	"errors"
+
+	"github.com/filecoin-project/go-filecoin/proofs"
+	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+type sbPlumbing interface {
+	SectorBuilder() sectorbuilder.SectorBuilder
+}
+
+// CalculatePoSt invokes the sector builder to calculate a proof-of-spacetime.
+func CalculatePoSt(ctx context.Context, plumbing sbPlumbing, sortedCommRs proofs.SortedCommRs, seed types.PoStChallengeSeed) ([]types.PoStProof, []uint64, error) {
+	req := sectorbuilder.GeneratePoStRequest{
+		SortedCommRs:  sortedCommRs,
+		ChallengeSeed: seed,
+	}
+	sb := plumbing.SectorBuilder()
+	if sb == nil {
+		return nil, nil, errors.New("no sector builder initialised")
+	}
+	res, err := sb.GeneratePoSt(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	return res.Proofs, res.Faults, nil
+}

--- a/protocol/block/mining_api_test.go
+++ b/protocol/block/mining_api_test.go
@@ -97,8 +97,8 @@ func newAPI(t *testing.T, assert *ast.Assertions) (bapi.MiningAPI, *node.Node) {
 	)
 	bt := nd.PorcelainAPI.BlockTime()
 	seed.GiveKey(t, nd, 0)
-	mAddr, moAddr := seed.GiveMiner(t, nd, 0)
-	_, err := storage.NewMiner(mAddr, moAddr, nd, nd.Repo.DealsDatastore(), nd.PorcelainAPI)
+	mAddr, ownerAddr := seed.GiveMiner(t, nd, 0)
+	_, err := storage.NewMiner(mAddr, ownerAddr, ownerAddr, nd, nd.Repo.DealsDatastore(), nd.PorcelainAPI)
 	assert.NoError(err)
 	return bapi.New(
 		nd.AddNewBlock,

--- a/protocol/block/mining_api_test.go
+++ b/protocol/block/mining_api_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	bapi "github.com/filecoin-project/go-filecoin/protocol/block"
 	"github.com/filecoin-project/go-filecoin/protocol/storage"
+	"github.com/filecoin-project/go-filecoin/types"
+
 	ast "github.com/stretchr/testify/assert"
 	req "github.com/stretchr/testify/require"
 	"testing"
@@ -98,7 +100,7 @@ func newAPI(t *testing.T, assert *ast.Assertions) (bapi.MiningAPI, *node.Node) {
 	bt := nd.PorcelainAPI.BlockTime()
 	seed.GiveKey(t, nd, 0)
 	mAddr, ownerAddr := seed.GiveMiner(t, nd, 0)
-	_, err := storage.NewMiner(mAddr, ownerAddr, ownerAddr, nd, nd.Repo.DealsDatastore(), nd.PorcelainAPI)
+	_, err := storage.NewMiner(mAddr, ownerAddr, ownerAddr, &storage.FakeProver{}, types.OneKiBSectorSize, nd, nd.Repo.DealsDatastore(), nd.PorcelainAPI)
 	assert.NoError(err)
 	return bapi.New(
 		nd.AddNewBlock,

--- a/protocol/storage/prover.go
+++ b/protocol/storage/prover.go
@@ -5,13 +5,21 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
-// This will likely depend on the sector size and proving period.
-const submitPostGasLimit = 300
+const (
+	// Maximum number of rounds delay to allow for when submitting a PoSt for computing any
+	// fee necessary due to late submission. The miner expects the PoSt message to be mined
+	// into a block at most `buffer` rounds in the future.
+	postSubmissionDelayBufferRounds = 10
+
+	// This will likely depend on the sector size and proving period.
+	submitPostGasLimit = 300
+)
 
 // ProofReader provides information about the blockchain to the proving process.
 type ProofReader interface {
@@ -19,6 +27,10 @@ type ProofReader interface {
 	ChainHeight() (*types.BlockHeight, error)
 	// ChallengeSeed returns the PoSt challenge seed for a proving period.
 	ChallengeSeed(ctx context.Context, periodStart *types.BlockHeight) (types.PoStChallengeSeed, error)
+	// PledgeCollateralRequirement returns the pledge collateral required to be posted by a miner.
+	PledgeCollateralRequirement(ctx context.Context, addr address.Address) (types.AttoFIL, error)
+	// WalletBalance returns the balance for an actor.
+	WalletBalance(ctx context.Context, addr address.Address) (types.AttoFIL, error)
 }
 
 // ProofCalculator creates the proof-of-spacetime bytes.
@@ -30,10 +42,11 @@ type ProofCalculator interface {
 
 // Prover orchestrates the calculation and submission of a proof-of-spacetime.
 type Prover struct {
-	actorAddress address.Address
-	ownerAddress address.Address
-	chain        ProofReader
-	calculator   ProofCalculator
+	actorAddress  address.Address
+	workerAddress address.Address
+	sectorSize    *types.BytesAmount
+	chain         ProofReader
+	calculator    ProofCalculator
 }
 
 // PoStInputs contains the sector id and related commitments used to generate a proof-of-spacetime.
@@ -52,19 +65,20 @@ type PoStSubmission struct {
 }
 
 // NewProver constructs a new Prover.
-func NewProver(actor address.Address, owner address.Address, reader ProofReader, caculator ProofCalculator) *Prover {
+func NewProver(actor address.Address, worker address.Address, sectorSize *types.BytesAmount, reader ProofReader, calculator ProofCalculator) *Prover {
 	return &Prover{
-		actorAddress: actor,
-		ownerAddress: owner,
-		chain:        reader,
-		calculator:   caculator,
+		actorAddress:  actor,
+		workerAddress: worker,
+		sectorSize:    sectorSize,
+		chain:         reader,
+		calculator:    calculator,
 	}
 }
 
 // CalculatePoSt computes and returns a proof-of-spacetime ready for posting on chain.
-func (sm *Prover) CalculatePoSt(ctx context.Context, start, end *types.BlockHeight, inputs []PoStInputs) (*PoStSubmission, error) {
+func (p *Prover) CalculatePoSt(ctx context.Context, start, end *types.BlockHeight, inputs []PoStInputs) (*PoStSubmission, error) {
 	// Gather PoSt request inputs.
-	seed, err := sm.chain.ChallengeSeed(ctx, start)
+	seed, err := p.chain.ChallengeSeed(ctx, start)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch PoSt challenge seed")
 	}
@@ -74,36 +88,64 @@ func (sm *Prover) CalculatePoSt(ctx context.Context, start, end *types.BlockHeig
 	for i, input := range inputs {
 		commRs[i] = input.CommR
 	}
-	proofs, faults, err := sm.calculator.CalculatePost(proofs.NewSortedCommRs(commRs...), seed)
+	proofs, faults, err := p.calculator.CalculatePost(proofs.NewSortedCommRs(commRs...), seed)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate PoSt")
+		return nil, errors.Wrap(err, "failed to calculate PoSt")
 	}
 
-	// Compute fees.
 	if len(faults) != 0 {
 		log.Warningf("some faults when generating PoSt: %v", faults)
 		// TODO: include faults in submission https://github.com/filecoin-project/go-filecoin/issues/2889
 	}
 
-	height, err := sm.chain.ChainHeight()
+	// Compute fees.
+	balance, err := p.chain.WalletBalance(ctx, p.workerAddress)
 	if err != nil {
-		// TODO: what should happen in this case?
-		return nil, errors.Errorf("failed to submit PoSt, as the current block height can not be determined: %s", err)
+		return nil, errors.Wrapf(err, "failed to check wallet balance for %s", p.workerAddress)
+	}
+
+	height, err := p.chain.ChainHeight()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to check chain height")
 	}
 	if height.LessThan(start) {
-		// TODO: what to do here? not sure this can happen, maybe through reordering?
-		return nil, errors.Errorf("PoSt generation time took negative block time: %s < %s", height, start)
-
+		return nil, errors.Errorf("chain height %s is before proving period start %s, abandoning proof", height, start)
 	}
 
-	if height.GreaterEqual(end) {
-		// TODO: pay late fees https://github.com/filecoin-project/go-filecoin/issues/2942
-		return nil, errors.Errorf("PoSt generation was too slow height=%s end=%s", height, end)
+	feeDue, err := p.calculateFee(ctx, height, end)
+	if err != nil {
+		return nil, err
+	}
+	if feeDue.GreaterThan(balance) {
+		log.Warningf("PoSt fee of %s exceeds available balance of %s for owner %s", feeDue, balance, p.workerAddress)
+		// Submit anyway, in case the balance is topped up before the PoSt message is mined.
 	}
 
 	return &PoStSubmission{
 		Proofs:   proofs,
-		Fee:      types.ZeroAttoFIL,
+		Fee:      feeDue,
 		GasLimit: types.NewGasUnits(submitPostGasLimit),
 	}, nil
+}
+
+func (p *Prover) calculateFee(ctx context.Context, height *types.BlockHeight, end *types.BlockHeight) (types.AttoFIL, error) {
+	gracePeriod := miner.GenerationAttackTime(p.sectorSize)
+	deadline := end.Add(gracePeriod)
+	if height.GreaterEqual(deadline) {
+		// The generation attack time has expired and the proof will be rejected.
+		// The earliest the proof could be mined is round (deadline+1).
+		// The miner can expect to be slashed of all its collateral and power.
+		return types.ZeroAttoFIL, errors.Errorf("PoSt generation was too slow height=%s end=%s deadline=%s", height, end, deadline)
+	}
+
+	collateral, err := p.chain.PledgeCollateralRequirement(ctx, p.actorAddress)
+	if err != nil {
+		return types.ZeroAttoFIL, errors.Errorf("Failed to check pledge collateral requirement for %s", p.actorAddress)
+	}
+
+	// Compute any fee due for lateness of the proof, leaving room for the proof to actually
+	// land on chain some number of rounds in the future.
+	expectedProofHeight := height.Add(types.NewBlockHeight(postSubmissionDelayBufferRounds))
+	feeDue := miner.LatePoStFee(collateral, end, expectedProofHeight, gracePeriod)
+	return feeDue, nil
 }

--- a/protocol/storage/prover_test.go
+++ b/protocol/storage/prover_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/protocol/storage"
@@ -20,76 +21,146 @@ func TestProver(t *testing.T) {
 	ctx := context.Background()
 	makeAddress := address.NewForTestGetter()
 	actorAddress := makeAddress()
-	ownerAddress := makeAddress()
+	workerAddress := makeAddress()
+	sectorSize := types.OneKiBSectorSize
 
 	var fakeSeed types.PoStChallengeSeed
 	fakeSeed[0] = 1
 	var fakeInputs []storage.PoStInputs
 	start := types.NewBlockHeight(100)
 	end := types.NewBlockHeight(200)
+	deadline := end.Add(miner.GenerationAttackTime(sectorSize))
+	collateralRequirement := types.NewAttoFILFromFIL(1)
 
-	t.Run("produces proof", func(t *testing.T) {
-		fake := &fakeProverDeps{
-			seed:   fakeSeed,
-			height: end.Sub(types.NewBlockHeight(1)),
-			proofs: []types.PoStProof{{1, 2, 3, 4}},
-			faults: []uint64{},
+	makeProofContext := func() *fakeProverContext {
+		return &fakeProverContext{
+			height:        end.Sub(types.NewBlockHeight(50)), // well inside the window
+			seed:          fakeSeed,
+			actorAddress:  actorAddress,
+			workerAddress: workerAddress,
+			collateral:    collateralRequirement,
+			balance:       collateralRequirement,
+			proofs:        []types.PoStProof{{1, 2, 3, 4}},
+			faults:        []uint64{},
 		}
-		prover := storage.NewProver(actorAddress, ownerAddress, fake, fake)
+	}
 
+	t.Run("produces on-time proof", func(t *testing.T) {
+		pc := makeProofContext()
+		prover := storage.NewProver(actorAddress, workerAddress, sectorSize, pc, pc)
 		submission, e := prover.CalculatePoSt(ctx, start, end, fakeInputs)
 		require.NoError(t, e)
-		assert.Equal(t, fake.proofs, submission.Proofs)
+		assert.Equal(t, pc.proofs, submission.Proofs)
+		assert.Equal(t, types.ZeroAttoFIL, submission.Fee)
+	})
+
+	t.Run("attaches a fee some buffer before lateness", func(t *testing.T) {
+		pc := makeProofContext()
+		pc.height = end.Sub(types.NewBlockHeight(5)) // a few rounds before on-time window ends
+		prover := storage.NewProver(actorAddress, workerAddress, sectorSize, pc, pc)
+		submission, e := prover.CalculatePoSt(ctx, start, end, fakeInputs)
+		require.NoError(t, e)
+		assert.Equal(t, pc.proofs, submission.Proofs)
+		// A fee is attached to allow for the proof being mined in the future, when it might be late.
+		assert.True(t, submission.Fee.GreaterThan(types.ZeroAttoFIL))
+	})
+
+	t.Run("attaches max fee at deadline", func(t *testing.T) {
+		pc := makeProofContext()
+		pc.height = deadline.Sub(types.NewBlockHeight(1)) // just before deadline
+		prover := storage.NewProver(actorAddress, workerAddress, sectorSize, pc, pc)
+		submission, e := prover.CalculatePoSt(ctx, start, end, fakeInputs)
+		require.NoError(t, e)
+		assert.Equal(t, pc.proofs, submission.Proofs)
+		assert.Equal(t, collateralRequirement, submission.Fee)
+	})
+
+	t.Run("attaches max fee at some buffer before deadline", func(t *testing.T) {
+		pc := makeProofContext()
+		pc.height = deadline.Sub(types.NewBlockHeight(5)) // well before deadline
+		prover := storage.NewProver(actorAddress, workerAddress, sectorSize, pc, pc)
+		submission, e := prover.CalculatePoSt(ctx, start, end, fakeInputs)
+		require.NoError(t, e)
+		assert.Equal(t, pc.proofs, submission.Proofs)
+		assert.Equal(t, collateralRequirement, submission.Fee)
+	})
+
+	t.Run("abandons proof after deadline", func(t *testing.T) {
+		pc := makeProofContext()
+		pc.height = deadline // proof could only appear in block deadline+1
+
+		prover := storage.NewProver(actorAddress, workerAddress, sectorSize, pc, pc)
+		_, e := prover.CalculatePoSt(ctx, start, end, fakeInputs)
+		require.Error(t, e)
+	})
+
+	t.Run("abandons proof when chain moves backwards", func(t *testing.T) {
+		pc := makeProofContext()
+		pc.height = start.Sub(types.NewBlockHeight(1))
+
+		prover := storage.NewProver(actorAddress, workerAddress, sectorSize, pc, pc)
+		_, e := prover.CalculatePoSt(ctx, start, end, fakeInputs)
+		require.Error(t, e)
 	})
 
 	t.Run("fails without chain height", func(t *testing.T) {
-		fake := &fakeProverDeps{
-			seed:   fakeSeed,
-			height: nil,
-			proofs: []types.PoStProof{{1, 2, 3, 4}},
-			faults: []uint64{},
-		}
-		prover := storage.NewProver(actorAddress, ownerAddress, fake, fake)
+		pc := makeProofContext()
+		pc.height = nil
 
+		prover := storage.NewProver(actorAddress, workerAddress, sectorSize, pc, pc)
 		_, e := prover.CalculatePoSt(ctx, start, end, fakeInputs)
 		require.Error(t, e)
 	})
 
 	t.Run("fails without challenge seed", func(t *testing.T) {
-		fake := &fakeProverDeps{
-			seed:   zeroSeed,
-			height: end.Sub(types.NewBlockHeight(1)),
-			proofs: []types.PoStProof{{1, 2, 3, 4}},
-			faults: []uint64{},
-		}
-		prover := storage.NewProver(actorAddress, ownerAddress, fake, fake)
+		pc := makeProofContext()
+		pc.seed = zeroSeed
 
+		prover := storage.NewProver(actorAddress, workerAddress, sectorSize, pc, pc)
 		_, e := prover.CalculatePoSt(ctx, start, end, fakeInputs)
 		require.Error(t, e)
 	})
 }
 
-type fakeProverDeps struct {
-	seed   types.PoStChallengeSeed
-	height *types.BlockHeight
-	proofs []types.PoStProof
-	faults []uint64
+type fakeProverContext struct {
+	height        *types.BlockHeight
+	seed          types.PoStChallengeSeed
+	actorAddress  address.Address
+	workerAddress address.Address
+	collateral    types.AttoFIL
+	balance       types.AttoFIL
+	proofs        []types.PoStProof
+	faults        []uint64
 }
 
-func (f *fakeProverDeps) ChainHeight() (*types.BlockHeight, error) {
+func (f *fakeProverContext) ChainHeight() (*types.BlockHeight, error) {
 	if f.height != nil {
 		return f.height, nil
 	}
 	return nil, errors.New("no height")
 }
 
-func (f *fakeProverDeps) ChallengeSeed(ctx context.Context, periodStart *types.BlockHeight) (types.PoStChallengeSeed, error) {
+func (f *fakeProverContext) ChallengeSeed(ctx context.Context, periodStart *types.BlockHeight) (types.PoStChallengeSeed, error) {
 	if f.seed != zeroSeed {
 		return f.seed, nil
 	}
 	return zeroSeed, errors.New("no seed")
 }
 
-func (f *fakeProverDeps) CalculatePost(sortedCommRs proofs.SortedCommRs, seed types.PoStChallengeSeed) ([]types.PoStProof, []uint64, error) {
+func (f *fakeProverContext) PledgeCollateralRequirement(ctx context.Context, addr address.Address) (types.AttoFIL, error) {
+	if addr == f.actorAddress && !f.collateral.IsZero() {
+		return f.collateral, nil
+	}
+	return types.ZeroAttoFIL, errors.New("no collateral for actor")
+}
+
+func (f *fakeProverContext) WalletBalance(ctx context.Context, addr address.Address) (types.AttoFIL, error) {
+	if addr == f.workerAddress && !f.balance.IsZero() {
+		return f.balance, nil
+	}
+	return types.ZeroAttoFIL, errors.New("no balance for worker")
+}
+
+func (f *fakeProverContext) CalculatePost(sortedCommRs proofs.SortedCommRs, seed types.PoStChallengeSeed) ([]types.PoStProof, []uint64, error) {
 	return f.proofs, f.faults, nil
 }

--- a/protocol/storage/testing.go
+++ b/protocol/storage/testing.go
@@ -1,0 +1,17 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// FakeProver provides fake PoSt proofs for a miner.
+type FakeProver struct{}
+
+// CalculatePoSt returns a fixed fake proof.
+func (p *FakeProver) CalculatePoSt(ctx context.Context, start, end *types.BlockHeight, inputs []PoStInputs) (*PoStSubmission, error) {
+	return &PoStSubmission{
+		Proofs: []types.PoStProof{[]byte("test proof")},
+	}, nil
+}


### PR DESCRIPTION
This change is in two commits. The first does the real work but introduced some messy dependency plumbing. The second re-arranges dependencies to avoid passing prover dependencies through the miner, but touches quite a few files on the way. The `CalculatePoSt` method is added to plumbing.

cc @acruikshank as this touches a few things you've edited recently.

Closes #2942