### PR TITLE
[WIP][DO-NOT-MERGE] re-enable codecov and disable parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -774,7 +774,7 @@ commands:
             trap "go run github.com/jstemmer/go-junit-report < test-results/go-test-suite/go-test.out > test-results/go-test-suite/go-test-report.xml" EXIT
             export TEST_PACKAGES="$(go list ./... | circleci tests split)"
             # Parallelism and timeout set to support medium-class containers, for builds on forked repos.
-            go run ./build test -cover -coverprofile coverage.out -timeout=30m -parallel=4 -functional=<< parameters.functional >> -integration=<< parameters.integration >> -sectorbuilder=<< parameters.sector_builder_tests >> -unit=<< parameters.unit >> -v 2>&1 | tee test-results/go-test-suite/go-test.out
+            go run ./build test -cover -coverprofile coverage.out -covermode=atomic -timeout=30m -parallel=4 -functional=<< parameters.functional >> -integration=<< parameters.integration >> -sectorbuilder=<< parameters.sector_builder_tests >> -unit=<< parameters.unit >> -v 2>&1 | tee test-results/go-test-suite/go-test.out
             mkdir -p /tmp/artifacts
             mv coverage.out /tmp/artifacts/coverage.out
       - codecov/upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,7 @@ jobs:
   unit_test_linux:
     docker:
       - image: circleci/golang:1.12.1
+    parallelism: 3
     working_directory: /go/src/github.com/filecoin-project/go-filecoin
     resource_class: large
     steps:
@@ -266,6 +267,7 @@ jobs:
   integration_test_linux:
     docker:
       - image: circleci/golang:1.12.1
+    parallelism: 3
     working_directory: /go/src/github.com/filecoin-project/go-filecoin
     resource_class: xlarge
     steps:
@@ -299,6 +301,7 @@ jobs:
   functional_test_linux:
     docker:
       - image: circleci/golang:1.12.1
+    parallelism: 4
     working_directory: /go/src/github.com/filecoin-project/go-filecoin
     resource_class: xlarge
     parameters:
@@ -769,9 +772,9 @@ commands:
           no_output_timeout: 30m
           command: |
             trap "go run github.com/jstemmer/go-junit-report < test-results/go-test-suite/go-test.out > test-results/go-test-suite/go-test-report.xml" EXIT
-            # export TEST_PACKAGES="$(go list ./... | circleci tests split)"
+            export TEST_PACKAGES="$(go list ./... | circleci tests split)"
             # Parallelism and timeout set to support medium-class containers, for builds on forked repos.
-            go run ./build test -cover -coverprofile coverage.out -timeout=30m -functional=<< parameters.functional >> -integration=<< parameters.integration >> -sectorbuilder=<< parameters.sector_builder_tests >> -unit=<< parameters.unit >> -v 2>&1 | tee test-results/go-test-suite/go-test.out
+            go run ./build test -cover -coverprofile coverage.out -timeout=30m -parallel=4 -functional=<< parameters.functional >> -integration=<< parameters.integration >> -sectorbuilder=<< parameters.sector_builder_tests >> -unit=<< parameters.unit >> -v 2>&1 | tee test-results/go-test-suite/go-test.out
             mkdir -p /tmp/artifacts
             mv coverage.out /tmp/artifacts/coverage.out
       - codecov/upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -777,8 +777,10 @@ commands:
             go run ./build test -cover -coverprofile coverage.out -covermode=atomic -timeout=30m -parallel=4 -functional=<< parameters.functional >> -integration=<< parameters.integration >> -sectorbuilder=<< parameters.sector_builder_tests >> -unit=<< parameters.unit >> -v 2>&1 | tee test-results/go-test-suite/go-test.out
             mkdir -p /tmp/artifacts
             mv coverage.out /tmp/artifacts/coverage.out
-      - codecov/upload:
-          file: /tmp/artifacts/coverage.out
+      - when:
+          condition: << parameters.unit >>
+          codecov/upload:
+            file: /tmp/artifacts/coverage.out
   linux_configure_env:
     steps:
      - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,6 @@ jobs:
   unit_test_linux:
     docker:
       - image: circleci/golang:1.12.1
-    parallelism: 3
     working_directory: /go/src/github.com/filecoin-project/go-filecoin
     resource_class: large
     steps:
@@ -267,7 +266,6 @@ jobs:
   integration_test_linux:
     docker:
       - image: circleci/golang:1.12.1
-    parallelism: 3
     working_directory: /go/src/github.com/filecoin-project/go-filecoin
     resource_class: xlarge
     steps:
@@ -301,7 +299,6 @@ jobs:
   functional_test_linux:
     docker:
       - image: circleci/golang:1.12.1
-    parallelism: 4
     working_directory: /go/src/github.com/filecoin-project/go-filecoin
     resource_class: xlarge
     parameters:
@@ -772,9 +769,9 @@ commands:
           no_output_timeout: 30m
           command: |
             trap "go run github.com/jstemmer/go-junit-report < test-results/go-test-suite/go-test.out > test-results/go-test-suite/go-test-report.xml" EXIT
-            export TEST_PACKAGES="$(go list ./... | circleci tests split)"
+            # export TEST_PACKAGES="$(go list ./... | circleci tests split)"
             # Parallelism and timeout set to support medium-class containers, for builds on forked repos.
