### PR TITLE
Plumb peer ID to syncer's fetcher

### DIFF
--- a/chain/syncer_integration_test.go
+++ b/chain/syncer_integration_test.go
@@ -330,7 +330,7 @@ func TestLoadFork(t *testing.T) {
 	// Set up chain store to have standard chain up to dstP.link2
 	_ = requirePutBlocks(t, blockSource, dstP.link1.ToSlice()...)
 	cids2 := requirePutBlocks(t, blockSource, dstP.link2.ToSlice()...)
-	err := syncer.HandleNewTipset(ctx, cids2)
+	err := syncer.HandleNewTipset(ctx, cids2, peer.ID(""))
 	require.NoError(t, err)
 
 	// Now sync the store with a heavier fork, forking off dstP.link1.
@@ -381,7 +381,7 @@ func TestLoadFork(t *testing.T) {
 	_ = requirePutBlocks(t, blockSource, forklink1.ToSlice()...)
 	_ = requirePutBlocks(t, blockSource, forklink2.ToSlice()...)
 	forkHead := requirePutBlocks(t, blockSource, forklink3.ToSlice()...)
-	err = syncer.HandleNewTipset(ctx, forkHead)
+	err = syncer.HandleNewTipset(ctx, forkHead, peer.ID(""))
 	require.NoError(t, err)
 	requireHead(t, chainStore, forklink3)
 
@@ -403,7 +403,7 @@ func TestLoadFork(t *testing.T) {
 	// without getting old blocks from network. i.e. the repo is trimmed
 	// of non-heaviest chain blocks
 	cids3 := requirePutBlocks(t, blockSource, dstP.link3.ToSlice()...)
-	err = loadSyncer.HandleNewTipset(ctx, cids3)
+	err = loadSyncer.HandleNewTipset(ctx, cids3, peer.ID(""))
 	assert.Error(t, err)
 
 	// Test that the syncer can sync a block on the heaviest chain
@@ -412,7 +412,7 @@ func TestLoadFork(t *testing.T) {
 	forklink4blk1 := th.RequireMkFakeChild(t, fakeChildParams)
 	forklink4 := th.RequireNewTipSet(t, forklink4blk1)
 	cidsFork4 := requirePutBlocks(t, blockSource, forklink4.ToSlice()...)
-	err = loadSyncer.HandleNewTipset(ctx, cidsFork4)
+	err = loadSyncer.HandleNewTipset(ctx, cidsFork4, peer.ID(""))
 	assert.NoError(t, err)
 }
 
@@ -546,7 +546,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 
 	// Sync first tipset, should have weight 22 + starting
 	sharedCids := requirePutBlocks(t, blockSource, f1b1, f2b1)
-	err = syncer.HandleNewTipset(ctx, sharedCids)
+	err = syncer.HandleNewTipset(ctx, sharedCids, peer.ID(""))
 	require.NoError(t, err)
 	assertHead(t, chainStore, tsShared)
 	measuredWeight, err := wFun(requireHeadTipset(t, chainStore))
@@ -578,7 +578,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 
 	f1 := th.RequireNewTipSet(t, f1b2a, f1b2b)
 	f1Cids := requirePutBlocks(t, blockSource, f1.ToSlice()...)
-	err = syncer.HandleNewTipset(ctx, f1Cids)
+	err = syncer.HandleNewTipset(ctx, f1Cids, peer.ID(""))
 	require.NoError(t, err)
 	assertHead(t, chainStore, f1)
 	measuredWeight, err = wFun(requireHeadTipset(t, chainStore))
@@ -603,7 +603,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 
 	f2 := th.RequireNewTipSet(t, f2b2)
 	f2Cids := requirePutBlocks(t, blockSource, f2.ToSlice()...)
-	err = syncer.HandleNewTipset(ctx, f2Cids)
+	err = syncer.HandleNewTipset(ctx, f2Cids, peer.ID(""))
 	require.NoError(t, err)
 	assertHead(t, chainStore, f2)
 	measuredWeight, err = wFun(requireHeadTipset(t, chainStore))

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
@@ -368,7 +369,7 @@ func (f *Builder) GetTipSet(key types.TipSetKey) (types.TipSet, error) {
 }
 
 // FetchTipSets fetchs the tipset at `tsKey` from the fetchers blockStore backed by the Builder.
-func (f *Builder) FetchTipSets(ctx context.Context, key types.TipSetKey, done func(t types.TipSet) (bool, error)) ([]types.TipSet, error) {
+func (f *Builder) FetchTipSets(ctx context.Context, key types.TipSetKey, from peer.ID, done func(t types.TipSet) (bool, error)) ([]types.TipSet, error) {
 	var tips []types.TipSet
 	for {
 		tip, err := f.GetTipSet(key)

--- a/net/fetcher.go
+++ b/net/fetcher.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-block-format"
 	bserv "github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/consensus"
@@ -18,7 +19,7 @@ type Fetcher interface {
 	// FetchTipSets will only fetch TipSets that evaluate to `false` when passed to `done`,
 	// this includes the provided `ts`. The TipSet that evaluates to true when
 	// passed to `done` will be in the returned slice. The returns slice of TipSets is in Traversal order.
-	FetchTipSets(ctx context.Context, tsKey types.TipSetKey, done func(ts types.TipSet) (bool, error)) ([]types.TipSet, error)
+	FetchTipSets(ctx context.Context, tsKey types.TipSetKey, from peer.ID, done func(ts types.TipSet) (bool, error)) ([]types.TipSet, error)
 }
 
 // BitswapFetcher is used to fetch data over the network.  It is implemented with
@@ -39,7 +40,7 @@ func NewBitswapFetcher(ctx context.Context, bsrv bserv.BlockService, bv consensu
 }
 
 // FetchTipSets fetchs the tipset at `tsKey` from the network using the fetchers bitswap session.
-func (bsf *BitswapFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetKey, done func(types.TipSet) (bool, error)) ([]types.TipSet, error) {
+func (bsf *BitswapFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetKey, from peer.ID, done func(types.TipSet) (bool, error)) ([]types.TipSet, error) {
 	var out []types.TipSet
 	cur := tsKey
 	for {

--- a/node/node.go
+++ b/node/node.go
@@ -26,7 +26,7 @@ import (
 	circuit "github.com/libp2p/go-libp2p-circuit"
 	"github.com/libp2p/go-libp2p-core/host"
 	p2pmetrics "github.com/libp2p/go-libp2p-core/metrics"
-	libp2ppeer "github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/routing"
 	"github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p-kad-dht/opts"
@@ -89,7 +89,7 @@ type nodeChainReader interface {
 }
 
 type nodeChainSyncer interface {
-	HandleNewTipset(ctx context.Context, tipsetCids types.TipSetKey) error
+	HandleNewTipset(ctx context.Context, tipsetCids types.TipSetKey, from peer.ID) error
 }
 
 // Node represents a full Filecoin node.
@@ -517,9 +517,9 @@ func (node *Node) Start(ctx context.Context) error {
 	}
 
 	// Start up 'hello' handshake service
-	syncCallBack := func(pid libp2ppeer.ID, cids []cid.Cid, height uint64) {
+	syncCallBack := func(pid peer.ID, cids []cid.Cid, height uint64) {
 		cidSet := types.NewTipSetKey(cids...)
-		err := node.Syncer.HandleNewTipset(context.Background(), cidSet)
+		err := node.Syncer.HandleNewTipset(context.Background(), cidSet, pid)
 		if err != nil {
 			log.Infof("error handling blocks: %s", cidSet.String())
 		}

--- a/testhelpers/net.go
+++ b/testhelpers/net.go
@@ -144,7 +144,7 @@ func (f *TestFetcher) AddSourceBlocks(blocks ...*types.Block) {
 }
 
 // FetchTipSets fetchs the tipset at `tsKey` from the network using the fetchers `sourceBlocks`.
-func (f *TestFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetKey, done func(t types.TipSet) (bool, error)) ([]types.TipSet, error) {
+func (f *TestFetcher) FetchTipSets(ctx context.Context, tsKey types.TipSetKey, from peer.ID, done func(t types.TipSet) (bool, error)) ([]types.TipSet, error) {
 	var out []types.TipSet
 	cur := tsKey
 	for {


### PR DESCRIPTION
@hannahhoward I plumbed the peer ID down to `FetchTipSets` let me know if I should push it further into `GetBlocks`.