### PR TITLE
Update power based on previous proving set

### DIFF
--- a/actor/builtin/miner/sector_set.go
+++ b/actor/builtin/miner/sector_set.go
@@ -63,6 +63,11 @@ func (ss SectorSet) IDs() ([]uint64, error) {
 	return ids, nil
 }
 
+// Size returns the number of sectorIDs in the SectorSet.
+func (ss SectorSet) Size() int {
+	return len(ss)
+}
+
 // TODO: use uint64 as map keys instead of this abomination, once refmt is fixed.
 // https://github.com/polydawn/refmt/issues/35
 func idStr(sectorID uint64) string {

--- a/chain/power_table_view_test.go
+++ b/chain/power_table_view_test.go
@@ -49,7 +49,7 @@ func TestMiner(t *testing.T) {
 
 	expected := types.NewBytesAmount(types.OneKiBSectorSize.Uint64() * numCommittedSectors)
 
-	assert.True(t, expected.Equal(actual))
+	assert.Equal(t, expected, actual)
 }
 
 func requireMinerWithNumCommittedSectors(ctx context.Context, t *testing.T, numCommittedSectors uint64) (bstore.Blockstore, address.Address, state.Tree) {

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -292,6 +292,19 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 				return nil, err
 			}
 		}
+		if m.NumCommittedSectors > 0 {
+			// Now submit a dummy PoSt right away to trigger power updates.
+			// Don't worry, bootstrap miner actors don't need to verify
+			// that the PoSt is well formed.
+			poStProof := make([]byte, types.OnePoStProofPartition.ProofLen())
+			if _, err := pnrg.Read(poStProof[:]); err != nil {
+				return nil, err
+			}
+			_, err = applyMessageDirect(ctx, st, sm, addr, maddr, types.NewAttoFILFromFIL(0), "submitPoSt", []types.PoStProof{poStProof}, types.EmptyIntSet())
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return minfos, nil

--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,7 @@ github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 h1:zwtduBRr5SSW
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4/go.mod h1:Izgrg8RkN3rCIMLGE9CyYmU9pY2Jer6DgANEnZ/L/cQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=

--- a/types/intset.go
+++ b/types/intset.go
@@ -96,6 +96,20 @@ func (is IntSet) String() string {
 	return fmt.Sprintf("%d", is.Values())
 }
 
+// Size returns the size of an IntSet.  It should be more efficient than
+// len(is.Values()).
+func (is IntSet) Size() int {
+	var size int
+	it := is.ba.Blocks()
+	// it.Next() must be called to point it at the first block
+	for it.Next() {
+		_, bitBlock := it.Value()
+		bm := bitarray.Bitmap64(bitBlock)
+		size += bm.PopCount()
+	}
+	return size
+}
+
 // EmptyIntSet returns an empty IntSet.
 func EmptyIntSet() IntSet {
 	return IntSet{ba: bitarray.NewSparseBitArray()}

--- a/types/intset_test.go
+++ b/types/intset_test.go
@@ -90,4 +90,22 @@ func TestIntSet(t *testing.T) {
 
 		assert.Equal(t, ints, result)
 	})
+
+	t.Run("Size", func(t *testing.T) {
+		intsA := make([]uint64, 33)
+		for idx := range intsA {
+			intsA[idx] = rand.Uint64()
+		}
+
+		assert.Equal(t, 33, types.NewIntSet(intsA...).Size())
+
+		intsB := make([]uint64, 1024)
+		for idx := range intsB {
+			intsB[idx] = rand.Uint64()
+		}
+
+		assert.Equal(t, 1024, types.NewIntSet(intsB...).Size())
+
+		assert.Equal(t, 0, types.EmptyIntSet().Size())
+	})
 }


### PR DESCRIPTION
## What's in this PR?
- move power and total storage updates to submitPoSt
- add power update tests
- proving set initialized to first sector on first PoSt submit
- address failures from out-dated power setting assumptions

## FYI
This is based against feat/2948 in PR at #2999 and you'll need to green light it again that one merges and I change the base to master.  Might be worth waiting for #2999 to merge until you review this.

Initializing the proving set to the first committed sector during commitSector is something some might consider in scope for #2999 but I added it here.