### PR TITLE
Remove state store from syncer, limit its knowledge to state IDs

### DIFF
--- a/chain/syncer_test.go
+++ b/chain/syncer_test.go
@@ -206,7 +206,7 @@ func loadSyncerFromRepo(t *testing.T, r repo.Repo, dstP *SyncerTestParams) (*cha
 	chainStore := chain.NewStore(chainDS, bs, calcGenBlk.Cid())
 
 	blockSource := th.NewTestFetcher()
-	syncer := chain.NewSyncer(cst, con, chainStore, blockSource, chain.Syncing)
+	syncer := chain.NewSyncer(con, chainStore, blockSource, chain.Syncing)
 
 	ctx := context.Background()
 	err = chainStore.Load(ctx)
@@ -278,7 +278,7 @@ func initSyncTest(t *testing.T, con consensus.Protocol, genFunc func(cst *hamt.C
 	chainStore := chain.NewStore(chainDS, bs, calcGenBlk.Cid())
 
 	fetcher := th.NewTestFetcher()
-	syncer := chain.NewSyncer(cst, con, chainStore, fetcher, syncMode) // note we use same cst for on and offline for tests
+	syncer := chain.NewSyncer(con, chainStore, fetcher, syncMode) // note we use same cst for on and offline for tests
 
 	// Initialize stores to contain dstP.genesis block and state
 	calcGenTS := th.RequireNewTipSet(t, calcGenBlk)
@@ -354,7 +354,7 @@ func assertHead(t *testing.T, chain HeadAndTipsetGetter, head types.TipSet) {
 	assert.Equal(t, head, headTipSet)
 }
 
-func requirePutBlocks(t *testing.T, f *th.TestFetcher, blocks ...*types.Block) types.TipSetKey {
+func requirePutBlocks(_ *testing.T, f *th.TestFetcher, blocks ...*types.Block) types.TipSetKey {
 	var cids []cid.Cid
 	for _, block := range blocks {
 		c := block.Cid()
@@ -1089,7 +1089,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 	// Now sync the chainStore with consensus using a MarketView.
 	verifier = verification.NewFakeVerifier(true, nil)
 	con = consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &consensus.MarketView{}, calcGenBlk.Cid(), verifier, th.BlockTimeTest)
-	syncer := chain.NewSyncer(cst, con, chainStore, blockSource, chain.Syncing)
+	syncer := chain.NewSyncer(con, chainStore, blockSource, chain.Syncing)
 	baseTS := requireHeadTipset(t, chainStore) // this is the last block of the bootstrapping chain creating miners
 	require.Equal(t, 1, baseTS.Len())
 	bootstrapStateRoot := baseTS.ToSlice()[0].StateRoot

--- a/consensus/expected_test.go
+++ b/consensus/expected_test.go
@@ -106,7 +106,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		tipSet := types.RequireNewTipSet(t, blocks...)
 
-		_, err = exp.RunStateTransition(ctx, tipSet, []types.TipSet{pTipSet}, stateTree)
+		_, err = exp.RunStateTransition(ctx, tipSet, []types.TipSet{pTipSet}, blocks[0].StateRoot)
 		assert.NoError(t, err)
 	})
 
@@ -126,7 +126,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		tipSet := types.RequireNewTipSet(t, blocks...)
 
-		_, err = exp.RunStateTransition(ctx, tipSet, []types.TipSet{pTipSet}, stateTree)
+		_, err = exp.RunStateTransition(ctx, tipSet, []types.TipSet{pTipSet}, genesisBlock.StateRoot)
 		assert.EqualError(t, err, "can't check for winning ticket: Couldn't get minerPower: something went wrong with the miner power")
 	})
 }

--- a/consensus/protocol.go
+++ b/consensus/protocol.go
@@ -13,6 +13,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/ipfs/go-cid"
+
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 )
@@ -28,11 +30,11 @@ type Protocol interface {
 
 	// IsHeaver returns 1 if tipset a is heavier than tipset b and -1 if
 	// tipset b is heavier than tipset a.
-	IsHeavier(ctx context.Context, a, b types.TipSet, aSt, bSt state.Tree) (bool, error)
+	IsHeavier(ctx context.Context, a, b types.TipSet, aStateID, bStateID cid.Cid) (bool, error)
 
-	// RunStateTransition returns the state resulting from applying the input ts to the parent
-	// state pSt.  It returns an error if the transition is invalid.
-	RunStateTransition(ctx context.Context, ts types.TipSet, ancestors []types.TipSet, pSt state.Tree) (state.Tree, error)
+	// RunStateTransition returns the state root CID resulting from applying the input ts to the
+	// prior `stateID`.  It returns an error if the transition is invalid.
+	RunStateTransition(ctx context.Context, ts types.TipSet, ancestors []types.TipSet, stateID cid.Cid) (cid.Cid, error)
 
 	// ValidateSyntax validates a single block is correctly formed.
 	ValidateSyntax(ctx context.Context, b *types.Block) error

--- a/node/node.go
+++ b/node/node.go
@@ -427,7 +427,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 	fcWallet := wallet.New(backend)
 
 	// only the syncer gets the storage which is online connected
-	chainSyncer := chain.NewSyncer(&cstOffline, nodeConsensus, chainStore, fetcher, chain.Syncing)
+	chainSyncer := chain.NewSyncer(nodeConsensus, chainStore, fetcher, chain.Syncing)
 	msgPool := core.NewMessagePool(nc.Repo.Config().Mpool, consensus.NewIngestionValidator(chainState, nc.Repo.Config().Mpool))
 	inbox := core.NewInbox(msgPool, core.InboxMaxAgeTipsets, chainStore)
 

--- a/state/tree.go
+++ b/state/tree.go
@@ -51,7 +51,7 @@ var _ Tree = &tree{}
 func LoadStateTree(ctx context.Context, store *hamt.CborIpldStore, c cid.Cid, builtinActors map[cid.Cid]exec.ExecutableActor) (Tree, error) {
 	root, err := hamt.LoadNode(ctx, store, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to load node")
+		return nil, errors.Wrapf(err, "failed to load node for %s", c)
 	}
 	stateTree := newEmptyStateTree(store)
 	stateTree.root = root

--- a/state/tree_test.go
+++ b/state/tree_test.go
@@ -75,7 +75,7 @@ func TestStateErrors(t *testing.T) {
 	assert.NoError(t, err)
 
 	tr2, err := LoadStateTree(ctx, cst, c, nil)
-	assert.EqualError(t, err, "failed to load node: not found")
+	assert.Error(t, err)
 	assert.Nil(t, tr2)
 }
 


### PR DESCRIPTION
Consensus already reads and writes the ipld store, with this change the syncer is no longer doing so on its behalf.

After this change, the syncer is oblivious to state representation. In unit tests, we can fake the state transition function and remove a ton of set up code. (We'll still want some integration tests that use a real consensus implementation).

This is part of #2128.