### PR TITLE
Fault Set Type [#2889]

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -65,6 +65,8 @@ const (
 	// MinerPoStStates is a *map[string]uint64, where string is address.Address.String()
 	// and uint8 is a miner PoStState
 	MinerPoStStates
+	// FaultSet is the faults generated during PoSt generation
+	FaultSet
 )
 
 func (t Type) String() string {
@@ -113,6 +115,8 @@ func (t Type) String() string {
 		return "types.IntSet"
 	case MinerPoStStates:
 		return "*map[string]uint64"
+	case FaultSet:
+		return "types.FaultSet"
 	default:
 		return "<unknown type>"
 	}
@@ -170,6 +174,8 @@ func (av *Value) String() string {
 		return av.Val.(types.IntSet).String()
 	case MinerPoStStates:
 		return fmt.Sprint(av.Val.(*map[address.Address]uint8))
+	case FaultSet:
+		return av.Val.(types.FaultSet).String()
 	default:
 		return "<unknown type>"
 	}
@@ -333,6 +339,12 @@ func (av *Value) Serialize() ([]byte, error) {
 			return nil, &typeError{&map[string]uint64{}, av.Val}
 		}
 		return cbor.DumpObject(addrs)
+	case FaultSet:
+		fs, ok := av.Val.(types.FaultSet)
+		if !ok {
+			return nil, &typeError{types.FaultSet{}, av.Val}
+		}
+		return cbor.DumpObject(fs)
 	default:
 		return nil, fmt.Errorf("unrecognized Type: %d", av.Type)
 	}
@@ -390,6 +402,8 @@ func ToValues(i []interface{}) ([]*Value, error) {
 			out = append(out, &Value{Type: IntSet, Val: v})
 		case *map[string]uint64:
 			out = append(out, &Value{Type: MinerPoStStates, Val: v})
+		case types.FaultSet:
+			out = append(out, &Value{Type: FaultSet, Val: v})
 		default:
 			return nil, fmt.Errorf("unsupported type: %T", v)
 		}
@@ -561,6 +575,15 @@ func Deserialize(data []byte, t Type) (*Value, error) {
 			Type: t,
 			Val:  lm,
 		}, nil
+	case FaultSet:
+		fs := types.NewFaultSet([]uint64{})
+		if err := cbor.DecodeInto(data, &fs); err != nil {
+			return nil, err
+		}
+		return &Value{
+			Type: t,
+			Val:  fs,
+		}, nil
 	case Invalid:
 		return nil, ErrInvalidType
 	default:
@@ -590,6 +613,7 @@ var typeTable = map[Type]reflect.Type{
 	Parameters:      reflect.TypeOf([]interface{}{}),
 	IntSet:          reflect.TypeOf(types.IntSet{}),
 	MinerPoStStates: reflect.TypeOf(&map[string]uint64{}),
+	FaultSet:        reflect.TypeOf(types.FaultSet{}),
 }
 
 // TypeMatches returns whether or not 'val' is the go type expected for the given ABI type

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -966,6 +966,10 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, poStProofs []types.PoStProof, fa
 			return nil, err
 		}
 
