### PR TITLE
Removed duplicate block storage

### DIFF
--- a/actor/builtin/miner/miner_internal_test.go
+++ b/actor/builtin/miner/miner_internal_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/filecoin-project/go-filecoin/types"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 func TestLatePoStFee(t *testing.T) {

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -1143,7 +1143,6 @@ func mustDeserializeAddress(t *testing.T, result [][]byte) address.Address {
 	return addr
 }
 
-
 func bh(h uint64) *types.BlockHeight {
 	return types.NewBlockHeight(uint64(h))
 }

--- a/actor/storage.go
+++ b/actor/storage.go
@@ -107,7 +107,7 @@ func LoadLookup(ctx context.Context, storage exec.Storage, cid cid.Cid) (exec.Lo
 	return LoadTypedLookup(ctx, storage, cid, nil)
 }
 
-// LoadTypedLookup loads hamt-ipld node from storage if the cid exists, or creates a new on if it is nil.
+// LoadTypedLookup loads hamt-ipld node from storage if the cid exists, or creates a new one if it is nil.
 // The provided type allows the lookup to correctly unmarshal values
 func LoadTypedLookup(ctx context.Context, storage exec.Storage, cid cid.Cid, valueType interface{}) (exec.Lookup, error) {
 	cborStore := &hamt.CborIpldStore{

--- a/chain/get_ancestors.go
+++ b/chain/get_ancestors.go
@@ -3,7 +3,6 @@ package chain
 import (
 	"context"
 
-	"github.com/ipfs/go-cid"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 
@@ -14,7 +13,6 @@ import (
 )
 
 type recentAncestorsChainReader interface {
-	GetBlock(context.Context, cid.Cid) (*types.Block, error)
 	GetHead() types.TipSetKey
 	GetTipSet(tsKey types.TipSetKey) (types.TipSet, error)
 }

--- a/chain/init.go
+++ b/chain/init.go
@@ -26,7 +26,7 @@ func Init(ctx context.Context, r repo.Repo, bs bstore.Blockstore, cst *hamt.Cbor
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate genesis block")
 	}
-	chainStore := NewStore(r.ChainDatastore(), genesis.Cid())
+	chainStore := NewStore(r.ChainDatastore(), bs, genesis.Cid())
 
 	// Persist the genesis tipset to the repo.
 	genTsas := &TipSetAndState{

--- a/chain/syncer.go
+++ b/chain/syncer.go
@@ -74,7 +74,6 @@ const (
 
 type syncerChainReader interface {
 	BlockHeight() (uint64, error)
-	GetBlock(context.Context, cid.Cid) (*types.Block, error)
 	GetHead() types.TipSetKey
 	GetTipSet(tsKey types.TipSetKey) (types.TipSet, error)
 	GetTipSetStateRoot(tsKey types.TipSetKey) (cid.Cid, error)
@@ -83,7 +82,6 @@ type syncerChainReader interface {
 	SetHead(ctx context.Context, s types.TipSet) error
 	HasTipSetAndStatesWithParentsAndHeight(pTsKey string, h uint64) bool
 	GetTipSetAndStatesByParentsAndHeight(pTsKey string, h uint64) ([]*TipSetAndState, error)
-	HasAllBlocks(ctx context.Context, cs []cid.Cid) bool
 }
 
 // Syncer updates its chain.Store according to the methods of its
@@ -431,8 +429,8 @@ func (syncer *Syncer) HandleNewTipset(ctx context.Context, tsKey types.TipSetKey
 	syncer.mu.Lock()
 	defer syncer.mu.Unlock()
 
-	// If the store already has all these blocks the syncer is finished.
-	if syncer.chainStore.HasAllBlocks(ctx, tsKey.ToSlice()) {
+	// If the store already has this tipset then the syncer is finished.
+	if _, err := syncer.chainStore.GetTipSet(tsKey); err == nil {
 		return nil
 	}
 

--- a/mining/worker.go
+++ b/mining/worker.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-hamt-ipld"
 	"github.com/ipfs/go-ipfs-blockstore"
 	logging "github.com/ipfs/go-log"
 	"github.com/pkg/errors"
@@ -92,7 +91,6 @@ type DefaultWorker struct {
 	processor     MessageApplier
 	powerTable    consensus.PowerTableView
 	blockstore    blockstore.Blockstore
-	cstore        *hamt.CborIpldStore
 }
 
 // NewDefaultWorker instantiates a new Worker.
@@ -103,7 +101,6 @@ func NewDefaultWorker(messageSource MessageSource,
 	processor MessageApplier,
 	powerTable consensus.PowerTableView,
 	bs blockstore.Blockstore,
-	cst *hamt.CborIpldStore,
 	miner address.Address,
 	minerOwner address.Address,
 	minerWorker address.Address,
@@ -117,7 +114,6 @@ func NewDefaultWorker(messageSource MessageSource,
 		processor,
 		powerTable,
 		bs,
-		cst,
 		miner,
 		minerOwner,
 		minerWorker,
@@ -140,7 +136,6 @@ func NewDefaultWorkerWithDeps(messageSource MessageSource,
 	processor MessageApplier,
 	powerTable consensus.PowerTableView,
 	bs blockstore.Blockstore,
-	cst *hamt.CborIpldStore,
 	miner address.Address,
 	minerOwner address.Address,
 	minerWorker address.Address,
@@ -156,7 +151,6 @@ func NewDefaultWorkerWithDeps(messageSource MessageSource,
 		processor:      processor,
 		powerTable:     powerTable,
 		blockstore:     bs,
-		cstore:         cst,
 		createPoSTFunc: createPoST,
 		minerAddr:      miner,
 		minerOwnerAddr: minerOwner,

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -39,7 +39,7 @@ func Test_Mine(t *testing.T) {
 	baseBlock := &types.Block{Height: 2, StateRoot: stateRoot}
 	tipSet := th.RequireNewTipSet(t, baseBlock)
 
-	st, pool, addrs, cst, bs := sharedSetup(t, mockSignerVal)
+	st, pool, addrs, _, bs := sharedSetup(t, mockSignerVal)
 	getStateTree := func(c context.Context, ts types.TipSet) (state.Tree, error) {
 		return st, nil
 	}
@@ -57,7 +57,7 @@ func Test_Mine(t *testing.T) {
 		outCh := make(chan mining.Output)
 		worker := mining.NewDefaultWorkerWithDeps(
 			pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(), mining.NewTestPowerTableView(1),
-			bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(),
+			bs, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(),
 			CreatePoSTFunc)
 
 		go worker.Mine(ctx, tipSet, 0, outCh)
@@ -70,7 +70,7 @@ func Test_Mine(t *testing.T) {
 		doSomeWorkCalled = false
 		ctx, cancel := context.WithCancel(context.Background())
 		worker := mining.NewDefaultWorkerWithDeps(pool, makeExplodingGetStateTree(st), getWeightTest, getAncestors, th.NewTestProcessor(),
-			mining.NewTestPowerTableView(1), bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
+			mining.NewTestPowerTableView(1), bs, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
 		outCh := make(chan mining.Output)
 		doSomeWorkCalled = false
 		go worker.Mine(ctx, tipSet, 0, outCh)
@@ -85,7 +85,7 @@ func Test_Mine(t *testing.T) {
 		doSomeWorkCalled = false
 		ctx, cancel := context.WithCancel(context.Background())
 		worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(),
-			mining.NewTestPowerTableView(1), bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
+			mining.NewTestPowerTableView(1), bs, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
 		input := types.TipSet{}
 		outCh := make(chan mining.Output)
 		go worker.Mine(ctx, input, 0, outCh)
@@ -200,7 +200,7 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 
 	mockSigner, blockSignerAddr := setupSigner()
 	newCid := types.NewCidForTestGetter()
-	st, pool, addrs, cst, bs := sharedSetup(t, mockSigner)
+	st, pool, addrs, _, bs := sharedSetup(t, mockSigner)
 	getStateTree := func(c context.Context, ts types.TipSet) (state.Tree, error) {
 		return st, nil
 	}
@@ -212,7 +212,7 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 	minerOwnerAddr := addrs[3]
 
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, th.NewTestProcessor(),
-		&th.TestView{}, bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
+		&th.TestView{}, bs, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
 
 	parents := types.NewTipSetKey(newCid())
 	stateRoot := newCid()
@@ -246,7 +246,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 	ctx := context.Background()
 	mockSigner, blockSignerAddr := setupSigner()
 	newCid := types.NewCidForTestGetter()
-	st, pool, addrs, cst, bs := sharedSetup(t, mockSigner)
+	st, pool, addrs, _, bs := sharedSetup(t, mockSigner)
 
 	getStateTree := func(c context.Context, ts types.TipSet) (state.Tree, error) {
 		return st, nil
@@ -255,7 +255,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		return nil, nil
 	}
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(),
-		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
+		&th.TestView{}, bs, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
 
 	// addr3 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
 	msg1 := types.NewMessage(addrs[2], addrs[0], 0, types.ZeroAttoFIL, "", nil)
@@ -326,7 +326,7 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 	mockSigner, blockSignerAddr := setupSigner()
 	newCid := types.NewCidForTestGetter()
 
-	st, pool, addrs, cst, bs := sharedSetup(t, mockSigner)
+	st, pool, addrs, _, bs := sharedSetup(t, mockSigner)
 
 	getStateTree := func(c context.Context, ts types.TipSet) (state.Tree, error) {
 		return st, nil
@@ -337,7 +337,7 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 	minerAddr := addrs[4]
 	minerOwnerAddr := addrs[3]
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(),
-		&th.TestView{}, bs, cst, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
+		&th.TestView{}, bs, minerAddr, minerOwnerAddr, blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
 
 	h := types.Uint64(100)
 	w := types.Uint64(1000)
@@ -371,7 +371,7 @@ func TestGenerateWithoutMessages(t *testing.T) {
 	mockSigner, blockSignerAddr := setupSigner()
 	newCid := types.NewCidForTestGetter()
 
-	st, pool, addrs, cst, bs := sharedSetup(t, mockSigner)
+	st, pool, addrs, _, bs := sharedSetup(t, mockSigner)
 	getStateTree := func(c context.Context, ts types.TipSet) (state.Tree, error) {
 		return st, nil
 	}
@@ -379,7 +379,7 @@ func TestGenerateWithoutMessages(t *testing.T) {
 		return nil, nil
 	}
 	worker := mining.NewDefaultWorkerWithDeps(pool, getStateTree, getWeightTest, getAncestors, consensus.NewDefaultProcessor(),
-		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
+		&th.TestView{}, bs, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
 
 	assert.Len(t, pool.Pending(), 0)
 	baseBlock := types.Block{
@@ -406,14 +406,14 @@ func TestGenerateError(t *testing.T) {
 	mockSigner, blockSignerAddr := setupSigner()
 	newCid := types.NewCidForTestGetter()
 
-	st, pool, addrs, cst, bs := sharedSetup(t, mockSigner)
+	st, pool, addrs, _, bs := sharedSetup(t, mockSigner)
 
 	getAncestors := func(ctx context.Context, ts types.TipSet, newBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
 		return nil, nil
 	}
 	worker := mining.NewDefaultWorkerWithDeps(pool, makeExplodingGetStateTree(st), getWeightTest, getAncestors,
 		consensus.NewDefaultProcessor(),
-		&th.TestView{}, bs, cst, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
+		&th.TestView{}, bs, addrs[4], addrs[3], blockSignerAddr, mockSigner, th.NewDefaultTestWorkerPorcelainAPI(), CreatePoSTFunc)
 
 	// This is actually okay and should result in a receipt
 	msg := types.NewMessage(addrs[0], addrs[1], 0, types.ZeroAttoFIL, "", nil)

--- a/node/node.go
+++ b/node/node.go
@@ -81,7 +81,6 @@ type pubSubProcessorFunc func(ctx context.Context, msg pubsub.Message) error
 
 type nodeChainReader interface {
 	GenesisCid() cid.Cid
-	GetBlock(context.Context, cid.Cid) (*types.Block, error)
 	GetHead() types.TipSetKey
 	GetTipSet(types.TipSetKey) (types.TipSet, error)
 	GetTipSetStateRoot(tsKey types.TipSetKey) (cid.Cid, error)
@@ -395,7 +394,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 	}
 
 	// set up chainstore
-	chainStore := chain.NewStore(nc.Repo.ChainDatastore(), genCid)
+	chainStore := chain.NewStore(nc.Repo.ChainDatastore(), bs, genCid)
 	chainState := cst.NewChainStateProvider(chainStore, &cstOffline)
 	powerTable := &consensus.MarketView{}
 
@@ -1044,8 +1043,8 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (mining.Worker, error)
 	}
 	return mining.NewDefaultWorker(
 		node.Inbox.Pool(), node.getStateTree, node.getWeight, node.getAncestors, processor, node.PowerTable,
-		node.Blockstore, node.CborStore(), minerAddr, minerOwnerAddr, minerWorker,
-		node.Wallet, node.PorcelainAPI), nil
+		node.Blockstore, minerAddr, minerOwnerAddr, minerWorker, node.Wallet,
+		node.PorcelainAPI), nil
 }
 
 // getStateFromKey returns the state tree based on tipset fetched with provided key tsKey

--- a/plumbing/msg/waiter.go
+++ b/plumbing/msg/waiter.go
@@ -24,7 +24,6 @@ var log = logging.Logger("messageimpl")
 
 // Abstracts over a store of blockchain state.
 type waiterChainReader interface {
-	GetBlock(context.Context, cid.Cid) (*types.Block, error)
 	GetHead() types.TipSetKey
 	GetTipSet(tsKey types.TipSetKey) (types.TipSet, error)
 	GetTipSetStateRoot(tsKey types.TipSetKey) (cid.Cid, error)


### PR DESCRIPTION
This resolves #2636.  It removes writing blockchain data to the protected chain store.  `Load` now reads from the global IPLD store.

With this change the store's `*Block(s)` methods all no longer make sense and have been deleted.  This makes for a better interface.  Consumers should not be accessing individual blocks through the chain store, they should be accessing tipsets.  This descopes the chain store's interface to something more manageable and expected.  Consumers were already using this pattern for the most part.