### PR TITLE
add GetPoStState for lateness determination

### DIFF
--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -477,23 +477,21 @@ func (ma *Actor) IsBootstrapMiner(ctx exec.VMContext) (bool, uint8, error) {
 	return ma.Bootstrap, 0, nil
 }
 
-// GetPoStState returns whether the miner's last submitPoSt within the proving period,
+// GetPoStState returns whether the miner's last submitPoSt is within the proving period,
 // late or after the generation attack threshold.
 func (ma *Actor) GetPoStState(ctx exec.VMContext) (*big.Int, uint8, error) {
-
 	var state State
-	bh := ctx.BlockHeight()
 	out, err := actor.WithState(ctx, &state, func() (interface{}, error) {
-		generationAttackGracePeriod := GenerationAttackTime(state.SectorSize)
 		// Don't check lateness unless there is storage to prove
-		if len(state.ProvingSet.Values()) == 0 {
+		if state.ProvingSet.Size() == 0 {
 			return int64(PoStStateNoStorage), nil
 		}
-		lateState, _ := lateState(state.ProvingPeriodEnd, bh, generationAttackGracePeriod)
+		lateState, _ := lateState(state.ProvingPeriodEnd, ctx.BlockHeight(), GenerationAttackTime(state.SectorSize))
 		return lateState, nil
 	})
 
 	if err != nil {
+		return nil, errors.CodeError(err), err
 		return nil, errors.CodeError(err), err
 	}
 

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -1120,6 +1120,9 @@ func TestMinerGetPoStState(t *testing.T) {
 
 	firstCommitBlockHeight := uint64(3)
 
+	lastHeightOfFirstPeriod := firstCommitBlockHeight + LargestSectorSizeProvingPeriodBlocks
+	lastHeightOfSecondPeriod := lastHeightOfFirstPeriod + LargestSectorGenerationAttackThresholdBlocks
+
 	t.Run("is reported as not late within the proving period", func(t *testing.T) {
 		mal := setupMinerActorLiason(t)
 		mal.requireCommit(firstCommitBlockHeight, uint64(1))
@@ -1130,7 +1133,6 @@ func TestMinerGetPoStState(t *testing.T) {
 		done := types.EmptyIntSet()
 		mal.requirePoSt(firstCommitBlockHeight+5, done)
 		mal.assertPoStStateAtHeight(PoStStateWithinProvingPeriod, firstCommitBlockHeight)
-		mal.assertPoStStateAtHeight(PoStStateWithinProvingPeriod, firstCommitBlockHeight+1)
 		mal.assertPoStStateAtHeight(PoStStateWithinProvingPeriod, firstCommitBlockHeight+6)
 	})
 
@@ -1138,23 +1140,21 @@ func TestMinerGetPoStState(t *testing.T) {
 		mal := setupMinerActorLiason(t)
 		mal.requireCommit(firstCommitBlockHeight, uint64(1))
 
-		mal.assertPoStStateAtHeight(PoStStateAfterProvingPeriod, firstCommitBlockHeight+LargestSectorSizeProvingPeriodBlocks+1)
+		mal.assertPoStStateAtHeight(PoStStateAfterProvingPeriod, lastHeightOfFirstPeriod+1)
 	})
 	t.Run("is reported as PoStStateAfterGenerationAttackThreshold after the proving period", func(t *testing.T) {
 		mal := setupMinerActorLiason(t)
 		mal.requireCommit(firstCommitBlockHeight, uint64(1))
 
-		mal.assertPoStStateAtHeight(PoStStateAfterGenerationAttackThreshold, firstCommitBlockHeight+LargestSectorSizeProvingPeriodBlocks+LargestSectorGenerationAttackThresholdBlocks+1)
+		mal.assertPoStStateAtHeight(PoStStateAfterGenerationAttackThreshold, lastHeightOfSecondPeriod)
 	})
 
 	t.Run("is reported as PoStStateNoStorage when actor has empty proving set", func(t *testing.T) {
 		mal := setupMinerActorLiason(t)
 		mal.assertPoStStateAtHeight(PoStStateNoStorage, firstCommitBlockHeight)
-		mal.assertPoStStateAtHeight(PoStStateNoStorage, firstCommitBlockHeight+LargestSectorSizeProvingPeriodBlocks+1)
-		mal.assertPoStStateAtHeight(PoStStateNoStorage, firstCommitBlockHeight+LargestSectorSizeProvingPeriodBlocks+LargestSectorGenerationAttackThresholdBlocks+1)
-
+		mal.assertPoStStateAtHeight(PoStStateNoStorage, lastHeightOfFirstPeriod+1)
+		mal.assertPoStStateAtHeight(PoStStateNoStorage, lastHeightOfSecondPeriod+1)
 	})
-
 }
 
 func mustDeserializeAddress(t *testing.T, result [][]byte) address.Address {

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -1115,12 +1115,10 @@ func TestLatePoStFee(t *testing.T) {
 	})
 }
 
-func TestActor_GetPoStState(t *testing.T) {
+func TestMinerGetPoStState(t *testing.T) {
 	tf.UnitTest(t)
 
 	firstCommitBlockHeight := uint64(3)
-	//secondProvingPeriodStart := LargestSectorSizeProvingPeriodBlocks + firstCommitBlockHeight
-	//thirdProvingPeriodStart := 2*LargestSectorSizeProvingPeriodBlocks + firstCommitBlockHeight
 
 	t.Run("is reported as not late within the proving period", func(t *testing.T) {
 		mal := setupMinerActorLiason(t)
@@ -1131,22 +1129,30 @@ func TestActor_GetPoStState(t *testing.T) {
 		// submit PoSt to update proving set with no done sectors
 		done := types.EmptyIntSet()
 		mal.requirePoSt(firstCommitBlockHeight+5, done)
-		mal.assertPoStStateAtHeight(WithinProvingPeriod, firstCommitBlockHeight)
-		mal.assertPoStStateAtHeight(WithinProvingPeriod, firstCommitBlockHeight+1)
-		mal.assertPoStStateAtHeight(WithinProvingPeriod, firstCommitBlockHeight+6)
+		mal.assertPoStStateAtHeight(PoStStateWithinProvingPeriod, firstCommitBlockHeight)
+		mal.assertPoStStateAtHeight(PoStStateWithinProvingPeriod, firstCommitBlockHeight+1)
+		mal.assertPoStStateAtHeight(PoStStateWithinProvingPeriod, firstCommitBlockHeight+6)
 	})
 
-	t.Run("is reported as AfterProvingPeriod after the proving period", func(t *testing.T) {
+	t.Run("is reported as PoStStateAfterProvingPeriod after the proving period", func(t *testing.T) {
 		mal := setupMinerActorLiason(t)
 		mal.requireCommit(firstCommitBlockHeight, uint64(1))
 
-		mal.assertPoStStateAtHeight(AfterProvingPeriod, firstCommitBlockHeight+LargestSectorSizeProvingPeriodBlocks+1)
+		mal.assertPoStStateAtHeight(PoStStateAfterProvingPeriod, firstCommitBlockHeight+LargestSectorSizeProvingPeriodBlocks+1)
 	})
-	t.Run("is reported as AfterGenerationAttackThreshold after the proving period", func(t *testing.T) {
+	t.Run("is reported as PoStStateAfterGenerationAttackThreshold after the proving period", func(t *testing.T) {
 		mal := setupMinerActorLiason(t)
 		mal.requireCommit(firstCommitBlockHeight, uint64(1))
 
-		mal.assertPoStStateAtHeight(AfterGenerationAttackThreshold, firstCommitBlockHeight+LargestSectorSizeProvingPeriodBlocks+LargestSectorGenerationAttackThresholdBlocks+1)
+		mal.assertPoStStateAtHeight(PoStStateAfterGenerationAttackThreshold, firstCommitBlockHeight+LargestSectorSizeProvingPeriodBlocks+LargestSectorGenerationAttackThresholdBlocks+1)
+	})
+
+	t.Run("is reported as PoStStateNoStorage when actor has empty proving set", func(t *testing.T) {
+		mal := setupMinerActorLiason(t)
+		mal.assertPoStStateAtHeight(PoStStateNoStorage, firstCommitBlockHeight)
+		mal.assertPoStStateAtHeight(PoStStateNoStorage, firstCommitBlockHeight+LargestSectorSizeProvingPeriodBlocks+1)
+		mal.assertPoStStateAtHeight(PoStStateNoStorage, firstCommitBlockHeight+LargestSectorSizeProvingPeriodBlocks+LargestSectorGenerationAttackThresholdBlocks+1)
+
 	})
 
 }


### PR DESCRIPTION
Support for #2939 
Storage fault monitor will ask a minor actor for its lateness status ("PoStState") so as to determine whether there is a fault and what type.  This leaves all the logic for determining lateness in one place -- since this is already calculated during an actual PoSt submission -- and will reduce the number of message queries to actors in order to tally unreported faults.

This PR implements the GetPoStState export in the miner actor.  Better name suggestions welcome.