### PR TITLE
Port most syncer tests to use chain.Builder and non-shared setup

### DIFF
--- a/chain/reorg_test.go
+++ b/chain/reorg_test.go
@@ -69,14 +69,14 @@ func TestReorgDiffSubset(t *testing.T) {
 // This function returns the forked head, the main head and the common ancestor.
 func getForkOldNewCommon(ctx context.Context, t *testing.T, builder *chain.Builder, a, b, c int) (types.TipSet, types.TipSet, types.TipSet) {
 	// Add "a" tipsets to the head of the chainStore.
-	commonHead := builder.AppendManyOn(a)
-	oldHead := types.RequireNewTipSet(t, commonHead)
+	commonHead := builder.AppendManyOn(a, types.UndefTipSet)
+	oldHead := commonHead
 
 	if c > 0 {
-		oldHead = types.RequireNewTipSet(t, builder.AppendManyOn(c, commonHead))
+		oldHead = builder.AppendManyOn(c, commonHead)
 	}
-	newHead := types.RequireNewTipSet(t, builder.AppendManyOn(b, commonHead))
-	return oldHead, newHead, types.RequireNewTipSet(t, commonHead)
+	newHead := builder.AppendManyOn(b, commonHead)
+	return oldHead, newHead, commonHead
 }
 
 // getSubsetOldNewCommon is a testing helper function that creates and stores
@@ -85,9 +85,9 @@ func getForkOldNewCommon(ctx context.Context, t *testing.T, builder *chain.Build
 // consists of this single block and another block together forming a tipset
 // that is a superset of the forked head.
 func getSubsetOldNewCommon(ctx context.Context, t *testing.T, builder *chain.Builder, a int) (types.TipSet, types.TipSet, types.TipSet) {
-	commonHead := builder.AppendManyOn(a)
-	block1 := builder.AppendOn(commonHead)
-	block2 := builder.AppendOn(commonHead)
+	commonHead := builder.AppendManyBlocksOnBlocks(a)
+	block1 := builder.AppendBlockOnBlocks(commonHead)
+	block2 := builder.AppendBlockOnBlocks(commonHead)
 
 	oldHead := types.RequireNewTipSet(t, block1)
 	superset := types.RequireNewTipSet(t, block1, block2)

--- a/chain/syncer.go
+++ b/chain/syncer.go
@@ -86,8 +86,8 @@ type syncStateEvaluator interface {
 	// prior `stateRoot`.  It returns an error if the transition is invalid.
 	RunStateTransition(ctx context.Context, ts types.TipSet, ancestors []types.TipSet, stateID cid.Cid) (cid.Cid, error)
 
-	// IsHeaver returns 1 if tipset a is heavier than tipset b and -1 if
-	// tipset b is heavier than tipset a.
+	// IsHeaver tests whether tipset `a` is heavier than tipset `b`.
+	// The state IDs identify the state to which the tipset applies (i.e. prior to its messages).
 	IsHeavier(ctx context.Context, a, b types.TipSet, aStateID, bStateID cid.Cid) (bool, error)
 }
 

--- a/chain/syncer_integration_test.go
+++ b/chain/syncer_integration_test.go
@@ -1,0 +1,618 @@
+package chain_test
+
+import (
+	"context"
+	"testing"
+
+	bserv "github.com/ipfs/go-blockservice"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-hamt-ipld"
+	bstore "github.com/ipfs/go-ipfs-blockstore"
+	"github.com/ipfs/go-ipfs-exchange-offline"
+	"github.com/libp2p/go-libp2p-peer"
+
+	"github.com/filecoin-project/go-filecoin/actor/builtin"
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/gengen/util"
+	"github.com/filecoin-project/go-filecoin/proofs/verification"
+	"github.com/filecoin-project/go-filecoin/repo"
+	"github.com/filecoin-project/go-filecoin/state"
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file contains test that use a full syncer dependency structure, including store and
+// consensus implementations.
+// See syncer_test.go for most syncer unit tests.
+// The tests here should probably be reworked to follow the unit test patterns, and this
+// integration test setup reserved for a few "sunny day" tests of integration specifically.
+
+type SyncerTestParams struct {
+	// Chain diagram below.  Note that blocks in the same tipset are in parentheses.
+	//
+	// genesis -> (link1blk1, link1blk2) -> (link2blk1, link2blk2, link2blk3) -> link3blk1 -> (link4blk1, link4blk2)
+
+	// Blocks
+	genesis                         *types.Block
+	link1blk1, link1blk2            *types.Block
+	link2blk1, link2blk2, link2blk3 *types.Block
+	link3blk1                       *types.Block
+	link4blk1, link4blk2            *types.Block
+
+	// Cids
+	genCid                                                       cid.Cid
+	genStateRoot, link1State, link2State, link3State, link4State cid.Cid
+
+	// TipSets
+	genTS, link1, link2, link3, link4 types.TipSet
+
+	// utils
+	cidGetter         func() cid.Cid
+	minerAddress      address.Address
+	minerOwnerAddress address.Address
+	minerPeerID       peer.ID
+}
+
+func initDSTParams() *SyncerTestParams {
+	var err error
+	minerAddress, err := address.NewActorAddress([]byte("miner"))
+	if err != nil {
+		panic(err)
+	}
+	minerOwnerAddress, err := address.NewActorAddress([]byte("minerOwner"))
+	if err != nil {
+		panic(err)
+	}
+	minerPeerID, err := th.RandPeerID()
+	if err != nil {
+		panic(err)
+	}
+
+	// Set up the test chain
+	bs := bstore.NewBlockstore(repo.NewInMemoryRepo().Datastore())
+	cst := hamt.NewCborStore()
+	genesis, err := initGenesis(minerAddress, minerOwnerAddress, minerPeerID, cst, bs)
+	if err != nil {
+		panic(err)
+	}
+	genCid := genesis.Cid()
+	genTS := th.MustNewTipSet(genesis)
+
+	// mock state root cids
+	cidGetter := types.NewCidForTestGetter()
+
+	genStateRoot := genesis.StateRoot
+
+	return &SyncerTestParams{
+		minerAddress:      minerAddress,
+		minerOwnerAddress: minerOwnerAddress,
+		minerPeerID:       minerPeerID,
+		genesis:           genesis,
+		genCid:            genCid,
+		genTS:             genTS,
+		cidGetter:         cidGetter,
+		genStateRoot:      genStateRoot,
+	}
+}
+
+// This function sets global variables according to the tests needs.  The
+// test chain's basic structure is always the same, but some tests want
+// mocked stateRoots or parent weight calculations from different consensus protocols.
+func requireSetTestChain(t *testing.T, con consensus.Protocol, mockStateRoots bool, dstP *SyncerTestParams) {
+
+	var err error
+	// see powerTableForWidenTest
+	minerPower := types.NewBytesAmount(25)
+	totalPower := types.NewBytesAmount(100)
+	mockSigner, _ := types.NewMockSignersAndKeyInfo(1)
+	minerWorker := mockSigner.Addresses[0]
+
+	fakeChildParams := th.FakeChildParams{
+		Parent:      dstP.genTS,
+		GenesisCid:  dstP.genCid,
+		StateRoot:   dstP.genStateRoot,
+		Consensus:   con,
+		MinerAddr:   dstP.minerAddress,
+		MinerWorker: minerWorker,
+		Signer:      mockSigner,
+	}
+
+	dstP.link1blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link1blk1.Proof, dstP.link1blk1.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
+	require.NoError(t, err)
+
+	dstP.link1blk2 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link1blk2.Proof, dstP.link1blk2.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
+	require.NoError(t, err)
+
+	dstP.link1 = th.RequireNewTipSet(t, dstP.link1blk1, dstP.link1blk2)
+
+	if mockStateRoots {
+		dstP.link1State = dstP.cidGetter()
+	} else {
+		dstP.link1State = dstP.genStateRoot
+	}
+
+	fakeChildParams.Parent = dstP.link1
+	fakeChildParams.StateRoot = dstP.link1State
+	dstP.link2blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link2blk1.Proof, dstP.link2blk1.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
+	require.NoError(t, err)
+
+	dstP.link2blk2 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link2blk2.Proof, dstP.link2blk2.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
+	require.NoError(t, err)
+
+	fakeChildParams.Nonce = uint64(1)
+	dstP.link2blk3 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link2blk3.Proof, dstP.link2blk3.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
+	require.NoError(t, err)
+
+	dstP.link2 = th.RequireNewTipSet(t, dstP.link2blk1, dstP.link2blk2, dstP.link2blk3)
+
+	if mockStateRoots {
+		dstP.link2State = dstP.cidGetter()
+	} else {
+		dstP.link2State = dstP.genStateRoot
+	}
+
+	fakeChildParams.Parent = dstP.link2
+	fakeChildParams.StateRoot = dstP.link2State
+	dstP.link3blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link3blk1.Proof, dstP.link3blk1.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
+	require.NoError(t, err)
+
+	dstP.link3 = th.RequireNewTipSet(t, dstP.link3blk1)
+
+	if mockStateRoots {
+		dstP.link3State = dstP.cidGetter()
+	} else {
+		dstP.link3State = dstP.genStateRoot
+	}
+
+	fakeChildParams.Parent = dstP.link3
+	fakeChildParams.StateRoot = dstP.link3State
+	fakeChildParams.NullBlockCount = uint64(2)
+	dstP.link4blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link4blk1.Proof, dstP.link4blk1.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
+	require.NoError(t, err)
+
+	fakeChildParams.Nonce = uint64(1)
+	dstP.link4blk2 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
+	dstP.link4blk2.Proof, dstP.link4blk2.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
+	require.NoError(t, err)
+
+	dstP.link4 = th.RequireNewTipSet(t, dstP.link4blk1, dstP.link4blk2)
+
+	if mockStateRoots {
+		dstP.link4State = dstP.cidGetter()
+	} else {
+		dstP.link4State = dstP.genStateRoot
+	}
+}
+
+// loadSyncerFromRepo creates a store and syncer from an existing repo.
+func loadSyncerFromRepo(t *testing.T, r repo.Repo, dstP *SyncerTestParams) (*chain.Syncer, *th.TestFetcher) {
+	powerTable := &th.TestView{}
+	bs := bstore.NewBlockstore(r.Datastore())
+	cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
+	verifier := &verification.FakeVerifier{
+		VerifyPoStValid: true,
+	}
+	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), powerTable, dstP.genCid, verifier, th.BlockTimeTest)
+
+	calcGenBlk, err := initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs) // flushes state
+	require.NoError(t, err)
+	calcGenBlk.StateRoot = dstP.genStateRoot
+	chainDS := r.ChainDatastore()
+	chainStore := chain.NewStore(chainDS, cst, &state.TreeStateLoader{}, calcGenBlk.Cid())
+
+	blockSource := th.NewTestFetcher()
+	syncer := chain.NewSyncer(con, chainStore, blockSource, chain.Syncing)
+
+	ctx := context.Background()
+	err = chainStore.Load(ctx)
+	require.NoError(t, err)
+	return syncer, blockSource
+}
+
+// initSyncTestDefault creates and returns the datastructures (syncer, store, repo, fetcher)
+// needed to run tests.  It also sets the global test variables appropriately.
+func initSyncTestDefault(t *testing.T, dstP *SyncerTestParams) (*chain.Syncer, *chain.Store, repo.Repo, *th.TestFetcher) {
+	processor := th.NewTestProcessor()
+	powerTable := &th.TestView{}
+	r := repo.NewInMemoryRepo()
+	bs := bstore.NewBlockstore(r.Datastore())
+	cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
+	verifier := &verification.FakeVerifier{
+		VerifyPoStValid: true,
+	}
+	con := consensus.NewExpected(cst, bs, processor, th.NewFakeBlockValidator(), powerTable, dstP.genCid, verifier, th.BlockTimeTest)
+	requireSetTestChain(t, con, false, dstP)
+	initGenesisWrapper := func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
+		return initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs)
+	}
+	return initSyncTest(t, con, initGenesisWrapper, cst, bs, r, dstP, chain.Syncing)
+}
+
+func initSyncTest(t *testing.T, con consensus.Protocol, genFunc func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error), cst *hamt.CborIpldStore, bs bstore.Blockstore, r repo.Repo, dstP *SyncerTestParams, syncMode chain.SyncMode) (*chain.Syncer, *chain.Store, repo.Repo, *th.TestFetcher) {
+	ctx := context.Background()
+
+	calcGenBlk, err := genFunc(cst, bs) // flushes state
+	require.NoError(t, err)
+	calcGenBlk.StateRoot = dstP.genStateRoot
+	chainDS := r.ChainDatastore()
+	chainStore := chain.NewStore(chainDS, cst, &state.TreeStateLoader{}, calcGenBlk.Cid())
+
+	fetcher := th.NewTestFetcher()
+	syncer := chain.NewSyncer(con, chainStore, fetcher, syncMode) // note we use same cst for on and offline for tests
+
+	// Initialize stores to contain dstP.genesis block and state
+	calcGenTS := th.RequireNewTipSet(t, calcGenBlk)
+
+	genTsas := &chain.TipSetAndState{
+		TipSet:          calcGenTS,
+		TipSetStateRoot: dstP.genStateRoot,
+	}
+	require.NoError(t, chainStore.PutTipSetAndState(ctx, genTsas))
+	err = chainStore.SetHead(ctx, calcGenTS) // Initialize chainStore store with correct dstP.genesis
+	require.NoError(t, err)
+	requireHead(t, chainStore, calcGenTS)
+	requireTsAdded(t, chainStore, calcGenTS)
+
+	return syncer, chainStore, r, fetcher
+}
+
+func containsTipSet(tsasSlice []*chain.TipSetAndState, ts types.TipSet) bool {
+	for _, tsas := range tsasSlice {
+		if tsas.TipSet.String() == ts.String() { //bingo
+			return true
+		}
+	}
+	return false
+}
+
+type requireTsAddedChainStore interface {
+	GetTipSet(types.TipSetKey) (types.TipSet, error)
+	GetTipSetAndStatesByParentsAndHeight(string, uint64) ([]*chain.TipSetAndState, error)
+}
+
+func requireTsAdded(t *testing.T, chain requireTsAddedChainStore, ts types.TipSet) {
+	h, err := ts.Height()
+	require.NoError(t, err)
+	// Tip Index correctly updated
+	gotTs, err := chain.GetTipSet(ts.Key())
+	require.NoError(t, err)
+	require.Equal(t, ts, gotTs)
+	parent, err := ts.Parents()
+	require.NoError(t, err)
+	childTsasSlice, err := chain.GetTipSetAndStatesByParentsAndHeight(parent.String(), h)
+	require.NoError(t, err)
+	require.True(t, containsTipSet(childTsasSlice, ts))
+}
+
+func requireHead(t *testing.T, chain HeadAndTipsetGetter, head types.TipSet) {
+	require.Equal(t, head, requireHeadTipset(t, chain))
+}
+
+func assertHead(t *testing.T, chain HeadAndTipsetGetter, head types.TipSet) {
+	headTipSet, err := chain.GetTipSet(chain.GetHead())
+	assert.NoError(t, err)
+	assert.Equal(t, head, headTipSet)
+}
+
+func requirePutBlocks(_ *testing.T, f *th.TestFetcher, blocks ...*types.Block) types.TipSetKey {
+	var cids []cid.Cid
+	for _, block := range blocks {
+		c := block.Cid()
+		cids = append(cids, c)
+	}
+	f.AddSourceBlocks(blocks...)
+	return types.NewTipSetKey(cids...)
+}
+
+// Syncer is capable of recovering from a fork reorg after Load.
+// See https://github.com/filecoin-project/go-filecoin/issues/1148#issuecomment-432008060
+func TestLoadFork(t *testing.T) {
+	tf.UnitTest(t)
+	dstP := initDSTParams()
+
+	syncer, chainStore, r, blockSource := initSyncTestDefault(t, dstP)
+	ctx := context.Background()
+
+	// Set up chain store to have standard chain up to dstP.link2
+	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
+	cids2 := requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
+	err := syncer.HandleNewTipset(ctx, cids2)
+	require.NoError(t, err)
+
+	// Now sync the store with a heavier fork, forking off dstP.link1.
+	forkbase := th.RequireNewTipSet(t, dstP.link2blk1)
+
+	signer, ki := types.NewMockSignersAndKeyInfo(2)
+	minerWorker, err := ki[0].Address()
+	require.NoError(t, err)
+
+	fakeChildParams := th.FakeChildParams{
+		Parent:      forkbase,
+		GenesisCid:  dstP.genCid,
+		MinerAddr:   dstP.minerAddress,
+		Nonce:       uint64(1),
+		StateRoot:   dstP.genStateRoot,
+		Signer:      signer,
+		MinerWorker: minerWorker,
+	}
+
+	forklink1blk1 := th.RequireMkFakeChild(t, fakeChildParams)
+
+	fakeChildParams.Nonce = uint64(1)
+	forklink1blk2 := th.RequireMkFakeChild(t, fakeChildParams)
+
+	fakeChildParams.Nonce = uint64(2)
+	forklink1blk3 := th.RequireMkFakeChild(t, fakeChildParams)
+	forklink1 := th.RequireNewTipSet(t, forklink1blk1, forklink1blk2, forklink1blk3)
+
+	fakeChildParams.Parent = forklink1
+	fakeChildParams.Nonce = uint64(0)
+	forklink2blk1 := th.RequireMkFakeChild(t, fakeChildParams)
+
+	fakeChildParams.Nonce = uint64(1)
+	forklink2blk2 := th.RequireMkFakeChild(t, fakeChildParams)
+
+	fakeChildParams.Nonce = uint64(2)
+	forklink2blk3 := th.RequireMkFakeChild(t, fakeChildParams)
+	forklink2 := th.RequireNewTipSet(t, forklink2blk1, forklink2blk2, forklink2blk3)
+
+	fakeChildParams.Nonce = uint64(0)
+	fakeChildParams.Parent = forklink2
+	forklink3blk1 := th.RequireMkFakeChild(t, fakeChildParams)
+
+	fakeChildParams.Nonce = uint64(1)
+	forklink3blk2 := th.RequireMkFakeChild(t, fakeChildParams)
+	forklink3 := th.RequireNewTipSet(t, forklink3blk1, forklink3blk2)
+
+	_ = requirePutBlocks(t, blockSource, forklink1.ToSlice()...)
+	_ = requirePutBlocks(t, blockSource, forklink2.ToSlice()...)
+	forkHead := requirePutBlocks(t, blockSource, forklink3.ToSlice()...)
+	err = syncer.HandleNewTipset(ctx, forkHead)
+	require.NoError(t, err)
+	requireHead(t, chainStore, forklink3)
+
+	// Put blocks in global IPLD blockstore
+	// TODO #2128 make this cleaner along with broad test cleanup.
+	bs := bstore.NewBlockstore(r.Datastore())
+	cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
+	requirePutBlocksToCborStore(t, cst, dstP.genTS.ToSlice()...)
+	requirePutBlocksToCborStore(t, cst, dstP.link1.ToSlice()...)
+	requirePutBlocksToCborStore(t, cst, dstP.link2.ToSlice()...)
+	requirePutBlocksToCborStore(t, cst, forklink1.ToSlice()...)
+	requirePutBlocksToCborStore(t, cst, forklink2.ToSlice()...)
+	requirePutBlocksToCborStore(t, cst, forklink3.ToSlice()...)
+
+	// Shut down store, reload and wire to syncer.
+	loadSyncer, blockSource := loadSyncerFromRepo(t, r, dstP)
+
+	// Test that the syncer can't sync a block on the old chain
+	// without getting old blocks from network. i.e. the repo is trimmed
+	// of non-heaviest chain blocks
+	cids3 := requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
+	err = loadSyncer.HandleNewTipset(ctx, cids3)
+	assert.Error(t, err)
+
+	// Test that the syncer can sync a block on the heaviest chain
+	// without getting old blocks from the network.
+	fakeChildParams.Parent = forklink3
+	forklink4blk1 := th.RequireMkFakeChild(t, fakeChildParams)
+	forklink4 := th.RequireNewTipSet(t, forklink4blk1)
+	cidsFork4 := requirePutBlocks(t, blockSource, forklink4.ToSlice()...)
+	err = loadSyncer.HandleNewTipset(ctx, cidsFork4)
+	assert.NoError(t, err)
+}
+
+// Syncer handles MarketView weight comparisons.
+// Current issue: when creating miner mining with addr0, addr0's storage head isn't found in the blockstore
+// and I can't figure out why because we pass in the correct blockstore to createStorageMinerWithpower.
+func TestTipSetWeightDeep(t *testing.T) {
+	tf.UnitTest(t)
+
+	r := repo.NewInMemoryRepo()
+	bs := bstore.NewBlockstore(r.Datastore())
+	cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
+
+	ctx := context.Background()
+
+	mockSigner, ki := types.NewMockSignersAndKeyInfo(3)
+	minerWorker1, err := ki[0].Address()
+	require.NoError(t, err)
+	minerWorker2, err := ki[1].Address()
+	require.NoError(t, err)
+
+	// set up dstP.genesis block with power
+	genCfg := &gengen.GenesisCfg{
+		ProofsMode: types.TestProofsMode,
+		Keys:       4,
+		Miners: []*gengen.CreateStorageMinerConfig{
+			{
+				NumCommittedSectors: 0,
+				SectorSize:          types.OneKiBSectorSize.Uint64(),
+			},
+			{
+				NumCommittedSectors: 10,
+				SectorSize:          types.OneKiBSectorSize.Uint64(),
+			},
+			{
+				NumCommittedSectors: 10,
+				SectorSize:          types.OneKiBSectorSize.Uint64(),
+			},
+			{
+				NumCommittedSectors: 980,
+				SectorSize:          types.OneKiBSectorSize.Uint64(),
+			},
+		},
+	}
+
+	totalPower := types.NewBytesAmount(1000).Mul(types.OneKiBSectorSize)
+
+	info, err := gengen.GenGen(ctx, genCfg, cst, bs, 0)
+	require.NoError(t, err)
+
+	var calcGenBlk types.Block
+	require.NoError(t, cst.Get(ctx, info.GenesisCid, &calcGenBlk))
+
+	chainStore := chain.NewStore(r.ChainDatastore(), cst, &state.TreeStateLoader{}, calcGenBlk.Cid())
+
+	verifier := &verification.FakeVerifier{
+		VerifyPoStValid: true,
+	}
+	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &th.TestView{}, calcGenBlk.Cid(), verifier, th.BlockTimeTest)
+
+	// Initialize stores to contain dstP.genesis block and state
+	calcGenTS := th.RequireNewTipSet(t, &calcGenBlk)
+	genTsas := &chain.TipSetAndState{
+		TipSet:          calcGenTS,
+		TipSetStateRoot: calcGenBlk.StateRoot,
+	}
+	require.NoError(t, chainStore.PutTipSetAndState(ctx, genTsas))
+	err = chainStore.SetHead(ctx, calcGenTS) // Initialize chainStore with correct dstP.genesis
+	require.NoError(t, err)
+	requireHead(t, chainStore, calcGenTS)
+	requireTsAdded(t, chainStore, calcGenTS)
+
+	// Setup a fetcher for feeding blocks into the syncer.
+	blockSource := th.NewTestFetcher()
+
+	// Now sync the chainStore with consensus using a MarketView.
+	verifier = &verification.FakeVerifier{
+		VerifyPoStValid: true,
+	}
+	con = consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &consensus.MarketView{}, calcGenBlk.Cid(), verifier, th.BlockTimeTest)
+	syncer := chain.NewSyncer(con, chainStore, blockSource, chain.Syncing)
+	baseTS := requireHeadTipset(t, chainStore) // this is the last block of the bootstrapping chain creating miners
+	require.Equal(t, 1, baseTS.Len())
+	bootstrapStateRoot := baseTS.ToSlice()[0].StateRoot
+	pSt, err := state.LoadStateTree(ctx, cst, baseTS.ToSlice()[0].StateRoot, builtin.Actors)
+	require.NoError(t, err)
+	/* Test chain diagram and weight calcs */
+	// (Note f1b1 = fork 1 block 1)
+	//
+	// f1b1 -> {f1b2a, f1b2b}
+	//
+	// f2b1 -> f2b2
+	//
+	//  sw=starting weight, apw=added parent weight, mw=miner weight, ew=expected weight
+	//  w({blk})          = sw + apw + mw      = sw + ew
+	//  w({fXb1})         = sw + 0   + 11      = sw + 11
+	//  w({f1b1, f2b1})   = sw + 0   + 11 * 2  = sw + 22
+	//  w({f1b2a, f1b2b}) = sw + 11  + 11 * 2  = sw + 33
+	//  w({f2b2})         = sw + 11  + 108 	   = sw + 119
+	startingWeight, err := con.Weight(ctx, baseTS, pSt)
+	require.NoError(t, err)
+
+	wFun := func(ts types.TipSet) (uint64, error) {
+		// No power-altering messages processed from here on out.
+		// And so bootstrapSt correctly retrives power table for all
+		// test blocks.
+		return con.Weight(ctx, ts, pSt)
+	}
+
+	fakeChildParams := th.FakeChildParams{
+		Parent:     baseTS,
+		GenesisCid: calcGenBlk.Cid(),
+		StateRoot:  bootstrapStateRoot,
+		Signer:     mockSigner,
+
+		MinerAddr:   info.Miners[1].Address,
+		MinerWorker: minerWorker1,
+	}
+
+	f1b1 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
+	f1b1.Proof, f1b1.Ticket, err = th.MakeProofAndWinningTicket(minerWorker1, info.Miners[1].Power, totalPower, mockSigner)
+	require.NoError(t, err)
+
+	fakeChildParams.Nonce = uint64(1)
+	fakeChildParams.MinerAddr = info.Miners[2].Address
+	f2b1 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
+	f2b1.Proof, f2b1.Ticket, err = th.MakeProofAndWinningTicket(minerWorker1, info.Miners[2].Power, totalPower, mockSigner)
+	require.NoError(t, err)
+
+	tsShared := th.RequireNewTipSet(t, f1b1, f2b1)
+
+	// Sync first tipset, should have weight 22 + starting
+	sharedCids := requirePutBlocks(t, blockSource, f1b1, f2b1)
+	err = syncer.HandleNewTipset(ctx, sharedCids)
+	require.NoError(t, err)
+	assertHead(t, chainStore, tsShared)
+	measuredWeight, err := wFun(requireHeadTipset(t, chainStore))
+	require.NoError(t, err)
+	expectedWeight := startingWeight + uint64(22000)
+	assert.Equal(t, expectedWeight, measuredWeight)
+
+	// fork 1 is heavier than the old head.
+	fakeChildParams = th.FakeChildParams{
+		Parent:     th.RequireNewTipSet(t, f1b1),
+		GenesisCid: calcGenBlk.Cid(),
+		StateRoot:  bootstrapStateRoot,
+		Signer:     mockSigner,
+
+		MinerAddr:   info.Miners[1].Address,
+		MinerWorker: minerWorker1,
+	}
+	f1b2a := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
+	f1b2a.Proof, f1b2a.Ticket, err = th.MakeProofAndWinningTicket(minerWorker1, info.Miners[1].Power, totalPower, mockSigner)
+	require.NoError(t, err)
+
+	fakeChildParams.Nonce = uint64(1)
+
+	fakeChildParams.MinerAddr = info.Miners[2].Address
+	fakeChildParams.MinerWorker = minerWorker2
+	f1b2b := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
+	f1b2b.Proof, f1b2b.Ticket, err = th.MakeProofAndWinningTicket(minerWorker2, info.Miners[2].Power, totalPower, mockSigner)
+	require.NoError(t, err)
+
+	f1 := th.RequireNewTipSet(t, f1b2a, f1b2b)
+	f1Cids := requirePutBlocks(t, blockSource, f1.ToSlice()...)
+	err = syncer.HandleNewTipset(ctx, f1Cids)
+	require.NoError(t, err)
+	assertHead(t, chainStore, f1)
+	measuredWeight, err = wFun(requireHeadTipset(t, chainStore))
+	require.NoError(t, err)
+	expectedWeight = startingWeight + uint64(33000)
+	assert.Equal(t, expectedWeight, measuredWeight)
+
+	// fork 2 has heavier weight because of addr3's power even though there
+	// are fewer blocks in the tipset than fork 1.
+	fakeChildParams = th.FakeChildParams{
+		Parent:     th.RequireNewTipSet(t, f2b1),
+		GenesisCid: calcGenBlk.Cid(),
+		Signer:     mockSigner,
+
+		StateRoot:   bootstrapStateRoot,
+		MinerAddr:   info.Miners[3].Address,
+		MinerWorker: minerWorker2,
+	}
+	f2b2 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
+	f2b2.Proof, f2b2.Ticket, err = th.MakeProofAndWinningTicket(minerWorker2, info.Miners[3].Power, totalPower, mockSigner)
+	require.NoError(t, err)
+
+	f2 := th.RequireNewTipSet(t, f2b2)
+	f2Cids := requirePutBlocks(t, blockSource, f2.ToSlice()...)
+	err = syncer.HandleNewTipset(ctx, f2Cids)
+	require.NoError(t, err)
+	assertHead(t, chainStore, f2)
+	measuredWeight, err = wFun(requireHeadTipset(t, chainStore))
+	require.NoError(t, err)
+	expectedWeight = startingWeight + uint64(119000)
+	assert.Equal(t, expectedWeight, measuredWeight)
+}
+
+func initGenesis(minerAddress address.Address, minerOwnerAddress address.Address, minerPeerID peer.ID, cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
+	return consensus.MakeGenesisFunc(
+		consensus.MinerActor(minerAddress, minerOwnerAddress, minerPeerID, types.ZeroAttoFIL, types.OneKiBSectorSize),
+	)(cst, bs)
+}

