### PR TITLE
Remove chain.Store's "BlockHeight" method

### DIFF
--- a/chain/get_ancestors_test.go
+++ b/chain/get_ancestors_test.go
@@ -62,7 +62,7 @@ func TestCollectTipSetsOfHeightAtLeastStartingEpochIsNull(t *testing.T) {
 	tf.UnitTest(t)
 	ctx := context.Background()
 	builder := chain.NewBuilder(t, address.Undef)
-	head := builder.Genesis()
+	head := builder.NewGenesis()
 
 	// Add 30 tipsets to the head of the chainStore.
 	head = builder.AppendManyOn(30, head)
@@ -172,7 +172,7 @@ func TestGetRecentAncestorsStartingEpochIsNull(t *testing.T) {
 	tf.UnitTest(t)
 	ctx := context.Background()
 	builder := chain.NewBuilder(t, address.Undef)
-	head := builder.Genesis()
+	head := builder.NewGenesis()
 
 	// Add 30 tipsets to the head of the chainStore.
 	head = builder.AppendManyOn(30, head)
@@ -202,7 +202,7 @@ func TestFindCommonAncestorSameChain(t *testing.T) {
 	tf.UnitTest(t)
 	ctx := context.Background()
 	builder := chain.NewBuilder(t, address.Undef)
-	head := builder.Genesis()
+	head := builder.NewGenesis()
 	// Add 30 tipsets to the head of the chainStore.
 	head = builder.AppendManyOn(30, head)
 	headIterOne := chain.IterAncestors(ctx, builder, head)
@@ -216,7 +216,7 @@ func TestFindCommonAncestorFork(t *testing.T) {
 	tf.UnitTest(t)
 	ctx := context.Background()
 	builder := chain.NewBuilder(t, address.Undef)
-	head := builder.Genesis()
+	head := builder.NewGenesis()
 
 	// Add 3 tipsets to the head of the chainStore.
 	commonHeadTip := builder.AppendManyOn(3, head)
@@ -240,7 +240,7 @@ func TestFindCommonAncestorNoFork(t *testing.T) {
 	tf.UnitTest(t)
 	ctx := context.Background()
 	builder := chain.NewBuilder(t, address.Undef)
-	head := builder.Genesis()
+	head := builder.NewGenesis()
 
 	// Add 30 tipsets to the head of the chainStore.
 	head = builder.AppendManyOn(30, head)
@@ -262,7 +262,7 @@ func TestFindCommonAncestorNullBlockFork(t *testing.T) {
 	tf.UnitTest(t)
 	ctx := context.Background()
 	builder := chain.NewBuilder(t, address.Undef)
-	head := builder.Genesis()
+	head := builder.NewGenesis()
 
 	// Add 10 tipsets to the head of the chainStore.
 	commonHead := builder.AppendManyOn(10, head)

--- a/chain/store.go
+++ b/chain/store.go
@@ -45,6 +45,7 @@ func newSource(cst state.IpldStore) *ipldSource {
 // GetBlock retrieves a filecoin block by cid from the IPLD store.
 func (source *ipldSource) GetBlock(ctx context.Context, c cid.Cid) (*types.Block, error) {
 	var block types.Block
+
 	err := source.cborStore.Get(ctx, c, &block)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get block %s", c.String())
@@ -350,13 +351,6 @@ func (store *Store) GetHead() types.TipSetKey {
 	}
 
 	return store.head.Key()
-}
-
-// BlockHeight returns the chain height of the head tipset.
-func (store *Store) BlockHeight() (uint64, error) {
-	store.mu.RLock()
-	defer store.mu.RUnlock()
-	return store.head.Height()
 }
 
 // GenesisCid returns the genesis cid of the chain tracked by the default store.

--- a/chain/store_test.go
+++ b/chain/store_test.go
@@ -173,7 +173,7 @@ func TestGetTipSetState(t *testing.T) {
 
 	// link testing state to test block
 	builder := chain.NewBuilder(t, address.Undef)
-	gen := builder.Genesis()
+	gen := builder.NewGenesis()
 	testTs := builder.BuildOn(gen, func(b *chain.BlockBuilder) {
 		b.SetStateRoot(root)
 	})

--- a/chain/syncer_test.go
+++ b/chain/syncer_test.go
@@ -377,7 +377,7 @@ func TestBlockNotLinkedRejected(t *testing.T) {
 // The chain builder has a single genesis block, which is set as the head of the store.
 func setup(ctx context.Context, t *testing.T) (*chain.Builder, *chain.Store, *chain.Syncer) {
 	builder := chain.NewBuilder(t, address.Undef)
-	genesis := builder.Genesis()
+	genesis := builder.NewGenesis()
 	genStateRoot, err := builder.GetTipSetStateRoot(genesis.Key())
 	require.NoError(t, err)
 

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -62,8 +62,8 @@ func NewBuilder(t *testing.T, miner address.Address) *Builder {
 	return b
 }
 
-// Genesis creates and returns a tipset of one block with no parents.
-func (f *Builder) Genesis() types.TipSet {
+// NewGenesis creates and returns a tipset of one block with no parents.
+func (f *Builder) NewGenesis() types.TipSet {
 	return types.RequireNewTipSet(f.t, f.AppendBlockOn(types.UndefTipSet))
 }
 

--- a/core/inbox.go
+++ b/core/inbox.go
@@ -28,7 +28,7 @@ type Inbox struct {
 // Exported for testing.
 type InboxChainProvider interface {
 	chain.TipSetProvider
-	BlockHeight() (uint64, error)
+	GetHead() types.TipSetKey
 }
 
 // NewInbox constructs a new inbox.
@@ -40,7 +40,11 @@ func NewInbox(pool *MessagePool, maxAgeRounds uint, chain InboxChainProvider) *I
 // An error probably means the message failed to validate,
 // but it could indicate a more serious problem with the system.
 func (ib *Inbox) Add(ctx context.Context, msg *types.SignedMessage) (cid.Cid, error) {
-	blockTime, err := ib.chain.BlockHeight()
+	head, err := ib.chain.GetTipSet(ib.chain.GetHead())
+	if err != nil {
+		return cid.Undef, err
+	}
+	blockTime, err := head.Height()
 	if err != nil {
 		return cid.Undef, err
 	}

--- a/plumbing/cst/chain_state.go
+++ b/plumbing/cst/chain_state.go
@@ -19,7 +19,6 @@ import (
 )
 
 type chainReader interface {
-	BlockHeight() (uint64, error)
 	GetHead() types.TipSetKey
 	GetTipSet(types.TipSetKey) (types.TipSet, error)
 	GetTipSetState(context.Context, types.TipSetKey) (state.Tree, error)

--- a/plumbing/msg/queryer.go
+++ b/plumbing/msg/queryer.go
@@ -17,9 +17,9 @@ import (
 
 // Abstracts over a store of blockchain state.
 type queryerChainReader interface {
-	BlockHeight() (uint64, error)
 	GetHead() types.TipSetKey
 	GetTipSetState(context.Context, types.TipSetKey) (state.Tree, error)
+	GetTipSet(types.TipSetKey) (types.TipSet, error)
 }
 
 // Queryer knows how to send read-only messages for querying actor state.
@@ -41,16 +41,20 @@ func NewQueryer(chainReader queryerChainReader, cst *hamt.CborIpldStore, bs bsto
 func (q *Queryer) Query(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error) {
 	encodedParams, err := abi.ToEncodedValues(params...)
 	if err != nil {
-		return nil, errors.Wrap(err, "couldnt encode message params")
+		return nil, errors.Wrap(err, "failed to encode message params")
 	}
 
 	st, err := q.chainReader.GetTipSetState(ctx, q.chainReader.GetHead())
 	if err != nil {
-		return nil, errors.Wrap(err, "could load tree for latest state root")
+		return nil, errors.Wrap(err, "failed to load tree for latest state root")
 	}
-	h, err := q.chainReader.BlockHeight()
+	head, err := q.chainReader.GetTipSet(q.chainReader.GetHead())
 	if err != nil {
-		return nil, errors.Wrap(err, "couldnt get base tipset height")
+		return nil, errors.Wrap(err, "failed to get the head tipset")
+	}
+	h, err := head.Height()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get the head tipset height")
 	}
 
 	vms := vm.NewStorageMap(q.bs)


### PR DESCRIPTION
This moves the needle on issue #3022.  PR #3061 makes state accesses within plumbing require referencing state wrt a specific tipset key.  This PR enforces the same for block heights by removing `BlockHeight` from `chain.Store`.

It also un-swallows a swallowed error in the syncer's finality calculation.

@anorth I think #3022 is broader in scope than this PR + #3061 and is only complete when *callers* of plumbing reference a specific tipsetkey.  However I wasn't sure so let me know if I am wrong and the issue is addressed here and I'll connect it to this PR / close out on merge.