+		if err = state.SectorCommitments.Drop(faults.SectorIds.Values()); err != nil {
+			return nil, err
+		}
+
 		sectorIDsToProve, err := state.SectorCommitments.IDs()
 		if err != nil {
 			return nil, err

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -271,7 +271,7 @@ var minerExports = exec.Exports{
 		Return: []abi.Type{abi.BytesAmount},
 	},
 	"submitPoSt": &exec.FunctionSignature{
-		Params: []abi.Type{abi.PoStProofs, abi.IntSet},
+		Params: []abi.Type{abi.PoStProofs, abi.FaultSet, abi.IntSet},
 		Return: []abi.Type{},
 	},
 	"slashStorageFault": &exec.FunctionSignature{
@@ -854,7 +854,7 @@ func (ma *Actor) GetActiveCollateral(ctx exec.VMContext) (types.AttoFIL, uint8, 
 
 // SubmitPoSt is used to submit a coalesced PoST to the chain to convince the chain
 // that you have been actually storing the files you claim to be.
-func (ma *Actor) SubmitPoSt(ctx exec.VMContext, poStProofs []types.PoStProof, done types.IntSet) (uint8, error) {
+func (ma *Actor) SubmitPoSt(ctx exec.VMContext, poStProofs []types.PoStProof, faults types.FaultSet, done types.IntSet) (uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -929,7 +929,7 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, poStProofs []types.PoStProof, do
 			req := verification.VerifyPoStRequest{
 				ChallengeSeed: seed,
 				SortedCommRs:  sortedCommRs,
-				Faults:        []uint64{},
+				Faults:        faults.SectorIds.Values(),
 				Proofs:        poStProofs,
 				SectorSize:    state.SectorSize,
 			}
@@ -950,8 +950,7 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, poStProofs []types.PoStProof, do
 		// Update miner power to the amount of data actually proved
 		// during the last proving period.
 		oldPower := state.Power
-		// TODO subtract total faulted size from ProvingSet size #2889
-		newPower := types.NewBytesAmount(uint64(state.ProvingSet.Size())).Mul(state.SectorSize)
+		newPower := types.NewBytesAmount(uint64(state.ProvingSet.Size() - faults.SectorIds.Size())).Mul(state.SectorSize)
 		state.Power = newPower
 		delta := newPower.Sub(oldPower)
 		_, ret, err := ctx.Send(address.StorageMarketAddress, "updateStorage", types.ZeroAttoFIL, []interface{}{delta})

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -953,12 +953,15 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, poStProofs []types.PoStProof, fa
 		newPower := types.NewBytesAmount(uint64(state.ProvingSet.Size() - faults.SectorIds.Size())).Mul(state.SectorSize)
 		state.Power = newPower
 		delta := newPower.Sub(oldPower)
-		_, ret, err := ctx.Send(address.StorageMarketAddress, "updateStorage", types.ZeroAttoFIL, []interface{}{delta})
-		if err != nil {
-			return nil, err
-		}
-		if ret != 0 {
-			return nil, Errors[ErrStoragemarketCallFailed]
+
+		if !delta.IsZero() {
+			_, ret, err := ctx.Send(address.StorageMarketAddress, "updateStorage", types.ZeroAttoFIL, []interface{}{delta})
+			if err != nil {
+				return nil, err
+			}
+			if ret != 0 {
+				return nil, Errors[ErrStoragemarketCallFailed]
+			}
 		}
 
 		// Update SectorSet, DoneSet and ProvingSet

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -704,23 +704,22 @@ func TestMinerSubmitPoStPowerUpdates(t *testing.T) {
 
 	t.Run("faults removes power and sector commitments", func(t *testing.T) {
 		mal := setupMinerActorLiason(t)
-
-		// commit several sectors
-		mal.requireCommit(firstCommitBlockHeight, uint64(1))
-		mal.requireCommit(firstCommitBlockHeight, uint64(2))
-		mal.requireCommit(firstCommitBlockHeight, uint64(3))
-
 		done := types.EmptyIntSet()
 
-		// PoSt twice to get power for my sectors
-		mal.requirePoSt(firstCommitBlockHeight+1, done, faults)
-		mal.requirePoSt(firstCommitBlockHeight+1, done, faults)
-		power := mal.requirePower(firstCommitBlockHeight + 2)
+		// commit several sectors and PoSt
+		mal.requireCommit(firstCommitBlockHeight, uint64(1))
+		mal.requireCommit(firstCommitBlockHeight+1, uint64(2))
+		mal.requireCommit(firstCommitBlockHeight+2, uint64(3))
+		mal.requirePoSt(firstCommitBlockHeight+5, done, faults)
+
+		// Second proving period
+		mal.requirePoSt(secondProvingPeriodStart, done, faults)
+		power := mal.requirePower(secondProvingPeriodStart + 1)
 		assert.Equal(t, types.NewBytesAmount(3).Mul(types.OneKiBSectorSize), power)
 
 		// PoSt with some faults and check that power has decreased
-		mal.requirePoSt(firstCommitBlockHeight+3, done, types.NewFaultSet([]uint64{1, 2}))
-		power = mal.requirePower(firstCommitBlockHeight + 4)
+		mal.requirePoSt(thirdProvingPeriodStart, done, types.NewFaultSet([]uint64{1, 2}))
+		power = mal.requirePower(thirdProvingPeriodStart + 1)
 		assert.Equal(t, types.NewBytesAmount(1).Mul(types.OneKiBSectorSize), power)
 
 		// Ensure that sector commitments have been updated

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -702,7 +702,7 @@ func TestMinerSubmitPoStPowerUpdates(t *testing.T) {
 		assert.Equal(t, types.NewBytesAmount(2).Mul(types.OneKiBSectorSize), power)
 	})
 
-	t.Run("power removed with faults", func(t *testing.T) {
+	t.Run("faults removes power and sector commitments", func(t *testing.T) {
 		mal := setupMinerActorLiason(t)
 
 		// commit several sectors
@@ -722,6 +722,12 @@ func TestMinerSubmitPoStPowerUpdates(t *testing.T) {
 		mal.requirePoSt(firstCommitBlockHeight+3, done, types.NewFaultSet([]uint64{1, 2}))
 		power = mal.requirePower(firstCommitBlockHeight + 4)
 		assert.Equal(t, types.NewBytesAmount(1).Mul(types.OneKiBSectorSize), power)
+
+		// Ensure that sector commitments have been updated
+		state := mal.requireReadState()
+		assert.False(t, state.SectorCommitments.Has(uint64(1)))
+		assert.False(t, state.SectorCommitments.Has(uint64(2)))
+		assert.True(t, state.SectorCommitments.Has(uint64(3)))
 	})
 }
 

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -300,7 +300,7 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 			if _, err := pnrg.Read(poStProof[:]); err != nil {
 				return nil, err
 			}
-			_, err = applyMessageDirect(ctx, st, sm, addr, maddr, types.NewAttoFILFromFIL(0), "submitPoSt", []types.PoStProof{poStProof}, types.EmptyIntSet())
+			_, err = applyMessageDirect(ctx, st, sm, addr, maddr, types.NewAttoFILFromFIL(0), "submitPoSt", []types.PoStProof{poStProof}, types.EmptyFaultSet(), types.EmptyIntSet())
 			if err != nil {
 				return nil, err
 			}

--- a/go.sum
+++ b/go.sum
@@ -711,10 +711,12 @@ google.golang.org/genproto v0.0.0-20180831171423-11092d34479b h1:lohp5blsw53GBXt
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19 h1:Lj2SnHtxkRGJDqnGaSjo+CCdIieEnwVazbOXILwQemk=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
+google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb h1:i1Ppqkc3WQXikh8bXiwHqAN5Rv3/qDCcRk0/Otx73BY=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0 h1:cfg4PD8YEdSFnm7qLV4++93WcmhH2nIUhMjhdCvl3j8=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
+google.golang.org/grpc v1.20.1 h1:Hz2g2wirWK7H0qIIhGIqRGTuMwTE8HEKFnDZZ7lm9NU=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 gopkg.in/airbrake/gobrake.v2 v2.0.9 h1:7z2uVWwn7oVeeugY1DtlPAy5H+KYgB1KeKTnqjNatLo=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=

--- a/go.sum
+++ b/go.sum
@@ -711,12 +711,10 @@ google.golang.org/genproto v0.0.0-20180831171423-11092d34479b h1:lohp5blsw53GBXt
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19 h1:Lj2SnHtxkRGJDqnGaSjo+CCdIieEnwVazbOXILwQemk=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
-google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb h1:i1Ppqkc3WQXikh8bXiwHqAN5Rv3/qDCcRk0/Otx73BY=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0 h1:cfg4PD8YEdSFnm7qLV4++93WcmhH2nIUhMjhdCvl3j8=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
-google.golang.org/grpc v1.20.1 h1:Hz2g2wirWK7H0qIIhGIqRGTuMwTE8HEKFnDZZ7lm9NU=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 gopkg.in/airbrake/gobrake.v2 v2.0.9 h1:7z2uVWwn7oVeeugY1DtlPAy5H+KYgB1KeKTnqjNatLo=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -778,7 +778,7 @@ func (sm *Miner) submitPoSt(ctx context.Context, start, end *types.BlockHeight, 
 	done := types.EmptyIntSet()
 
 	gasPrice := types.NewGasPrice(submitPostGasPrice)
-	_, err = sm.porcelainAPI.MessageSend(ctx, sm.workerAddr, sm.minerAddr, submission.Fee, gasPrice, submission.GasLimit, "submitPoSt", submission.Proofs, done)
+	_, err = sm.porcelainAPI.MessageSend(ctx, sm.workerAddr, sm.minerAddr, submission.Fee, gasPrice, submission.GasLimit, "submitPoSt", submission.Proofs, submission.Faults, done)
 	if err != nil {
 		log.Errorf("failed to submit PoSt: %s", err)
 		return

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -451,7 +451,7 @@ func TestOnNewHeaviestTipSet(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		// assert proof generated in sector builder is sent to submitPoSt
-		require.Equal(t, 2, len(postParams))
+		require.Equal(t, 3, len(postParams))
 		assert.Equal(t, []types.PoStProof{[]byte("test proof")}, postParams[0])
 	})
 

--- a/protocol/storage/prover.go
+++ b/protocol/storage/prover.go
@@ -62,6 +62,7 @@ type PoStSubmission struct {
 	Proofs   []types.PoStProof
 	Fee      types.AttoFIL
 	GasLimit types.GasUnits
+	Faults   types.FaultSet
 }
 
 // NewProver constructs a new Prover.
@@ -95,7 +96,6 @@ func (p *Prover) CalculatePoSt(ctx context.Context, start, end *types.BlockHeigh
 
 	if len(faults) != 0 {
 		log.Warningf("some faults when generating PoSt: %v", faults)
-		// TODO: include faults in submission https://github.com/filecoin-project/go-filecoin/issues/2889
 	}
 
 	// Compute fees.
@@ -125,6 +125,7 @@ func (p *Prover) CalculatePoSt(ctx context.Context, start, end *types.BlockHeigh
 		Proofs:   proof,
 		Fee:      feeDue,
 		GasLimit: types.NewGasUnits(submitPostGasLimit),
+		Faults:   types.NewFaultSet(faults),
 	}, nil
 }
 

--- a/types/fault_set.go
+++ b/types/fault_set.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+
 	cbor "github.com/ipfs/go-ipld-cbor"
 )
 
@@ -8,13 +10,28 @@ func init() {
 	cbor.RegisterCborType(FaultSet{})
 }
 
-// FaultSet indicates sectors that have failed during a proving period
+// FaultSet indicates sectors that have failed PoSt during a proving period
 //
 // https://github.com/filecoin-project/specs/blob/master/data-structures.md#faultset
 type FaultSet struct {
-	// Offset is the offset from the start of the proving period
-	Offset uint64 `json:"offset"`
+	// Offset is the offset from the start of the proving period, currently unused
+	Offset uint64 `json:"offset,omitempty" refmt:"idx"`
 
 	// SectorIds are the faulted sectors
-	SectorIds IntSet `json:"sectorIds"`
+	SectorIds IntSet `json:"sectorIds" refmt:"ids"`
+}
+
+// NewFaultSet constructs a FaultSet from a slice of sector ids that have faulted
+func NewFaultSet(sectorIds []uint64) FaultSet {
+	return FaultSet{SectorIds: NewIntSet(sectorIds...)}
+}
+
+// EmptyFaultSet constructs an empty FaultSet as a convenience
+func EmptyFaultSet() FaultSet {
+	return FaultSet{SectorIds: EmptyIntSet()}
+}
+
+// String returns a printable representation of the FaultSet
+func (fs FaultSet) String() string {
+	return fmt.Sprintf("%d / %s", fs.Offset, fs.SectorIds.String())
 }

--- a/types/fault_set.go
+++ b/types/fault_set.go
@@ -1,0 +1,20 @@
+package types
+
+import (
+	cbor "github.com/ipfs/go-ipld-cbor"
+)
+
+func init() {
+	cbor.RegisterCborType(FaultSet{})
+}
+
+// FaultSet indicates sectors that have failed during a proving period
+//
+// https://github.com/filecoin-project/specs/blob/master/data-structures.md#faultset
+type FaultSet struct {
+	// Offset is the offset from the start of the proving period
+	Offset uint64 `json:"offset"`
+
+	// SectorIds are the faulted sectors
+	SectorIds IntSet `json:"sectorIds"`
+}

--- a/types/fault_set_test.go
+++ b/types/fault_set_test.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	"testing"
+
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	cbor "github.com/ipfs/go-ipld-cbor"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFaultSetCborMarshaling(t *testing.T) {
+	tf.UnitTest(t)
+
+	t.Run("encode/decode symmetry", func(t *testing.T) {
+		faultSet := NewFaultSet([]uint64{4096, 1, 2, 3, 8192})
+		decoded := NewFaultSet([]uint64{})
+
+		out, err := cbor.DumpObject(faultSet)
+		assert.NoError(t, err)
+
+		err = cbor.DecodeInto(out, &decoded)
+		assert.NoError(t, err)
+
+		assert.Equal(t, faultSet.SectorIds.Values(), decoded.SectorIds.Values())
+	})
+}

--- a/types/intset.go
+++ b/types/intset.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"github.com/Workiva/go-datastructures/bitarray"
+	"github.com/filecoin-project/go-filecoin/rleplus"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/polydawn/refmt/obj/atlas"
 )
@@ -14,16 +15,13 @@ func init() {
 var intSetAtlasEntry = atlas.BuildEntry(IntSet{}).Transform().
 	TransformMarshal(atlas.MakeMarshalTransformFunc(
 		func(is IntSet) ([]byte, error) {
-			// TODO #2889: we should be using RLE+ to serialize intsets when it lands,
-			// not the CBOR serialization of the slice of integers in the set.
-			return cbor.DumpObject(is.Values())
+			bytes, _, err := rleplus.Encode(is.Values())
+			return bytes, err
 		})).
 	TransformUnmarshal(atlas.MakeUnmarshalTransformFunc(
 		func(x []byte) (IntSet, error) {
-			// TODO #2889: we must decode from RLE+ instead of the
-			// serialization of the slice of integers in the set.
-			var ints []uint64
-			if err := cbor.DecodeInto(x, &ints); err != nil {
+			ints, err := rleplus.Decode(x)
+			if err != nil {
 				return EmptyIntSet(), err
 			}
 			return NewIntSet(ints...), nil


### PR DESCRIPTION
## Summary
Add a `FaultSet` type and ABI type registration.  Add a fault set as a parameter to the `SubmitPoSt` method.  Use RLE+ serialization for IntSets.

## TODO
- [x] Verify if [power adjustment](https://github.com/filecoin-project/go-filecoin/blob/14945fe813ba8f74083b295c6f1da07c3594af21/actor/builtin/miner/miner.go#L848) from faults should be done in this PR @ZenGround0 
- [x] If ^^ is true, test power adjustment with faults
- [x] Verify with @laser that rust-fil-proofs can return and take sector ids during PoSt processing.  It may be dealing with indices into the SortedCommR slice.

Resolves #2889 