--- a/chain/syncer_test.go
+++ b/chain/syncer_test.go
@@ -4,793 +4,207 @@ import (
 	"context"
 	"testing"
 
-	bserv "github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-hamt-ipld"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
-	"github.com/ipfs/go-ipfs-exchange-offline"
-	"github.com/libp2p/go-libp2p-peer"
-
-	"github.com/filecoin-project/go-filecoin/actor/builtin"
-	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/chain"
-	"github.com/filecoin-project/go-filecoin/consensus"
-	"github.com/filecoin-project/go-filecoin/gengen/util"
-	"github.com/filecoin-project/go-filecoin/proofs/verification"
-	"github.com/filecoin-project/go-filecoin/repo"
-	"github.com/filecoin-project/go-filecoin/state"
-	th "github.com/filecoin-project/go-filecoin/testhelpers"
-	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
-	"github.com/filecoin-project/go-filecoin/types"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/repo"
+	"github.com/filecoin-project/go-filecoin/state"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
-type SyncerTestParams struct {
-	// Chain diagram below.  Note that blocks in the same tipset are in parentheses.
-	//
-	// genesis -> (link1blk1, link1blk2) -> (link2blk1, link2blk2, link2blk3) -> link3blk1 -> (link4blk1, link4blk2)
-
-	// Blocks
-	genesis                         *types.Block
-	link1blk1, link1blk2            *types.Block
-	link2blk1, link2blk2, link2blk3 *types.Block
-	link3blk1                       *types.Block
-	link4blk1, link4blk2            *types.Block
-
-	// Cids
-	genCid                                                       cid.Cid
-	genStateRoot, link1State, link2State, link3State, link4State cid.Cid
-
-	// TipSets
-	genTS, link1, link2, link3, link4 types.TipSet
-
-	// utils
-	cidGetter         func() cid.Cid
-	minerAddress      address.Address
-	minerOwnerAddress address.Address
-	minerPeerID       peer.ID
-}
-
-func initDSTParams() *SyncerTestParams {
-	var err error
-	minerAddress, err := address.NewActorAddress([]byte("miner"))
-	if err != nil {
-		panic(err)
-	}
-	minerOwnerAddress, err := address.NewActorAddress([]byte("minerOwner"))
-	if err != nil {
-		panic(err)
-	}
-	minerPeerID, err := th.RandPeerID()
-	if err != nil {
-		panic(err)
-	}
-
-	// Set up the test chain
-	bs := bstore.NewBlockstore(repo.NewInMemoryRepo().Datastore())
-	cst := hamt.NewCborStore()
-	genesis, err := initGenesis(minerAddress, minerOwnerAddress, minerPeerID, cst, bs)
-	if err != nil {
-		panic(err)
-	}
-	genCid := genesis.Cid()
-	genTS := th.MustNewTipSet(genesis)
-
-	// mock state root cids
-	cidGetter := types.NewCidForTestGetter()
-
-	genStateRoot := genesis.StateRoot
-
-	return &SyncerTestParams{
-		minerAddress:      minerAddress,
-		minerOwnerAddress: minerOwnerAddress,
-		minerPeerID:       minerPeerID,
-		genesis:           genesis,
-		genCid:            genCid,
-		genTS:             genTS,
-		cidGetter:         cidGetter,
-		genStateRoot:      genStateRoot,
-	}
-}
-
-// This function sets global variables according to the tests needs.  The
-// test chain's basic structure is always the same, but some tests want
-// mocked stateRoots or parent weight calculations from different consensus protocols.
-func requireSetTestChain(t *testing.T, con consensus.Protocol, mockStateRoots bool, dstP *SyncerTestParams) {
-
-	var err error
-	// see powerTableForWidenTest
-	minerPower := types.NewBytesAmount(25)
-	totalPower := types.NewBytesAmount(100)
-	mockSigner, _ := types.NewMockSignersAndKeyInfo(1)
-	minerWorker := mockSigner.Addresses[0]
-
-	fakeChildParams := th.FakeChildParams{
-		Parent:      dstP.genTS,
-		GenesisCid:  dstP.genCid,
-		StateRoot:   dstP.genStateRoot,
-		Consensus:   con,
-		MinerAddr:   dstP.minerAddress,
-		MinerWorker: minerWorker,
-		Signer:      mockSigner,
-	}
-
-	dstP.link1blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	dstP.link1blk1.Proof, dstP.link1blk1.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
-	require.NoError(t, err)
-
-	dstP.link1blk2 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	dstP.link1blk2.Proof, dstP.link1blk2.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
-	require.NoError(t, err)
-
-	dstP.link1 = th.RequireNewTipSet(t, dstP.link1blk1, dstP.link1blk2)
-
-	if mockStateRoots {
-		dstP.link1State = dstP.cidGetter()
-	} else {
-		dstP.link1State = dstP.genStateRoot
-	}
-
-	fakeChildParams.Parent = dstP.link1
-	fakeChildParams.StateRoot = dstP.link1State
-	dstP.link2blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	dstP.link2blk1.Proof, dstP.link2blk1.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
-	require.NoError(t, err)
-
-	dstP.link2blk2 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	dstP.link2blk2.Proof, dstP.link2blk2.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
-	require.NoError(t, err)
-
-	fakeChildParams.Nonce = uint64(1)
-	dstP.link2blk3 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	dstP.link2blk3.Proof, dstP.link2blk3.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
-	require.NoError(t, err)
-
-	dstP.link2 = th.RequireNewTipSet(t, dstP.link2blk1, dstP.link2blk2, dstP.link2blk3)
-
-	if mockStateRoots {
-		dstP.link2State = dstP.cidGetter()
-	} else {
-		dstP.link2State = dstP.genStateRoot
-	}
-
-	fakeChildParams.Parent = dstP.link2
-	fakeChildParams.StateRoot = dstP.link2State
-	dstP.link3blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	dstP.link3blk1.Proof, dstP.link3blk1.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
-	require.NoError(t, err)
-
-	dstP.link3 = th.RequireNewTipSet(t, dstP.link3blk1)
-
-	if mockStateRoots {
-		dstP.link3State = dstP.cidGetter()
-	} else {
-		dstP.link3State = dstP.genStateRoot
-	}
-
-	fakeChildParams.Parent = dstP.link3
-	fakeChildParams.StateRoot = dstP.link3State
-	fakeChildParams.NullBlockCount = uint64(2)
-	dstP.link4blk1 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	dstP.link4blk1.Proof, dstP.link4blk1.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
-	require.NoError(t, err)
-
-	fakeChildParams.Nonce = uint64(1)
-	dstP.link4blk2 = th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	dstP.link4blk2.Proof, dstP.link4blk2.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
-	require.NoError(t, err)
-
-	dstP.link4 = th.RequireNewTipSet(t, dstP.link4blk1, dstP.link4blk2)
-
-	if mockStateRoots {
-		dstP.link4State = dstP.cidGetter()
-	} else {
-		dstP.link4State = dstP.genStateRoot
-	}
-}
-
-// loadSyncerFromRepo creates a store and syncer from an existing repo.
-func loadSyncerFromRepo(t *testing.T, r repo.Repo, dstP *SyncerTestParams) (*chain.Syncer, *th.TestFetcher) {
-	powerTable := &th.TestView{}
-	bs := bstore.NewBlockstore(r.Datastore())
-	cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
-	verifier := &verification.FakeVerifier{
-		VerifyPoStValid: true,
-	}
-	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), powerTable, dstP.genCid, verifier, th.BlockTimeTest)
-
-	calcGenBlk, err := initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs) // flushes state
-	require.NoError(t, err)
-	calcGenBlk.StateRoot = dstP.genStateRoot
-	chainDS := r.ChainDatastore()
-	chainStore := chain.NewStore(chainDS, cst, &state.TreeStateLoader{}, calcGenBlk.Cid())
-
-	blockSource := th.NewTestFetcher()
-	syncer := chain.NewSyncer(con, chainStore, blockSource, chain.Syncing)
-
-	ctx := context.Background()
-	err = chainStore.Load(ctx)
-	require.NoError(t, err)
-	return syncer, blockSource
-}
-
-// initSyncTestDefault creates and returns the datastructures (syncer, store, repo, fetcher)
-// needed to run tests.  It also sets the global test variables appropriately.
-func initSyncTestDefault(t *testing.T, dstP *SyncerTestParams) (*chain.Syncer, *chain.Store, repo.Repo, *th.TestFetcher) {
-	processor := th.NewTestProcessor()
-	powerTable := &th.TestView{}
-	r := repo.NewInMemoryRepo()
-	bs := bstore.NewBlockstore(r.Datastore())
-	cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
-	verifier := &verification.FakeVerifier{
-		VerifyPoStValid: true,
-	}
-	con := consensus.NewExpected(cst, bs, processor, th.NewFakeBlockValidator(), powerTable, dstP.genCid, verifier, th.BlockTimeTest)
-	requireSetTestChain(t, con, false, dstP)
-	initGenesisWrapper := func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
-		return initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs)
-	}
-	return initSyncTest(t, con, initGenesisWrapper, cst, bs, r, dstP, chain.Syncing)
-}
-
-// initSyncTestWithMode creates and returns the datastructures (syncer, store, repo
-// fetcher) needed to run tests. It also mutates the chain syncer to
-// use the specified sync mode for easier testing of caught up and syncing mode
-// behavior.
-func initSyncTestWithMode(t *testing.T, dstP *SyncerTestParams, syncMode chain.SyncMode) (consensus.Protocol, *chain.Syncer, *th.TestFetcher) {
-	processor := th.NewTestProcessor()
-	powerTable := &th.TestView{}
-	r := repo.NewInMemoryRepo()
-	bs := bstore.NewBlockstore(r.Datastore())
-	cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
-	verifier := &verification.FakeVerifier{
-		VerifyPoStValid: true,
-	}
-	con := consensus.NewExpected(cst, bs, processor, th.NewFakeBlockValidator(), powerTable, dstP.genCid, verifier, th.BlockTimeTest)
-	requireSetTestChain(t, con, false, dstP)
-	initGenesisWrapper := func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
-		return initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs)
-	}
-	sync, _, _, tf := initSyncTest(t, con, initGenesisWrapper, cst, bs, r, dstP, syncMode)
-	return con, sync, tf
-}
-
-// initSyncTestWithPowerTable creates and returns the datastructures (syncer, store, repo, fetcher)
-// needed to run tests.  It also sets the global test variables appropriately.
-func initSyncTestWithPowerTable(t *testing.T, powerTable consensus.PowerTableView, dstP *SyncerTestParams) (*chain.Syncer, *chain.Store, consensus.Protocol, *th.TestFetcher) {
-	processor := th.NewTestProcessor()
-	r := repo.NewInMemoryRepo()
-	bs := bstore.NewBlockstore(r.Datastore())
-	cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
-	verifier := &verification.FakeVerifier{
-		VerifyPoStValid: true,
-	}
-	con := consensus.NewExpected(cst, bs, processor, th.NewFakeBlockValidator(), powerTable, dstP.genCid, verifier, th.BlockTimeTest)
-	requireSetTestChain(t, con, false, dstP)
-	initGenesisWrapper := func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
-		return initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs)
-	}
-	sync, testchain, _, fetcher := initSyncTest(t, con, initGenesisWrapper, cst, bs, r, dstP, chain.Syncing)
-	return sync, testchain, con, fetcher
-}
-
-func initSyncTest(t *testing.T, con consensus.Protocol, genFunc func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error), cst *hamt.CborIpldStore, bs bstore.Blockstore, r repo.Repo, dstP *SyncerTestParams, syncMode chain.SyncMode) (*chain.Syncer, *chain.Store, repo.Repo, *th.TestFetcher) {
-	ctx := context.Background()
-
-	calcGenBlk, err := genFunc(cst, bs) // flushes state
-	require.NoError(t, err)
-	calcGenBlk.StateRoot = dstP.genStateRoot
-	chainDS := r.ChainDatastore()
-	chainStore := chain.NewStore(chainDS, cst, &state.TreeStateLoader{}, calcGenBlk.Cid())
-
-	fetcher := th.NewTestFetcher()
-	syncer := chain.NewSyncer(con, chainStore, fetcher, syncMode) // note we use same cst for on and offline for tests
-
-	// Initialize stores to contain dstP.genesis block and state
-	calcGenTS := th.RequireNewTipSet(t, calcGenBlk)
-
-	genTsas := &chain.TipSetAndState{
-		TipSet:          calcGenTS,
-		TipSetStateRoot: dstP.genStateRoot,
-	}
-	require.NoError(t, chainStore.PutTipSetAndState(ctx, genTsas))
-	err = chainStore.SetHead(ctx, calcGenTS) // Initialize chainStore store with correct dstP.genesis
-	require.NoError(t, err)
-	requireHead(t, chainStore, calcGenTS)
-	requireTsAdded(t, chainStore, calcGenTS)
-
-	return syncer, chainStore, r, fetcher
-}
-
-func containsTipSet(tsasSlice []*chain.TipSetAndState, ts types.TipSet) bool {
-	for _, tsas := range tsasSlice {
-		if tsas.TipSet.String() == ts.String() { //bingo
-			return true
-		}
-	}
-	return false
-}
-
-type requireTsAddedChainStore interface {
-	GetTipSet(types.TipSetKey) (types.TipSet, error)
-	GetTipSetAndStatesByParentsAndHeight(string, uint64) ([]*chain.TipSetAndState, error)
-}
-
-func requireTsAdded(t *testing.T, chain requireTsAddedChainStore, ts types.TipSet) {
-	h, err := ts.Height()
-	require.NoError(t, err)
-	// Tip Index correctly updated
-	gotTs, err := chain.GetTipSet(ts.Key())
-	require.NoError(t, err)
-	require.Equal(t, ts, gotTs)
-	parent, err := ts.Parents()
-	require.NoError(t, err)
-	childTsasSlice, err := chain.GetTipSetAndStatesByParentsAndHeight(parent.String(), h)
-	require.NoError(t, err)
-	require.True(t, containsTipSet(childTsasSlice, ts))
-}
-
-func assertTsAdded(t *testing.T, chainStore requireTsAddedChainStore, ts types.TipSet) {
-	h, err := ts.Height()
-	assert.NoError(t, err)
-	// Tip Index correctly updated
-	gotTs, err := chainStore.GetTipSet(ts.Key())
-	assert.NoError(t, err)
-	assert.Equal(t, ts, gotTs)
-	parent, err := ts.Parents()
-	assert.NoError(t, err)
-	childTsasSlice, err := chainStore.GetTipSetAndStatesByParentsAndHeight(parent.String(), h)
-	assert.NoError(t, err)
-	assert.True(t, containsTipSet(childTsasSlice, ts))
-}
-
-func assertNoAdd(t *testing.T, chainStore requireTsAddedChainStore, cids types.TipSetKey) {
-	// Tip Index correctly updated
-	_, err := chainStore.GetTipSet(cids)
-	assert.Error(t, err)
-}
-
-func requireHead(t *testing.T, chain HeadAndTipsetGetter, head types.TipSet) {
-	require.Equal(t, head, requireHeadTipset(t, chain))
-}
-
-func assertHead(t *testing.T, chain HeadAndTipsetGetter, head types.TipSet) {
-	headTipSet, err := chain.GetTipSet(chain.GetHead())
-	assert.NoError(t, err)
-	assert.Equal(t, head, headTipSet)
-}
-
-func requirePutBlocks(_ *testing.T, f *th.TestFetcher, blocks ...*types.Block) types.TipSetKey {
-	var cids []cid.Cid
-	for _, block := range blocks {
-		c := block.Cid()
-		cids = append(cids, c)
-	}
-	f.AddSourceBlocks(blocks...)
-	return types.NewTipSetKey(cids...)
-}
-
-/* Regular Degular syncing */
-
-// Syncer syncs a single block
-func TestSyncOneBlock(t *testing.T) {
+func TestOneBlock(t *testing.T) {
 	tf.UnitTest(t)
-	dstP := initDSTParams()
-
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
-	expectedTs := th.RequireNewTipSet(t, dstP.link1blk1)
+	builder, store, syncer := setup(ctx, t)
+	genesis := builder.RequireTipSet(store.GetHead())
 
-	cids := requirePutBlocks(t, blockSource, dstP.link1blk1)
-	err := syncer.HandleNewTipset(ctx, cids)
-	assert.NoError(t, err)
+	t1 := builder.AppendOn(genesis, 1)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, t1.Key()))
 
