### PR TITLE
support version command over HTTP

### DIFF
--- a/commands/main.go
+++ b/commands/main.go
@@ -183,6 +183,7 @@ var rootSubcmdsDaemon = map[string]*cmds.Command{
 	"stats":            statsCmd,
 	"swarm":            swarmCmd,
 	"wallet":           walletCmd,
+	"version":          versionCmd,
 }
 
 func init() {

--- a/commands/version_daemon_test.go
+++ b/commands/version_daemon_test.go
@@ -51,8 +51,9 @@ func TestVersionOverHttp(t *testing.T) {
 	commit := strings.Trim(getCodeCommit(t), "\n ")
 	expected := fmt.Sprintf("{\"Commit\":\"%s\"}\n", commit)
 
-	defer res.Body.Close()
+	defer res.Body.Close() // nolint: errcheck
 	body, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
 	require.Equal(t, expected, string(body))
 }
 

--- a/commands/version_daemon_test.go
+++ b/commands/version_daemon_test.go
@@ -2,29 +2,66 @@ package commands_test
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os/exec"
+	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+
+	"github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multiaddr-net"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVersion(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	var gitOut, verOut []byte
+	commit := getCodeCommit(t)
+
+	verOut, err := exec.Command(th.MustGetFilecoinBinary(), "version").Output()
+	require.NoError(t, err)
+
+	version := string(verOut)
+	assert.Exactly(t, version, fmt.Sprintf("commit: %s", commit))
+}
+
+func TestVersionOverHttp(t *testing.T) {
+	tf.IntegrationTest(t)
+
+	td := th.NewDaemon(t).Start()
+	defer td.ShutdownSuccess()
+
+	maddr, err := multiaddr.NewMultiaddr(td.CmdAddr())
+	require.NoError(t, err)
+
+	_, host, err := manet.DialArgs(maddr)
+	require.NoError(t, err)
+
+	url := fmt.Sprintf("http://%s/api/version", host)
+	req, err := http.NewRequest("POST", url, nil)
+	require.NoError(t, err)
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	commit := strings.Trim(getCodeCommit(t), "\n ")
+	expected := fmt.Sprintf("{\"Commit\":\"%s\"}\n", commit)
+
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+	require.Equal(t, expected, string(body))
+}
+
+func getCodeCommit(t *testing.T) string {
+	var gitOut []byte
 	var err error
 	gitArgs := []string{"rev-parse", "--verify", "HEAD"}
 	if gitOut, err = exec.Command("git", gitArgs...).Output(); err != nil {
 		assert.NoError(t, err)
 	}
-	commit := string(gitOut)
-
-	if verOut, err = exec.Command(th.MustGetFilecoinBinary(), "version").Output(); err != nil {
-		assert.NoError(t, err)
-	}
-	version := string(verOut)
-	assert.Exactly(t, version, fmt.Sprintf("commit: %s", commit))
+	return string(gitOut)
 }


### PR DESCRIPTION
Addresses [issue #63 in the js-filecoin-api](https://github.com/filecoin-project/js-filecoin-api-client/issues/63).

### Problem

When we changed the `version` command to allow it to work without a running daemon, we ended up removing it from the HTTP API. This was unintentional.

### Solution

Restore the version command to the HTTP API. The `version` CLI command does not contact the daemon, and returns the version of the CLI client. Making a request to the /api/version endpoint now works and returns the version of the daemon.

This is maybe a little hacky, but it's a simple solution that works until we get a better HTTP API.