### PR TITLE
storagemarket.GetLateMiners

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -24,8 +24,6 @@ const (
 	Invalid = Type(iota)
 	// Address is a address.Address
 	Address
-	// Addresses is a *[]address.Address
-	Addresses
 	// AttoFIL is a types.AttoFIL
 	AttoFIL
 	// BytesAmount is a *types.BytesAmount
@@ -64,6 +62,9 @@ const (
 	Parameters
 	// IntSet is a set of uint64
 	IntSet
+	// MinerPoStStates is a *map[string]uint64, where string is address.Address.String()
+	// and uint8 is a miner PoStState
+	MinerPoStStates
 )
 
 func (t Type) String() string {
@@ -72,8 +73,6 @@ func (t Type) String() string {
 		return "<invalid>"
 	case Address:
 		return "address.Address"
-	case Addresses:
-		return "*[]address.Address"
 	case AttoFIL:
 		return "types.AttoFIL"
 	case BytesAmount:
@@ -112,6 +111,8 @@ func (t Type) String() string {
 		return "[]interface{}"
 	case IntSet:
 		return "types.IntSet"
+	case MinerPoStStates:
+		return "*map[string]uint64"
 	default:
 		return "<unknown type>"
 	}
@@ -129,8 +130,6 @@ func (av *Value) String() string {
 		return "<invalid>"
 	case Address:
 		return av.Val.(address.Address).String()
-	case Addresses:
-		return fmt.Sprint(av.Val.(*[]address.Address))
 	case AttoFIL:
 		return av.Val.(types.AttoFIL).String()
 	case BytesAmount:
@@ -169,6 +168,8 @@ func (av *Value) String() string {
 		return fmt.Sprint(av.Val.([]interface{}))
 	case IntSet:
 		return av.Val.(types.IntSet).String()
+	case MinerPoStStates:
+		return fmt.Sprint(av.Val.(*map[address.Address]uint8))
 	default:
 		return "<unknown type>"
 	}
@@ -194,12 +195,6 @@ func (av *Value) Serialize() ([]byte, error) {
 			return nil, &typeError{address.Undef, av.Val}
 		}
 		return addr.Bytes(), nil
-	case Addresses:
-		addrs, ok := av.Val.(*[]address.Address)
-		if !ok {
-			return nil, typeError{&[]address.Address{}, av.Val}
-		}
-		return cbor.DumpObject(addrs)
 	case AttoFIL:
 		ba, ok := av.Val.(types.AttoFIL)
 		if !ok {
@@ -332,6 +327,12 @@ func (av *Value) Serialize() ([]byte, error) {
 			return nil, &typeError{types.IntSet{}, av.Val}
 		}
 		return cbor.DumpObject(is)
+	case MinerPoStStates:
+		addrs, ok := av.Val.(*map[string]uint64)
+		if !ok {
+			return nil, &typeError{&map[string]uint64{}, av.Val}
+		}
+		return cbor.DumpObject(addrs)
 	default:
 		return nil, fmt.Errorf("unrecognized Type: %d", av.Type)
 	}
@@ -349,8 +350,6 @@ func ToValues(i []interface{}) ([]*Value, error) {
 		switch v := v.(type) {
 		case address.Address:
 			out = append(out, &Value{Type: Address, Val: v})
-		case *[]address.Address:
-			out = append(out, &Value{Type: Addresses, Val: v})
 		case types.AttoFIL:
 			out = append(out, &Value{Type: AttoFIL, Val: v})
 		case *types.BytesAmount:
@@ -389,6 +388,8 @@ func ToValues(i []interface{}) ([]*Value, error) {
 			out = append(out, &Value{Type: Parameters, Val: v})
 		case types.IntSet:
 			out = append(out, &Value{Type: IntSet, Val: v})
+		case *map[string]uint64:
+			out = append(out, &Value{Type: MinerPoStStates, Val: v})
 		default:
 			return nil, fmt.Errorf("unsupported type: %T", v)
 		}
@@ -422,16 +423,6 @@ func Deserialize(data []byte, t Type) (*Value, error) {
 		return &Value{
 			Type: t,
 			Val:  addr,
-		}, nil
-	case Addresses:
-		var arr *[]address.Address
-		if err := cbor.DecodeInto(data, &arr); err != nil {
-			return nil, err
-
-		}
-		return &Value{
-			Type: t,
-			Val:  arr,
 		}, nil
 	case AttoFIL:
 		return &Value{
@@ -560,6 +551,16 @@ func Deserialize(data []byte, t Type) (*Value, error) {
 			Type: t,
 			Val:  is,
 		}, nil
+	case MinerPoStStates:
+		var lm *map[string]uint64
+		if err := cbor.DecodeInto(data, &lm); err != nil {
+			return nil, err
+
+		}
+		return &Value{
+			Type: t,
+			Val:  lm,
+		}, nil
 	case Invalid:
 		return nil, ErrInvalidType
 	default:
@@ -568,27 +569,27 @@ func Deserialize(data []byte, t Type) (*Value, error) {
 }
 
 var typeTable = map[Type]reflect.Type{
-	Address:        reflect.TypeOf(address.Address{}),
-	Addresses:      reflect.TypeOf(&[]address.Address{}),
-	AttoFIL:        reflect.TypeOf(types.AttoFIL{}),
-	Bytes:          reflect.TypeOf([]byte{}),
-	BytesAmount:    reflect.TypeOf(&types.BytesAmount{}),
-	ChannelID:      reflect.TypeOf(&types.ChannelID{}),
-	BlockHeight:    reflect.TypeOf(&types.BlockHeight{}),
-	Integer:        reflect.TypeOf(&big.Int{}),
-	String:         reflect.TypeOf(string("")),
-	UintArray:      reflect.TypeOf([]uint64{}),
-	PeerID:         reflect.TypeOf(peer.ID("")),
-	SectorID:       reflect.TypeOf(uint64(0)),
-	CommitmentsMap: reflect.TypeOf(map[string]types.Commitments{}),
-	PoStProofs:     reflect.TypeOf([]types.PoStProof{}),
-	Boolean:        reflect.TypeOf(false),
-	ProofsMode:     reflect.TypeOf(types.TestProofsMode),
-	PoRepProof:     reflect.TypeOf(types.PoRepProof{}),
-	PoStProof:      reflect.TypeOf(types.PoStProof{}),
-	Predicate:      reflect.TypeOf(&types.Predicate{}),
-	Parameters:     reflect.TypeOf([]interface{}{}),
-	IntSet:         reflect.TypeOf(types.IntSet{}),
+	Address:         reflect.TypeOf(address.Address{}),
+	AttoFIL:         reflect.TypeOf(types.AttoFIL{}),
+	Bytes:           reflect.TypeOf([]byte{}),
+	BytesAmount:     reflect.TypeOf(&types.BytesAmount{}),
+	ChannelID:       reflect.TypeOf(&types.ChannelID{}),
+	BlockHeight:     reflect.TypeOf(&types.BlockHeight{}),
+	Integer:         reflect.TypeOf(&big.Int{}),
+	String:          reflect.TypeOf(string("")),
+	UintArray:       reflect.TypeOf([]uint64{}),
+	PeerID:          reflect.TypeOf(peer.ID("")),
+	SectorID:        reflect.TypeOf(uint64(0)),
+	CommitmentsMap:  reflect.TypeOf(map[string]types.Commitments{}),
+	PoStProofs:      reflect.TypeOf([]types.PoStProof{}),
+	Boolean:         reflect.TypeOf(false),
+	ProofsMode:      reflect.TypeOf(types.TestProofsMode),
+	PoRepProof:      reflect.TypeOf(types.PoRepProof{}),
+	PoStProof:       reflect.TypeOf(types.PoStProof{}),
+	Predicate:       reflect.TypeOf(&types.Predicate{}),
+	Parameters:      reflect.TypeOf([]interface{}{}),
+	IntSet:          reflect.TypeOf(types.IntSet{}),
+	MinerPoStStates: reflect.TypeOf(&map[string]uint64{}),
 }
 
 // TypeMatches returns whether or not 'val' is the go type expected for the given ABI type

--- a/abi/encoding_test.go
+++ b/abi/encoding_test.go
@@ -4,10 +4,11 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/filecoin-project/go-filecoin/address"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
-	"github.com/stretchr/testify/assert"
 )
 
 // TODO: tests that check the exact serialization of different inputs.
@@ -29,11 +30,16 @@ func TestBasicEncodingRoundTrip(t *testing.T) {
 		"a string":   {"flugzeug"},
 		"mixed":      {big.NewInt(17), []byte("beep"), "mr rogers", addrGetter()},
 		"sector ids": {uint64(1234), uint64(0)},
-		"predicate": {&types.Predicate{
-			To:     addrGetter(),
-			Method: "someMethod",
-			Params: []interface{}{uint64(3), []byte("proof")},
-		}},
+		"predicate": {
+			&types.Predicate{
+				To:     addrGetter(),
+				Method: "someMethod",
+				Params: []interface{}{uint64(3), []byte("proof")},
+			},
+		},
+		"miner post states": {
+			&map[string]uint64{address.TestAddress.String(): 1, address.TestAddress2.String(): 2},
+		},
 	}
 
 	for tname, tcase := range cases {

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -335,7 +335,7 @@ func TestMinerGetPower(t *testing.T) {
 
 		st, vms := th.RequireCreateStorages(ctx, t)
 
-		minerAddr := th.CreateTestMinerWith(types.NewAttoFILFromFIL(240), t, st, vms, address.TestAddress, th.RequireRandomPeerID(t))
+		minerAddr := th.CreateTestMinerWith(types.NewAttoFILFromFIL(240), t, st, vms, address.TestAddress, th.RequireRandomPeerID(t), 0)
 
 		// retrieve power (trivial result for no proven sectors)
 		result := callQueryMethodSuccess("getPower", ctx, t, st, vms, address.TestAddress, minerAddr)
@@ -352,7 +352,7 @@ func TestMinerGetProvingPeriod(t *testing.T) {
 
 		st, vms := th.RequireCreateStorages(ctx, t)
 
-		minerAddr := th.CreateTestMinerWith(types.NewAttoFILFromFIL(240), t, st, vms, address.TestAddress, th.RequireRandomPeerID(t))
+		minerAddr := th.CreateTestMinerWith(types.NewAttoFILFromFIL(240), t, st, vms, address.TestAddress, th.RequireRandomPeerID(t), 0)
 
 		// retrieve proving period
 		result := callQueryMethodSuccess("getProvingPeriod", ctx, t, st, vms, address.TestAddress, minerAddr)
@@ -377,7 +377,7 @@ func TestMinerGetProvingPeriod(t *testing.T) {
 
 		st, vms := th.RequireCreateStorages(ctx, t)
 
-		minerAddr := th.CreateTestMinerWith(types.NewAttoFILFromFIL(240), t, st, vms, address.TestAddress, th.RequireRandomPeerID(t))
+		minerAddr := th.CreateTestMinerWith(types.NewAttoFILFromFIL(240), t, st, vms, address.TestAddress, th.RequireRandomPeerID(t), 0)
 
 		// commit sector to set ProvingPeriodEnd
 		commR := th.MakeCommitment()
@@ -446,7 +446,7 @@ func TestMinerCommitSector(t *testing.T) {
 		amtCollateralForPledge := MinimumCollateralPerSector.CalculatePrice(types.NewBytesAmount(numSectorsToPledge))
 
 		origPid := th.RequireRandomPeerID(t)
-		minerAddr := th.CreateTestMinerWith(amtCollateralForPledge, t, st, vms, address.TestAddress, origPid)
+		minerAddr := th.CreateTestMinerWith(amtCollateralForPledge, t, st, vms, address.TestAddress, origPid, 0)
 
 		commR := th.MakeCommitment()
 		commRStar := th.MakeCommitment()
@@ -476,7 +476,7 @@ func TestMinerCommitSector(t *testing.T) {
 		st, vms := th.RequireCreateStorages(ctx, t)
 
 		origPid := th.RequireRandomPeerID(t)
-		minerAddr := th.CreateTestMinerWith(types.NewAttoFILFromFIL(100), t, st, vms, address.TestAddress, origPid)
+		minerAddr := th.CreateTestMinerWith(types.NewAttoFILFromFIL(100), t, st, vms, address.TestAddress, origPid, 0)
 
 		commR := th.MakeCommitment()
 		commRStar := th.MakeCommitment()

--- a/actor/builtin/storagemarket/storagemarket.go
+++ b/actor/builtin/storagemarket/storagemarket.go
@@ -199,6 +199,9 @@ func (sma *Actor) UpdateStorage(vmctx exec.VMContext, delta *types.BytesAmount) 
 }
 
 func (sma *Actor) GetLateMiners(vmctx exec.VMContext) (*map[string]uint64, uint8, error) {
+	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
+		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
 	var state State
 	ctx := context.Background()
 
@@ -239,7 +242,7 @@ func (sma *Actor) GetLateMiners(vmctx exec.VMContext) (*map[string]uint64, uint8
 
 	res, ok := ret.(*map[string]uint64)
 	if !ok {
-		return res, 1, fmt.Errorf("expected []address.Address to be returned, but got %T instead", ret)
+		return res, 1, errors.NewFaultErrorf("expected []address.Address to be returned, but got %T instead", ret)
 	}
 
 	return res, 0, nil

--- a/actor/builtin/storagemarket/storagemarket.go
+++ b/actor/builtin/storagemarket/storagemarket.go
@@ -104,7 +104,7 @@ var storageMarketExports = exec.Exports{
 		Params: []abi.Type{},
 		Return: []abi.Type{abi.ProofsMode},
 	},
-	"getSlashableMiners": &exec.FunctionSignature{
+	"getProvingMiners": &exec.FunctionSignature{
 		Params: nil,
 		Return: []abi.Type{abi.Addresses},
 	},
@@ -197,7 +197,7 @@ func (sma *Actor) UpdateStorage(vmctx exec.VMContext, delta *types.BytesAmount) 
 	return 0, nil
 }
 
-func (sma *Actor) GetSlashableMiners(vmctx exec.VMContext) (*[]address.Address, uint8, error) {
+func (sma *Actor) GetProvingMiners(vmctx exec.VMContext) (*[]address.Address, uint8, error) {
 	var state State
 	ctx := context.Background()
 	ret, err := actor.WithState(vmctx, &state, func() (interface{}, error) {
@@ -219,13 +219,13 @@ func (sma *Actor) GetSlashableMiners(vmctx exec.VMContext) (*[]address.Address, 
 				return nil, err
 			}
 
-			var slashable bool
-			slashable, err = sma.getSlashableForMiner(vmctx, addr)
+			var isProving bool
+			isProving, err = sma.getMinerIsProving(vmctx, addr)
 			if err != nil {
 				return nil, err
 			}
 
-			if slashable {
+			if isProving {
 				miners = append(miners, addr)
 			}
 		}
@@ -288,17 +288,17 @@ func (sma *Actor) GetProofsMode(vmctx exec.VMContext) (types.ProofsMode, uint8, 
 	return size, 0, nil
 }
 
-func (sma *Actor) getSlashableForMiner(vmctx exec.VMContext, minerAddr address.Address) (bool, error) {
-	msgResult, _, err := vmctx.Send(minerAddr, "getSlashable", types.ZeroAttoFIL, nil)
+func (sma *Actor) getMinerIsProving(vmctx exec.VMContext, minerAddr address.Address) (bool, error) {
+	msgResult, _, err := vmctx.Send(minerAddr, "isProving", types.ZeroAttoFIL, nil)
 	if err != nil {
 		return false, err
 	}
 
-	slashable, err := abi.Deserialize(msgResult[0], abi.Boolean)
+	isProving, err := abi.Deserialize(msgResult[0], abi.Boolean)
 	if err != nil {
 		return false, err
 	}
-	return slashable.Val.(bool), nil
+	return isProving.Val.(bool), nil
 }
 
 // isSupportedSectorSize produces a boolean indicating whether or not the

--- a/actor/builtin/storagemarket/storagemarket.go
+++ b/actor/builtin/storagemarket/storagemarket.go
@@ -104,7 +104,7 @@ var storageMarketExports = exec.Exports{
 		Params: []abi.Type{},
 		Return: []abi.Type{abi.ProofsMode},
 	},
-	"getMiners": &exec.FunctionSignature{
+	"getSlashableMiners": &exec.FunctionSignature{
 		Params: nil,
 		Return: []abi.Type{abi.Addresses},
 	},
@@ -197,7 +197,7 @@ func (sma *Actor) UpdateStorage(vmctx exec.VMContext, delta *types.BytesAmount) 
 	return 0, nil
 }
 
-func (sma *Actor) GetMiners(vmctx exec.VMContext) (*[]address.Address, uint8, error) {
+func (sma *Actor) GetSlashableMiners(vmctx exec.VMContext) (*[]address.Address, uint8, error) {
 	var state State
 	ctx := context.Background()
 	ret, err := actor.WithState(vmctx, &state, func() (interface{}, error) {

--- a/actor/builtin/storagemarket/storagemarket_test.go
+++ b/actor/builtin/storagemarket/storagemarket_test.go
@@ -317,7 +317,7 @@ func mustCreateStorageMiner(t *testing.T, st state.Tree, vms vm.StorageMap, heig
 // assertGetSlashableMiners calls "getSlashableMiners" message / method, deserializes the result and returns the
 // addresses of miners in storage
 func assertGetSlashableMiners(t *testing.T, st state.Tree, vms vm.StorageMap) *[]address.Address {
-	res, err := th.CreateAndApplyTestMessage(t, st, vms, address.StorageMarketAddress, 0, 0, "getMiners", nil)
+	res, err := th.CreateAndApplyTestMessage(t, st, vms, address.StorageMarketAddress, 0, 0, "getSlashableMiners", nil)
 	require.NoError(t, err)
 	require.NoError(t, res.ExecutionError)
 	assert.Equal(t, uint8(0), res.Receipt.ExitCode)

--- a/actor/builtin/storagemarket/storagemarket_test.go
+++ b/actor/builtin/storagemarket/storagemarket_test.go
@@ -117,6 +117,7 @@ func TestStorageMarketGetLateMiners(t *testing.T) {
 	emptyMiners := map[string]uint64{}
 
 	type testCase struct {
+		Name           string
 		BlockHeight    uint64
 		ExpectedMiners map[string]uint64
 	}
@@ -125,13 +126,15 @@ func TestStorageMarketGetLateMiners(t *testing.T) {
 		st, vms := th.RequireCreateStorages(ctx, t)
 
 		tc := []testCase{
-			{BlockHeight: 2, ExpectedMiners: emptyMiners},
-			{BlockHeight: 2000, ExpectedMiners: emptyMiners},
+			{Name: "just after commit", BlockHeight: 2, ExpectedMiners: emptyMiners},
+			{Name: "super late", BlockHeight: 2000, ExpectedMiners: emptyMiners},
 		}
 
 		for _, el := range tc {
-			miners := *assertGetLateMiners(t, st, vms, el.BlockHeight)
-			assert.Equal(t, el.ExpectedMiners, miners)
+			t.Run(el.Name, func(t *testing.T) {
+				miners := *assertGetLateMiners(t, st, vms, el.BlockHeight)
+				assert.Equal(t, el.ExpectedMiners, miners)
+			})
 		}
 	})
 
@@ -145,12 +148,14 @@ func TestStorageMarketGetLateMiners(t *testing.T) {
 		}
 
 		tc := []testCase{
-			{BlockHeight: 2, ExpectedMiners: emptyMiners},
-			{BlockHeight: 2000, ExpectedMiners: emptyMiners},
+			{Name: "just after commit", BlockHeight: 2, ExpectedMiners: emptyMiners},
+			{Name: "super late", BlockHeight: 2000, ExpectedMiners: emptyMiners},
 		}
 		for _, el := range tc {
-			miners := *assertGetLateMiners(t, st, vms, el.BlockHeight)
-			assert.Equal(t, miners, el.ExpectedMiners)
+			t.Run(el.Name, func(t *testing.T) {
+				miners := *assertGetLateMiners(t, st, vms, el.BlockHeight)
+				assert.Equal(t, miners, el.ExpectedMiners)
+			})
 		}
 	})
 
@@ -175,20 +180,22 @@ func TestStorageMarketGetLateMiners(t *testing.T) {
 		thirdProvingPeriodStart := 2*miner.LargestSectorSizeProvingPeriodBlocks + firstCommitBlockHeight
 
 		tc := []testCase{
-			{BlockHeight: firstCommitBlockHeight, ExpectedMiners: emptyMiners},
-			{BlockHeight: secondProvingPeriodStart, ExpectedMiners: emptyMiners},
-			{BlockHeight: secondProvingPeriodStart + 1, ExpectedMiners: map[string]uint64{
+			{Name: "1st commit bh", BlockHeight: firstCommitBlockHeight, ExpectedMiners: emptyMiners},
+			{Name: "2nd proving pd start", BlockHeight: secondProvingPeriodStart, ExpectedMiners: emptyMiners},
+			{Name: "just after 2nd proving period start", BlockHeight: secondProvingPeriodStart + 1, ExpectedMiners: map[string]uint64{
 				addr1.String(): miner.PoStStateAfterProvingPeriod,
 				addr2.String(): miner.PoStStateAfterProvingPeriod},
 			},
-			{BlockHeight: thirdProvingPeriodStart + 1, ExpectedMiners: map[string]uint64{
+			{Name: "after 3rd proving period start", BlockHeight: thirdProvingPeriodStart + 1, ExpectedMiners: map[string]uint64{
 				addr1.String(): miner.PoStStateAfterGenerationAttackThreshold,
 				addr2.String(): miner.PoStStateAfterGenerationAttackThreshold},
 			},
 		}
 		for _, el := range tc {
-			miners := *assertGetLateMiners(t, st, vms, el.BlockHeight)
-			assert.Equal(t, el.ExpectedMiners, miners)
+			t.Run(el.Name, func(t *testing.T) {
+				miners := *assertGetLateMiners(t, st, vms, el.BlockHeight)
+				assert.Equal(t, el.ExpectedMiners, miners)
+			})
 		}
 	})
 }

--- a/actor/builtin/storagemarket/storagemarket_test.go
+++ b/actor/builtin/storagemarket/storagemarket_test.go
@@ -114,14 +114,15 @@ func TestStorageMarketGetSlashableMiners(t *testing.T) {
 	tf.UnitTest(t)
 
 	ctx := context.Background()
-	st, vms := th.RequireCreateStorages(ctx, t)
 
 	t.Run("returns empty slice if no storage miners", func(t *testing.T) {
+		st, vms := th.RequireCreateStorages(ctx, t)
 		addrs := *assertGetSlashableMiners(t, st, vms)
 		assert.Len(t, addrs, 0)
 	})
 
 	t.Run("if no storage miners have commitments, empty set", func(t *testing.T) {
+		st, vms := th.RequireCreateStorages(ctx, t)
 		// create miners without commitments
 		_ = []address.Address{
 			mustCreateStorageMiner(t, st, vms, 0),
@@ -134,19 +135,20 @@ func TestStorageMarketGetSlashableMiners(t *testing.T) {
 	})
 
 	t.Run("gets number of miners with commitments (slashable miners)", func(t *testing.T) {
+		st, vms := th.RequireCreateStorages(ctx, t)
+
+		// create 3 bootstrap miners by passing in 0 block height, so that VerifyProof is skipped
+		// Otherwise this test will fail
 		expected := []address.Address{
 			mustCreateStorageMiner(t, st, vms, 0),
-			mustCreateStorageMiner(t, st, vms, 1),
-			mustCreateStorageMiner(t, st, vms, 2),
+			mustCreateStorageMiner(t, st, vms, 0),
+			mustCreateStorageMiner(t, st, vms, 0),
 		}
 
-		// make a commitment
+		// 2 of the 3 miners make a commitment
 		blockHeight := 3
 		sectorID := uint64(1)
 		requireMakeCommitment(t, st, vms, expected[0], blockHeight, sectorID)
-
-		// TODO this is failing with :
-		// failed to verify seal proof: Bytes could not be converted to Fr
 
 		blockHeight = 4
 		sectorID = uint64(2)

--- a/actor/builtin/storagemarket/storagemarket_test.go
+++ b/actor/builtin/storagemarket/storagemarket_test.go
@@ -110,7 +110,7 @@ func TestProofsMode(t *testing.T) {
 	assert.Equal(t, types.TestProofsMode, proofsMode)
 }
 
-func TestStorageMarketGetMiners(t *testing.T) {
+func TestStorageMarketGetSlashableMiners(t *testing.T) {
 	tf.UnitTest(t)
 
 	ctx := context.Background()

--- a/actor/builtin/storagemarket/storagemarket_test.go
+++ b/actor/builtin/storagemarket/storagemarket_test.go
@@ -117,7 +117,7 @@ func TestStorageMarketGetMiners(t *testing.T) {
 	st, vms := th.RequireCreateStorages(ctx, t)
 
 	t.Run("returns empty slice if no miners", func(t *testing.T) {
-		addrs := *assertGetMiners(t, st, vms)
+		addrs := *assertGetSlashableMiners(t, st, vms)
 		assert.Len(t, addrs, 0)
 	})
 
@@ -129,7 +129,7 @@ func TestStorageMarketGetMiners(t *testing.T) {
 			mustCreateStorageMiner(t, st, vms, 2),
 		}
 
-		addrs := *assertGetMiners(t, st, vms)
+		addrs := *assertGetSlashableMiners(t, st, vms)
 		assert.Len(t, addrs, 0)
 	})
 
@@ -153,7 +153,7 @@ func TestStorageMarketGetMiners(t *testing.T) {
 		requireMakeCommitment(t, st, vms, expected[1], blockHeight, sectorID)
 
 		// expect the miner address that made the commitment will be returned
-		addrs := *assertGetMiners(t, st, vms)
+		addrs := *assertGetSlashableMiners(t, st, vms)
 		assert.Len(t, addrs, 2)
 	})
 }
@@ -314,9 +314,9 @@ func mustCreateStorageMiner(t *testing.T, st state.Tree, vms vm.StorageMap, heig
 	return minerAddr
 }
 
-// assertGetMiners calls "getMiners" message / method, deserializes the result and returns the
+// assertGetSlashableMiners calls "getSlashableMiners" message / method, deserializes the result and returns the
 // addresses of miners in storage
-func assertGetMiners(t *testing.T, st state.Tree, vms vm.StorageMap) *[]address.Address {
+func assertGetSlashableMiners(t *testing.T, st state.Tree, vms vm.StorageMap) *[]address.Address {
 	res, err := th.CreateAndApplyTestMessage(t, st, vms, address.StorageMarketAddress, 0, 0, "getMiners", nil)
 	require.NoError(t, err)
 	require.NoError(t, res.ExecutionError)

--- a/actor/builtin/storagemarket/storagemarket_test.go
+++ b/actor/builtin/storagemarket/storagemarket_test.go
@@ -116,12 +116,12 @@ func TestStorageMarketGetSlashableMiners(t *testing.T) {
 	ctx := context.Background()
 	st, vms := th.RequireCreateStorages(ctx, t)
 
-	t.Run("returns empty slice if no miners", func(t *testing.T) {
+	t.Run("returns empty slice if no storage miners", func(t *testing.T) {
 		addrs := *assertGetSlashableMiners(t, st, vms)
 		assert.Len(t, addrs, 0)
 	})
 
-	t.Run("excludes storage miners with no commitments", func(t *testing.T) {
+	t.Run("if no storage miners have commitments, empty set", func(t *testing.T) {
 		// create miners without commitments
 		_ = []address.Address{
 			mustCreateStorageMiner(t, st, vms, 0),
@@ -152,7 +152,7 @@ func TestStorageMarketGetSlashableMiners(t *testing.T) {
 		sectorID = uint64(2)
 		requireMakeCommitment(t, st, vms, expected[1], blockHeight, sectorID)
 
-		// expect the miner address that made the commitment will be returned
+		// expect only the miner addresses that made commitments will be returned
 		addrs := *assertGetSlashableMiners(t, st, vms)
 		assert.Len(t, addrs, 2)
 	})

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -118,6 +118,9 @@ func (api *API) ActorLs(ctx context.Context) (<-chan state.GetAllActorsResult, e
 	return api.chain.LsActors(ctx)
 }
 
+// StorageMinerLs returns a list of storage miner addresses
+func (api *API) StorageMinerLs(ctx context.Context) {}
+
 // BlockTime returns the block time used by the consensus protocol.
 func (api *API) BlockTime() time.Duration {
 	return api.expected.BlockTime()

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -118,9 +118,6 @@ func (api *API) ActorLs(ctx context.Context) (<-chan state.GetAllActorsResult, e
 	return api.chain.LsActors(ctx)
 }
 
-// StorageMinerLs returns a list of storage miner addresses
-func (api *API) StorageMinerLs(ctx context.Context) {}
-
 // BlockTime returns the block time used by the consensus protocol.
 func (api *API) BlockTime() time.Duration {
 	return api.expected.BlockTime()

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -139,7 +139,8 @@ func CreateTestMinerWith(
 
 	result, err := ApplyTestMessage(stateTree, vms, msg, types.NewBlockHeight(0))
 	require.NoError(t, err)
-
+	require.NotNil(t, result)
+	require.NoError(t, result.ExecutionError)
 	addr, err := address.NewFromBytes(result.Receipt.Return[0])
 	require.NoError(t, err)
 	return addr

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -116,22 +116,7 @@ func VMStorage() vm.StorageMap {
 	return vm.NewStorageMap(blockstore.NewBlockstore(datastore.NewMapDatastore()))
 }
 
-// MustSign signs a given address with the provided mocksigner or panics if it
-// cannot.
-func MustSign(s types.MockSigner, msgs ...*types.Message) []*types.SignedMessage {
-	var smsgs []*types.SignedMessage
-	for _, m := range msgs {
-		gasLimit := types.NewGasUnits(999)
-		sm, err := types.NewSignedMessage(*m, &s, types.NewGasPrice(0), gasLimit)
-		if err != nil {
-			panic(err)
-		}
-		smsgs = append(smsgs, sm)
-	}
-	return smsgs
-}
-
-// CreateTestMiner creates a new bootstrap test miner with the given peerID and miner
+// CreateTestMiner creates a new test miner with the given peerID and miner
 // owner address within the state tree defined by st and vms with 100 FIL as
 // collateral.
 func CreateTestMiner(t *testing.T, st state.Tree, vms vm.StorageMap, minerOwnerAddr address.Address, pid peer.ID) address.Address {


### PR DESCRIPTION
Support for #2939 

The fault monitor needs a list of storage miners that are late. Storage miner has the list of miners and can ask each actor for its lateness. Create an export in storage market that returns a pointer to a map of address strings with PoStStates, but only if that state is late.