-	assertTsAdded(t, chainStore, expectedTs)
-	assertHead(t, chainStore, expectedTs)
+	verifyTip(t, store, t1, t1.At(0).StateRoot)
+	verifyHead(t, store, t1)
 }
 
-// Syncer syncs a single tipset.
-func TestSyncOneTipSet(t *testing.T) {
+func TestMultiBlockTip(t *testing.T) {
 	tf.UnitTest(t)
-	dstP := initDSTParams()
-
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
+	builder, store, syncer := setup(ctx, t)
+	genesis := builder.RequireTipSet(store.GetHead())
 
-	cids := requirePutBlocks(t, blockSource, dstP.link1blk1, dstP.link1blk2)
-	err := syncer.HandleNewTipset(ctx, cids)
-	assert.NoError(t, err)
+	tip := builder.AppendOn(genesis, 2)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, tip.Key()))
 
-	assertTsAdded(t, chainStore, dstP.link1)
-	assertHead(t, chainStore, dstP.link1)
+	verifyTip(t, store, tip, builder.StateForKey(tip.Key()))
+	verifyHead(t, store, tip)
 }
 
-// Syncer syncs one tipset, block by block.
-func TestSyncTipSetBlockByBlock(t *testing.T) {
+func TestTipSetIncremental(t *testing.T) {
 	tf.UnitTest(t)
-	dstP := initDSTParams()
-
-	pt := th.NewTestPowerTableView(types.NewBytesAmount(1), types.NewBytesAmount(1))
-	syncer, chainStore, _, blockSource := initSyncTestWithPowerTable(t, pt, dstP)
 	ctx := context.Background()
-	expTs1 := th.RequireNewTipSet(t, dstP.link1blk1)
+	builder, store, syncer := setup(ctx, t)
+	genesis := builder.RequireTipSet(store.GetHead())
 
-	_ = requirePutBlocks(t, blockSource, dstP.link1blk1, dstP.link1blk2)
-	err := syncer.HandleNewTipset(ctx, types.NewTipSetKey(dstP.link1blk1.Cid()))
-	assert.NoError(t, err)
+	t1 := builder.AppendOn(genesis, 1)
+	t2 := builder.AppendOn(genesis, 1)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, t1.Key()))
 
