### PR TITLE
Disable codecov comments on PRs until the numbers are accurate

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,13 +8,13 @@ coverage:
     patch: off
     changes: off
 
-comment:
-  layout: "diff, flags, files"
-  behavior: default
-  require_changes: false  # if true: only post the comment if coverage changes
-  require_base: yes       # [yes :: must have a base report to post]
-  require_head: yes       # [yes :: must have a head report to post]
-  branches: null          # branch names that can post comment
+comment: off
+#  layout: "diff, flags, files"
+#  behavior: default
+#  require_changes: false  # if true: only post the comment if coverage changes
+#  require_base: yes       # [yes :: must have a base report to post]
+#  require_head: yes       # [yes :: must have a head report to post]
+#  branches: null          # branch names that can post comment
 
 ignore:
   - "*/testing.go"


### PR DESCRIPTION
The number we see from coverage reports are wrong. Until we can fix it, let's not post bogus numbers into PRs and train people to ignore them.

I have other work attempting to fix it.

See #2785 
