### PR TITLE
Deployment Relay Check

### DIFF
--- a/functional-tests/network-deployment/README.md
+++ b/functional-tests/network-deployment/README.md
@@ -1,0 +1,92 @@
+Network Deployment Tests
+========================
+
+These tests can be run against a deployed kittyhawk network to verify
+expected behavior.
+
+All tests can be run by invoking the `test` command with the `-deployment <network>`
+flag from the project root.
+
+```
+$ go run ./build test -deployment nightly -unit false
+```
+
+## Writing Tests
+
+A deployment test is any test with a call to `tf.Deployment(t)`. The call to `tf.Deployment`
+returns the network name the test should be configured for. This value can be passed into
+`environment.NewDevnet`, and `fast.PODevnet` so everything is configured correctly.
+
+Due to the large setup cost (chain syncing / processing) using the same process is desired for
+related tests as long as no state between tests is shared (creating a miner in one, and using it
+in another).
+
+```
+package networkdeployment_test
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/tools/fast/environment"
+	"github.com/filecoin-project/go-filecoin/tools/fast/series"
+	localplugin "github.com/filecoin-project/go-filecoin/tools/iptb-plugins/filecoin/local"
+)
+
+func TestFoo(t *testing.T) {
+	network := tf.DeploymentTest(t)
+
+	ctx := context.Background()
+
+	// Create a directory for the test using the test name (mostly for FAST)
+	dir, err := ioutil.TempDir("", t.Name())
+	require.NoError(t, err)
+
+	// Create an environment to connect to the devnet
+	env, err := environment.NewDevnet(network, dir)
+	require.NoError(t, err)
+
+	// Teardown will shutdown all running processes the environment knows about
+	// and cleanup anything the environment setup. This includes the directory
+	// the environment was created to use.
+	defer func() {
+		require.NoError(t, env.Teardown(ctx))
+	}()
+
+	// Setup options for nodes.
+	options := make(map[string]string)
+	options[localplugin.AttrLogJSON] = "0"                               // Disable JSON logs
+	options[localplugin.AttrLogLevel] = "4"                              // Set log level to Info
+	options[localplugin.AttrFilecoinBinary] = th.MustGetFilecoinBinary() // Set binary
+
+	ctx = series.SetCtxSleepDelay(ctx, time.Second*30)
+
+	genesisURI := env.GenesisCar()
+
+	fastenvOpts := fast.FilecoinOpts{
+		InitOpts:   []fast.ProcessInitOption{fast.POGenesisFile(genesisURI), fast.PODevnet(network)},
+		DaemonOpts: []fast.ProcessDaemonOption{},
+	}
+
+	node, err := env.NewProcess(ctx, localplugin.PluginName, options, fastenvOpts)
+	require.NoError(t, err)
+
+	err = series.InitAndStart(ctx, node)
+	require.NoError(t, err)
+
+  // Tests can reuse the same enviroment or even a shared process. Tests should not depend
+  // on output of any other test such as a created miner, etc
+
+  t.Run("Do something with node", func(t *testing.T) {
+  })
+
+  t.Run("Do something else with node", func(t *testing.T) {
+  })
+```