-	assertTsAdded(t, chainStore, expTs1)
-	assertHead(t, chainStore, expTs1)
+	verifyTip(t, store, t1, builder.StateForKey(t1.Key()))
+	verifyHead(t, store, t1)
 
-	err = syncer.HandleNewTipset(ctx, types.NewTipSetKey(dstP.link1blk2.Cid()))
-	assert.NoError(t, err)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, t2.Key()))
+	verifyTip(t, store, t2, builder.StateForKey(t2.Key()))
 
-	assertTsAdded(t, chainStore, dstP.link1)
-	assertHead(t, chainStore, dstP.link1)
+	merged := types.RequireNewTipSet(t, t1.At(0), t2.At(0))
+	verifyTip(t, store, merged, builder.StateForKey(merged.Key()))
+	verifyHead(t, store, merged)
 }
 
-// Syncer syncs a chain, tipset by tipset.
-func TestSyncChainTipSetByTipSet(t *testing.T) {
+func TestChainIncremental(t *testing.T) {
 	tf.UnitTest(t)
-	dstP := initDSTParams()
-
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
+	builder, store, syncer := setup(ctx, t)
+	genesis := builder.RequireTipSet(store.GetHead())
 
-	cids1 := requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
-	cids2 := requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
-	cids3 := requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
-	cids4 := requirePutBlocks(t, blockSource, dstP.link4.ToSlice()...)
+	t1 := builder.AppendOn(genesis, 2)
+	t2 := builder.AppendOn(t1, 3)
+	t3 := builder.AppendOn(t2, 1)
+	t4 := builder.AppendOn(t3, 2)
 
-	err := syncer.HandleNewTipset(ctx, cids1)
-	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, dstP.link1)
-	assertHead(t, chainStore, dstP.link1)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, t1.Key()))
+	verifyTip(t, store, t1, builder.StateForKey(t1.Key()))
+	verifyHead(t, store, t1)
 
-	err = syncer.HandleNewTipset(ctx, cids2)
-	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, dstP.link2)
-	assertHead(t, chainStore, dstP.link2)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, t2.Key()))
+	verifyTip(t, store, t2, builder.StateForKey(t2.Key()))
+	verifyHead(t, store, t2)
 
-	err = syncer.HandleNewTipset(ctx, cids3)
-	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, dstP.link3)
-	assertHead(t, chainStore, dstP.link3)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, t3.Key()))
+	verifyTip(t, store, t3, builder.StateForKey(t3.Key()))
+	verifyHead(t, store, t3)
 
-	err = syncer.HandleNewTipset(ctx, cids4)
-	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, dstP.link4)
-	assertHead(t, chainStore, dstP.link4)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, t4.Key()))
+	verifyTip(t, store, t4, builder.StateForKey(t4.Key()))
+	verifyHead(t, store, t4)
 }
 
-// Syncer syncs a whole chain given only the head cids.
-func TestSyncChainHead(t *testing.T) {
+func TestChainJump(t *testing.T) {
 	tf.UnitTest(t)
-	dstP := initDSTParams()
-
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
+	builder, store, syncer := setup(ctx, t)
+	genesis := builder.RequireTipSet(store.GetHead())
 
-	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
-	cids4 := requirePutBlocks(t, blockSource, dstP.link4.ToSlice()...)
+	t1 := builder.AppendOn(genesis, 2)
+	t2 := builder.AppendOn(t1, 3)
+	t3 := builder.AppendOn(t2, 1)
+	t4 := builder.AppendOn(t3, 2)
 
-	err := syncer.HandleNewTipset(ctx, cids4)
-	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, dstP.link4)
-	assertTsAdded(t, chainStore, dstP.link3)
-	assertTsAdded(t, chainStore, dstP.link2)
-	assertTsAdded(t, chainStore, dstP.link1)
-	assertHead(t, chainStore, dstP.link4)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, t4.Key()))
+	verifyTip(t, store, t1, builder.StateForKey(t1.Key()))
+	verifyTip(t, store, t2, builder.StateForKey(t2.Key()))
+	verifyTip(t, store, t3, builder.StateForKey(t3.Key()))
+	verifyTip(t, store, t4, builder.StateForKey(t4.Key()))
+	verifyHead(t, store, t4)
 }
 
-// Syncer determines the heavier fork.
-func TestSyncIgnoreLightFork(t *testing.T) {
+func TestIgnoreLightFork(t *testing.T) {
 	tf.UnitTest(t)
-	dstP := initDSTParams()
-
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
+	builder, store, syncer := setup(ctx, t)
+	genesis := builder.RequireTipSet(store.GetHead())
 
-	forkbase := th.RequireNewTipSet(t, dstP.link2blk1)
-	signer, ki := types.NewMockSignersAndKeyInfo(1)
-	minerWorker, err := ki[0].Address()
-	require.NoError(t, err)
+	forkbase := builder.AppendOn(genesis, 1)
+	forkHead := builder.AppendOn(forkbase, 1)
 
-	forkblk1 := th.RequireMkFakeChild(t,
-		th.FakeChildParams{
-			MinerAddr:   dstP.minerAddress,
-			Signer:      signer,
-			MinerWorker: minerWorker,
-			Parent:      forkbase,
-			GenesisCid:  dstP.genCid,
-			StateRoot:   dstP.genStateRoot,
-		})
-	forklink1 := th.RequireNewTipSet(t, forkblk1)
-
-	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
-	cids4 := requirePutBlocks(t, blockSource, dstP.link4.ToSlice()...)
-
-	forkCids1 := requirePutBlocks(t, blockSource, forklink1.ToSlice()...)
+	t1 := builder.AppendOn(forkbase, 1)
+	t2 := builder.AppendOn(t1, 1)
+	t3 := builder.AppendOn(t2, 1)
+	t4 := builder.AppendOn(t3, 1)
 
 	// Sync heaviest branch first.
-	err = syncer.HandleNewTipset(ctx, cids4)
-	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, dstP.link4)
-	assertHead(t, chainStore, dstP.link4)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, t4.Key()))
+	verifyTip(t, store, t4, builder.StateForKey(t4.Key()))
+	verifyHead(t, store, t4)
 
-	// lighter fork should be processed but not change head.
-	assert.NoError(t, syncer.HandleNewTipset(ctx, forkCids1))
-	assertTsAdded(t, chainStore, forklink1)
-	assertHead(t, chainStore, dstP.link4)
+	// Lighter fork is processed but not change head.
+	assert.NoError(t, syncer.HandleNewTipset(ctx, forkHead.Key()))
+	verifyTip(t, store, forkHead, builder.StateForKey(forkHead.Key()))
+	verifyHead(t, store, t4)
 }
 
-// Correctly sync a heavier fork
-func TestHeavierFork(t *testing.T) {
+func TestAcceptHeavierFork(t *testing.T) {
 	tf.UnitTest(t)
-	dstP := initDSTParams()
-
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
+	builder, store, syncer := setup(ctx, t)
+	genesis := builder.RequireTipSet(store.GetHead())
 
-	signer, ki := types.NewMockSignersAndKeyInfo(2)
-	minerWorker, err := ki[0].Address()
-	require.NoError(t, err)
+	forkbase := builder.AppendOn(genesis, 1)
 
-	forkbase := th.RequireNewTipSet(t, dstP.link2blk1)
-	fakeChildParams := th.FakeChildParams{
-		Parent:      forkbase,
-		GenesisCid:  dstP.genCid,
-		StateRoot:   dstP.genStateRoot,
-		MinerAddr:   dstP.minerAddress,
-		Signer:      signer,
-		MinerWorker: minerWorker,
-		Nonce:       uint64(1),
-	}
+	main1 := builder.AppendOn(forkbase, 1)
+	main2 := builder.AppendOn(main1, 1)
+	main3 := builder.AppendOn(main2, 1)
+	main4 := builder.AppendOn(main3, 1)
 
-	forklink1blk1 := th.RequireMkFakeChild(t, fakeChildParams)
+	// Fork is heavier with more blocks, despite shorter (with default fake weighing function
+	// from FakeStateEvaluator).
+	fork1 := builder.AppendOn(forkbase, 3)
+	fork2 := builder.AppendOn(fork1, 1)
+	fork3 := builder.AppendOn(fork2, 1)
 
-	fakeChildParams.Nonce = uint64(1)
-	forklink1blk2 := th.RequireMkFakeChild(t, fakeChildParams)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, main4.Key()))
+	verifyTip(t, store, main4, builder.StateForKey(main4.Key()))
+	verifyHead(t, store, main4)
 
