### PR TITLE
add fetcher callback to halt fetching

### DIFF
--- a/chain/syncer.go
+++ b/chain/syncer.go
@@ -340,15 +340,12 @@ func (syncer *Syncer) HandleNewTipset(ctx context.Context, tsKey types.TipSetKey
 	defer syncer.mu.Unlock()
 
 	// If the store already has this tipset then the syncer is finished.
-	if _, err := syncer.chainStore.GetTipSet(tsKey); err == nil {
+	if syncer.chainStore.HasTipSetAndState(ctx, tsKey.String()) {
 		return nil
 	}
 
-	haltOnState := func(t types.TipSetKey) bool {
-		if syncer.chainStore.HasTipSetAndState(ctx, t.String()) {
-			return true
-		}
-		return false
+	haltOnState := func(t types.TipSet) bool {
+		return syncer.chainStore.HasTipSetAndState(ctx, t.String())
 	}
 
 	var chain []types.TipSet

--- a/chain/syncer_integration_test.go
+++ b/chain/syncer_integration_test.go
@@ -398,10 +398,6 @@ func TestLoadFork(t *testing.T) {
 
 	// Shut down store, reload and wire to syncer.
 	loadSyncer, blockSource := loadSyncerFromRepo(t, r, dstP)
-	// The fetcher will need to fetch these so that is may pass them to the
-	// done callback inorder to determine when to stop fetching.
-	// DONOTMERGE get specific approval on this before merging
-	blockSource.AddSourceBlocks(forklink3.ToSlice()...)
 
 	// Test that the syncer can't sync a block on the old chain
 	// without getting old blocks from network. i.e. the repo is trimmed
@@ -491,9 +487,6 @@ func TestTipSetWeightDeep(t *testing.T) {
 
 	// Setup a fetcher for feeding blocks into the syncer.
 	blockSource := th.NewTestFetcher()
-	// the block source needs the genesis
-	// DONOTMERGE
-	blockSource.AddSourceBlocks(genTsas.TipSet.ToSlice()...)
 
 	// Now sync the chainStore with consensus using a MarketView.
 	verifier = &verification.FakeVerifier{

--- a/chain/syncer_integration_test.go
+++ b/chain/syncer_integration_test.go
@@ -491,6 +491,9 @@ func TestTipSetWeightDeep(t *testing.T) {
 
 	// Setup a fetcher for feeding blocks into the syncer.
 	blockSource := th.NewTestFetcher()
+	// the block source needs the genesis
+	// DONOTMERGE
+	blockSource.AddSourceBlocks(genTsas.TipSet.ToSlice()...)
 
 	// Now sync the chainStore with consensus using a MarketView.
 	verifier = &verification.FakeVerifier{

--- a/chain/syncer_integration_test.go
+++ b/chain/syncer_integration_test.go
@@ -251,6 +251,7 @@ func initSyncTest(t *testing.T, con consensus.Protocol, genFunc func(cst *hamt.C
 	chainStore := chain.NewStore(chainDS, cst, &state.TreeStateLoader{}, calcGenBlk.Cid())
 
 	fetcher := th.NewTestFetcher()
+	fetcher.AddSourceBlocks(calcGenBlk)
 	syncer := chain.NewSyncer(con, chainStore, fetcher, syncMode) // note we use same cst for on and offline for tests
 
 	// Initialize stores to contain dstP.genesis block and state
@@ -397,6 +398,10 @@ func TestLoadFork(t *testing.T) {
 
 	// Shut down store, reload and wire to syncer.
 	loadSyncer, blockSource := loadSyncerFromRepo(t, r, dstP)
+	// The fetcher will need to fetch these so that is may pass them to the
+	// done callback inorder to determine when to stop fetching.
+	// DONOTMERGE get specific approval on this before merging
+	blockSource.AddSourceBlocks(forklink3.ToSlice()...)
 
 	// Test that the syncer can't sync a block on the old chain
 	// without getting old blocks from network. i.e. the repo is trimmed

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -370,12 +370,15 @@ func (f *Builder) GetTipSet(key types.TipSetKey) (types.TipSet, error) {
 // FetchTipSets fetchs the tipset at `tsKey` from the fetchers blockStore backed by the Builder.
 // FetchTipSets will only fetch TipSets whos TipSetKeys evaluate to `false` when passed to `done`,
 // this includes the provided `tsKey`.
-func (f *Builder) FetchTipSets(ctx context.Context, key types.TipSetKey, done func(t types.TipSetKey) bool) ([]types.TipSet, error) {
+func (f *Builder) FetchTipSets(ctx context.Context, key types.TipSetKey, done func(t types.TipSet) bool) ([]types.TipSet, error) {
 	var tips []types.TipSet
-	for !done(key) {
+	for {
 		tip, err := f.GetTipSet(key)
 		if err != nil {
 			return nil, err
+		}
+		if done(tip) {
+			break
 		}
 		tips = append(tips, tip)
 		key, err = tip.Parents()

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -367,10 +367,12 @@ func (f *Builder) GetTipSet(key types.TipSetKey) (types.TipSet, error) {
 	return types.NewTipSet(blocks...)
 }
 
-// FetchTipSets returns `recur` tipsets from `key` by following parent keys.
-func (f *Builder) FetchTipSets(ctx context.Context, key types.TipSetKey, recur int) ([]types.TipSet, error) {
+// FetchTipSets fetchs the tipset at `tsKey` from the fetchers blockStore backed by the Builder.
+// FetchTipSets will only fetch TipSets whos TipSetKeys evaluate to `false` when passed to `done`,
+// this includes the provided `tsKey`.
+func (f *Builder) FetchTipSets(ctx context.Context, key types.TipSetKey, done func(t types.TipSetKey) bool) ([]types.TipSet, error) {
 	var tips []types.TipSet
-	for i := 0; i < recur; i++ {
+	for !done(key) {
 		tip, err := f.GetTipSet(key)
 		if err != nil {
 			return nil, err

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -375,6 +375,7 @@ func (f *Builder) FetchTipSets(ctx context.Context, key types.TipSetKey, done fu
 		if err != nil {
 			return nil, err
 		}
+		tips = append(tips, tip)
 		ok, err := done(tip)
 		if err != nil {
 			return nil, err
@@ -382,7 +383,6 @@ func (f *Builder) FetchTipSets(ctx context.Context, key types.TipSetKey, done fu
 		if ok {
 			break
 		}
-		tips = append(tips, tip)
 		key, err = tip.Parents()
 		if err != nil {
 			return nil, err

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -368,16 +368,18 @@ func (f *Builder) GetTipSet(key types.TipSetKey) (types.TipSet, error) {
 }
 
 // FetchTipSets fetchs the tipset at `tsKey` from the fetchers blockStore backed by the Builder.
-// FetchTipSets will only fetch TipSets whos TipSetKeys evaluate to `false` when passed to `done`,
-// this includes the provided `tsKey`.
-func (f *Builder) FetchTipSets(ctx context.Context, key types.TipSetKey, done func(t types.TipSet) bool) ([]types.TipSet, error) {
+func (f *Builder) FetchTipSets(ctx context.Context, key types.TipSetKey, done func(t types.TipSet) (bool, error)) ([]types.TipSet, error) {
 	var tips []types.TipSet
 	for {
 		tip, err := f.GetTipSet(key)
 		if err != nil {
 			return nil, err
 		}
-		if done(tip) {
+		ok, err := done(tip)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			break
 		}
 		tips = append(tips, tip)

--- a/chain/util.go
+++ b/chain/util.go
@@ -1,0 +1,14 @@
+package chain
+
+import (
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// Reverse reverses the order of the slice `chain`.
+func Reverse(chain []types.TipSet) {
+	// https://github.com/golang/go/wiki/SliceTricks#reversing
+	for i := len(chain)/2 - 1; i >= 0; i-- {
+		opp := len(chain) - 1 - i
+		chain[i], chain[opp] = chain[opp], chain[i]
+	}
+}

--- a/consensus/block_validation.go
+++ b/consensus/block_validation.go
@@ -71,6 +71,11 @@ func (dv *DefaultBlockValidator) ValidateSemantic(ctx context.Context, child *ty
 
 // ValidateSyntax validates a single block is correctly formed.
 func (dv *DefaultBlockValidator) ValidateSyntax(ctx context.Context, blk *types.Block) error {
+	// TODO special handling for genesis block
+	// figure out in: https://github.com/filecoin-project/go-filecoin/issues/3121
+	if blk.Height == 0 {
+		return nil
+	}
 	now := uint64(dv.Now().Unix())
 	if uint64(blk.Timestamp) > now {
 		return fmt.Errorf("block %s with timestamp %d generate in future at time %d", blk.Cid().String(), blk.Timestamp, now)

--- a/consensus/block_validation.go
+++ b/consensus/block_validation.go
@@ -79,7 +79,7 @@ func (dv *DefaultBlockValidator) ValidateSyntax(ctx context.Context, blk *types.
 		return fmt.Errorf("block %s has nil StateRoot", blk.Cid().String())
 	}
 	if blk.Miner.Empty() {
-		return fmt.Errorf("block %s has nil miner address", blk.Miner.String())
+		return fmt.Errorf("block %s has nil miner address", blk.Cid().String())
 	}
 	if len(blk.Ticket) == 0 {
 		return fmt.Errorf("block %s has nil ticket", blk.Cid().String())

--- a/consensus/block_validation_test.go
+++ b/consensus/block_validation_test.go
@@ -102,6 +102,7 @@ func TestBlockValidSyntax(t *testing.T) {
 		StateRoot: validSt,
 		Miner:     validAd,
 		Ticket:    validTi,
+		Height:    1,
 	}
 	require.NoError(t, validator.ValidateSyntax(ctx, blk))
 

--- a/core/policy.go
+++ b/core/policy.go
@@ -57,7 +57,7 @@ func (p *DefaultQueuePolicy) HandleNewHead(ctx context.Context, target PolicyTar
 
 	// Remove from the queue all messages that have now been mined in new blocks.
 	// Rearrange the tipsets into increasing height order so messages are discovered in nonce order.
-	reverse(newTips)
+	chain.Reverse(newTips)
 	for _, tipset := range newTips {
 		for i := 0; i < tipset.Len(); i++ {
 			for _, minedMsg := range tipset.At(i).Messages {
@@ -86,12 +86,4 @@ func (p *DefaultQueuePolicy) HandleNewHead(ctx context.Context, target PolicyTar
 		}
 	}
 	return nil
-}
-
-func reverse(list []types.TipSet) {
-	// https://github.com/golang/go/wiki/SliceTricks#reversing
-	for i := len(list)/2 - 1; i >= 0; i-- {
-		opp := len(list) - 1 - i
-		list[i], list[opp] = list[opp], list[i]
-	}
 }

--- a/net/fetcher.go
+++ b/net/fetcher.go
@@ -15,8 +15,9 @@ import (
 
 // Fetcher defines an interface that may be used to fetch data from the network.
 type Fetcher interface {
-	// FetchTipSets will only fetch TipSets whos TipSetKeys evaluate to `false` when passed to `done`,
-	// this includes the provided `tsKey`. The returns slice of TipSets is in Traversal order.
+	// FetchTipSets will only fetch TipSets that evaluate to `false` when passed to `done`,
+	// this includes the provided `ts`. The TipSet that evaluates to true when
+	// passed to `done` will be in the returned slice. The returns slice of TipSets is in Traversal order.
 	FetchTipSets(ctx context.Context, tsKey types.TipSetKey, done func(ts types.TipSet) (bool, error)) ([]types.TipSet, error)
 }
 
@@ -52,6 +53,7 @@ func (bsf *BitswapFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetK
 			return nil, err
 		}
 
+		out = append(out, ts)
 		ok, err := done(ts)
 		if err != nil {
 			return nil, err
@@ -59,8 +61,6 @@ func (bsf *BitswapFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetK
 		if ok {
 			break
 		}
-
-		out = append(out, ts)
 
 		cur, err = ts.Parents()
 		if err != nil {

--- a/testhelpers/net.go
+++ b/testhelpers/net.go
@@ -145,10 +145,10 @@ func (f *TestFetcher) AddSourceBlocks(blocks ...*types.Block) {
 // FetchTipSets fetchs the tipset at `tsKey` from the network using the fetchers `sourceBlocks`
 // FetchTipSets will only fetch TipSets whos TipSetKeys evaluate to `false` when passed to `done`,
 // this includes the provided `tsKey`.
-func (f *TestFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetKey, done func(t types.TipSetKey) bool) ([]types.TipSet, error) {
+func (f *TestFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetKey, done func(t types.TipSet) bool) ([]types.TipSet, error) {
 	var out []types.TipSet
 	cur := tsKey
-	for !done(cur) {
+	for {
 		res, err := f.GetBlocks(ctx, cur.ToSlice())
 		if err != nil {
 			return nil, err
@@ -157,6 +157,10 @@ func (f *TestFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetKey, d
 		ts, err := types.NewTipSet(res...)
 		if err != nil {
 			return nil, err
+		}
+
+		if done(ts) {
+			break
 		}
 
 		out = append(out, ts)

--- a/testhelpers/net.go
+++ b/testhelpers/net.go
@@ -142,10 +142,8 @@ func (f *TestFetcher) AddSourceBlocks(blocks ...*types.Block) {
 	}
 }
 
-// FetchTipSets fetchs the tipset at `tsKey` from the network using the fetchers `sourceBlocks`
-// FetchTipSets will only fetch TipSets whos TipSetKeys evaluate to `false` when passed to `done`,
-// this includes the provided `tsKey`.
-func (f *TestFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetKey, done func(t types.TipSet) bool) ([]types.TipSet, error) {
+// FetchTipSets fetchs the tipset at `tsKey` from the network using the fetchers `sourceBlocks`.
+func (f *TestFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetKey, done func(t types.TipSet) (bool, error)) ([]types.TipSet, error) {
 	var out []types.TipSet
 	cur := tsKey
 	for {
@@ -159,7 +157,12 @@ func (f *TestFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetKey, d
 			return nil, err
 		}
 
-		if done(ts) {
+		ok, err := done(ts)
+		if err != nil {
+			return nil, err
+		}
+
+		if ok {
 			break
 		}
 

--- a/testhelpers/net.go
+++ b/testhelpers/net.go
@@ -157,16 +157,14 @@ func (f *TestFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetKey, d
 			return nil, err
 		}
 
+		out = append(out, ts)
 		ok, err := done(ts)
 		if err != nil {
 			return nil, err
 		}
-
 		if ok {
 			break
 		}
-
-		out = append(out, ts)
 
 		cur, err = ts.Parents()
 		if err != nil {


### PR DESCRIPTION
### What
This PR changes the Fetcher interface to accept a callback method that can be used to halt fetching blocks.
This PR then replaces calls to `collectChain` with this method.