--- a/functional-tests/network-deployment/bootstrap_test.go
+++ b/functional-tests/network-deployment/bootstrap_test.go
@@ -2,7 +2,6 @@ package networkdeployment_test
 
 import (
 	"context"
-	"io"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -12,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/filecoin-project/go-filecoin/fixtures"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/tools/fast"
@@ -20,13 +18,8 @@ import (
 	"github.com/filecoin-project/go-filecoin/tools/fast/series"
 	localplugin "github.com/filecoin-project/go-filecoin/tools/iptb-plugins/filecoin/local"
 
-	"github.com/ipfs/go-cid"
-	"github.com/libp2p/go-libp2p-circuit"
-	"github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
-	notif "github.com/libp2p/go-libp2p-routing/notifications"
 	"github.com/multiformats/go-multiaddr"
-	"github.com/multiformats/go-multiaddr-dns"
 )
 
 func init() {
@@ -80,5 +73,69 @@ func TestBootstrap(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Check that we are connected to bootstrap peers", func(t *testing.T) {
+		maddrChan := make(chan multiaddr.Multiaddr, 16)
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		go func() {
+			defer close(maddrChan)
+			protop2p := multiaddr.ProtocolWithCode(multiaddr.P_P2P)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(5 * time.Second):
+					peers, err := client.SwarmPeers(ctx)
+					assert.NoError(t, err)
+
+					for _, peer := range peers {
+						transport, err := multiaddr.NewMultiaddr(peer.Addr)
+						require.NoError(t, err)
+
+						// /ipfs/<ID>
+						peercomp, err := multiaddr.NewComponent(protop2p.Name, peer.Peer)
+						require.NoError(t, err)
+
+						fullmaddr := transport.Encapsulate(peercomp)
+						maddrChan <- fullmaddr
+					}
+				}
+			}
+		}()
+
+		bootstrapAddrs := networkBootstrapPeers(network)
+		require.NotEmpty(t, bootstrapAddrs)
+
+		bootstrapPeers, err := createResolvedPeerInfoMap(ctx, bootstrapAddrs)
+		require.NoError(t, err)
+
+		for maddr := range maddrChan {
+			pinfo, err := pstore.InfoFromP2pAddr(maddr)
+			require.NoError(t, err)
+
+			if _, ok := bootstrapPeers[pinfo.ID]; !ok {
+				continue
+			}
+
+			// pinfo will have only a single address as it comes from a single multiaddr
+			require.NotEmpty(t, pinfo.Addrs)
+			addr := pinfo.Addrs[0]
+
+			t.Logf("Looking at addr %s", addr)
+			for _, a := range bootstrapPeers[pinfo.ID].Addrs {
+				if addr.Equal(a) {
+					t.Logf("Found addr for peer %s", pinfo.ID)
+					delete(bootstrapPeers, pinfo.ID)
+				}
+			}
+
+			if len(bootstrapPeers) == 0 {
+				cancel()
+			}
+
+			for peerID := range bootstrapPeers {
+				t.Logf("Still waiting for %s", peerID)
+			}
+		}
 	})
 }

--- a/functional-tests/network-deployment/bootstrap_test.go
+++ b/functional-tests/network-deployment/bootstrap_test.go
@@ -1,0 +1,84 @@
+package networkdeployment_test
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	//logging "github.com/ipfs/go-log"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/fixtures"
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/tools/fast/environment"
+	"github.com/filecoin-project/go-filecoin/tools/fast/series"
+	localplugin "github.com/filecoin-project/go-filecoin/tools/iptb-plugins/filecoin/local"
+
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-circuit"
+	"github.com/libp2p/go-libp2p-peer"
+	pstore "github.com/libp2p/go-libp2p-peerstore"
+	notif "github.com/libp2p/go-libp2p-routing/notifications"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multiaddr-dns"
+)
+
+func init() {
+	//logging.SetDebugLogging()
+}
+
+// TestBootstrap verifies information about the bootstrap peers
+func TestBootstrap(t *testing.T) {
+	network := tf.DeploymentTest(t)
+
+	ctx := context.Background()
+
+	// Create a directory for the test using the test name (mostly for FAST)
+	dir, err := ioutil.TempDir("", t.Name())
+	require.NoError(t, err)
+
+	// Create an environment to connect to the devnet
+	env, err := environment.NewDevnet(network, dir)
+	require.NoError(t, err)
+
+	// Teardown will shutdown all running processes the environment knows about
+	// and cleanup anything the environment setup. This includes the directory
+	// the environment was created to use.
+	defer func() {
+		require.NoError(t, env.Teardown(ctx))
+	}()
+
+	// Setup options for nodes.
+	options := make(map[string]string)
+	options[localplugin.AttrLogJSON] = "0"                               // Disable JSON logs
+	options[localplugin.AttrLogLevel] = "4"                              // Set log level to Info
+	options[localplugin.AttrFilecoinBinary] = th.MustGetFilecoinBinary() // Set binary
+
+	ctx = series.SetCtxSleepDelay(ctx, time.Second*30)
+
+	genesisURI := env.GenesisCar()
+
+	fastenvOpts := fast.FilecoinOpts{
+		InitOpts:   []fast.ProcessInitOption{fast.POGenesisFile(genesisURI), fast.PODevnet(network)},
+		DaemonOpts: []fast.ProcessDaemonOption{},
+	}
+
+	//
+	//
+	//
+
+	client, err := env.NewProcess(ctx, localplugin.PluginName, options, fastenvOpts)
+	require.NoError(t, err)
+
+	err = series.InitAndStart(ctx, client)
+	require.NoError(t, err)
+
+	t.Run("Check that we are connected to bootstrap peers", func(t *testing.T) {
+	})
+}