-	fakeChildParams.Nonce = uint64(2)
-	forklink1blk3 := th.RequireMkFakeChild(t, fakeChildParams)
-
-	forklink1 := th.RequireNewTipSet(t, forklink1blk1, forklink1blk2, forklink1blk3)
-
-	fakeChildParams.Parent = forklink1
-	fakeChildParams.Nonce = uint64(0)
-	forklink2blk1 := th.RequireMkFakeChild(t, fakeChildParams)
-
-	fakeChildParams.Nonce = uint64(1)
-	forklink2blk2 := th.RequireMkFakeChild(t, fakeChildParams)
-
-	fakeChildParams.Nonce = uint64(2)
-	forklink2blk3 := th.RequireMkFakeChild(t, fakeChildParams)
-	forklink2 := th.RequireNewTipSet(t, forklink2blk1, forklink2blk2, forklink2blk3)
-
-	fakeChildParams.Nonce = uint64(0)
-	fakeChildParams.Parent = forklink2
-	forklink3blk1 := th.RequireMkFakeChild(t, fakeChildParams)
-
-	fakeChildParams.Nonce = uint64(1)
-	forklink3blk2 := th.RequireMkFakeChild(t, fakeChildParams)
-	forklink3 := th.RequireNewTipSet(t, forklink3blk1, forklink3blk2)
-
-	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
-	cids4 := requirePutBlocks(t, blockSource, dstP.link4.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, forklink1.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, forklink2.ToSlice()...)
-	forkHead := requirePutBlocks(t, blockSource, forklink3.ToSlice()...)
-
-	err = syncer.HandleNewTipset(ctx, cids4)
-	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, dstP.link4)
-	assertHead(t, chainStore, dstP.link4)
-
-	// heavier fork updates head
-	err = syncer.HandleNewTipset(ctx, forkHead)
-	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, forklink1)
-	assertTsAdded(t, chainStore, forklink2)
-	assertTsAdded(t, chainStore, forklink3)
-	assertHead(t, chainStore, forklink3)
+	// Heavier fork updates head
+	assert.NoError(t, syncer.HandleNewTipset(ctx, fork3.Key()))
+	verifyTip(t, store, fork1, builder.StateForKey(fork1.Key()))
+	verifyTip(t, store, fork2, builder.StateForKey(fork2.Key()))
+	verifyTip(t, store, fork3, builder.StateForKey(fork3.Key()))
+	verifyHead(t, store, fork3)
 }
 
-// Syncer errors when input blocks massively exceed the current block height in
-// caught up mode
-func TestFarFutureTipsetsWhenCaughtUp(t *testing.T) {
-	tf.BadUnitTestWithSideEffects(t)
-	dstP := initDSTParams()
-	con, syncer, blockSource := initSyncTestWithMode(t, dstP, chain.CaughtUp)
-	mockSigner, _ := types.NewMockSignersAndKeyInfo(1)
-	minerWorker := mockSigner.Addresses[0]
-	fakeChildParams := th.FakeChildParams{
-		Parent:      dstP.genTS,
-		GenesisCid:  dstP.genCid,
-		StateRoot:   dstP.genStateRoot,
-		Consensus:   con,
-		MinerAddr:   dstP.minerAddress,
-		MinerWorker: minerWorker,
-		Signer:      mockSigner,
-	}
-	ctx := context.Background()
-	minerPower := types.NewBytesAmount(25)
-	totalPower := types.NewBytesAmount(100)
-
-	var err error
-	var tipsetCids types.TipSetKey
-	for i := 0; i < chain.FinalityLimit+10; i++ {
-		require.NoError(t, err)
-
-		linkBlk := th.RequireMkFakeChildWithCon(t, fakeChildParams)
-		linkBlk.Proof, linkBlk.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
-		require.NoError(t, err)
-
-		fakeChildParams.Parent = th.RequireNewTipSet(t, linkBlk)
-		tipsetCids = requirePutBlocks(t, blockSource, linkBlk)
-	}
-
-	assert.Error(t, syncer.HandleNewTipset(ctx, tipsetCids))
-}
-
-// Syncer succeeds when input blocks massively exceed the current block height
-// in syncing mode
-func TestFarFutureTipsetsWhenSyncing(t *testing.T) {
-	tf.BadUnitTestWithSideEffects(t)
-	dstP := initDSTParams()
-	con, syncer, blockSource := initSyncTestWithMode(t, dstP, chain.Syncing)
-	mockSigner, _ := types.NewMockSignersAndKeyInfo(1)
-	minerWorker := mockSigner.Addresses[0]
-	fakeChildParams := th.FakeChildParams{
-		Parent:      dstP.genTS,
-		GenesisCid:  dstP.genCid,
-		StateRoot:   dstP.genStateRoot,
-		Consensus:   con,
-		MinerAddr:   dstP.minerAddress,
-		MinerWorker: minerWorker,
-		Signer:      mockSigner,
-	}
-	ctx := context.Background()
-	minerPower := types.NewBytesAmount(25)
-	totalPower := types.NewBytesAmount(100)
-
-	var err error
-	var tipsetCids types.TipSetKey
-	for i := 0; i < chain.FinalityLimit+1; i++ {
-		require.NoError(t, err)
-
-		linkBlk := th.RequireMkFakeChildWithCon(t, fakeChildParams)
-		linkBlk.Proof, linkBlk.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, mockSigner)
-		require.NoError(t, err)
-
-		fakeChildParams.Parent = th.RequireNewTipSet(t, linkBlk)
-		tipsetCids = requirePutBlocks(t, blockSource, linkBlk)
-	}
-
-	assert.NoError(t, syncer.HandleNewTipset(ctx, tipsetCids))
-}
-
-// Syncer errors if blocks don't form a tipset
-func TestBlocksNotATipSet(t *testing.T) {
+func TestFarFutureTipsets(t *testing.T) {
 	tf.UnitTest(t)
-	dstP := initDSTParams()
-
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
 
-	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
-	badCids := types.NewTipSetKey(dstP.link1blk1.Cid(), dstP.link2blk1.Cid())
-	err := syncer.HandleNewTipset(ctx, badCids)
-	assert.Error(t, err)
-	assertNoAdd(t, chainStore, badCids)
+	t.Run("accepts when syncing", func(t *testing.T) {
+		builder, store, _ := setup(ctx, t)
+		genesis := builder.RequireTipSet(store.GetHead())
+		farHead := builder.AppendManyOn(chain.FinalityLimit+1, genesis)
+
+		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, chain.Syncing)
+		assert.NoError(t, syncer.HandleNewTipset(ctx, farHead.Key()))
+	})
+
+	t.Run("rejects when caught up", func(t *testing.T) {
+		builder, store, _ := setup(ctx, t)
+		genesis := builder.RequireTipSet(store.GetHead())
+		farHead := builder.AppendManyOn(chain.FinalityLimit+1, genesis)
+
+		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, chain.CaughtUp)
+		err := syncer.HandleNewTipset(ctx, farHead.Key())
+		assert.Error(t, err)
+	})
 }
 
-/* particularly tricky edge cases relating to subtle Expected Consensus requirements */
-
-// Syncer is capable of recovering from a fork reorg after Load.
-func TestLoadFork(t *testing.T) {
+func TestNoUncessesaryFetch(t *testing.T) {
 	tf.UnitTest(t)
-	dstP := initDSTParams()
-
-	syncer, chainStore, r, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
+	builder, store, syncer := setup(ctx, t)
+	genesis := builder.RequireTipSet(store.GetHead())
 
-	// Set up chain store to have standard chain up to dstP.link2
-	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
-	cids2 := requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
-	err := syncer.HandleNewTipset(ctx, cids2)
-	require.NoError(t, err)
+	head := builder.AppendManyOn(4, genesis)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, head.Key()))
 
-	// Now sync the store with a heavier fork, forking off dstP.link1.
-	forkbase := th.RequireNewTipSet(t, dstP.link2blk1)
-
-	signer, ki := types.NewMockSignersAndKeyInfo(2)
-	minerWorker, err := ki[0].Address()
-	require.NoError(t, err)
-
-	fakeChildParams := th.FakeChildParams{
-		Parent:      forkbase,
-		GenesisCid:  dstP.genCid,
-		MinerAddr:   dstP.minerAddress,
-		Nonce:       uint64(1),
-		StateRoot:   dstP.genStateRoot,
-		Signer:      signer,
-		MinerWorker: minerWorker,
-	}
-
-	forklink1blk1 := th.RequireMkFakeChild(t, fakeChildParams)
-
-	fakeChildParams.Nonce = uint64(1)
-	forklink1blk2 := th.RequireMkFakeChild(t, fakeChildParams)
-
-	fakeChildParams.Nonce = uint64(2)
-	forklink1blk3 := th.RequireMkFakeChild(t, fakeChildParams)
-	forklink1 := th.RequireNewTipSet(t, forklink1blk1, forklink1blk2, forklink1blk3)
-
-	fakeChildParams.Parent = forklink1
-	fakeChildParams.Nonce = uint64(0)
-	forklink2blk1 := th.RequireMkFakeChild(t, fakeChildParams)
-
-	fakeChildParams.Nonce = uint64(1)
-	forklink2blk2 := th.RequireMkFakeChild(t, fakeChildParams)
-
-	fakeChildParams.Nonce = uint64(2)
-	forklink2blk3 := th.RequireMkFakeChild(t, fakeChildParams)
-	forklink2 := th.RequireNewTipSet(t, forklink2blk1, forklink2blk2, forklink2blk3)
-
-	fakeChildParams.Nonce = uint64(0)
-	fakeChildParams.Parent = forklink2
-	forklink3blk1 := th.RequireMkFakeChild(t, fakeChildParams)
-
-	fakeChildParams.Nonce = uint64(1)
-	forklink3blk2 := th.RequireMkFakeChild(t, fakeChildParams)
-	forklink3 := th.RequireNewTipSet(t, forklink3blk1, forklink3blk2)
-
-	_ = requirePutBlocks(t, blockSource, forklink1.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, forklink2.ToSlice()...)
-	forkHead := requirePutBlocks(t, blockSource, forklink3.ToSlice()...)
-	err = syncer.HandleNewTipset(ctx, forkHead)
-	require.NoError(t, err)
-	requireHead(t, chainStore, forklink3)
-
-	// Put blocks in global IPLD blockstore
-	// TODO #2128 make this cleaner along with broad test cleanup.
-	bs := bstore.NewBlockstore(r.Datastore())
-	cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
-	requirePutBlocksToCborStore(t, cst, dstP.genTS.ToSlice()...)
-	requirePutBlocksToCborStore(t, cst, dstP.link1.ToSlice()...)
-	requirePutBlocksToCborStore(t, cst, dstP.link2.ToSlice()...)
-	requirePutBlocksToCborStore(t, cst, forklink1.ToSlice()...)
-	requirePutBlocksToCborStore(t, cst, forklink2.ToSlice()...)
-	requirePutBlocksToCborStore(t, cst, forklink3.ToSlice()...)
-
-	// Shut down store, reload and wire to syncer.
-	loadSyncer, blockSource := loadSyncerFromRepo(t, r, dstP)
-
-	// Test that the syncer can't sync a block on the old chain
-	// without getting old blocks from network. i.e. the repo is trimmed
-	// of non-heaviest chain blocks
-	cids3 := requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
-	err = loadSyncer.HandleNewTipset(ctx, cids3)
-	assert.Error(t, err)
-
-	// Test that the syncer can sync a block on the heaviest chain
-	// without getting old blocks from the network.
-	fakeChildParams.Parent = forklink3
-	forklink4blk1 := th.RequireMkFakeChild(t, fakeChildParams)
-	forklink4 := th.RequireNewTipSet(t, forklink4blk1)
-	cidsFork4 := requirePutBlocks(t, blockSource, forklink4.ToSlice()...)
-	err = loadSyncer.HandleNewTipset(ctx, cidsFork4)
-	assert.NoError(t, err)
+	// A new syncer unable to fetch blocks from the network can handle a tipset that's already
+	// in the store and linked to genesis.
+	emptyFetcher := chain.NewBuilder(t, address.Undef)
+	newSyncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, emptyFetcher, chain.Syncing)
+	assert.NoError(t, newSyncer.HandleNewTipset(ctx, head.Key()))
 }
 
 // Syncer must track state of subsets of parent tipsets tracked in the store
@@ -809,119 +223,62 @@ func TestLoadFork(t *testing.T) {
 // kept in the store because syncing C1 requires retrieving parent state.
 func TestSubsetParent(t *testing.T) {
 	tf.UnitTest(t)
-	dstP := initDSTParams()
-
-	syncer, _, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
+	builder, store, syncer := setup(ctx, t)
+	genesis := builder.RequireTipSet(store.GetHead())
 
-	// Set up store to have standard chain up to dstP.link2
-	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
-	cids2 := requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
-	err := syncer.HandleNewTipset(ctx, cids2)
-	require.NoError(t, err)
+	// Set up chain with {A1, A2} -> {B1, B2, B3}
+	tipA1A2 := builder.AppendOn(genesis, 2)
+	tipB1B2B3 := builder.AppendOn(tipA1A2, 3)
+	require.NoError(t, syncer.HandleNewTipset(ctx, tipB1B2B3.Key()))
 
 	// Sync one tipset with a parent equal to a subset of an existing
-	// tipset in the store.
-	forkbase := th.RequireNewTipSet(t, dstP.link2blk1, dstP.link2blk2)
-
-	signer, ki := types.NewMockSignersAndKeyInfo(2)
-	minerWorker, err := ki[0].Address()
-	require.NoError(t, err)
-
-	fakeChildParams := th.FakeChildParams{
-		Parent:      forkbase,
-		GenesisCid:  dstP.genCid,
-		MinerAddr:   dstP.minerAddress,
-		StateRoot:   dstP.genStateRoot,
-		Signer:      signer,
-		MinerWorker: minerWorker,
-	}
-
-	forkblk1 := th.RequireMkFakeChild(t, fakeChildParams)
-
-	fakeChildParams.Nonce = uint64(1)
-	forkblk2 := th.RequireMkFakeChild(t, fakeChildParams)
-
-	forklink := th.RequireNewTipSet(t, forkblk1, forkblk2)
-	forkHead := requirePutBlocks(t, blockSource, forklink.ToSlice()...)
-	err = syncer.HandleNewTipset(ctx, forkHead)
-	assert.NoError(t, err)
+	// tipset in the store: {B1, B2} -> {C1, C2}
+	tipB1B2 := types.RequireNewTipSet(t, tipB1B2B3.At(0), tipB1B2B3.At(1))
+	tipC1C2 := builder.AppendOn(tipB1B2, 2)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, tipC1C2.Key()))
 
 	// Sync another tipset with a parent equal to a subset of the tipset
