### PR TITLE
add IpldStore and StateLoading interfaces

### DIFF
--- a/chain/init.go
+++ b/chain/init.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/repo"
+	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -26,7 +27,7 @@ func Init(ctx context.Context, r repo.Repo, bs bstore.Blockstore, cst *hamt.Cbor
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate genesis block")
 	}
-	chainStore := NewStore(r.ChainDatastore(), cst, &TreeStateLoader{}, genesis.Cid())
+	chainStore := NewStore(r.ChainDatastore(), cst, &state.TreeStateLoader{}, genesis.Cid())
 
 	// Persist the genesis tipset to the repo.
 	genTsas := &TipSetAndState{

--- a/chain/init.go
+++ b/chain/init.go
@@ -26,7 +26,7 @@ func Init(ctx context.Context, r repo.Repo, bs bstore.Blockstore, cst *hamt.Cbor
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate genesis block")
 	}
-	chainStore := NewStore(r.ChainDatastore(), cst, genesis.Cid())
+	chainStore := NewStore(r.ChainDatastore(), cst, &TreeStateLoader{}, genesis.Cid())
 
 	// Persist the genesis tipset to the repo.
 	genTsas := &TipSetAndState{

--- a/chain/store.go
+++ b/chain/store.go
@@ -8,13 +8,13 @@ import (
 	"github.com/cskr/pubsub"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-hamt-ipld"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	logging "github.com/ipfs/go-log"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
+	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/metrics/tracing"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/state"
@@ -31,13 +31,21 @@ var logStore = logging.Logger("chain.store")
 
 var headKey = datastore.NewKey("/chain/heaviestTipSet")
 
+// TreeStateLoader implements the state.StateLoader interface.
+type TreeStateLoader struct{}
+
+// LoadStateTree is a wrapper around state.LoadStateTree.
+func (stl *TreeStateLoader) LoadStateTree(ctx context.Context, store state.IpldStore, c cid.Cid, builtinActors map[cid.Cid]exec.ExecutableActor) (state.Tree, error) {
+	return state.LoadStateTree(ctx, store, c, builtinActors)
+}
+
 type ipldSource struct {
 	// cst is a store allowing access
 	// (un)marshalling and interop with go-ipld-hamt.
-	cborStore *hamt.CborIpldStore
+	cborStore state.IpldStore
 }
 
-func newSource(cst *hamt.CborIpldStore) *ipldSource {
+func newSource(cst state.IpldStore) *ipldSource {
 	return &ipldSource{
 		cborStore: cst,
 	}
@@ -59,6 +67,10 @@ type Store struct {
 	// ipldSource is a wrapper around ipld storage.  It is used
 	// for reading filecoin block and state objects kept by the node.
 	stateAndBlockSource *ipldSource
+
+	// stateTreeeLoader is used for loading the state tree from a
+	// CborIPLDStore
+	stateTreeLoader state.TreeLoader
 
 	// ds is the datastore for the chain's private metadata which consists
 	// of the tipset key to state root cid mapping, and the heaviest tipset
@@ -85,9 +97,10 @@ type Store struct {
 }
 
 // NewStore constructs a new default store.
-func NewStore(ds repo.Datastore, cst *hamt.CborIpldStore, genesisCid cid.Cid) *Store {
+func NewStore(ds repo.Datastore, cst state.IpldStore, stl state.TreeLoader, genesisCid cid.Cid) *Store {
 	return &Store{
 		stateAndBlockSource: newSource(cst),
+		stateTreeLoader:     stl,
 		ds:                  ds,
 		headEvents:          pubsub.New(128),
 		tipIndex:            NewTipIndex(),
@@ -238,7 +251,7 @@ func (store *Store) GetTipSetState(ctx context.Context, key types.TipSetKey) (st
 	if err != nil {
 		return nil, err
 	}
-	return state.LoadStateTree(ctx, store.stateAndBlockSource.cborStore, stateCid, builtin.Actors)
+	return store.stateTreeLoader.LoadStateTree(ctx, store.stateAndBlockSource.cborStore, stateCid, builtin.Actors)
 }
 
 // GetTipSetStateRoot returns the aggregate state root CID of the tipset identified by `key`.

--- a/chain/store.go
+++ b/chain/store.go
@@ -14,7 +14,6 @@ import (
 	"go.opencensus.io/trace"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
-	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/metrics/tracing"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/state"
@@ -30,14 +29,6 @@ var GenesisKey = datastore.NewKey("/consensus/genesisCid")
 var logStore = logging.Logger("chain.store")
 
 var headKey = datastore.NewKey("/chain/heaviestTipSet")
-
-// TreeStateLoader implements the state.StateLoader interface.
-type TreeStateLoader struct{}
-
-// LoadStateTree is a wrapper around state.LoadStateTree.
-func (stl *TreeStateLoader) LoadStateTree(ctx context.Context, store state.IpldStore, c cid.Cid, builtinActors map[cid.Cid]exec.ExecutableActor) (state.Tree, error) {
-	return state.LoadStateTree(ctx, store, c, builtinActors)
-}
 
 type ipldSource struct {
 	// cst is a store allowing access

--- a/chain/store_test.go
+++ b/chain/store_test.go
@@ -39,7 +39,7 @@ func initStoreTest(ctx context.Context, t *testing.T, dstP *SyncerTestParams) {
 func newChainStore(dstP *SyncerTestParams) *chain.Store {
 	r := repo.NewInMemoryRepo()
 	ds := r.Datastore()
-	return chain.NewStore(ds, hamt.NewCborStore(), dstP.genCid)
+	return chain.NewStore(ds, hamt.NewCborStore(), &chain.TreeStateLoader{}, dstP.genCid)
 }
 
 // requirePutTestChain adds all test chain tipsets to the passed in chain store.
@@ -178,7 +178,7 @@ func TestGetTipSetState(t *testing.T) {
 	// setup chain store
 	r := repo.NewInMemoryRepo()
 	ds := r.Datastore()
-	store := chain.NewStore(ds, cst, gen.Cid())
+	store := chain.NewStore(ds, cst, &chain.TreeStateLoader{}, gen.Cid())
 
 	// add tipset and state to chain store
 	require.NoError(t, store.PutTipSetAndState(ctx, &chain.TipSetAndState{
@@ -391,7 +391,7 @@ func TestLoadAndReboot(t *testing.T) {
 	requirePutBlocksToCborStore(t, cst, dstP.link3.ToSlice()...)
 	requirePutBlocksToCborStore(t, cst, dstP.link4.ToSlice()...)
 
-	chainStore := chain.NewStore(ds, cst, dstP.genCid)
+	chainStore := chain.NewStore(ds, cst, &chain.TreeStateLoader{}, dstP.genCid)
 	requirePutTestChain(t, chainStore, dstP)
 	assertSetHead(t, chainStore, dstP.genTS) // set the genesis block
 
@@ -399,7 +399,7 @@ func TestLoadAndReboot(t *testing.T) {
 	chainStore.Stop()
 
 	// rebuild chain with same datastore and cborstore
-	rebootChain := chain.NewStore(ds, cst, dstP.genCid)
+	rebootChain := chain.NewStore(ds, cst, &chain.TreeStateLoader{}, dstP.genCid)
 	err := rebootChain.Load(ctx)
 	assert.NoError(t, err)
 

--- a/chain/store_test.go
+++ b/chain/store_test.go
@@ -39,7 +39,7 @@ func initStoreTest(ctx context.Context, t *testing.T, dstP *SyncerTestParams) {
 func newChainStore(dstP *SyncerTestParams) *chain.Store {
 	r := repo.NewInMemoryRepo()
 	ds := r.Datastore()
-	return chain.NewStore(ds, hamt.NewCborStore(), &chain.TreeStateLoader{}, dstP.genCid)
+	return chain.NewStore(ds, hamt.NewCborStore(), &state.TreeStateLoader{}, dstP.genCid)
 }
 
 // requirePutTestChain adds all test chain tipsets to the passed in chain store.
@@ -178,7 +178,7 @@ func TestGetTipSetState(t *testing.T) {
 	// setup chain store
 	r := repo.NewInMemoryRepo()
 	ds := r.Datastore()
-	store := chain.NewStore(ds, cst, &chain.TreeStateLoader{}, gen.Cid())
+	store := chain.NewStore(ds, cst, &state.TreeStateLoader{}, gen.Cid())
 
 	// add tipset and state to chain store
 	require.NoError(t, store.PutTipSetAndState(ctx, &chain.TipSetAndState{
@@ -391,7 +391,7 @@ func TestLoadAndReboot(t *testing.T) {
 	requirePutBlocksToCborStore(t, cst, dstP.link3.ToSlice()...)
 	requirePutBlocksToCborStore(t, cst, dstP.link4.ToSlice()...)
 
-	chainStore := chain.NewStore(ds, cst, &chain.TreeStateLoader{}, dstP.genCid)
+	chainStore := chain.NewStore(ds, cst, &state.TreeStateLoader{}, dstP.genCid)
 	requirePutTestChain(t, chainStore, dstP)
 	assertSetHead(t, chainStore, dstP.genTS) // set the genesis block
 
@@ -399,7 +399,7 @@ func TestLoadAndReboot(t *testing.T) {
 	chainStore.Stop()
 
 	// rebuild chain with same datastore and cborstore
-	rebootChain := chain.NewStore(ds, cst, &chain.TreeStateLoader{}, dstP.genCid)
+	rebootChain := chain.NewStore(ds, cst, &state.TreeStateLoader{}, dstP.genCid)
 	err := rebootChain.Load(ctx)
 	assert.NoError(t, err)
 

--- a/chain/syncer_test.go
+++ b/chain/syncer_test.go
@@ -203,7 +203,7 @@ func loadSyncerFromRepo(t *testing.T, r repo.Repo, dstP *SyncerTestParams) (*cha
 	require.NoError(t, err)
 	calcGenBlk.StateRoot = dstP.genStateRoot
 	chainDS := r.ChainDatastore()
-	chainStore := chain.NewStore(chainDS, cst, calcGenBlk.Cid())
+	chainStore := chain.NewStore(chainDS, cst, &chain.TreeStateLoader{}, calcGenBlk.Cid())
 
 	blockSource := th.NewTestFetcher()
 	syncer := chain.NewSyncer(con, chainStore, blockSource, chain.Syncing)
@@ -275,7 +275,7 @@ func initSyncTest(t *testing.T, con consensus.Protocol, genFunc func(cst *hamt.C
 	require.NoError(t, err)
 	calcGenBlk.StateRoot = dstP.genStateRoot
 	chainDS := r.ChainDatastore()
-	chainStore := chain.NewStore(chainDS, cst, calcGenBlk.Cid())
+	chainStore := chain.NewStore(chainDS, cst, &chain.TreeStateLoader{}, calcGenBlk.Cid())
 
 	fetcher := th.NewTestFetcher()
 	syncer := chain.NewSyncer(con, chainStore, fetcher, syncMode) // note we use same cst for on and offline for tests
@@ -1067,7 +1067,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 	var calcGenBlk types.Block
 	require.NoError(t, cst.Get(ctx, info.GenesisCid, &calcGenBlk))
 
-	chainStore := chain.NewStore(r.ChainDatastore(), cst, calcGenBlk.Cid())
+	chainStore := chain.NewStore(r.ChainDatastore(), cst, &chain.TreeStateLoader{}, calcGenBlk.Cid())
 
 	verifier := verification.NewFakeVerifier(true, nil)
 	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &th.TestView{}, calcGenBlk.Cid(), verifier, th.BlockTimeTest)

--- a/chain/syncer_test.go
+++ b/chain/syncer_test.go
@@ -203,7 +203,7 @@ func loadSyncerFromRepo(t *testing.T, r repo.Repo, dstP *SyncerTestParams) (*cha
 	require.NoError(t, err)
 	calcGenBlk.StateRoot = dstP.genStateRoot
 	chainDS := r.ChainDatastore()
-	chainStore := chain.NewStore(chainDS, cst, &chain.TreeStateLoader{}, calcGenBlk.Cid())
+	chainStore := chain.NewStore(chainDS, cst, &state.TreeStateLoader{}, calcGenBlk.Cid())
 
 	blockSource := th.NewTestFetcher()
 	syncer := chain.NewSyncer(con, chainStore, blockSource, chain.Syncing)
@@ -275,7 +275,7 @@ func initSyncTest(t *testing.T, con consensus.Protocol, genFunc func(cst *hamt.C
 	require.NoError(t, err)
 	calcGenBlk.StateRoot = dstP.genStateRoot
 	chainDS := r.ChainDatastore()
-	chainStore := chain.NewStore(chainDS, cst, &chain.TreeStateLoader{}, calcGenBlk.Cid())
+	chainStore := chain.NewStore(chainDS, cst, &state.TreeStateLoader{}, calcGenBlk.Cid())
 
 	fetcher := th.NewTestFetcher()
 	syncer := chain.NewSyncer(con, chainStore, fetcher, syncMode) // note we use same cst for on and offline for tests
@@ -1067,7 +1067,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 	var calcGenBlk types.Block
 	require.NoError(t, cst.Get(ctx, info.GenesisCid, &calcGenBlk))
 
-	chainStore := chain.NewStore(r.ChainDatastore(), cst, &chain.TreeStateLoader{}, calcGenBlk.Cid())
+	chainStore := chain.NewStore(r.ChainDatastore(), cst, &state.TreeStateLoader{}, calcGenBlk.Cid())
 
 	verifier := verification.NewFakeVerifier(true, nil)
 	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &th.TestView{}, calcGenBlk.Cid(), verifier, th.BlockTimeTest)

--- a/node/node.go
+++ b/node/node.go
@@ -393,7 +393,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 	}
 
 	// set up chainstore
-	chainStore := chain.NewStore(nc.Repo.ChainDatastore(), &ipldCborStore, &chain.TreeStateLoader{}, genCid)
+	chainStore := chain.NewStore(nc.Repo.ChainDatastore(), &ipldCborStore, &state.TreeStateLoader{}, genCid)
 	chainState := cst.NewChainStateProvider(chainStore, &ipldCborStore)
 	powerTable := &consensus.MarketView{}
 

--- a/node/node.go
+++ b/node/node.go
@@ -393,7 +393,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 	}
 
 	// set up chainstore
-	chainStore := chain.NewStore(nc.Repo.ChainDatastore(), &ipldCborStore, genCid)
+	chainStore := chain.NewStore(nc.Repo.ChainDatastore(), &ipldCborStore, &chain.TreeStateLoader{}, genCid)
 	chainState := cst.NewChainStateProvider(chainStore, &ipldCborStore)
 	powerTable := &consensus.MarketView{}
 


### PR DESCRIPTION
### What
This PR defines `IpldStore` and `TreeLoader` interfaces and modifies the chain store to accept them. A goal of this PR is to ease testing of the chain store and syncer by allowing the CborIplsStore and State Tree Loading operations to be mocked/faked. 