--- a/functional-tests/network-deployment/miner_workflow_test.go
+++ b/functional-tests/network-deployment/miner_workflow_test.go
@@ -1,0 +1,136 @@
+package networkdeployment_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-ipfs-files"
+	logging "github.com/ipfs/go-log"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/tools/fast/environment"
+	"github.com/filecoin-project/go-filecoin/tools/fast/series"
+	localplugin "github.com/filecoin-project/go-filecoin/tools/iptb-plugins/filecoin/local"
+)
+
+func init() {
+	logging.SetDebugLogging()
+}
+
+func TestMiner(t *testing.T) {
+	network := tf.DeploymentTest(t)
+
+	ctx := context.Background()
+
+	// Create a directory for the test using the test name (mostly for FAST)
+	dir, err := ioutil.TempDir("", t.Name())
+	require.NoError(t, err)
+
+	// Create an environment to connect to the devnet
+	env, err := environment.NewDevnet(network, dir)
+	require.NoError(t, err)
+
+	// Teardown will shutdown all running processes the environment knows about
+	// and cleanup anything the environment setup. This includes the directory
+	// the environment was created to use.
+	defer func() {
+		require.NoError(t, env.Teardown(ctx))
+	}()
+
+	// Setup options for nodes.
+	options := make(map[string]string)
+	options[localplugin.AttrLogJSON] = "0"                               // Disable JSON logs
+	options[localplugin.AttrLogLevel] = "4"                              // Set log level to Info
+	options[localplugin.AttrFilecoinBinary] = th.MustGetFilecoinBinary() // Set binary
+
+	ctx = series.SetCtxSleepDelay(ctx, time.Second*30)
+
+	genesisURI := env.GenesisCar()
+
+	fastenvOpts := fast.FilecoinOpts{
+		InitOpts:   []fast.ProcessInitOption{fast.POGenesisFile(genesisURI), fast.PODevnet(network)},
+		DaemonOpts: []fast.ProcessDaemonOption{},
+	}
+
+	//
+	//
+	//
+
+	miner, err := env.NewProcess(ctx, localplugin.PluginName, options, fastenvOpts)
+	require.NoError(t, err)
+
+	client, err := env.NewProcess(ctx, localplugin.PluginName, options, fastenvOpts)
+	require.NoError(t, err)
+
+	// Start Miner
+	err = series.InitAndStart(ctx, miner)
+	require.NoError(t, err)
+
+	// Start Client
+	err = series.InitAndStart(ctx, client)
+	require.NoError(t, err)
+
+	// Everyone needs FIL to deal with gas costs and make sure their wallets
+	// exists (sending FIL to a wallet addr creates it)
+	err = env.GetFunds(ctx, miner)
+	require.NoError(t, err)
+
+	err = env.GetFunds(ctx, client)
+	require.NoError(t, err)
+
+	t.Run("Verify mining", func(t *testing.T) {
+		collateral := big.NewInt(10)
+		price := big.NewFloat(0.000000001)
+		expiry := big.NewInt(128)
+
+		defer client.DumpLastOutput(os.Stdout)
+		defer miner.DumpLastOutput(os.Stdout)
+
+		// Create a miner on the miner node
+		ask, err := series.CreateStorageMinerWithAsk(ctx, miner, collateral, price, expiry)
+		require.NoError(t, err)
+
+		// Connect the client and the miner
+		err = series.Connect(ctx, client, miner)
+		require.NoError(t, err)
+
+		// Store some data with the miner with the given ask, returns the cid for
+		// the imported data, and the deal which was created
+		var data bytes.Buffer
+		dataReader := io.LimitReader(rand.Reader, 4096)
+		dataReader = io.TeeReader(dataReader, &data)
+		_, deal, err := series.ImportAndStoreWithDuration(ctx, client, ask, 32, files.NewReaderFile(dataReader))
+		require.NoError(t, err)
+
+		vouchers, err := client.ClientPayments(ctx, deal.ProposalCid)
+		require.NoError(t, err)
+
+		lastVoucher := vouchers[len(vouchers)-1]
+
+		// Wait for the deal to be complete
+		err = series.WaitForDealState(ctx, client, deal, storagedeal.Complete)
+		require.NoError(t, err)
+
+		// Redeem
+		err = series.WaitForBlockHeight(ctx, miner, &lastVoucher.ValidAt)
+		require.NoError(t, err)
+
+		_, err = miner.DealsRedeem(ctx, deal.ProposalCid)
+		require.NoError(t, err)
+
+		// Check PoSt / Miner Power
+		// Redeem
+	})
+}