-	// just synced.
-	newForkbase := th.RequireNewTipSet(t, forkblk1, forkblk2)
+	// just synced: C1 -> D1
+	tipC1 := types.RequireNewTipSet(t, tipC1C2.At(0))
+	tipD1OnC1 := builder.AppendOn(tipC1, 1)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, tipD1OnC1.Key()))
 
-	fakeChildParams.Parent = newForkbase
-	fakeChildParams.Nonce = uint64(0)
-	newForkblk := th.RequireMkFakeChild(t, fakeChildParams)
-	newForklink := th.RequireNewTipSet(t, newForkblk)
-	newForkHead := requirePutBlocks(t, blockSource, newForklink.ToSlice()...)
-	err = syncer.HandleNewTipset(ctx, newForkHead)
-	assert.NoError(t, err)
+	// A full parent also works fine: {C1, C2} -> D1
+	tipD1OnC1C2 := builder.AppendOn(tipC1C2, 1)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, tipD1OnC1C2.Key()))
 }
 
 // Check that the syncer correctly adds widened chain ancestors to the store.
 func TestWidenChainAncestor(t *testing.T) {
 	tf.UnitTest(t)
-	dstP := initDSTParams()
-
-	syncer, chainStore, _, blockSource := initSyncTestDefault(t, dstP)
 	ctx := context.Background()
+	builder, store, syncer := setup(ctx, t)
+	genesis := builder.RequireTipSet(store.GetHead())
 
-	signer, ki := types.NewMockSignersAndKeyInfo(2)
-	minerWorker, err := ki[0].Address()
-	require.NoError(t, err)
+	link1 := builder.AppendOn(genesis, 2)
+	link2 := builder.AppendOn(link1, 3)
+	link3 := builder.AppendOn(link2, 1)
+	link4 := builder.AppendOn(link3, 2)
 
-	fakeChildParams := th.FakeChildParams{
-		MinerAddr:   dstP.minerAddress,
-		Parent:      dstP.link1,
-		GenesisCid:  dstP.genCid,
-		StateRoot:   dstP.genStateRoot,
-		Signer:      signer,
-		MinerWorker: minerWorker,
-		Nonce:       uint64(27),
-	}
+	// Build another block with parents link1, but not included in link2.
+	link2Alt := builder.AppendOn(link1, 1)
+	// Build a tipset containing one block from link2, plus this new sibling.
+	link2UnionSubset := types.RequireNewTipSet(t, link2.At(0), link2Alt.At(0))
 
-	link2blkother := th.RequireMkFakeChild(t, fakeChildParams)
+	// Sync the subset of link2 first
+	assert.NoError(t, syncer.HandleNewTipset(ctx, link2UnionSubset.Key()))
+	verifyTip(t, store, link2UnionSubset, builder.StateForKey(link2UnionSubset.Key()))
+	verifyHead(t, store, link2UnionSubset)
 
-	link2intersect := th.RequireNewTipSet(t, dstP.link2blk1, link2blkother)
+	// Sync chain with head at link4
+	require.NoError(t, syncer.HandleNewTipset(ctx, link4.Key()))
+	verifyTip(t, store, link4, builder.StateForKey(link4.Key()))
+	verifyHead(t, store, link4)
 
-	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
-	cids4 := requirePutBlocks(t, blockSource, dstP.link4.ToSlice()...)
-
-	intersectCids := requirePutBlocks(t, blockSource, link2intersect.ToSlice()...)
-
-	// Sync the subset of dstP.link2 first
-	err = syncer.HandleNewTipset(ctx, intersectCids)
-	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, link2intersect)
-	assertHead(t, chainStore, link2intersect)
-
-	// Sync chain with head at dstP.link4
-	err = syncer.HandleNewTipset(ctx, cids4)
-	assert.NoError(t, err)
-	assertTsAdded(t, chainStore, dstP.link4)
-	assertHead(t, chainStore, dstP.link4)
-
-	// Check that the widened tipset (link2intersect U dstP.link2) is tracked
-	link2Union := th.RequireNewTipSet(t, dstP.link2blk1, dstP.link2blk2, dstP.link2blk3, link2blkother)
-	assertTsAdded(t, chainStore, link2Union)
-}
-
-type powerTableForWidenTest struct{}
-
-func (pt *powerTableForWidenTest) Total(ctx context.Context, st state.Tree, bs bstore.Blockstore) (*types.BytesAmount, error) {
-	return types.NewBytesAmount(100), nil
-}
-
-func (pt *powerTableForWidenTest) Miner(ctx context.Context, st state.Tree, bs bstore.Blockstore, mAddr address.Address) (*types.BytesAmount, error) {
-	return types.NewBytesAmount(25), nil
-}
-
-func (pt *powerTableForWidenTest) HasPower(ctx context.Context, st state.Tree, bs bstore.Blockstore, mAddr address.Address) bool {
-	return true
+	// Check that the widened tipset (link2UnionSubset U link2) is tracked
+	link2Union := types.RequireNewTipSet(t, link2.At(0), link2.At(1), link2.At(2), link2Alt.At(0))
+	verifyTip(t, store, link2Union, builder.StateForKey(link2Union.Key()))
 }
 
 // Syncer finds a heaviest tipset by combining blocks from the ancestors of a
@@ -932,317 +289,143 @@ func (pt *powerTableForWidenTest) HasPower(ctx context.Context, st state.Tree, b
 // should correctly set this tipset as the head.
 //
 // From above we have the test-chain:
-// dstP.genesis -> (link1blk1, dstP.link1blk2) -> (link2blk1, dstP.link2blk2, dstP.link2blk3) -> dstP.link3blk1 -> (link4blk1, dstP.link4blk2)
+// genesis -> (link1blk1, link1blk2) -> (link2blk1, link2blk2, link2blk3) -> link3blk1 -> (link4blk1, link4blk2)
 //
-// Now we introduce a disjoint fork on top of dstP.link1
-// dstP.genesis -> (link1blk1, dstP.link1blk2) -> (forklink2blk1, forklink2blk2, forklink2blk3, forklink3blk4) -> forklink3blk1
+// Now we introduce a disjoint fork on top of link1
+// genesis -> (link1blk1, link1blk2) -> (forklink2blk1, forklink2blk2, forklink2blk3, forklink3blk4) -> forklink3blk1
 //
-// Using the provided powertable all new tipsets contribute to the weight: + 35*(num of blocks in tipset).
+// When all blocks contribute equally to weight:
 // So, the weight of the  head of the test chain =
-//   W(link1) + 105 + 35 + 70 = W(link1) + 210 = 280
+//   W(link1) + 3 + 1 + 2 = W(link1) + 6 = 8
 // and the weight of the head of the fork chain =
-//   W(link1) + 140 + 35 = W(link1) + 175 = 245
-// and the weight of the union of dstP.link2 of both branches (a valid tipset) is
-//   W(link1) + 245 = 315
+//   W(link1) + 4 + 1 = W(link1) + 5 = 7
+// and the weight of the union of link2 of both branches (a valid tipset) is
+//   W(link1) + 7 = 9
 //
 // Therefore the syncer should set the head of the store to the union of the links..
 func TestHeaviestIsWidenedAncestor(t *testing.T) {
 	tf.UnitTest(t)
-	dstP := initDSTParams()
-
-	pt := &powerTableForWidenTest{}
-	syncer, chainStore, con, blockSource := initSyncTestWithPowerTable(t, pt, dstP)
 	ctx := context.Background()
+	builder, store, syncer := setup(ctx, t)
+	genesis := builder.RequireTipSet(store.GetHead())
 
-	minerPower := types.NewBytesAmount(25)
-	totalPower := types.NewBytesAmount(100)
-	signer, ki := types.NewMockSignersAndKeyInfo(2)
-	minerWorker, err := ki[0].Address()
-	require.NoError(t, err)
+	link1 := builder.AppendOn(genesis, 2)
+	link2 := builder.AppendOn(link1, 3)
+	link3 := builder.AppendOn(link2, 1)
+	link4 := builder.AppendOn(link3, 2)
 
-	fakeChildParams := th.FakeChildParams{
-		Parent:      dstP.link1,
-		Consensus:   con,
-		GenesisCid:  dstP.genCid,
-		StateRoot:   dstP.genStateRoot,
-		MinerAddr:   dstP.minerAddress,
-		MinerWorker: minerWorker,
-		Signer:      signer,
-		Nonce:       uint64(1),
-	}
+	forkLink2 := builder.AppendOn(link1, 4)
+	forkLink3 := builder.AppendOn(forkLink2, 1)
 
-	forklink2blk1 := th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	forklink2blk1.Proof, forklink2blk1.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, signer)
-	require.NoError(t, err)
+	// Sync main chain
+	assert.NoError(t, syncer.HandleNewTipset(ctx, link4.Key()))
 
-	fakeChildParams.Nonce = uint64(52)
-	forklink2blk2 := th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	forklink2blk2.Proof, forklink2blk2.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, signer)
-	require.NoError(t, err)
-
-	fakeChildParams.Nonce = uint64(53)
-	forklink2blk3 := th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	forklink2blk3.Proof, forklink2blk3.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, signer)
-	require.NoError(t, err)
-
-	fakeChildParams.Nonce = uint64(54)
-	forklink2blk4 := th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	forklink2blk4.Proof, forklink2blk4.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, signer)
-	require.NoError(t, err)
-
-	forklink2 := th.RequireNewTipSet(t, forklink2blk1, forklink2blk2, forklink2blk3, forklink2blk4)
-
-	fakeChildParams.Nonce = uint64(0)
-	fakeChildParams.Parent = forklink2
-	forklink3blk1 := th.RequireMkFakeChildWithCon(t, fakeChildParams)
-	forklink3blk1.Proof, forklink3blk1.Ticket, err = th.MakeProofAndWinningTicket(minerWorker, minerPower, totalPower, signer)
-	require.NoError(t, err)
-
-	forklink3 := th.RequireNewTipSet(t, forklink3blk1)
-
-	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
-	_ = requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
-	testhead := requirePutBlocks(t, blockSource, dstP.link4.ToSlice()...)
-
-	_ = requirePutBlocks(t, blockSource, forklink2.ToSlice()...)
-	forkhead := requirePutBlocks(t, blockSource, forklink3.ToSlice()...)
-
-	// Put testhead
-	err = syncer.HandleNewTipset(ctx, testhead)
-	assert.NoError(t, err)
-
-	// Put forkhead
-	err = syncer.HandleNewTipset(ctx, forkhead)
-	assert.NoError(t, err)
+	// Sync fork chain
+	assert.NoError(t, syncer.HandleNewTipset(ctx, forkLink3.Key()))
 
 	// Assert that widened chain is the new head
-	wideTs := th.RequireNewTipSet(t, dstP.link2blk1, dstP.link2blk2, dstP.link2blk3, forklink2blk1, forklink2blk2, forklink2blk3, forklink2blk4)
-	assertTsAdded(t, chainStore, wideTs)
-	assertHead(t, chainStore, wideTs)
+	wideBlocks := link2.ToSlice()
+	wideBlocks = append(wideBlocks, forkLink2.ToSlice()...)
+	wideTs := types.RequireNewTipSet(t, wideBlocks...)
+
+	verifyTip(t, store, wideTs, builder.ComputeState(wideTs))
+	verifyHead(t, store, wideTs)
 }
 
