### PR TITLE
Poll daemon to determine if it's ready

### DIFF
--- a/bin/node_restart
+++ b/bin/node_restart
@@ -3,10 +3,17 @@ set -e
 filecoin_repo="/var/local/filecoin/repo"
 filecoin_exec="go-filecoin --repodir=${filecoin_repo}"
 
-
+# Number of time to check before giving up
+limit=3600
+count=0
 while ! ${filecoin_exec} id >&2 2> /dev/null
 do
   echo "Waiting for daemon to start..." && sleep 1
+  ((i++))
+  if (( $count > $limit )); then
+    echo "API did not come online in $limit seconds"
+    exit 1
+  fi
 done
 
 for node_addr in $(cat /var/filecoin/car/peers.txt)

--- a/bin/node_restart
+++ b/bin/node_restart
@@ -9,7 +9,7 @@ count=0
 while ! ${filecoin_exec} id >&2 2> /dev/null
 do
   echo "Waiting for daemon to start..." && sleep 1
-  ((i++))
+  ((count++))
   if (( $count > $limit )); then
     echo "API did not come online in $limit seconds"
     exit 1

--- a/bin/node_restart
+++ b/bin/node_restart
@@ -4,7 +4,7 @@ filecoin_repo="/var/local/filecoin/repo"
 filecoin_exec="go-filecoin --repodir=${filecoin_repo}"
 
 
-while [ ! -f "${filecoin_repo}/api" ]
+while ! ${filecoin_exec} id >&2 2> /dev/null
 do
   echo "Waiting for daemon to start..." && sleep 1
 done


### PR DESCRIPTION
When a node dies from OOM, the API file will not be cleaned up properly. This resulted in the api file check to pass with a false positive.