### PR TITLE
fix destination file when copying libbls_signatures_ffi.a

### DIFF
--- a/scripts/install-bls-signatures.sh
+++ b/scripts/install-bls-signatures.sh
@@ -22,6 +22,6 @@ else
     mkdir -p bls-signatures/lib/pkgconfig
 
     find "${subm_dir}" -type f -name libbls_signatures.h -exec mv -- "{}" ./bls-signatures/include/ \;
-    find "${subm_dir}" -type f -name libbls_signatures_ffi.a -exec cp -- "{}" ./bls-signatures/lib/ \;
+    find "${subm_dir}" -type f -name libbls_signatures_ffi.a -exec cp -- "{}" ./bls-signatures/lib/libbls_signatures.a \;
     find "${subm_dir}" -type f -name libbls_signatures.pc -exec cp -- "{}" ./bls-signatures/lib/pkgconfig/ \;
 fi


### PR DESCRIPTION
resolves: https://github.com/filecoin-project/go-filecoin/issues/3120

but will be irrelevant when https://github.com/filecoin-project/go-filecoin/pull/3099 gets merged, since https://github.com/filecoin-project/go-bls-sigs/blob/master/install-bls-signatures already has this change