-            go run ./build test -cover -coverprofile coverage.out -timeout=30m -parallel=4 -functional=<< parameters.functional >> -integration=<< parameters.integration >> -sectorbuilder=<< parameters.sector_builder_tests >> -unit=<< parameters.unit >> -v 2>&1 | tee test-results/go-test-suite/go-test.out
+            go run ./build test -cover -coverprofile coverage.out -timeout=30m -functional=<< parameters.functional >> -integration=<< parameters.integration >> -sectorbuilder=<< parameters.sector_builder_tests >> -unit=<< parameters.unit >> -v 2>&1 | tee test-results/go-test-suite/go-test.out
             mkdir -p /tmp/artifacts
             mv coverage.out /tmp/artifacts/coverage.out
       - codecov/upload:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,13 +8,13 @@ coverage:
     patch: off
     changes: off
 
-comment: off
-#  layout: "diff, flags, files"
-#  behavior: default
-#  require_changes: false  # if true: only post the comment if coverage changes
-#  require_base: yes       # [yes :: must have a base report to post]
-#  require_head: yes       # [yes :: must have a head report to post]
-#  branches: null          # branch names that can post comment
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: yes       # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null          # branch names that can post comment
 
 ignore:
   - "*/testing.go"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,6 @@
 coverage:
+  notify:
+    after_n_builds: 10
   range: 50..100
   round: down
   precision: 0

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,19 +2,22 @@ coverage:
   range: 50..100
   round: down
   precision: 0
-
   status:
     project: off
     patch: off
     changes: off
 
-comment: off
-#  layout: "diff, flags, files"
-#  behavior: default
-#  require_changes: false  # if true: only post the comment if coverage changes
-#  require_base: yes       # [yes :: must have a base report to post]
-#  require_head: yes       # [yes :: must have a head report to post]
-#  branches: null          # branch names that can post comment
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: yes       # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null          # branch names that can post comment
 
 ignore:
   - "*/testing.go"
+
+codecov:
+  notify:
+    require_ci_to_pass: no

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,6 @@
 coverage:
   notify:
-    after_n_builds: 10
+    after_n_builds: 3
   range: 50..100
   round: down
   precision: 0

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,13 +8,13 @@ coverage:
     patch: off
     changes: off
 
-comment:
-  layout: "diff, flags, files"
-  behavior: default
-  require_changes: false  # if true: only post the comment if coverage changes
-  require_base: yes       # [yes :: must have a base report to post]
-  require_head: yes       # [yes :: must have a head report to post]
-  branches: null          # branch names that can post comment
+comment: off
+#  layout: "diff, flags, files"
+#  behavior: default
+#  require_changes: false  # if true: only post the comment if coverage changes
+#  require_base: yes       # [yes :: must have a base report to post]
+#  require_head: yes       # [yes :: must have a head report to post]
+#  branches: null          # branch names that can post comment
 
 ignore:
   - "*/testing.go"

--- a/README.md
+++ b/README.md
@@ -234,3 +234,4 @@ The Filecoin Project is dual-licensed under Apache 2.0 and MIT terms:
 [3]: https://github.com/RichardLitt/standard-readme
 [4]: https://golang.org/doc/install
 [5]: https://www.rust-lang.org/en-US/install.html
+

--- a/build/main.go
+++ b/build/main.go
@@ -28,7 +28,7 @@ func init() {
 		fmt.Println("Failed to set GO111MODULE env")
 		os.Exit(1)
 	}
-	log.Print("testing12")
+	log.Print("testing123")
 }
 
 // command is a structure representing a shell command to be run in the

--- a/build/main.go
+++ b/build/main.go
@@ -28,6 +28,7 @@ func init() {
 		fmt.Println("Failed to set GO111MODULE env")
 		os.Exit(1)
 	}
+	log.Print("testing")
 }
 
 // command is a structure representing a shell command to be run in the

--- a/build/main.go
+++ b/build/main.go
@@ -28,7 +28,7 @@ func init() {
 		fmt.Println("Failed to set GO111MODULE env")
 		os.Exit(1)
 	}
-	log.Print("testing")
+	log.Print("testing2")
 }
 
 // command is a structure representing a shell command to be run in the

--- a/build/main.go
+++ b/build/main.go
@@ -28,7 +28,7 @@ func init() {
 		fmt.Println("Failed to set GO111MODULE env")
 		os.Exit(1)
 	}
-	log.Print("testing123")
+	log.Print("testing1234")
 }
 
 // command is a structure representing a shell command to be run in the

--- a/build/main.go
+++ b/build/main.go
@@ -28,7 +28,7 @@ func init() {
 		fmt.Println("Failed to set GO111MODULE env")
 		os.Exit(1)
 	}
-	log.Print("testing1234")
+	log.Print("testing12345")
 }
 
 // command is a structure representing a shell command to be run in the

--- a/build/main.go
+++ b/build/main.go
@@ -28,7 +28,7 @@ func init() {
 		fmt.Println("Failed to set GO111MODULE env")
 		os.Exit(1)
 	}
-	log.Print("testing2")
+	log.Print("testing12")
 }
 
 // command is a structure representing a shell command to be run in the


### PR DESCRIPTION
TESTING CODECOV

allow go test to detect number of cores and automatically set parallelism.
remove circleci container parallelism and test splitting. this should make codecov happier