### PR TITLE
better error messaging for voucher decoding

### DIFF
--- a/commands/main.go
+++ b/commands/main.go
@@ -334,7 +334,7 @@ var previewOption = cmdkit.BoolOption("preview", "Preview the Gas cost of this c
 func parseGasOptions(req *cmds.Request) (types.AttoFIL, types.GasUnits, bool, error) {
 	priceOption := req.Options["gas-price"]
 	if priceOption == nil {
-		return types.ZeroAttoFIL, types.NewGasUnits(0), false, errors.New("price option is required")
+		return types.ZeroAttoFIL, types.NewGasUnits(0), false, errors.New("gas-price option is required")
 	}
 
 	price, ok := types.NewAttoFILFromFILString(priceOption.(string))
@@ -344,7 +344,7 @@ func parseGasOptions(req *cmds.Request) (types.AttoFIL, types.GasUnits, bool, er
 
 	limitOption := req.Options["gas-limit"]
 	if limitOption == nil {
-		return types.ZeroAttoFIL, types.NewGasUnits(0), false, errors.New("limit option is required")
+		return types.ZeroAttoFIL, types.NewGasUnits(0), false, errors.New("gas-limit option is required")
 	}
 
 	gasLimitInt, ok := limitOption.(uint64)

--- a/types/payment_voucher.go
+++ b/types/payment_voucher.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"errors"
+
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/multiformats/go-multibase"
 	"sort"
@@ -54,13 +56,13 @@ type PaymentVoucher struct {
 func DecodeVoucher(voucherRaw string) (*PaymentVoucher, error) {
 	_, cborVoucher, err := multibase.Decode(voucherRaw)
 	if err != nil {
-		return nil, err
+		return nil, errors.New("voucher could not be decoded")
 	}
 
 	var voucher PaymentVoucher
 	err = cbor.DecodeInto(cborVoucher, &voucher)
 	if err != nil {
-		return nil, err
+		return nil, errors.New("voucher string could not be decoded into voucher")
 	}
 
 	return &voucher, nil


### PR DESCRIPTION
closes #2909

### Problem

Error messaging for redeeming a message voucher is bad. In the case of the bug, there was an attempt to redeem something other than a payment voucher, and the error mentions getting an int instead of a map in a stream. Prior to the decoding error, there was an attempt to call redeem without providing a gas-limit or gas-price, but the error only mentioned 'limit' and 'price'.

### Solution

Provide error message that simply suggest indicated that the payment voucher decoding has failed. Precisely why it has failed is going to be hard to recover, and precisely where in the decoding it failed is irrelevant. Also fix the error messages for required gas price and limit.