### PR TITLE
Reduce message validation failure after re-org to debug level

### DIFF
--- a/core/inbox.go
+++ b/core/inbox.go
@@ -72,7 +72,9 @@ func (ib *Inbox) HandleNewHead(ctx context.Context, oldHead, newHead types.TipSe
 			for _, msg := range block.Messages {
 				_, err = ib.pool.Add(ctx, msg, uint64(block.Height))
 				if err != nil {
-					log.Info(err)
+					// Messages from the removed chain are frequently invalidated, e.g. because that
+					// same message is already mined on the new chain.
+					log.Debug(err)
 				}
 			}
 		}

--- a/core/policy.go
+++ b/core/policy.go
@@ -15,7 +15,7 @@ import (
 // pools a little before the sending node gives up on them.
 const OutboxMaxAgeRounds = 10
 
-var log = logging.Logger("mqueue")
+var log = logging.Logger("core")
 
 // QueuePolicy manages a message queue state in response to changes on the blockchain.
 type QueuePolicy interface {


### PR DESCRIPTION
This quiets the "nonce too low" validation failure that is extremely common whenever the chain head switches and the same message/s were mined in both chains.

`08:40:52.287  INFO     mqueue: validation error adding message to pool: nonce too low inbox.go:75`

@ZenGround0 if we cherry-pick anything into 0.3, I propose including this too.