### PR TITLE
add Fetcher interface, impl with BitswapFetcher

### DIFF
--- a/net/fetcher.go
+++ b/net/fetcher.go
@@ -13,28 +13,60 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
-// Fetcher is used to fetch data over the network.  It is implemented with
+// Fetcher defines an interface that may be used to fetch data from the network.
+type Fetcher interface {
+	FetchTipSets(ctx context.Context, tsKey types.TipSetKey, recur int) ([]types.TipSet, error)
+}
+
+// BitswapFetcher is used to fetch data over the network.  It is implemented with
 // a persistent bitswap session on a networked blockservice.
-type Fetcher struct {
+type BitswapFetcher struct {
 	// session is a bitswap session that enables efficient transfer.
 	session   *bserv.Session
 	validator consensus.BlockSyntaxValidator
 }
 
-// NewFetcher returns a Fetcher wired up to the input BlockService and a newly
+// NewBitswapFetcher returns a BitswapFetcher wired up to the input BlockService and a newly
 // initialized persistent session of the block service.
-func NewFetcher(ctx context.Context, bsrv bserv.BlockService, bv consensus.BlockSyntaxValidator) *Fetcher {
-	return &Fetcher{
+func NewBitswapFetcher(ctx context.Context, bsrv bserv.BlockService, bv consensus.BlockSyntaxValidator) *BitswapFetcher {
+	return &BitswapFetcher{
 		session:   bserv.NewSession(ctx, bsrv),
 		validator: bv,
 	}
 }
 
+// FetchTipSets fetchs the tipset at `tsKey` from the network using the fetchers bitswap session.
+// FetchTipSets will fetch `recur` partens of `tsKey`. FetchTipSets does not return partial results.
+func (bsf *BitswapFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetKey, recur int) ([]types.TipSet, error) {
+	var out []types.TipSet
+	cur := tsKey
+	for i := 0; i < recur; i++ {
+		res, err := bsf.GetBlocks(ctx, cur.ToSlice())
+		if err != nil {
+			return nil, err
+		}
+
+		ts, err := types.NewTipSet(res...)
+		if err != nil {
+			return nil, err
+		}
+
+		cur, err = ts.Parents()
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, ts)
+	}
+
+	return out, nil
+}
+
 // GetBlocks fetches the blocks with the given cids from the network using the
-// Fetcher's bitswap session.
-func (f *Fetcher) GetBlocks(ctx context.Context, cids []cid.Cid) ([]*types.Block, error) {
+// BitswapFetcher's bitswap session.
+func (bsf *BitswapFetcher) GetBlocks(ctx context.Context, cids []cid.Cid) ([]*types.Block, error) {
 	var unsanitized []blocks.Block
-	for b := range f.session.GetBlocks(ctx, cids) {
+	for b := range bsf.session.GetBlocks(ctx, cids) {
 		unsanitized = append(unsanitized, b)
 	}
 
@@ -56,7 +88,7 @@ func (f *Fetcher) GetBlocks(ctx context.Context, cids []cid.Cid) ([]*types.Block
 		}
 
 		// reject blocks that are syntactically invalid.
-		if err := f.validator.ValidateSyntax(ctx, block); err != nil {
+		if err := bsf.validator.ValidateSyntax(ctx, block); err != nil {
 			continue
 		}
 

--- a/net/fetcher_test.go
+++ b/net/fetcher_test.go
@@ -28,7 +28,7 @@ func TestFetchHappyPath(t *testing.T) {
 	tf.UnitTest(t)
 
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
-	fetcher := net.NewFetcher(context.Background(), bserv.New(bs, offline.Exchange(bs)), th.NewFakeBlockValidator())
+	fetcher := net.NewBitswapFetcher(context.Background(), bserv.New(bs, offline.Exchange(bs)), th.NewFakeBlockValidator())
 	block1 := types.NewBlockForTest(nil, uint64(0))
 	block2 := types.NewBlockForTest(nil, uint64(1))
 	block3 := types.NewBlockForTest(nil, uint64(3))
@@ -54,7 +54,7 @@ func TestFetchNoBlockFails(t *testing.T) {
 	tf.UnitTest(t)
 
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
-	fetcher := net.NewFetcher(context.Background(), bserv.New(bs, offline.Exchange(bs)), th.NewFakeBlockValidator())
+	fetcher := net.NewBitswapFetcher(context.Background(), bserv.New(bs, offline.Exchange(bs)), th.NewFakeBlockValidator())
 	block1 := types.NewBlockForTest(nil, uint64(0))
 	block2 := types.NewBlockForTest(nil, uint64(1))
 
@@ -71,7 +71,7 @@ func TestFetchNotBlockFormat(t *testing.T) {
 	tf.UnitTest(t)
 
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
-	fetcher := net.NewFetcher(context.Background(), bserv.New(bs, offline.Exchange(bs)), th.NewFakeBlockValidator())
+	fetcher := net.NewBitswapFetcher(context.Background(), bserv.New(bs, offline.Exchange(bs)), th.NewFakeBlockValidator())
 	notABlock := types.NewMsgs(1)[0]
 	notABlockObj, err := notABlock.ToNode()
 	require.NoError(t, err)

--- a/node/node.go
+++ b/node/node.go
@@ -158,7 +158,7 @@ type Node struct {
 	sectorBuilder sectorbuilder.SectorBuilder
 
 	// Fetcher is the interface for fetching data from nodes.
-	Fetcher *net.Fetcher
+	Fetcher net.Fetcher
 
 	// Exchange is the interface for fetching data from other nodes.
 	Exchange exchange.Interface
@@ -386,7 +386,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 	//nwork := bsnet.NewFromIpfsHost(innerHost, router)
 	bswap := bitswap.New(ctx, nwork, bs)
 	bservice := bserv.New(bs, bswap)
-	fetcher := net.NewFetcher(ctx, bservice, blkValid)
+	fetcher := net.NewBitswapFetcher(ctx, bservice, blkValid)
 
 	cstOffline := hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
 	genCid, err := readGenesisCid(nc.Repo.Datastore())

--- a/testhelpers/net.go
+++ b/testhelpers/net.go
@@ -142,6 +142,33 @@ func (f *TestFetcher) AddSourceBlocks(blocks ...*types.Block) {
 	}
 }
 
+// FetchTipSets fetchs the tipset at `tsKey` from the network using the fetchers bitswap session.
+// FetchTipSets will fetch `recur` partens of `tsKey`. FetchTipSets does not return partial results.
+func (f *TestFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetKey, recur int) ([]types.TipSet, error) {
+	var out []types.TipSet
+	cur := tsKey
+	for i := 0; i < recur; i++ {
+		res, err := f.GetBlocks(ctx, cur.ToSlice())
+		if err != nil {
+			return nil, err
+		}
+
+		ts, err := types.NewTipSet(res...)
+		if err != nil {
+			return nil, err
+		}
+
+		cur, err = ts.Parents()
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, ts)
+	}
+
+	return out, nil
+}
+
 // GetBlocks returns any blocks in the source with matching cids.
 func (f *TestFetcher) GetBlocks(ctx context.Context, cids []cid.Cid) ([]*types.Block, error) {
 	var ret []*types.Block


### PR DESCRIPTION
### What
This PR defines a Fetcher interface and renames the original Fetcher to BitswapFetcher. The goal here is to define an interface for other types of fetchers. Some examples include a blocksync fetcher and a graphsync fetcher. 