--- a/functional-tests/network-deployment/relay_check_test.go
+++ b/functional-tests/network-deployment/relay_check_test.go
@@ -344,8 +344,8 @@ func scanDhtProviders(ctx context.Context, t *testing.T, node *fast.Filecoin, dh
 	return eventChan, nil
 }
 
-// returns the list of peer address for network relay peers
-func networkRelayPeers(network string) []string {
+// returns the list of peer address for the network bootstrap peers
+func networkBootstrapPeers(network string) []string {
 	// Currently all bootstrap addresses are relay peers
 
 	switch network {
@@ -358,4 +358,9 @@ func networkRelayPeers(network string) []string {
 	}
 
 	return []string{}
+}
+
+// returns the list of peer address for network relay peers
+func networkRelayPeers(network string) []string {
+	return networkBootstrapPeers(network)
 }

--- a/functional-tests/network-deployment/relay_check_test.go
+++ b/functional-tests/network-deployment/relay_check_test.go
@@ -1,0 +1,361 @@
+package networkdeployment_test
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	//logging "github.com/ipfs/go-log"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/fixtures"
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/tools/fast/environment"
+	"github.com/filecoin-project/go-filecoin/tools/fast/series"
+	localplugin "github.com/filecoin-project/go-filecoin/tools/iptb-plugins/filecoin/local"
+
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-circuit"
+	"github.com/libp2p/go-libp2p-peer"
+	pstore "github.com/libp2p/go-libp2p-peerstore"
+	notif "github.com/libp2p/go-libp2p-routing/notifications"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multiaddr-dns"
+)
+
+func init() {
+	//logging.SetDebugLogging()
+}
+
+// TestRelayCheck is a two part test
+// 1) Check that the relay peers are advertising their addresses under
+//    the correct dht key
+// 2) Check that a node behind a NAT aquires a circuit relay address from
+//    one of the relay peers
+func TestRelayCheck(t *testing.T) {
+	network := tf.DeploymentTest(t)
+
+	ctx := context.Background()
+
+	// Create a directory for the test using the test name (mostly for FAST)
+	dir, err := ioutil.TempDir("", t.Name())
+	require.NoError(t, err)
+
+	// Create an environment to connect to the devnet
+	env, err := environment.NewDevnet(network, dir)
+	require.NoError(t, err)
+
+	// Teardown will shutdown all running processes the environment knows about
+	// and cleanup anything the environment setup. This includes the directory
+	// the environment was created to use.
+	defer func() {
+		require.NoError(t, env.Teardown(ctx))
+	}()
+
+	// Setup options for nodes.
+	options := make(map[string]string)
+	options[localplugin.AttrLogJSON] = "0"                               // Disable JSON logs
+	options[localplugin.AttrLogLevel] = "4"                              // Set log level to Info
+	options[localplugin.AttrFilecoinBinary] = th.MustGetFilecoinBinary() // Set binary
+
+	ctx = series.SetCtxSleepDelay(ctx, time.Second*30)
+
+	genesisURI := env.GenesisCar()
+
+	fastenvOpts := fast.FilecoinOpts{
+		InitOpts:   []fast.ProcessInitOption{fast.POGenesisFile(genesisURI), fast.PODevnet(network)},
+		DaemonOpts: []fast.ProcessDaemonOption{},
+	}
+
+	//
+	//
+	//
+
+	client, err := env.NewProcess(ctx, localplugin.PluginName, options, fastenvOpts)
+	require.NoError(t, err)
+
+	err = series.InitAndStart(ctx, client)
+	require.NoError(t, err)
+
+	// In this test we query the dht looking for providers of the relay key
+	// and verify that all of the expected providers show up at some point.
+	t.Run("Check for relay providers", func(t *testing.T) {
+		dhtKey, err := cid.Decode("zb2rhZ6FpTqFZyiAtpQFRKmybPMjq5A7oPHfmD5WeBko5kRAo")
+		require.NoError(t, err)
+
+		maddrChan := make(chan multiaddr.Multiaddr, 16)
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		// scanDhtProviders runs a `findprovs` at least every 5 seconds and reads through all
+		// of the events looking for `notif.Provider` events. These events contain PeerInfo
+		// which we convert into a slice of multiaddrs and publish on our maddrChan.
+
+		eventChan, err := scanDhtProviders(ctx, t, client, dhtKey)
+		require.NoError(t, err)
+
+		go func() {
+			defer close(maddrChan)
+			for event := range eventChan {
+				// There is only a single PeerInfo in the response see command `findprovs`.
+				pinfo := event.Responses[0]
+
+				// For some reason if a peer responses to a query, it will not include its
+				// own addresses. This might be a bug. However, all it means is that we need
+				// to take at least two arounds from two different peers, which is largely
+				// just luck of the draw.
+				if len(pinfo.Addrs) == 0 {
+					t.Logf("No addresses returned for peer %s", pinfo.ID)
+					continue
+				}
+
+				t.Logf("Found record for peer %s", pinfo.ID)
+
+				// Converts the pinfo into a set of addresses
+				maddrs, err := pstore.InfoToP2pAddrs(pinfo)
+				if err != nil {
+					t.Logf("Failed to get maddrs")
+					continue
+				}
+
+				for _, maddr := range maddrs {
+					maddrChan <- maddr
+				}
+			}
+		}()
+
+		relayPeersAddrs := networkRelayPeers(network)
+		require.NotEmpty(t, relayPeersAddrs)
+
+		// To verify that all of the relay peers are advertising correctly we need to
+		// see one of their addresses come through when we query the relay provider key.
+		// Below we construct a peer.ID mapping to a PeerInfo that contains addresses we
+		// expect to see.
+		// The address we expect to see is either the dns4 multiaddr from relayPeersAddrs,
+		// or the resolved ip4 address.
+		relayPeers, err := createResolvedPeerInfoMap(ctx, relayPeersAddrs)
+		require.NoError(t, err)
+
+		for maddr := range maddrChan {
+			pinfo, err := pstore.InfoFromP2pAddr(maddr)
+			require.NoError(t, err)
+
+			if _, ok := relayPeers[pinfo.ID]; !ok {
+				continue
+			}
+
+			// pinfo will have only a single address as it comes from a single multiaddr
+			require.NotEmpty(t, pinfo.Addrs)
+			addr := pinfo.Addrs[0]
+
+			t.Logf("Looking at addr %s", addr)
+			for _, a := range relayPeers[pinfo.ID].Addrs {
+				if addr.Equal(a) {
+					t.Logf("Found addr for peer %s", pinfo.ID)
+					delete(relayPeers, pinfo.ID)
+				}
+			}
+
+			if len(relayPeers) == 0 {
+				cancel()
+			}
+
+			for peerID := range relayPeers {
+				t.Logf("Still waiting for %s", peerID)
+			}
+		}
+	})
+
+	// In this test we want to verify that we retrieve a circuit relay address
+	// from one of our expected relay providers.
+	t.Run("Has circuit address", func(t *testing.T) {
+		details, err := client.ID(ctx)
+		require.NoError(t, err)
+
+		maddrChan := make(chan multiaddr.Multiaddr, 16)
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		go func() {
+			defer close(maddrChan)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(5 * time.Second):
+					details, err := client.ID(ctx)
+					assert.NoError(t, err)
+
+					for _, maddr := range details.Addresses {
+						maddrChan <- maddr
+					}
+				}
+			}
+		}()
+
+		relayPeersAddrs := networkRelayPeers(network)
+		require.NotEmpty(t, relayPeersAddrs)
+
+		relayPeers, err := createResolvedPeerInfoMap(ctx, relayPeersAddrs)
+		require.NoError(t, err)
+
+		// To verify that we have a circuit address from one of our relays we need to
+		// strip off the circuit component, and compare the address to the known addresses
+		// of our relays
+
+		protop2p := multiaddr.ProtocolWithCode(multiaddr.P_P2P)
+		protocircuit := multiaddr.ProtocolWithCode(relay.P_CIRCUIT)
+
+		// /ipfs/<ID>
+		peercomp, err := multiaddr.NewComponent(protop2p.Name, details.ID.String())
+		require.NoError(t, err)
+
+		// /p2p-circuit
+		relaycomp, err := multiaddr.NewComponent(protocircuit.Name, "")
+		require.NoError(t, err)
+
+		// /p2p-circuit/ipfs/<ID>
+		relaypeer := relaycomp.Encapsulate(peercomp)
+
+		for maddr := range maddrChan {
+			if _, err := maddr.ValueForProtocol(relay.Protocol.Code); err != nil {
+				continue
+			}
+
+			t.Logf("Found circuit addr %s", maddr)
+
+			relayaddr := maddr.Decapsulate(relaypeer)
+			pinfo, err := pstore.InfoFromP2pAddr(relayaddr)
+			require.NoError(t, err)
+
+			if _, ok := relayPeers[pinfo.ID]; !ok {
+				continue
+			}
+
+			// pinfo will have only a single address as it comes from a single multiaddr
+			require.NotEmpty(t, pinfo.Addrs)
+			addr := pinfo.Addrs[0]
+
+			if _, ok := relayPeers[pinfo.ID]; !ok {
+				t.Logf("Found circuit address %s from unexpected peer %s", maddr, pinfo.ID)
+				continue
+			}
+
+			for _, a := range relayPeers[pinfo.ID].Addrs {
+				if addr.Equal(a) {
+					t.Logf("Addr relays through %s", pinfo.ID)
+					cancel()
+					break
+				}
+			}
+		}
+	})
+}
+
+func createResolvedPeerInfoMap(ctx context.Context, addrs []string) (map[peer.ID]*pstore.PeerInfo, error) {
+	protop2p := multiaddr.ProtocolWithCode(multiaddr.P_P2P)
+
+	relayPeers := make(map[peer.ID]*pstore.PeerInfo)
+	for _, addr := range addrs {
+		maddr, err := multiaddr.NewMultiaddr(addr)
+		if err != nil {
+			return nil, err
+		}
+
+		pinfo, err := pstore.InfoFromP2pAddr(maddr)
+		if err != nil {
+			return nil, err
+		}
+
+		// PeerInfo stores just the transport of the multiaddr and removes the peer
+		// component from the end. However, when we resolve the dns4 address to ip4
+		// we get back the full address, so we want to strip the peer component
+		// for consistently
+
+		// This is the /ipfs/<peer-id> component
+		peercomp, err := multiaddr.NewComponent(protop2p.Name, pinfo.ID.String())
+		if err != nil {
+			return nil, err
+		}
+
+		rmaddrs, err := madns.Resolve(ctx, maddr)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, maddr := range rmaddrs {
+			pinfo.Addrs = append(pinfo.Addrs, maddr.Decapsulate(peercomp))
+		}
+
+		relayPeers[pinfo.ID] = pinfo
+	}
+
+	return relayPeers, nil
+}
+
+func scanDhtProviders(ctx context.Context, t *testing.T, node *fast.Filecoin, dhtKey cid.Cid) (<-chan notif.QueryEvent, error) {
+	eventChan := make(chan notif.QueryEvent, 16)
+
+	go func() {
+		defer close(eventChan)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(5 * time.Second):
+				t.Logf("Finding Providers for %s", dhtKey)
+				decoder, err := node.DHTFindProvs(ctx, dhtKey)
+				if err != nil {
+					t.Logf("Failed to run `findprovs`: %s", err)
+					continue
+				}
+
+				// Read all of the events from `findprovs`
+				for {
+					var event notif.QueryEvent
+					if err := decoder.Decode(&event); err != nil {
+						if err == io.EOF {
+							break
+						}
+
+						t.Logf("Decode failed %s", err)
+						continue
+					}
+
+					if event.Type == notif.Provider {
+						if len(event.Responses) == 0 {
+							t.Logf("No responses for provider event")
+							continue
+						}
+
+						eventChan <- event
+					}
+				}
+			}
+		}
+	}()
+
+	return eventChan, nil
+}
+
+// returns the list of peer address for network relay peers
+func networkRelayPeers(network string) []string {
+	// Currently all bootstrap addresses are relay peers
+
+	switch network {
+	case "nightly":
+		return fixtures.DevnetNightlyBootstrapAddrs
+	case "test":
+		return fixtures.DevnetTestBootstrapAddrs
+	case "user":
+		return fixtures.DevnetUserBootstrapAddrs
+	}
+
+	return []string{}
+}

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect
 	github.com/multiformats/go-multiaddr v0.0.4
