### PR TITLE
Allow larger runs in RLE+

### DIFF
--- a/rleplus/rleplus_test.go
+++ b/rleplus/rleplus_test.go
@@ -2,6 +2,7 @@ package rleplus_test
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"testing"
 
@@ -62,15 +63,11 @@ func TestRleplus(t *testing.T) {
 		}
 	})
 
-	t.Run("Encode limits run lengths to 2^14", func(t *testing.T) {
-		// Create a run larger than 2^14
-		var ints []uint64
-		for i := 0; i <= 1<<14; i++ {
-			ints = append(ints, uint64(i))
-		}
-
+	t.Run("Encode allows all runs sizes possible uint64", func(t *testing.T) {
+		// create a run of math.MaxUint64 - 1
+		ints := []uint64{math.MaxUint64}
 		_, _, err := rleplus.Encode(ints)
-		assert.Error(t, err, "run length too large for RLE+ version 0")
+		assert.NilError(t, err)
 	})
 
 	t.Run("Decode", func(t *testing.T) {
@@ -119,7 +116,7 @@ func TestRleplus(t *testing.T) {
 
 	t.Run("Decode returns an error with a bad encoding", func(t *testing.T) {
 		// create an encoding with a buffer with a run which is too long
-		_, err := rleplus.Decode([]byte{0xe0, 0xff, 0xff, 0xff})
+		_, err := rleplus.Decode([]byte{0xe0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
 		assert.Error(t, err, "invalid encoding for RLE+ version 0")
 	})
 

--- a/rleplus/rleplus_test.go
+++ b/rleplus/rleplus_test.go
@@ -64,7 +64,7 @@ func TestRleplus(t *testing.T) {
 	})
 
 	t.Run("Encode allows all runs sizes possible uint64", func(t *testing.T) {
-		// create a run of math.MaxUint64 - 1
+		// create a run of math.MaxUint64
 		ints := []uint64{math.MaxUint64}
 		_, _, err := rleplus.Encode(ints)
 		assert.NilError(t, err)


### PR DESCRIPTION
## Problem
When RLE+ was implemented, the maximum run length was 16384, because of the very specific use case (fault sets) and how they were specified.  Now there is some flux in the specification of exactly what is encoded with RLE+ -- whether it is indices into a list of sector commitments or sector ids, and how many numbers can be encoded with RLE+.

## Solution
Allow runs of up to `MaxUint64`.  This will cover any use cases we will likely run across with go-filecoin, and still prevents attacks by limiting the allowed size of uvarints to 10 bytes.

