### PR TITLE
UpdateStorage accepts negative values

### DIFF
--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -568,7 +568,7 @@ func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR,
 		copy(comms.CommRStar[:], commRStar)
 		state.LastUsedSectorID = sectorID
 		state.SectorCommitments[sectorIDstr] = comms
-		_, ret, err := ctx.Send(address.StorageMarketAddress, "updatePower", types.ZeroAttoFIL, []interface{}{inc})
+		_, ret, err := ctx.Send(address.StorageMarketAddress, "updateStorage", types.ZeroAttoFIL, []interface{}{inc})
 		if err != nil {
 			return nil, err
 		}

--- a/actor/builtin/storagemarket/storagemarket.go
+++ b/actor/builtin/storagemarket/storagemarket.go
@@ -92,7 +92,7 @@ var storageMarketExports = exec.Exports{
 		Params: []abi.Type{abi.BytesAmount, abi.PeerID},
 		Return: []abi.Type{abi.Address},
 	},
-	"updatePower": &exec.FunctionSignature{
+	"updateStorage": &exec.FunctionSignature{
 		Params: []abi.Type{abi.BytesAmount},
 		Return: nil,
 	},
@@ -156,10 +156,10 @@ func (sma *Actor) CreateStorageMiner(vmctx exec.VMContext, sectorSize *types.Byt
 	return ret.(address.Address), 0, nil
 }
 
-// UpdatePower is called to reflect a change in the overall power of the network.
+// UpdateStorage is called to reflect a change in the overall power of the network.
 // This occurs either when a miner adds a new commitment, or when one is removed
-// (via slashing or willful removal). The delta is in number of sectors.
-func (sma *Actor) UpdatePower(vmctx exec.VMContext, delta *types.BytesAmount) (uint8, error) {
+// (via slashing, faults or willful removal). The delta is in number of bytes.
+func (sma *Actor) UpdateStorage(vmctx exec.VMContext, delta *types.BytesAmount) (uint8, error) {
 	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
 		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}

--- a/core/testing.go
+++ b/core/testing.go
@@ -2,38 +2,13 @@ package core
 
 import (
 	"context"
-	"testing"
 
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-hamt-ipld"
-	"github.com/ipfs/go-ipfs-blockstore"
-	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/abi"
-	"github.com/filecoin-project/go-filecoin/actor"
-	"github.com/filecoin-project/go-filecoin/actor/builtin"
-	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/consensus"
-	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
-	"github.com/filecoin-project/go-filecoin/vm"
 )
-
-// MustGetNonce returns the next nonce for an actor at an address or panics.
-func MustGetNonce(st state.Tree, a address.Address) uint64 {
-	ctx := context.Background()
-	actr, err := st.GetActor(ctx, a)
-	if err != nil {
-		panic(err)
-	}
-
-	nonce, err := actor.NextNonce(actr)
-	if err != nil {
-		panic(err)
-	}
-	return nonce
-}
 
 // MustAdd adds the given messages to the messagepool or panics if it cannot.
 func MustAdd(p *MessagePool, height uint64, msgs ...*types.SignedMessage) {
@@ -130,20 +105,4 @@ func MustDecodeCid(cidStr string) cid.Cid {
 	}
 
 	return decode
-}
-
-// CreateStorages creates an empty state tree and storage map.
-func CreateStorages(ctx context.Context, t *testing.T) (state.Tree, vm.StorageMap) {
-	cst := hamt.NewCborStore()
-	d := datastore.NewMapDatastore()
-	bs := blockstore.NewBlockstore(d)
-	blk, err := consensus.DefaultGenesis(cst, bs)
-	require.NoError(t, err)
-
-	st, err := state.LoadStateTree(ctx, cst, blk.StateRoot, builtin.Actors)
-	require.NoError(t, err)
-
-	vms := vm.NewStorageMap(bs)
-
-	return st, vms
 }

--- a/testhelpers/consensus.go
+++ b/testhelpers/consensus.go
@@ -185,13 +185,19 @@ func newMessageApplier(smsg *types.SignedMessage, processor *consensus.DefaultPr
 	return nil, err
 }
 
-// CreateAndApplyTestMessage wraps the given parameters in a message and calls ApplyTestMessage
-func CreateAndApplyTestMessage(t *testing.T, st state.Tree, vms vm.StorageMap, to address.Address, val, bh uint64, method string, ancestors []types.TipSet, params ...interface{}) (*consensus.ApplicationResult, error) {
+// CreateAndApplyTestMessageFrom wraps the given parameters in a message and calls ApplyTestMessage.
+func CreateAndApplyTestMessageFrom(t *testing.T, st state.Tree, vms vm.StorageMap, from address.Address, to address.Address, val, bh uint64, method string, ancestors []types.TipSet, params ...interface{}) (*consensus.ApplicationResult, error) {
 	t.Helper()
 
 	pdata := actor.MustConvertParams(params...)
-	msg := types.NewMessage(address.TestAddress, to, 0, types.NewAttoFILFromFIL(val), method, pdata)
+	msg := types.NewMessage(from, to, 0, types.NewAttoFILFromFIL(val), method, pdata)
 	return applyTestMessageWithAncestors(st, vms, msg, types.NewBlockHeight(bh), ancestors)
+}
+
+// CreateAndApplyTestMessage wraps the given parameters in a message and calls
+// CreateAndApplyTestMessageFrom sending the message from address.TestAddress
+func CreateAndApplyTestMessage(t *testing.T, st state.Tree, vms vm.StorageMap, to address.Address, val, bh uint64, method string, ancestors []types.TipSet, params ...interface{}) (*consensus.ApplicationResult, error) {
+	return CreateAndApplyTestMessageFrom(t, st, vms, address.TestAddress, to, val, bh, method, ancestors, params...)
 }
 
 func applyTestMessageWithAncestors(st state.Tree, store vm.StorageMap, msg *types.Message, bh *types.BlockHeight, ancestors []types.TipSet) (*consensus.ApplicationResult, error) {

--- a/types/bytes_amount_test.go
+++ b/types/bytes_amount_test.go
@@ -145,6 +145,15 @@ func TestBytesAmountSubtraction(t *testing.T) {
 
 }
 
+func TestBytesAmountNegative(t *testing.T) {
+	tf.UnitTest(t)
+
+	a, ok := NewBytesAmountFromString("-300", 10)
+	assert.True(t, ok)
+
+	assert.Equal(t, NewBytesAmount(100), a.Add(NewBytesAmount(400)))
+}
+
 func TestBytesAmountCborMarshaling(t *testing.T) {
 	tf.UnitTest(t)
 


### PR DESCRIPTION
This PR includes tests demonstrating that UpdateStorage already accepts negative values.

It also refactors state machine test helpers so that we can effectively test UpdateStorage which previously was not tested.

Feedback welcome if leveraging possibility of negative values in `BytesAmount` is too hacky and negative values should be more explicitly created in that type.