### PR TITLE
MinerPower bug fix & test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/libp2p/go-libp2p-swarm v0.1.1
 	github.com/libp2p/go-stream-muxer v0.0.1
 	github.com/libp2p/go-testutil v0.0.1 // indirect
-	github.com/magiconair/properties v1.8.1
+	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/miekg/dns v1.1.15 // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/minio/sha256-simd v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/libp2p/go-libp2p-swarm v0.1.1
 	github.com/libp2p/go-stream-muxer v0.0.1
 	github.com/libp2p/go-testutil v0.0.1 // indirect
-	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/magiconair/properties v1.8.1
 	github.com/miekg/dns v1.1.15 // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/minio/sha256-simd v0.1.0

--- a/tools/fast/action_miner.go
+++ b/tools/fast/action_miner.go
@@ -3,6 +3,8 @@ package fast
 import (
 	"context"
 	"math/big"
+	"strconv"
+	"strings"
 
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -65,17 +67,27 @@ func (f *Filecoin) MinerOwner(ctx context.Context, minerAddr address.Address) (a
 	return out, nil
 }
 
-// MinerPower runs the `miner power` command against the filecoin process
-func (f *Filecoin) MinerPower(ctx context.Context, minerAddr address.Address) (*big.Int, error) {
-	var out big.Int
+// MinerPower runs the `miner power` command against the filecoin process and returns the result
+// as two *big.Ints
+func (f *Filecoin) MinerPower(ctx context.Context, minerAddr address.Address) (int64, int64, error) {
+	var out string
 
 	sMinerAddr := minerAddr.String()
 
 	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "miner", "power", sMinerAddr); err != nil {
-		return big.NewInt(0), err
+		return 0, 0, err
 	}
 
-	return &out, nil
+	powers := strings.Split(out, " / ")
+	minerPwr, err := strconv.ParseInt(powers[0], 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	totalPwr, err := strconv.ParseInt(powers[1], 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	return minerPwr, totalPwr, nil
 }
 
 // MinerSetPrice runs the `miner set-price` command against the filecoin process

--- a/tools/fast/action_miner.go
+++ b/tools/fast/action_miner.go
@@ -69,25 +69,25 @@ func (f *Filecoin) MinerOwner(ctx context.Context, minerAddr address.Address) (a
 
 // MinerPower runs the `miner power` command against the filecoin process and returns the result
 // as two *big.Ints
-func (f *Filecoin) MinerPower(ctx context.Context, minerAddr address.Address) (int64, int64, error) {
+func (f *Filecoin) MinerPower(ctx context.Context, minerAddr address.Address) (*big.Int, *big.Int, error) {
 	var out string
 
 	sMinerAddr := minerAddr.String()
 
 	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "miner", "power", sMinerAddr); err != nil {
-		return 0, 0, err
+		return big.NewInt(0), big.NewInt(0), err
 	}
 
 	powers := strings.Split(out, " / ")
 	minerPwr, err := strconv.ParseInt(powers[0], 10, 64)
 	if err != nil {
-		return 0, 0, err
+		return big.NewInt(0), big.NewInt(0), err
 	}
 	totalPwr, err := strconv.ParseInt(powers[1], 10, 64)
 	if err != nil {
-		return 0, 0, err
+		return big.NewInt(0), big.NewInt(0), err
 	}
-	return minerPwr, totalPwr, nil
+	return big.NewInt(minerPwr), big.NewInt(totalPwr), nil
 }
 
 // MinerSetPrice runs the `miner set-price` command against the filecoin process

--- a/tools/fast/action_miner_test.go
+++ b/tools/fast/action_miner_test.go
@@ -1,0 +1,80 @@
+package fast_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	files "github.com/ipfs/go-ipfs-files"
+	logging "github.com/ipfs/go-log"
+	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/tools/fast/fastesting"
+	"github.com/filecoin-project/go-filecoin/tools/fast/series"
+)
+
+func TestFilecoin_MinerPower(t *testing.T) {
+	tf.IntegrationTest(t)
+	logging.SetDebugLogging()
+
+	// Give the deal time to complete
+	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{
+		InitOpts:   []fast.ProcessInitOption{fast.POAutoSealIntervalSeconds(1)},
+		DaemonOpts: []fast.ProcessDaemonOption{fast.POBlockTime(100 * time.Millisecond)},
+	})
+
+	defer func() {
+		require.NoError(t, env.Teardown(ctx))
+	}()
+
+	clientDaemon := env.GenesisMiner
+	require.NoError(t, clientDaemon.MiningStart(ctx))
+	defer func() {
+		require.NoError(t, clientDaemon.MiningStop(ctx))
+	}()
+
+	minerDaemon := env.RequireNewNodeWithFunds(10000)
+	_, _ = requireMinerClientMakeADeal(ctx, t, minerDaemon, clientDaemon)
+
+	assertPowerOutput(ctx, t, minerDaemon, 0, 1024)
+}
+
+func requireMinerClientMakeADeal(ctx context.Context, t *testing.T, minerDaemon, clientDaemon *fast.Filecoin) (*storagedeal.Response, uint64) {
+	collateral := big.NewInt(int64(1))
+	price := big.NewFloat(float64(1))
+	expiry := big.NewInt(int64(10000))
+	_, err := series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, price, expiry)
+	require.NoError(t, err)
+
+	f := files.NewBytesFile([]byte("HODLHODLHODL"))
+	dataCid, err := clientDaemon.ClientImport(ctx, f)
+	require.NoError(t, err)
+
+	minerAddress := requireGetMinerAddress(ctx, t, minerDaemon)
+
+	dealDuration := uint64(5)
+	dealResponse, err := clientDaemon.ClientProposeStorageDeal(ctx, dataCid, minerAddress, 0, dealDuration, true)
+	require.NoError(t, err)
+	return dealResponse, dealDuration
+}
+
+func requireGetMinerAddress(ctx context.Context, t *testing.T, daemon *fast.Filecoin) address.Address {
+	var minerAddress address.Address
+	err := daemon.ConfigGet(ctx, "mining.minerAddress", &minerAddress)
+	require.NoError(t, err)
+	return minerAddress
+}
+
+func assertPowerOutput(ctx context.Context, t *testing.T, d *fast.Filecoin, expMinerPwr, expTotalPwr int64) {
+	minerAddr := requireGetMinerAddress(ctx, t, d)
+	actualMinerPwr, actualTotalPwr, err := d.MinerPower(ctx, minerAddr)
+	require.NoError(t, err)
+	assert.Equal(t, actualMinerPwr, expMinerPwr, "for miner power")
+	assert.Equal(t, actualTotalPwr, expTotalPwr, "for total power")
+}

--- a/tools/fast/action_miner_test.go
+++ b/tools/fast/action_miner_test.go
@@ -75,6 +75,6 @@ func assertPowerOutput(ctx context.Context, t *testing.T, d *fast.Filecoin, expM
 	minerAddr := requireGetMinerAddress(ctx, t, d)
 	actualMinerPwr, actualTotalPwr, err := d.MinerPower(ctx, minerAddr)
 	require.NoError(t, err)
-	assert.Equal(t, actualMinerPwr, expMinerPwr, "for miner power")
-	assert.Equal(t, actualTotalPwr, expTotalPwr, "for total power")
+	assert.Equal(t, actualMinerPwr.Int64(), expMinerPwr, "for miner power")
+	assert.Equal(t, actualTotalPwr.Int64(), expTotalPwr, "for total power")
 }


### PR DESCRIPTION
## Problem
FAST's `Filecoin.MinerPower`, it is borked.

Based on @travisperson 's comment I've filed an [issue to change the output of the `miner power` command](https://github.com/filecoin-project/go-filecoin/issues/3144
) -- feel free to update to your liking.


## Solution
MinerPower was not updated to parse the latest output consisting of `<minerpower> / <totalpower>`.  It was missed because it hadn't been used yet. Fix this, include a regression test.