### PR TITLE
Add NextDoneSet and ProvingSet abstractions to miner actor

### DIFF
--- a/actor/builtin/miner/sector_set.go
+++ b/actor/builtin/miner/sector_set.go
@@ -1,0 +1,74 @@
+package miner
+
+import (
+	"strconv"
+
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/filecoin-project/go-filecoin/vm/errors"
+)
+
+// Note that this type's interface is a bit of a placeholder.  We expect to
+// move to something like actor.Lookup eventually which will manage its own
+// hash linked storage.  See #2887.  This will require some interface changes.
+
+// SectorSet is a collection of sector commitments indexed by their integer
+// sectorID.  Due to a bug in refmt, the sector id-keys need to be stringified.
+// See also: https://github.com/polydawn/refmt/issues/35.
+type SectorSet map[string]types.Commitments
+
+// NewSectorSet initializes a SectorSet with no entries.
+func NewSectorSet() SectorSet {
+	return make(map[string]types.Commitments)
+}
+
+// Has returns true if the SectorSet is already tracking id, else false.
+func (ss SectorSet) Has(id uint64) bool {
+	_, ok := ss[idStr(id)]
+	return ok
+}
+
+// Add updates the SectorSet to include the new commitment at the given id.
+func (ss SectorSet) Add(id uint64, comms types.Commitments) {
+	ss[idStr(id)] = comms
+}
+
+// Get returns the commitment at the given id and a bool indicating success.
+func (ss SectorSet) Get(id uint64) (types.Commitments, bool) {
+	comms, ok := ss[idStr(id)]
+	return comms, ok
+}
+
+// Drop removes all the provided sectorIDs from the collection, erroring if any
+// do not exist in the SectorSet.
+func (ss SectorSet) Drop(ids []uint64) error {
+	for _, id := range ids {
+		if _, ok := ss[idStr(id)]; !ok {
+			return Errors[ErrInvalidSector]
+		}
+		delete(ss, idStr(id))
+	}
+	return nil
+}
+
+// IDs returns all of the sectorIDs in the sectorset.  They are not sorted.
+func (ss SectorSet) IDs() ([]uint64, error) {
+	var ids []uint64
+	for idStr := range ss {
+		id, err := str2ID(idStr)
+		if err != nil {
+			return nil, errors.RevertErrorWrap(err, "corrupt sectorset id")
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// TODO: use uint64 as map keys instead of this abomination, once refmt is fixed.
+// https://github.com/polydawn/refmt/issues/35
+func idStr(sectorID uint64) string {
+	return strconv.FormatUint(sectorID, 10)
+}
+
+func str2ID(idStr string) (uint64, error) {
+	return strconv.ParseUint(idStr, 10, 64)
+}

--- a/actor/builtin/miner/sector_set_test.go
+++ b/actor/builtin/miner/sector_set_test.go
@@ -1,0 +1,100 @@
+package miner_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/filecoin-project/go-filecoin/actor/builtin/miner"
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+)
+
+func TestSectorSet(t *testing.T) {
+	tf.UnitTest(t)
+
+	t.Run("Add", func(t *testing.T) {
+		ss := NewSectorSet()
+		comm1 := th.MakeCommitments()
+		comm2 := th.MakeCommitments()
+		ss.Add(1, comm1)
+		ss.Add(3, comm2)
+		assert.Equal(t, 2, len(ss))
+		for k, v := range ss {
+			if k == "1" {
+				assert.Equal(t, comm1, v)
+			}
+			if k == "3" {
+				assert.Equal(t, comm2, v)
+			}
+		}
+	})
+
+	t.Run("Has", func(t *testing.T) {
+		ss := NewSectorSet()
+		comm1 := th.MakeCommitments()
+		ss.Add(1, comm1)
+		assert.True(t, ss.Has(1))
+		assert.False(t, ss.Has(2))
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		ss := NewSectorSet()
+		comm1 := th.MakeCommitments()
+		comm2 := th.MakeCommitments()
+		ss.Add(1, comm1)
+		ss.Add(3, comm2)
+		commRet, ok := ss.Get(1)
+		assert.True(t, ok)
+		assert.Equal(t, comm1, commRet)
+
+		_, ok = ss.Get(2)
+		assert.False(t, ok)
+	})
+
+	t.Run("Drop", func(t *testing.T) {
+		ss := NewSectorSet()
+		comm1 := th.MakeCommitments()
+		comm2 := th.MakeCommitments()
+		comm3 := th.MakeCommitments()
+		comm4 := th.MakeCommitments()
+		comm5 := th.MakeCommitments()
+
+		ss.Add(1, comm1)
+		ss.Add(2, comm2)
+		ss.Add(3, comm3)
+		ss.Add(5, comm4)
+		ss.Add(8, comm5)
+
+		assert.NoError(t, ss.Drop([]uint64{5, 1, 2}))
+		assert.True(t, ss.Has(3))
+		assert.True(t, ss.Has(8))
+		assert.False(t, ss.Has(1))
+		assert.False(t, ss.Has(2))
+		assert.False(t, ss.Has(5))
+	})
+
+	t.Run("IDs", func(t *testing.T) {
+		ss := NewSectorSet()
+		comm1 := th.MakeCommitments()
+		comm2 := th.MakeCommitments()
+		comm3 := th.MakeCommitments()
+		comm4 := th.MakeCommitments()
+		comm5 := th.MakeCommitments()
+
+		ss.Add(1, comm1)
+		ss.Add(2, comm2)
+		ss.Add(3, comm3)
+		ss.Add(5, comm4)
+		ss.Add(8, comm5)
+
+		ids, err := ss.IDs()
+		assert.NoError(t, err)
+		assert.Equal(t, 5, len(ids))
+		assert.Contains(t, ids, uint64(1))
+		assert.Contains(t, ids, uint64(2))
+		assert.Contains(t, ids, uint64(3))
+		assert.Contains(t, ids, uint64(5))
+		assert.Contains(t, ids, uint64(8))
+	})
+}

--- a/actor/builtin/miner_redeem_test.go
+++ b/actor/builtin/miner_redeem_test.go
@@ -174,6 +174,8 @@ func createStorageMinerWithCommitment(ctx context.Context, st state.Tree, vms vm
 	commitments[sectorIDstr] = types.Commitments{CommD: commD32, CommR: [32]byte{}, CommRStar: [32]byte{}}
 	minerState := &miner.State{
 		SectorCommitments: commitments,
+		NextDoneSet:       types.EmptyIntSet(),
+		ProvingSet:        types.EmptyIntSet(),
 		LastPoSt:          lastPoSt,
 	}
 	executableActor := miner.Actor{}

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -766,9 +766,12 @@ func (sm *Miner) submitPoSt(ctx context.Context, start, end *types.BlockHeight, 
 		log.Errorf("failed to calculate PoSt: %s", err)
 		return
 	}
+	// TODO #2998. The done set should be updated by CLI users.
+	// Using the 0 value is just a placeholder until that work lands.
+	done := types.EmptyIntSet()
 
 	gasPrice := types.NewGasPrice(submitPostGasPrice)
-	_, err = sm.porcelainAPI.MessageSend(ctx, sm.minerOwnerAddr, sm.minerAddr, submission.Fee, gasPrice, submission.GasLimit, "submitPoSt", submission.Proofs)
+	_, err = sm.porcelainAPI.MessageSend(ctx, sm.minerOwnerAddr, sm.minerAddr, submission.Fee, gasPrice, submission.GasLimit, "submitPoSt", submission.Proofs, done)
 	if err != nil {
 		log.Errorf("failed to submit PoSt: %s", err)
 		return

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -429,7 +429,7 @@ func TestOnNewHeaviestTipSet(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		// assert proof generated in sector builder is sent to submitPoSt
-		require.Equal(t, 1, len(postParams))
+		require.Equal(t, 2, len(postParams))
 		assert.Equal(t, []types.PoStProof{[]byte("test proof")}, postParams[0])
 	})
 

--- a/testhelpers/mining.go
+++ b/testhelpers/mining.go
@@ -32,6 +32,16 @@ func MakeCommitment() []byte {
 	return MakeRandomBytes(32)
 }
 
+// MakeCommitments creates three random commitments for constructing a
+// types.Commitments.
+func MakeCommitments() types.Commitments {
+	comms := types.Commitments{}
+	copy(comms.CommD[:], MakeCommitment()[:])
+	copy(comms.CommR[:], MakeCommitment()[:])
+	copy(comms.CommRStar[:], MakeCommitment()[:])
+	return comms
+}
+
 // MakeRandomBytes generates a randomized byte slice of size 'size'
 func MakeRandomBytes(size int) []byte {
 	comm := make([]byte, size)

--- a/types/intset_test.go
+++ b/types/intset_test.go
@@ -5,9 +5,10 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIntSet(t *testing.T) {


### PR DESCRIPTION
This PR adds the NextDoneSet and ProvingSet abstractions to the miner actor.  It is best read commit by commit.  The first commit introduces a done parameter into submitPoSt.  The second adds the NextDoneSet abstraction.  The third introduces a SectorSet abstraction to keep the next commit clean.  The fourth introduces the ProvingSet.

The edge case of the ProvingSet being updated during the first commitSector message is not handled in this PR.  I'm working on this in an upcoming followup.