### PR TITLE
Remove build_docker_image from test_all workflow.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -549,13 +549,6 @@ workflows:
       - functional_test_linux:
           requires:
             - build_linux
-      - build_docker_img:
-          requires:
-            - build_linux
-            - unit_test_linux
-            - integration_test_linux
-            - functional_test_linux
-          <<: *master_filter
 
   build_nightly_osx:
     triggers:


### PR DESCRIPTION
We don't need a docker image in test_all. The output is ignored.

Fixes #2750.