-	github.com/multiformats/go-multiaddr-dns v0.0.3 // indirect
+	github.com/multiformats/go-multiaddr-dns v0.0.3
 	github.com/multiformats/go-multiaddr-net v0.0.1
 	github.com/multiformats/go-multibase v0.0.1
 	github.com/multiformats/go-multihash v0.0.6

--- a/testhelpers/testflags/flags.go
+++ b/testhelpers/testflags/flags.go
@@ -11,6 +11,20 @@ var integrationTest = flag.Bool("integration", true, "Run the integration go tes
 var unitTest = flag.Bool("unit", true, "Run the unit go tests")
 var functionalTest = flag.Bool("functional", false, "Run the functional go tests")
 var sectorBuilderTest = flag.Bool("sectorbuilder", false, "Run the sector builder tests")
+var deploymentTest = flag.String("deployment", "", "Run the deployment tests against a network")
+
+// DeploymentTest will run the test its called from iff the `-deployment` flag
+// is passed when calling `go test`. Otherwise the test will be skipped. DeploymentTest
+// will run the test its called from in parallel.
+// The network under test will be returned.
+func DeploymentTest(t *testing.T) string {
+	if len(*deploymentTest) == 0 {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	return *deploymentTest
+}
 
 // FunctionalTest will run the test its called from iff the `-functional` flag
 // is passed when calling `go test`. Otherwise the test will be skipped. FunctionalTest

--- a/tools/fast/action_client.go
+++ b/tools/fast/action_client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
+	"github.com/filecoin-project/go-filecoin/types"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-ipfs-files"
@@ -69,4 +70,15 @@ func (f *Filecoin) ClientQueryStorageDeal(ctx context.Context, prop cid.Cid) (*s
 // A json decoer is returned that asks may be decoded from.
 func (f *Filecoin) ClientListAsks(ctx context.Context) (*json.Decoder, error) {
 	return f.RunCmdLDJSONWithStdin(ctx, nil, "go-filecoin", "client", "list-asks")
+}
+
+// ClientPayments runs the client payments command against the filecoin process.
+func (f *Filecoin) ClientPayments(ctx context.Context, deal cid.Cid) ([]types.PaymentVoucher, error) {
+	var out []types.PaymentVoucher
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "client", "payments", deal.String()); err != nil {
+		return nil, err
+	}
+
+	return out, nil
 }

--- a/tools/fast/action_dht.go
+++ b/tools/fast/action_dht.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
-	"github.com/libp2p/go-libp2p-core/routing"
 	"github.com/multiformats/go-multiaddr"
 )
 

--- a/tools/fast/action_dht.go
+++ b/tools/fast/action_dht.go
@@ -2,6 +2,7 @@ package fast
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 
 	"github.com/ipfs/go-cid"
@@ -40,14 +41,7 @@ func (f *Filecoin) DHTFindPeer(ctx context.Context, pid peer.ID) ([]multiaddr.Mu
 }
 
 // DHTFindProvs runs the `dht findprovs` command against the filecoin process
-func (f *Filecoin) DHTFindProvs(ctx context.Context, key cid.Cid) ([]routing.QueryEvent, error) {
-	var out []routing.QueryEvent
-
-	args := []string{"go-filecoin", "swarm", "findprovs", key.String()}
-
-	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
-		return nil, err
-	}
-
-	return out, nil
+func (f *Filecoin) DHTFindProvs(ctx context.Context, key cid.Cid) (*json.Decoder, error) {
+	args := []string{"go-filecoin", "dht", "findprovs", key.String()}
+	return f.RunCmdLDJSONWithStdin(ctx, nil, args...)
 }

--- a/tools/fast/process_options.go
+++ b/tools/fast/process_options.go
@@ -31,6 +31,13 @@ func POAutoSealIntervalSeconds(seconds int) ProcessInitOption {
 	}
 }
 
+// PODevnet provides the `--devnet-<net>` option to process at init
+func PODevnet(net string) ProcessInitOption {
+	return func() []string {
+		return []string{fmt.Sprintf("--devnet-%s", net)}
+	}
+}
+
 // PODevnetTest provides the `--devnet-test` option to process at init
 func PODevnetTest() ProcessInitOption {
 	return func() []string {

--- a/tools/fast/series/wait_for_deal_state.go
+++ b/tools/fast/series/wait_for_deal_state.go
@@ -3,6 +3,8 @@ package series
 import (
 	"context"
 
+	"fmt"
+
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 )
@@ -20,6 +22,8 @@ func WaitForDealState(ctx context.Context, client *fast.Filecoin, deal *storaged
 		if dr.State == state {
 			break
 		}
+
+		fmt.Println(dr.State)
 
 		CtxSleepDelay(ctx)
 	}


### PR DESCRIPTION
Draft of #3040

I'm currently writing these checks as a set of tests as it's the easier way to handle running them at the moment. Using the golang test runner has a downside that it buffers any `t.Log` output which will probably not be idea for some longer running tests that we want log output from.