### PR TITLE
terminate the extra return

### DIFF
--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -524,7 +524,6 @@ func (ma *Actor) GetPoStState(ctx exec.VMContext) (*big.Int, uint8, error) {
 
 	if err != nil {
 		return nil, errors.CodeError(err), err
-		return nil, errors.CodeError(err), err
 	}
 
 	result, ok := out.(int64)


### PR DESCRIPTION
## Why does this PR exist?

While stumbling through the code forest with @sidke this morning, we came across an extra return statement. Being good citizens, we terminated it with extreme prejudice.

## What's in this PR?

Oh not much. Just deleted an extra return statement.