-/* Tests with Unmocked state */
-
-// Syncer handles MarketView weight comparisons.
-// Current issue: when creating miner mining with addr0, addr0's storage head isn't found in the blockstore
-// and I can't figure out why because we pass in the correct blockstore to createStorageMinerWithpower.
-
-func TestTipSetWeightDeep(t *testing.T) {
+func TestBlocksNotATipSetRejected(t *testing.T) {
 	tf.UnitTest(t)
-
-	r := repo.NewInMemoryRepo()
-	bs := bstore.NewBlockstore(r.Datastore())
-	cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
-
 	ctx := context.Background()
+	builder, store, syncer := setup(ctx, t)
+	genesis := builder.RequireTipSet(store.GetHead())
 
-	mockSigner, ki := types.NewMockSignersAndKeyInfo(3)
-	minerWorker1, err := ki[0].Address()
-	require.NoError(t, err)
-	minerWorker2, err := ki[1].Address()
-	require.NoError(t, err)
+	b1 := builder.AppendBlockOn(genesis)
+	b2 := builder.AppendBlockOnBlocks(b1)
 
-	// set up dstP.genesis block with power
-	genCfg := &gengen.GenesisCfg{
-		ProofsMode: types.TestProofsMode,
-		Keys:       4,
-		Miners: []*gengen.CreateStorageMinerConfig{
-			{
-				NumCommittedSectors: 0,
-				SectorSize:          types.OneKiBSectorSize.Uint64(),
-			},
-			{
-				NumCommittedSectors: 10,
-				SectorSize:          types.OneKiBSectorSize.Uint64(),
-			},
-			{
-				NumCommittedSectors: 10,
-				SectorSize:          types.OneKiBSectorSize.Uint64(),
-			},
-			{
-				NumCommittedSectors: 980,
-				SectorSize:          types.OneKiBSectorSize.Uint64(),
-			},
-		},
-	}
+	badKey := types.NewTipSetKey(b1.Cid(), b2.Cid())
+	err := syncer.HandleNewTipset(ctx, badKey)
+	assert.Error(t, err)
 
-	totalPower := types.NewBytesAmount(1000).Mul(types.OneKiBSectorSize)
-
-	info, err := gengen.GenGen(ctx, genCfg, cst, bs, 0)
-	require.NoError(t, err)
-
-	var calcGenBlk types.Block
-	require.NoError(t, cst.Get(ctx, info.GenesisCid, &calcGenBlk))
-
-	chainStore := chain.NewStore(r.ChainDatastore(), cst, &state.TreeStateLoader{}, calcGenBlk.Cid())
-
-	verifier := &verification.FakeVerifier{
-		VerifyPoStValid: true,
-	}
-	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &th.TestView{}, calcGenBlk.Cid(), verifier, th.BlockTimeTest)
-
-	// Initialize stores to contain dstP.genesis block and state
-	calcGenTS := th.RequireNewTipSet(t, &calcGenBlk)
-	genTsas := &chain.TipSetAndState{
-		TipSet:          calcGenTS,
-		TipSetStateRoot: calcGenBlk.StateRoot,
-	}
-	require.NoError(t, chainStore.PutTipSetAndState(ctx, genTsas))
-	err = chainStore.SetHead(ctx, calcGenTS) // Initialize chainStore with correct dstP.genesis
-	require.NoError(t, err)
-	requireHead(t, chainStore, calcGenTS)
-	requireTsAdded(t, chainStore, calcGenTS)
-
-	// Setup a fetcher for feeding blocks into the syncer.
-	blockSource := th.NewTestFetcher()
-
-	// Now sync the chainStore with consensus using a MarketView.
-	verifier = &verification.FakeVerifier{
-		VerifyPoStValid: true,
-	}
-	con = consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &consensus.MarketView{}, calcGenBlk.Cid(), verifier, th.BlockTimeTest)
-	syncer := chain.NewSyncer(con, chainStore, blockSource, chain.Syncing)
-	baseTS := requireHeadTipset(t, chainStore) // this is the last block of the bootstrapping chain creating miners
-	require.Equal(t, 1, baseTS.Len())
-	bootstrapStateRoot := baseTS.ToSlice()[0].StateRoot
-	pSt, err := state.LoadStateTree(ctx, cst, baseTS.ToSlice()[0].StateRoot, builtin.Actors)
-	require.NoError(t, err)
-	/* Test chain diagram and weight calcs */
-	// (Note f1b1 = fork 1 block 1)
-	//
-	// f1b1 -> {f1b2a, f1b2b}
-	//
-	// f2b1 -> f2b2
-	//
-	//  sw=starting weight, apw=added parent weight, mw=miner weight, ew=expected weight
-	//  w({blk})          = sw + apw + mw      = sw + ew
-	//  w({fXb1})         = sw + 0   + 11      = sw + 11
-	//  w({f1b1, f2b1})   = sw + 0   + 11 * 2  = sw + 22
-	//  w({f1b2a, f1b2b}) = sw + 11  + 11 * 2  = sw + 33
-	//  w({f2b2})         = sw + 11  + 108 	   = sw + 119
-	startingWeight, err := con.Weight(ctx, baseTS, pSt)
-	require.NoError(t, err)
-
-	wFun := func(ts types.TipSet) (uint64, error) {
-		// No power-altering messages processed from here on out.
-		// And so bootstrapSt correctly retrives power table for all
-		// test blocks.
-		return con.Weight(ctx, ts, pSt)
-	}
-
-	fakeChildParams := th.FakeChildParams{
-		Parent:     baseTS,
-		GenesisCid: calcGenBlk.Cid(),
-		StateRoot:  bootstrapStateRoot,
-		Signer:     mockSigner,
-
-		MinerAddr:   info.Miners[1].Address,
-		MinerWorker: minerWorker1,
-	}
-
-	f1b1 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f1b1.Proof, f1b1.Ticket, err = th.MakeProofAndWinningTicket(minerWorker1, info.Miners[1].Power, totalPower, mockSigner)
-	require.NoError(t, err)
-
-	fakeChildParams.Nonce = uint64(1)
-	fakeChildParams.MinerAddr = info.Miners[2].Address
-	f2b1 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f2b1.Proof, f2b1.Ticket, err = th.MakeProofAndWinningTicket(minerWorker1, info.Miners[2].Power, totalPower, mockSigner)
-	require.NoError(t, err)
-
-	tsShared := th.RequireNewTipSet(t, f1b1, f2b1)
-
-	// Sync first tipset, should have weight 22 + starting
-	sharedCids := requirePutBlocks(t, blockSource, f1b1, f2b1)
-	err = syncer.HandleNewTipset(ctx, sharedCids)
-	require.NoError(t, err)
-	assertHead(t, chainStore, tsShared)
-	measuredWeight, err := wFun(requireHeadTipset(t, chainStore))
-	require.NoError(t, err)
-	expectedWeight := startingWeight + uint64(22000)
-	assert.Equal(t, expectedWeight, measuredWeight)
-
-	// fork 1 is heavier than the old head.
-	fakeChildParams = th.FakeChildParams{
-		Parent:     th.RequireNewTipSet(t, f1b1),
-		GenesisCid: calcGenBlk.Cid(),
-		StateRoot:  bootstrapStateRoot,
-		Signer:     mockSigner,
-
-		MinerAddr:   info.Miners[1].Address,
-		MinerWorker: minerWorker1,
-	}
-	f1b2a := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f1b2a.Proof, f1b2a.Ticket, err = th.MakeProofAndWinningTicket(minerWorker1, info.Miners[1].Power, totalPower, mockSigner)
-	require.NoError(t, err)
-
-	fakeChildParams.Nonce = uint64(1)
-
-	fakeChildParams.MinerAddr = info.Miners[2].Address
-	fakeChildParams.MinerWorker = minerWorker2
-	f1b2b := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f1b2b.Proof, f1b2b.Ticket, err = th.MakeProofAndWinningTicket(minerWorker2, info.Miners[2].Power, totalPower, mockSigner)
-	require.NoError(t, err)
-
-	f1 := th.RequireNewTipSet(t, f1b2a, f1b2b)
-	f1Cids := requirePutBlocks(t, blockSource, f1.ToSlice()...)
-	err = syncer.HandleNewTipset(ctx, f1Cids)
-	require.NoError(t, err)
-	assertHead(t, chainStore, f1)
-	measuredWeight, err = wFun(requireHeadTipset(t, chainStore))
-	require.NoError(t, err)
-	expectedWeight = startingWeight + uint64(33000)
-	assert.Equal(t, expectedWeight, measuredWeight)
-
-	// fork 2 has heavier weight because of addr3's power even though there
-	// are fewer blocks in the tipset than fork 1.
-	fakeChildParams = th.FakeChildParams{
-		Parent:     th.RequireNewTipSet(t, f2b1),
-		GenesisCid: calcGenBlk.Cid(),
-		Signer:     mockSigner,
-
-		StateRoot:   bootstrapStateRoot,
-		MinerAddr:   info.Miners[3].Address,
-		MinerWorker: minerWorker2,
-	}
-	f2b2 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	f2b2.Proof, f2b2.Ticket, err = th.MakeProofAndWinningTicket(minerWorker2, info.Miners[3].Power, totalPower, mockSigner)
-	require.NoError(t, err)
-
-	f2 := th.RequireNewTipSet(t, f2b2)
-	f2Cids := requirePutBlocks(t, blockSource, f2.ToSlice()...)
-	err = syncer.HandleNewTipset(ctx, f2Cids)
-	require.NoError(t, err)
-	assertHead(t, chainStore, f2)
-	measuredWeight, err = wFun(requireHeadTipset(t, chainStore))
-	require.NoError(t, err)
-	expectedWeight = startingWeight + uint64(119000)
-	assert.Equal(t, expectedWeight, measuredWeight)
+	_, err = store.GetTipSet(badKey)
+	assert.Error(t, err) // Not present
 }
 
