### PR TITLE
Split deal proposal context

### DIFF
--- a/protocol/storage/client.go
+++ b/protocol/storage/client.go
@@ -183,14 +183,14 @@ func (smc *Client) ProposeDeal(ctx context.Context, miner address.Address, data 
 	// Always set payer because it is used for signing
 	proposal.Payment.Payer = fromAddress
 
-	// The payment setup requires that the payment is mined into a block, currently we
-	// will wait for at most 5 blocks to be mined before giving up
-	ctxPaymentSetup, cancel := context.WithTimeout(ctx, 5*smc.api.BlockTime())
-	defer cancel()
-
 	// create payment information
 	totalCost := price.MulBigInt(big.NewInt(int64(pieceSize * duration)))
 	if totalCost.GreaterThan(types.ZeroAttoFIL) {
+		// The payment setup requires that the payment is mined into a block, currently we
+		// will wait for at most 5 blocks to be mined before giving up
+		ctxPaymentSetup, cancel := context.WithTimeout(ctx, 5*smc.api.BlockTime())
+		defer cancel()
+
 		cpResp, err := smc.api.CreatePayments(ctxPaymentSetup, porcelain.CreatePaymentsParams{
 			From:            fromAddress,
 			To:              minerOwner,


### PR DESCRIPTION
The timeout context in deal proposal was being used to cover two different cases that should be handled independently.

First we need to verify that we are connected to the miner, and secondly we need to have our payment channel mined into a block. Everything else can use the regular context.