### PR TITLE
Use proving set instead of sector commitments for PoSt validation

### DIFF
--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -910,7 +910,7 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, poStProofs []types.PoStProof, do
 			for _, id := range state.ProvingSet.Values() {
 				commitment, found := state.SectorCommitments.Get(id)
 				if !found {
-					return nil, errors.NewFaultErrorf("miner ProvingSet contains sector id %d missing in SectorCommitments", id)
+					return nil, errors.NewFaultErrorf("miner ProvingSet sector id %d missing in SectorCommitments", id)
 				}
 				commRs = append(commRs, commitment.CommR)
 			}

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -730,7 +730,7 @@ func TestMinerSubmitPoStVerification(t *testing.T) {
 		assert.Equal(t, types.OneKiBSectorSize, verifier.PoStRequest.SectorSize)
 
 		seed := types.PoStChallengeSeed{}
-		copy(seed[:], vmctx.TestRandomness)
+		copy(seed[:], vmctx.RandomnessValue)
 
 		sortedRs := proofs.NewSortedCommRs(comm1.CommR, comm2.CommR)
 

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -717,10 +717,8 @@ func TestMinerSubmitPoStVerification(t *testing.T) {
 
 		// The 3 sector is not in the proving set, so its CommR should not appear in the VerifyPoSt request
 		minerState.ProvingSet = types.NewIntSet(1, 2)
-		vmctx := th.NewFakeVMContext(message, minerState)
-
 		verifier := &th.FakeVerifier{Valid: true}
-		vmctx.TestVerifier = verifier
+		vmctx := th.NewFakeVMContextWithVerifier(message, minerState, verifier)
 
 		miner := Actor{Bootstrap: false}
 
@@ -770,10 +768,8 @@ func TestMinerSubmitPoStVerification(t *testing.T) {
 		minerState.SectorCommitments.Add(1, types.Commitments{CommR: comm1.CommR})
 
 		minerState.ProvingSet = types.NewIntSet(1)
-		vmctx := th.NewFakeVMContext(message, minerState)
-
 		verifier := &th.FakeVerifier{Err: errors.New("verifier error")}
-		vmctx.TestVerifier = verifier
+		vmctx := th.NewFakeVMContextWithVerifier(message, minerState, verifier)
 
 		miner := Actor{Bootstrap: false}
 
@@ -792,10 +788,8 @@ func TestMinerSubmitPoStVerification(t *testing.T) {
 		minerState.SectorCommitments.Add(1, types.Commitments{CommR: comm1.CommR})
 
 		minerState.ProvingSet = types.NewIntSet(1)
-		vmctx := th.NewFakeVMContext(message, minerState)
-
 		verifier := &th.FakeVerifier{Valid: false}
-		vmctx.TestVerifier = verifier
+		vmctx := th.NewFakeVMContextWithVerifier(message, minerState, verifier)
 
 		miner := Actor{Bootstrap: false}
 

--- a/actor/storage.go
+++ b/actor/storage.go
@@ -71,10 +71,7 @@ func ReadState(ctx exec.VMContext, st interface{}) error {
 		return vmerrors.FaultErrorWrap(err, "Could not read actor storage")
 	}
 
-	chunk := make([]byte, len(memory))
-	copy(chunk, memory)
-
-	if err := UnmarshalStorage(chunk, st); err != nil {
+	if err := UnmarshalStorage(memory, st); err != nil {
 		return vmerrors.FaultErrorWrap(err, "Could not unmarshall actor storage")
 	}
 

--- a/actor/storage.go
+++ b/actor/storage.go
@@ -38,13 +38,8 @@ func UnmarshalStorage(raw []byte, to interface{}) error {
 // Note that if 'f' returns an error, modifications to the storage are not
 // saved.
 func WithState(ctx exec.VMContext, st interface{}, f func() (interface{}, error)) (interface{}, error) {
-	chunk, err := ctx.ReadStorage()
-	if err != nil {
-		return nil, vmerrors.FaultErrorWrap(err, "Could not read actor storage")
-	}
-
-	if err := UnmarshalStorage(chunk, st); err != nil {
-		return nil, vmerrors.FaultErrorWrap(err, "Could not unmarshall actor storage")
+	if err := ReadState(ctx, st); err != nil {
+		return nil, err
 	}
 
 	ret, err := f()
@@ -52,11 +47,38 @@ func WithState(ctx exec.VMContext, st interface{}, f func() (interface{}, error)
 		return nil, err
 	}
 
-	if err := ctx.WriteStorage(st); err != nil {
-		return nil, vmerrors.FaultErrorWrap(err, "Could not write actor storage")
+	stage := ctx.Storage()
+
+	cid, err := stage.Put(st)
+	if err != nil {
+		return nil, vmerrors.RevertErrorWrap(err, "Could not stage memory chunk")
+	}
+
+	err = stage.Commit(cid, stage.Head())
+	if err != nil {
+		return nil, vmerrors.RevertErrorWrap(err, "Could not commit actor memory")
 	}
 
 	return ret, nil
+}
+
+// ReadState is a helper method to read the cbor node at the actor's Head into the given struct
+func ReadState(ctx exec.VMContext, st interface{}) error {
+	storage := ctx.Storage()
+
+	memory, err := storage.Get(storage.Head())
+	if err != nil {
+		return vmerrors.FaultErrorWrap(err, "Could not read actor storage")
+	}
+
+	chunk := make([]byte, len(memory))
+	copy(chunk, memory)
+
+	if err := UnmarshalStorage(chunk, st); err != nil {
+		return vmerrors.FaultErrorWrap(err, "Could not unmarshall actor storage")
+	}
+
+	return nil
 }
 
 // SetKeyValue convenience method to load a lookup, set one key value pair and commit.

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"github.com/filecoin-project/go-filecoin/proofs/verification"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-hamt-ipld"
@@ -79,18 +80,21 @@ type VMContext interface {
 
 	CreateNewActor(addr address.Address, code cid.Cid, initalizationParams interface{}) error
 
-	// TODO: Remove these when Storage above is completely implemented
-	ReadStorage() ([]byte, error)
-	WriteStorage(interface{}) error
+	Verifier() Verfier
 }
 
 // Storage defines the storage module exposed to actors.
 type Storage interface {
-	// TODO: Forgot that Put() can fail in the spec, need to update.
 	Put(interface{}) (cid.Cid, error)
 	Get(cid.Cid) ([]byte, error)
 	Commit(cid.Cid, cid.Cid) error
 	Head() cid.Cid
+}
+
+// Verifier is the proof verification interface
+type Verfier interface {
+	VerifySeal(req verification.VerifySealRequest) (verification.VerifySealResponse, error)
+	VerifyPoSt(req verification.VerifyPoStRequest) (verification.VerifyPoStResponse, error)
 }
 
 // Lookup defines an internal interface for actor storage.

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -2,13 +2,13 @@ package exec
 
 import (
 	"context"
-	"github.com/filecoin-project/go-filecoin/proofs/verification"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-hamt-ipld"
 
 	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/proofs/verification"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm/errors"
 )

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -80,7 +80,7 @@ type VMContext interface {
 
 	CreateNewActor(addr address.Address, code cid.Cid, initalizationParams interface{}) error
 
-	Verifier() Verfier
+	Verifier() Verifier
 }
 
 // Storage defines the storage module exposed to actors.
@@ -92,7 +92,7 @@ type Storage interface {
 }
 
 // Verifier is the proof verification interface
-type Verfier interface {
+type Verifier interface {
 	VerifySeal(req verification.VerifySealRequest) (verification.VerifySealResponse, error)
 	VerifyPoSt(req verification.VerifyPoStRequest) (verification.VerifyPoStResponse, error)
 }

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -615,12 +615,12 @@ func (sm *Miner) getActorSectorCommitments(ctx context.Context) (map[string]type
 		ctx,
 		address.Undef,
 		sm.minerAddr,
-		"getSectorCommitments",
+		"getProvingSetCommitments",
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "query method failed")
 	}
-	sig, err := sm.porcelainAPI.ActorGetSignature(ctx, sm.minerAddr, "getSectorCommitments")
+	sig, err := sm.porcelainAPI.ActorGetSignature(ctx, sm.minerAddr, "getProvingSetCommitments")
 	if err != nil {
 		return nil, errors.Wrap(err, "query method failed")
 	}

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -691,6 +691,9 @@ func (sm *Miner) OnNewHeaviestTipSet(ts types.TipSet) error {
 		return errors.Errorf("failed to get miner actor commitments: %s", err)
 	}
 
+	// get ProvingSet
+	// iterate through ProvingSetValues pulling commitment from commitments
+
 	var inputs []PoStInputs
 	for k, v := range commitments {
 		n, err := strconv.ParseUint(k, 10, 64)

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -335,7 +335,7 @@ func TestOnNewHeaviestTipSet(t *testing.T) {
 		api, miner, _ := minerWithAcceptedDealTestSetup(t, proposalCid, sector.SectorID)
 
 		handlers := successMessageHandlers(t)
-		handlers["getSectorCommitments"] = func(a address.Address, v types.AttoFIL, p ...interface{}) ([][]byte, error) {
+		handlers["getProvingSetCommitments"] = func(a address.Address, v types.AttoFIL, p ...interface{}) ([][]byte, error) {
 			return nil, errors.New("test error")
 		}
 		api.messageHandlers = handlers
@@ -351,7 +351,7 @@ func TestOnNewHeaviestTipSet(t *testing.T) {
 		api, miner, _ := minerWithAcceptedDealTestSetup(t, proposalCid, sector.SectorID)
 
 		handlers := successMessageHandlers(t)
-		handlers["getSectorCommitments"] = func(a address.Address, v types.AttoFIL, p ...interface{}) ([][]byte, error) {
+		handlers["getProvingSetCommitments"] = func(a address.Address, v types.AttoFIL, p ...interface{}) ([][]byte, error) {
 			commitments := map[string]types.Commitments{}
 			commitments["notanumber"] = types.Commitments{}
 			return mustEncodeResults(t, commitments), nil
@@ -480,7 +480,7 @@ func successMessageHandlers(t *testing.T) messageHandlerMap {
 		return mustEncodeResults(t, false), nil
 	}
 
-	handlers["getSectorCommitments"] = func(a address.Address, v types.AttoFIL, p ...interface{}) ([][]byte, error) {
+	handlers["getProvingSetCommitments"] = func(a address.Address, v types.AttoFIL, p ...interface{}) ([][]byte, error) {
 		commitments := map[string]types.Commitments{}
 		commitments["42"] = types.Commitments{}
 		return mustEncodeResults(t, commitments), nil

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -257,6 +257,13 @@ func NewFakeVMContext(message *types.Message, state interface{}) *FakeVMContext 
 	}
 }
 
+// NewFakeVMContextWithVerifier creates a fake VMContext with the given verifier
+func NewFakeVMContextWithVerifier(message *types.Message, state interface{}, verifier exec.Verifier) *FakeVMContext {
+	vmctx := NewFakeVMContext(message, state)
+	vmctx.TestVerifier = verifier
+	return vmctx
+}
+
 // Message is the message that triggered this invocation
 func (tc *FakeVMContext) Message() *types.Message {
 	return tc.TestMessage

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -17,6 +17,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -279,7 +279,7 @@ func (tc *FakeVMContext) MyBalance() types.AttoFIL {
 	return tc.TestBalance
 }
 
-// IsFromAccountActor returns true if the type of actor that sent the message is an account actor
+// IsFromAccountActor returns true if the actor that sent the message is an account actor
 func (tc *FakeVMContext) IsFromAccountActor() bool {
 	return tc.ActorTyper()
 }

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -204,7 +204,7 @@ func (ts testStorage) Get(cid.Cid) ([]byte, error) {
 	return node.RawData(), nil
 }
 
-// Commit satisifes the Storage interface but does nothing
+// Commit satisfies the Storage interface but does nothing
 func (ts testStorage) Commit(cid.Cid, cid.Cid) error {
 	return nil
 }

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -3,6 +3,7 @@ package testhelpers
 import (
 	"context"
 	"errors"
+	"github.com/filecoin-project/go-filecoin/proofs/verification"
 	"testing"
 
 	"github.com/ipfs/go-cid"
@@ -289,4 +290,27 @@ func (tc *FakeVMContext) CreateNewActor(addr address.Address, code cid.Cid, init
 
 func (tc *FakeVMContext) Verifier() exec.Verfier {
 	return tc.TestVerifier
+}
+
+type FakeVerifier struct {
+	Valid       bool
+	Err         error
+	SealRequest verification.VerifySealRequest
+	PoStRequest verification.VerifyPoStRequest
+}
+
+func (tv *FakeVerifier) VerifySeal(req verification.VerifySealRequest) (verification.VerifySealResponse, error) {
+	if tv.Err != nil {
+		return verification.VerifySealResponse{}, tv.Err
+	}
+	tv.SealRequest = req
+	return verification.VerifySealResponse{IsValid: tv.Valid}, nil
+}
+
+func (tv *FakeVerifier) VerifyPoSt(req verification.VerifyPoStRequest) (verification.VerifyPoStResponse, error) {
+	if tv.Err != nil {
+		return verification.VerifyPoStResponse{}, tv.Err
+	}
+	tv.PoStRequest = req
+	return verification.VerifyPoStResponse{IsValid: tv.Valid}, nil
 }

--- a/vm/context.go
+++ b/vm/context.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"github.com/filecoin-project/go-filecoin/proofs/verification"
 	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/abi"
@@ -12,6 +11,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/exec"
+	"github.com/filecoin-project/go-filecoin/proofs/verification"
 	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"

--- a/vm/context.go
+++ b/vm/context.go
@@ -216,7 +216,7 @@ func (ctx *Context) SampleChainRandomness(sampleHeight *types.BlockHeight) ([]by
 }
 
 // Verifier returns an interface to the proof verification code
-func (ctx *Context) Verifier() exec.Verfier {
+func (ctx *Context) Verifier() exec.Verifier {
 	return &verification.RustVerifier{}
 }
 

--- a/vm/context_test.go
+++ b/vm/context_test.go
@@ -61,14 +61,16 @@ func TestVMContextStorage(t *testing.T) {
 	node, err := cbor.WrapObject([]byte("hello"), types.DefaultHashFunction, -1)
 	assert.NoError(t, err)
 
-	assert.NoError(t, vmCtx.WriteStorage(node.RawData()))
+	cid, err := vmCtx.Storage().Put(node.RawData())
+	require.NoError(t, err)
+	err = vmCtx.Storage().Commit(cid, vmCtx.Storage().Head())
 	assert.NoError(t, cstate.Commit(ctx))
 
 	// make sure we can read it back
 	toActorBack, err := st.GetActor(ctx, toAddr)
 	assert.NoError(t, err)
 	vmCtxParams.To = toActorBack
-	storage, err := NewVMContext(vmCtxParams).ReadStorage()
+	storage, err := vmCtx.Storage().Get(vmCtx.Storage().Head())
 	assert.NoError(t, err)
 	assert.Equal(t, storage, node.RawData())
 }

--- a/vm/context_test.go
+++ b/vm/context_test.go
@@ -64,6 +64,7 @@ func TestVMContextStorage(t *testing.T) {
 	cid, err := vmCtx.Storage().Put(node.RawData())
 	require.NoError(t, err)
 	err = vmCtx.Storage().Commit(cid, vmCtx.Storage().Head())
+	require.NoError(t, err)
 	assert.NoError(t, cstate.Commit(ctx))
 
 	// make sure we can read it back


### PR DESCRIPTION
closes #3003

### Problem

PoSt verification should only cover sectors in the current proving set. We are currently proving over all sectors. This includes sectors that have been added during the current proving set, which should be excluded.

### Solution

Only include sectors in the proving set in verification. This involves some rather minor changes to `SubmitPoSt` and `GetSectorCommitments` (now `GetProvingSetCommitments`). The problem is the part of the code that changed in `SubmitPoSt` was not under test. This prompted a much larger refactor to make all of miner actor testable. A consequence is that all actor code will now be more testable.

### What Changes in this PR

Major thrusts of work are fairly well encapsulated within 6 commits:

1. Commit 1: __Send only proving set CommRs to VerifyPoSt__: This completes the verification side of the issue, but at this stage, it is completely untested. Since the miner is coupled to rust proofs, testing this code will require a valid proof based off a real sealed sector. This is not something we want to do in a unit test, so the next step is to decouple rust proofs code from the actor.
2. Commit 2: __Introduce VMContext.Verifier abstraction, remove `ReadStorage` and `WriteStorage`:__ This is all in preparation for faking out the VMContext and it's verifier.
3. Commit 3: __Introduce FakeVMContext and use it to test SubmitPoSt verification:__ The FakeVMContext is designed to provide reasonable trade off between default functionality and flexibility. It allows us to fully mock out the state machine infrastructure and call actor methods directly for the first time. The `TestMinerSubmitPoStVerification` takes advantage of this to provide full coverage of all the code previously hidden in the non-bootstrap miner block.
4. Commit 4: __Convert getSectorCommitments to getProvingSetCommitments:__ This satisfies the proving side of this issue. The miner's prover calls this method to get all commitments it needs to prove on. This commit changes the miner method to only return commitments in the proving set and renames it to signal this functionality.
5. Commit 5: __Test `getProvingSetCommitments`:__ The new test takes advantage of the new FakeVMContext test infrastructure to provide full coverage of the query method.
6. Commit 6: __Refactor testVerfier into testhelpers:__ This is general purpose code (although probably only need by miner for now), and miner_test is way too long.