-type tipSetGetter interface {
+func TestBlockNotLinkedRejected(t *testing.T) {
+	tf.UnitTest(t)
+	ctx := context.Background()
+	builder, store, syncer := setup(ctx, t)
+	genesis := builder.RequireTipSet(store.GetHead())
+
+	// Set up a parallel builder from which the syncer cannot fetch.
+	// The two builders are expected to produce exactly the same blocks from the same sequence
+	// of calls.
+	shadowBuilder := chain.NewBuilder(t, address.Undef)
+	gen2 := types.RequireNewTipSet(t, shadowBuilder.AppendBlockOnBlocks())
+	require.True(t, genesis.Equals(gen2))
+
+	// The syncer fails to fetch this block so cannot sync it.
+	b1 := shadowBuilder.AppendOn(genesis, 1)
+	assert.Error(t, syncer.HandleNewTipset(ctx, b1.Key()))
+
+	// Make the same block available from the syncer's builder
+	builder.AppendBlockOn(genesis)
+	assert.NoError(t, syncer.HandleNewTipset(ctx, b1.Key()))
+}
+
+///// Set-up /////
+
+// Initializes a chain builder, store and syncer.
+// The chain builder has a single genesis block, which is set as the head of the store.
+func setup(ctx context.Context, t *testing.T) (*chain.Builder, *chain.Store, *chain.Syncer) {
+	builder := chain.NewBuilder(t, address.Undef)
+	genesis := builder.Genesis()
+	genStateRoot, err := builder.GetTipSetStateRoot(genesis.Key())
+	require.NoError(t, err)
+
+	store := chain.NewStore(repo.NewInMemoryRepo().ChainDatastore(), hamt.NewCborStore(), &state.TreeStateLoader{}, genesis.At(0).Cid())
+	// Initialize chainStore store genesis state and tipset as head.
+	require.NoError(t, store.PutTipSetAndState(ctx, &chain.TipSetAndState{genStateRoot, genesis}))
+	require.NoError(t, store.SetHead(ctx, genesis))
+
+	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but
+	// *not* as the store, to which the syncer must ensure to put blocks.
+	eval := &chain.FakeStateEvaluator{}
+	syncer := chain.NewSyncer(eval, store, builder, chain.Syncing)
+
+	return builder, store, syncer
+}
+
+///// Verification helpers /////
+
+// Sub-interface of the store used for verification.
+type syncStoreReader interface {
+	GetHead() types.TipSetKey
 	GetTipSet(types.TipSetKey) (types.TipSet, error)
-}
-
-func requireGetTipSet(ctx context.Context, t *testing.T, chainStore tipSetGetter, key types.TipSetKey) types.TipSet {
-	ts, err := chainStore.GetTipSet(key)
-	require.NoError(t, err)
-	return ts
-}
-
-type tipSetStateRootGetter interface {
 	GetTipSetStateRoot(tsKey types.TipSetKey) (cid.Cid, error)
+	GetTipSetAndStatesByParentsAndHeight(string, uint64) ([]*chain.TipSetAndState, error)
 }
 
-func requireGetTipSetStateRoot(ctx context.Context, t *testing.T, chainStore tipSetStateRootGetter, key types.TipSetKey) cid.Cid {
-	stateCid, err := chainStore.GetTipSetStateRoot(key)
+// Verifies that a tipset and associated state root are stored in the chain store.
+func verifyTip(t *testing.T, store syncStoreReader, tip types.TipSet, stateRoot cid.Cid) {
+	foundTip, err := store.GetTipSet(tip.Key())
 	require.NoError(t, err)
-	return stateCid
+	assert.Equal(t, tip, foundTip)
+
+	foundState, err := store.GetTipSetStateRoot(tip.Key())
+	require.NoError(t, err)
+	assert.Equal(t, stateRoot, foundState)
+
+	parent, err := tip.Parents()
+	assert.NoError(t, err)
+	h, err := tip.Height()
+	assert.NoError(t, err)
+	childTsasSlice, err := store.GetTipSetAndStatesByParentsAndHeight(parent.String(), h)
+	assert.NoError(t, err)
+	assert.True(t, containsTipSet(childTsasSlice, tip))
 }
 
-func initGenesis(minerAddress address.Address, minerOwnerAddress address.Address, minerPeerID peer.ID, cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
-	return consensus.MakeGenesisFunc(
-		consensus.MinerActor(minerAddress, minerOwnerAddress, minerPeerID, types.ZeroAttoFIL, types.OneKiBSectorSize),
-	)(cst, bs)
+// Verifies that the store's head is as expected.
+func verifyHead(t *testing.T, store syncStoreReader, head types.TipSet) {
+	headTipSet, err := store.GetTipSet(store.GetHead())
+	require.NoError(t, err)
+	assert.Equal(t, head, headTipSet)
 }

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/address"
@@ -21,6 +22,8 @@ import (
 // State root CIDs are computed by an abstract StateBuilder. The default FakeStateBuilder produces
 // state CIDs that are distinct but not CIDs of any real state tree. A more sophisticated
 // builder could actually apply the messages to a state tree (not yet implemented).
+// The builder is deterministic: two builders receiving the same sequence of calls will produce
+// exactly the same chain.
 type Builder struct {
 	t            *testing.T
 	minerAddress address.Address
@@ -28,6 +31,8 @@ type Builder struct {
 	seq          uint64 // For unique tickets
 
 	blocks map[cid.Cid]*types.Block
+	// Cache of the state root CID computed for each tipset key.
+	tipStateCids map[string]cid.Cid
 }
 
 var _ BlockProvider = (*Builder)(nil)
@@ -42,96 +47,177 @@ func NewBuilder(t *testing.T, miner address.Address) *Builder {
 		miner, err = address.NewActorAddress([]byte("miner"))
 		require.NoError(t, err)
 	}
-	return &Builder{
+
+	b := &Builder{
 		t:            t,
 		minerAddress: miner,
 		stateBuilder: &FakeStateBuilder{},
 		blocks:       make(map[cid.Cid]*types.Block),
+		tipStateCids: make(map[string]cid.Cid),
 	}
+
+	nullState, err := makeCid("null")
+	require.NoError(t, err)
+	b.tipStateCids[types.NewTipSetKey().String()] = nullState
+	return b
 }
 
-// AppendOn creates and returns a new block child of `parents`, with no messages.
-func (f *Builder) AppendOn(parents ...*types.Block) *types.Block {
+// Genesis creates and returns a tipset of one block with no parents.
+func (f *Builder) Genesis() types.TipSet {
+	return types.RequireNewTipSet(f.t, f.AppendBlockOn(types.UndefTipSet))
+}
+
+// AppendBlockOnBlocks creates and returns a new block child of `parents`, with no messages.
+func (f *Builder) AppendBlockOnBlocks(parents ...*types.Block) *types.Block {
 	tip := types.UndefTipSet
 	if len(parents) > 0 {
 		tip = types.RequireNewTipSet(f.t, parents...)
 	}
-	return f.BuildOnTip(tip, nil)
+	return f.AppendBlockOn(tip)
 }
 
-// AppendManyOn appends `count` blocks to the chain.
-func (f *Builder) AppendManyOn(count int, parents ...*types.Block) *types.Block {
+// AppendBlockOn creates and returns a new block child of `parent`, with no messages.
+func (f *Builder) AppendBlockOn(parent types.TipSet) *types.Block {
+	return f.Build(parent, 1, nil).At(0)
+}
+
+// AppendOn creates and returns a new `width`-block tipset child of `parents`, with no messages.
+func (f *Builder) AppendOn(parent types.TipSet, width int) types.TipSet {
+	return f.Build(parent, width, nil)
+}
+
+// AppendManyBlocksOnBlocks appends `height` blocks to the chain.
+func (f *Builder) AppendManyBlocksOnBlocks(height int, parents ...*types.Block) *types.Block {
 	tip := types.UndefTipSet
 	if len(parents) > 0 {
 		tip = types.RequireNewTipSet(f.t, parents...)
 	}
-	return f.BuildManyOn(count, tip, nil)
+	return f.BuildManyOn(height, tip, nil).At(0)
 }
 
-// BuildOn creates and returns a new block child of singleton tipset `parent`. See BuildOnTip.
-func (f *Builder) BuildOn(parent *types.Block, build func(b *BlockBuilder)) *types.Block {
+// AppendManyBlocksOn appends `height` blocks to the chain.
+func (f *Builder) AppendManyBlocksOn(height int, parent types.TipSet) *types.Block {
+	return f.BuildManyOn(height, parent, nil).At(0)
+}
+
+// AppendManyOn appends `height` tipsets to the chain.
+func (f *Builder) AppendManyOn(height int, parent types.TipSet) types.TipSet {
+	return f.BuildManyOn(height, parent, nil)
+}
+
+// BuildOnBlock creates and returns a new block child of singleton tipset `parent`. See Build.
+func (f *Builder) BuildOnBlock(parent *types.Block, build func(b *BlockBuilder)) *types.Block {
 	tip := types.UndefTipSet
 	if parent != nil {
 		tip = types.RequireNewTipSet(f.t, parent)
 	}
-	return f.BuildOnTip(tip, build)
+	return f.BuildOn(tip, build).At(0)
 }
 
-// BuildManyOn builds a chain by invoking BuildOnTip `count` times.
-func (f *Builder) BuildManyOn(count int, parent types.TipSet, build func(b *BlockBuilder)) *types.Block {
-	require.True(f.t, count > 0, "")
-	for i := 0; i < count; i++ {
-		parent = types.RequireNewTipSet(f.t, f.BuildOnTip(parent, build))
+// BuildOn creates and returns a new single-block tipset child of `parent`.
+func (f *Builder) BuildOn(parent types.TipSet, build func(b *BlockBuilder)) types.TipSet {
+	return f.Build(parent, 1, singleBuilder(build))
+}
+
+// BuildManyOn builds a chain by invoking Build `height` times.
+func (f *Builder) BuildManyOn(height int, parent types.TipSet, build func(b *BlockBuilder)) types.TipSet {
+	require.True(f.t, height > 0, "")
+	for i := 0; i < height; i++ {
+		parent = f.Build(parent, 1, singleBuilder(build))
 	}
-	return parent.At(0)
+	return parent
 }
 
-// BuildOnTip creates and returns a new block child of `parent`.
+// Build creates and returns a new tipset child of `parent`.
+// The tipset carries `width` > 0 blocks with the same height and parents, but different tickets.
+// Note: the blocks will all have the same miner, which is unrealistic and forbidden by consensus;
+// generalise this to random miner addresses when that is rejected by the syncer.
 // The `build` function is invoked to modify the block before it is stored.
-func (f *Builder) BuildOnTip(parent types.TipSet, build func(b *BlockBuilder)) *types.Block {
-	ticket := make([]byte, binary.Size(f.seq))
-	binary.BigEndian.PutUint64(ticket, f.seq)
-	f.seq++
-
-	// Sum weight of parents' parent weight, plus one for each parent.
-	// Note: as with the state builder, we should probably factor this out.
-	parentWeight := types.Uint64(0)
-	for i := 0; i < parent.Len(); i++ {
-		parentWeight += parent.At(i).ParentWeight + 1
-	}
+func (f *Builder) Build(parent types.TipSet, width int, build func(b *BlockBuilder, i int)) types.TipSet {
+	require.True(f.t, width > 0)
+	var blocks []*types.Block
 
 	height := types.Uint64(0)
+	grandparentKey := types.NewTipSetKey()
 	if parent.Defined() {
+		var err error
 		height = parent.At(0).Height + 1
+		grandparentKey, err = parent.Parents()
+		require.NoError(f.t, err)
 	}
 
-	b := &types.Block{
-		Ticket:          ticket,
-		Miner:           f.minerAddress,
-		ParentWeight:    parentWeight,
-		Parents:         parent.Key(),
-		Height:          height,
-		Messages:        []*types.SignedMessage{},
-		MessageReceipts: []*types.MessageReceipt{},
-		// Omitted fields below
-		//StateRoot:       stateRoot,
-		//Proof            PoStProof
-		//Timestamp        Uint64
-	}
-	// Nonce intentionally omitted as it will go away.
-
-	if build != nil {
-		build(&BlockBuilder{b})
-	}
-
-	// Compute state root from block.
-	var err error
-	b.StateRoot, err = f.stateBuilder.ComputeStateRoot(b)
+	parentWeight, err := f.stateBuilder.Weigh(parent, f.StateForKey(grandparentKey))
 	require.NoError(f.t, err)
 
-	f.blocks[b.Cid()] = b
-	return b
+	for i := 0; i < width; i++ {
+		ticket := make([]byte, binary.Size(f.seq))
+		binary.BigEndian.PutUint64(ticket, f.seq)
+		f.seq++
 
+		b := &types.Block{
+			Ticket:          ticket,
+			Miner:           f.minerAddress,
+			ParentWeight:    types.Uint64(parentWeight),
+			Parents:         parent.Key(),
+			Height:          height,
+			Messages:        []*types.SignedMessage{},
+			MessageReceipts: []*types.MessageReceipt{},
+			// Omitted fields below
+			//StateRoot:       stateRoot,
+			//Proof            PoStProof
+			//Timestamp        Uint64
+		}
+		// Nonce intentionally omitted as it will go away.
+
+		if build != nil {
+			build(&BlockBuilder{b}, i)
+		}
+
+		// Compute state root for this block.
+		tipSet, err := types.NewTipSet(b)
+		require.NoError(f.t, err)
+		b.StateRoot = f.ComputeState(tipSet)
+		require.NoError(f.t, err)
+
+		f.blocks[b.Cid()] = b
+		blocks = append(blocks, b)
+	}
+	tip := types.RequireNewTipSet(f.t, blocks...)
+	// Compute and remember state for the tipset.
+	f.tipStateCids[tip.Key().String()] = f.ComputeState(tip)
+	return tip
+}
+
+// StateForKey loads (or computes) the state root for a tipset key.
+func (f *Builder) StateForKey(key types.TipSetKey) cid.Cid {
+	state, found := f.tipStateCids[key.String()]
+	if found {
+		return state
+	}
+	// No state yet computed for this tip (perhaps because the blocks in it have not previously
+	// been considered together as a tipset).
+	tip, err := f.GetTipSet(key)
+	require.NoError(f.t, err)
+	return f.ComputeState(tip)
+}
+
+// ComputeState computes the state for a tipset from its parent state.
+func (f *Builder) ComputeState(tip types.TipSet) cid.Cid {
+	parentKey, err := tip.Parents()
+	require.NoError(f.t, err)
+	// Load the state of the parent tipset and compute the required state (recursively).
+	prev := f.StateForKey(parentKey)
+	state, err := f.stateBuilder.ComputeState(prev, tip)
+	require.NoError(f.t, err)
+	return state
+}
+
+// Wraps a simple build function in one that also accepts an index, propagating a nil function.
+func singleBuilder(build func(b *BlockBuilder)) func(b *BlockBuilder, i int) {
+	if build == nil {
+		return nil
+	}
+	return func(b *BlockBuilder, i int) { build(b) }
 }
 
 ///// Block builder /////
@@ -172,28 +258,75 @@ func (bb *BlockBuilder) SetStateRoot(root cid.Cid) {
 
 // StateBuilder abstracts the computation of state root CIDs from the chain builder.
 type StateBuilder interface {
-	ComputeStateRoot(block *types.Block) (cid.Cid, error)
+	ComputeState(prev cid.Cid, tip types.TipSet) (cid.Cid, error)
+	Weigh(tip types.TipSet, state cid.Cid) (uint64, error)
 }
 
 // FakeStateBuilder computes a fake state CID by hashing the CIDs of a block's parents and messages.
 type FakeStateBuilder struct {
 }
 
-// ComputeStateRoot computes a fake state root for `Block`.
-func (FakeStateBuilder) ComputeStateRoot(block *types.Block) (cid.Cid, error) {
-	var fakeState []cid.Cid
-	for it := block.Parents.Iter(); !it.Complete(); it.Next() {
-		fakeState = append(fakeState, it.Value())
-	}
-	for i := 0; i < len(block.Messages); i++ {
-		mCid, err := block.Messages[i].Cid()
-		if err != nil {
-			return cid.Undef, err
+// ComputeState computes a fake state from a previous state root CID and the messages contained
+// in a tipset. Note that if the tipset is empty of messages, the resulting state is the same
+// as the input state.
+// This differs from the true state transition function in that messages that are duplicated
+// between blocks in the tipset are not ignored.
+func (FakeStateBuilder) ComputeState(prev cid.Cid, tip types.TipSet) (cid.Cid, error) {
+	// Accumulate the cids of the previous state and of all messages in the tipset.
+	inputs := []cid.Cid{prev}
+	for i := 0; i < tip.Len(); i++ {
+		for j := 0; j < len(tip.At(i).Messages); j++ {
+			mCId, err := tip.At(i).Messages[j].Cid()
+			if err != nil {
+				return cid.Undef, err
+			}
+			inputs = append(inputs, mCId)
 		}
-		fakeState = append(fakeState, mCid)
 	}
 
-	return makeCid(fakeState)
+	if len(inputs) == 1 {
+		// If there are no messages, the state doesn't change!
+		return prev, nil
+	}
+	return makeCid(inputs)
+}
+
+// Weigh computes a tipset's weight as its parent weight plus one for each block in the tipset.
+func (FakeStateBuilder) Weigh(tip types.TipSet, state cid.Cid) (uint64, error) {
+	parentWeight := uint64(0)
+	if tip.Defined() {
+		var err error
+		parentWeight, err = tip.ParentWeight()
+		if err != nil {
+			return 0, err
+		}
+	}
+	return parentWeight + uint64(tip.Len()), nil
+}
+
+///// State evaluator /////
+
+// FakeStateEvaluator is a syncStateEvaluator delegates to the FakeStateBuilder.
+type FakeStateEvaluator struct {
+	FakeStateBuilder
+}
+
+// RunStateTransition delegates to StateBuilder.ComputeState.
+func (e *FakeStateEvaluator) RunStateTransition(ctx context.Context, ts types.TipSet, ancestors []types.TipSet, stateID cid.Cid) (cid.Cid, error) {
+	return e.ComputeState(stateID, ts)
+}
+
+// IsHeavier compares chains weighed with StateBuilder.Weigh.
+func (e *FakeStateEvaluator) IsHeavier(ctx context.Context, a, b types.TipSet, aStateID, bStateID cid.Cid) (bool, error) {
+	aw, err := e.Weigh(a, aStateID)
+	if err != nil {
+		return false, err
+	}
+	bw, err := e.Weigh(b, bStateID)
+	if err != nil {
+		return false, err
+	}
+	return aw > bw, nil
 }
 
 ///// Interface and accessor implementations /////
@@ -249,6 +382,22 @@ func (f *Builder) FetchTipSets(ctx context.Context, key types.TipSetKey, recur i
 		}
 	}
 	return tips, nil
+}
+
+// GetTipSetStateRoot returns the state root that was computed for a tipset.
+func (f *Builder) GetTipSetStateRoot(key types.TipSetKey) (cid.Cid, error) {
+	found, ok := f.tipStateCids[key.String()]
+	if !ok {
+		return cid.Undef, errors.Errorf("no state for %s", key)
+	}
+	return found, nil
+}
+
+// RequireTipSet returns a tipset by key, which must exist.
+func (f *Builder) RequireTipSet(key types.TipSetKey) types.TipSet {
+	tip, err := f.GetTipSet(key)
+	require.NoError(f.t, err)
+	return tip
 }
 
 ///// Internals /////

--- a/chain/traversal_test.go
+++ b/chain/traversal_test.go
@@ -23,10 +23,10 @@ func TestIterAncestors(t *testing.T) {
 		ctx := context.Background()
 		store := chain.NewBuilder(t, miner)
 
-		root := store.AppendOn()
-		b11 := store.AppendOn(root)
-		b12 := store.AppendOn(root)
-		b21 := store.AppendOn(b11, b12)
+		root := store.AppendBlockOnBlocks()
+		b11 := store.AppendBlockOnBlocks(root)
+		b12 := store.AppendBlockOnBlocks(root)
+		b21 := store.AppendBlockOnBlocks(b11, b12)
 
 		t0 := types.RequireNewTipSet(t, root)
 		t1 := types.RequireNewTipSet(t, b11, b12)
@@ -52,10 +52,10 @@ func TestIterAncestors(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		store := chain.NewBuilder(t, miner)
 
-		root := store.AppendOn()
-		b11 := store.AppendOn(root)
-		b12 := store.AppendOn(root)
-		b21 := store.AppendOn(b11, b12)
+		root := store.AppendBlockOnBlocks()
+		b11 := store.AppendBlockOnBlocks(root)
+		b12 := store.AppendBlockOnBlocks(root)
+		b21 := store.AppendBlockOnBlocks(b11, b12)
 
 		types.RequireNewTipSet(t, root)
 		t1 := types.RequireNewTipSet(t, b11, b12)


### PR DESCRIPTION
Expand chain.Builder to keep track of computed state roots.

Sorry the diff here is a bit large. There is no change in syncer functionality or test coverage intended, though the tests themselves are now much shorter. The chain builder has more code in order to consistently compute state CIDs.