### PR TITLE
Bugs/action client ignores allow duplicates

### DIFF
--- a/commands/client_daemon_test.go
+++ b/commands/client_daemon_test.go
@@ -3,25 +3,24 @@ package commands_test
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"math/big"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-ipfs-files"
+	logging "github.com/ipfs/go-log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/fixtures"
-	"github.com/filecoin-project/go-filecoin/protocol/storage"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 	"github.com/filecoin-project/go-filecoin/tools/fast/fastesting"
 	"github.com/filecoin-project/go-filecoin/tools/fast/series"
-	"github.com/ipfs/go-ipfs-files"
-	logging "github.com/ipfs/go-log"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestListAsks(t *testing.T) {

--- a/commands/client_daemon_test.go
+++ b/commands/client_daemon_test.go
@@ -103,25 +103,19 @@ func TestDuplicateDeals(t *testing.T) {
 	askPrice := big.NewFloat(0.5)
 	expiry := big.NewInt(int64(10000))
 
+	ask, err := series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, askPrice, expiry)
+	require.NoError(t, err)
+
+	_, err = minerClientMakeDealWithAllowDupes(ctx, t, true, minerDaemon, clientDaemon, ask.ID, duration)
+	require.NoError(t, err)
+
 	t.Run("Can make a second deal if --allow-duplicates is passed", func(t *testing.T) {
-		ask, err := series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, askPrice, expiry)
-		require.NoError(t, err)
-		_, err = minerClientMakeDealWithAllowDupes(ctx, t, true, minerDaemon, clientDaemon, ask.ID, duration)
-
-		require.NoError(t, err)
-
 		dealResp, err := minerClientMakeDealWithAllowDupes(ctx, t, true, minerDaemon, clientDaemon, ask.ID, duration)
 		assert.NoError(t, err)
 		require.NotNil(t, dealResp)
-		assert.Equal(t, storagedeal.Staged, dealResp.State)
+		assert.Equal(t, storagedeal.Accepted, dealResp.State)
 	})
 	t.Run("Cannot make a second deal --allow-duplicates is NOT passed", func(t *testing.T) {
-		ask, err := series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, askPrice, expiry)
-		require.NoError(t, err)
-		_, err = minerClientMakeDealWithAllowDupes(ctx, t, true, minerDaemon, clientDaemon, ask.ID, duration)
-
-		require.NoError(t, err)
-
 		dealResp, err := minerClientMakeDealWithAllowDupes(ctx, t, false, minerDaemon, clientDaemon, ask.ID, duration)
 		assert.Error(t, err)
 		assert.Nil(t, dealResp)

--- a/commands/client_daemon_test.go
+++ b/commands/client_daemon_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/ipfs/go-ipfs-files"
-	logging "github.com/ipfs/go-log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -79,7 +78,6 @@ func TestStorageDealsAfterRestart(t *testing.T) {
 
 func TestDuplicateDeals(t *testing.T) {
 	tf.IntegrationTest(t)
-	logging.SetDebugLogging()
 
 	// Give the deal time to complete
 	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{
@@ -130,7 +128,7 @@ func minerClientMakeDealWithAllowDupes(ctx context.Context, t *testing.T, allowD
 	var minerAddress address.Address
 	err = minerDaemon.ConfigGet(ctx, "mining.minerAddress", &minerAddress)
 	require.NoError(t, err)
-	dealResponse, err := clientDaemon.ClientProposeStorageDeal(ctx, dataCid, minerAddress, askID, duration, allowDupes)
+	dealResponse, err := clientDaemon.ClientProposeStorageDeal(ctx, dataCid, minerAddress, askID, duration, fast.AOAllowDuplicates(allowDupes))
 	return dealResponse, err
 }
 

--- a/commands/deals_daemon_test.go
+++ b/commands/deals_daemon_test.go
@@ -70,7 +70,8 @@ func TestDealsRedeem(t *testing.T) {
 	minerOwnerAddress := minerOwnerAddresses[0]
 
 	dealDuration := uint64(5)
-	dealResponse, err := clientDaemon.ClientProposeStorageDeal(ctx, dataCid, minerAddress, 0, dealDuration, true)
+
+	dealResponse, err := clientDaemon.ClientProposeStorageDeal(ctx, dataCid, minerAddress, 0, dealDuration)
 	require.NoError(t, err)
 
 	// atLeastStartH is either the start height of the deal or a height after the deal has started.

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/libp2p/go-libp2p-swarm v0.1.1
 	github.com/libp2p/go-stream-muxer v0.0.1
 	github.com/libp2p/go-testutil v0.0.1 // indirect
-	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/magiconair/properties v1.8.1
 	github.com/miekg/dns v1.1.15 // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/minio/sha256-simd v0.1.0

--- a/tools/fast/action_client.go
+++ b/tools/fast/action_client.go
@@ -44,8 +44,16 @@ func (f *Filecoin) ClientProposeStorageDeal(ctx context.Context, data cid.Cid,
 	sAsk := fmt.Sprintf("%d", ask)
 	sDuration := fmt.Sprintf("%d", duration)
 
-	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "client", "propose-storage-deal", sMiner, sData, sAsk, sDuration); err != nil {
-		return nil, err
+	// RunCmd does not allow empty arguments (e.g. in the cast that allowDuplicates is false, use an
+	// empty string as a param).
+	if allowDuplicates {
+		if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "client", "propose-storage-deal", sMiner, sData, sAsk, sDuration); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "client", "propose-storage-deal", "--allow-duplicates", sMiner, sData, sAsk, sDuration); err != nil {
+			return nil, err
+		}
 	}
 	return &out, nil
 }

--- a/tools/fast/action_client.go
+++ b/tools/fast/action_client.go
@@ -36,7 +36,7 @@ func (f *Filecoin) ClientImport(ctx context.Context, data files.File) (cid.Cid, 
 
 // ClientProposeStorageDeal runs the client propose-storage-deal command against the filecoin process.
 func (f *Filecoin) ClientProposeStorageDeal(ctx context.Context, data cid.Cid,
-	miner address.Address, ask uint64, duration uint64, allowDuplicates bool) (*storagedeal.Response, error) {
+	miner address.Address, ask uint64, duration uint64, options ...ActionOption) (*storagedeal.Response, error) {
 
 	var out storagedeal.Response
 	sData := data.String()
@@ -44,15 +44,11 @@ func (f *Filecoin) ClientProposeStorageDeal(ctx context.Context, data cid.Cid,
 	sAsk := fmt.Sprintf("%d", ask)
 	sDuration := fmt.Sprintf("%d", duration)
 
-	// RunCmd does not allow empty arguments (e.g. in the cast that allowDuplicates is false, use an
-	// empty string as a param).
-
-	args := []string{"go-filecoin", "client", "propose-storage-deal", "--allow-duplicates", sMiner, sData, sAsk, sDuration}
-
-	// delete the flag
-	if !allowDuplicates {
-		args = append(args[:3], args[4:]...)
+	args := []string{"go-filecoin", "client", "propose-storage-deal", sMiner, sData, sAsk, sDuration}
+	for _, opt := range options {
+		args = append(args, opt()...)
 	}
+
 	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
 		return nil, err
 	}

--- a/tools/fast/action_client.go
+++ b/tools/fast/action_client.go
@@ -47,11 +47,11 @@ func (f *Filecoin) ClientProposeStorageDeal(ctx context.Context, data cid.Cid,
 	// RunCmd does not allow empty arguments (e.g. in the cast that allowDuplicates is false, use an
 	// empty string as a param).
 	if allowDuplicates {
-		if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "client", "propose-storage-deal", sMiner, sData, sAsk, sDuration); err != nil {
+		if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "client", "propose-storage-deal", "--allow-duplicates", sMiner, sData, sAsk, sDuration); err != nil {
 			return nil, err
 		}
 	} else {
-		if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "client", "propose-storage-deal", "--allow-duplicates", sMiner, sData, sAsk, sDuration); err != nil {
+		if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "client", "propose-storage-deal", sMiner, sData, sAsk, sDuration); err != nil {
 			return nil, err
 		}
 	}

--- a/tools/fast/action_client.go
+++ b/tools/fast/action_client.go
@@ -46,14 +46,15 @@ func (f *Filecoin) ClientProposeStorageDeal(ctx context.Context, data cid.Cid,
 
 	// RunCmd does not allow empty arguments (e.g. in the cast that allowDuplicates is false, use an
 	// empty string as a param).
-	if allowDuplicates {
-		if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "client", "propose-storage-deal", "--allow-duplicates", sMiner, sData, sAsk, sDuration); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "client", "propose-storage-deal", sMiner, sData, sAsk, sDuration); err != nil {
-			return nil, err
-		}
+
+	args := []string{"go-filecoin", "client", "propose-storage-deal", "--allow-duplicates", sMiner, sData, sAsk, sDuration}
+
+	// delete the flag
+	if !allowDuplicates {
+		args = append(args[:3], args[4:]...)
+	}
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
+		return nil, err
 	}
 	return &out, nil
 }

--- a/tools/fast/action_miner_test.go
+++ b/tools/fast/action_miner_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	files "github.com/ipfs/go-ipfs-files"
-	logging "github.com/ipfs/go-log"
 	"github.com/magiconair/properties/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,7 +20,6 @@ import (
 
 func TestFilecoin_MinerPower(t *testing.T) {
 	tf.IntegrationTest(t)
-	logging.SetDebugLogging()
 
 	// Give the deal time to complete
 	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{
@@ -59,7 +57,7 @@ func requireMinerClientMakeADeal(ctx context.Context, t *testing.T, minerDaemon,
 	minerAddress := requireGetMinerAddress(ctx, t, minerDaemon)
 
 	dealDuration := uint64(5)
-	dealResponse, err := clientDaemon.ClientProposeStorageDeal(ctx, dataCid, minerAddress, 0, dealDuration, true)
+	dealResponse, err := clientDaemon.ClientProposeStorageDeal(ctx, dataCid, minerAddress, 0, dealDuration)
 	require.NoError(t, err)
 	return dealResponse, dealDuration
 }

--- a/tools/fast/process.go
+++ b/tools/fast/process.go
@@ -1,6 +1,7 @@
 package fast
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -197,6 +198,16 @@ func (f *Filecoin) DumpLastOutputJSON(w io.Writer) {
 // LastCmdStdErr is the standard error output from the last command run
 func (f *Filecoin) LastCmdStdErr() io.ReadCloser {
 	return f.lastCmdOutput.Stderr()
+}
+
+// LastCmdStdErrStr is a shortcut to just get the output as string
+func (f *Filecoin) LastCmdStdErrStr() string {
+	buf := new(bytes.Buffer)
+	out := f.LastCmdStdErr()
+	if _, err := buf.ReadFrom(out); err != nil {
+		return "Problem reading from LastCmdStdErr buffer"
+	}
+	return buf.String()
 }
 
 // RunCmdWithStdin runs `args` against Filecoin process `f`, a testbedi.Output and an error are returned.

--- a/tools/fast/process.go
+++ b/tools/fast/process.go
@@ -201,13 +201,13 @@ func (f *Filecoin) LastCmdStdErr() io.ReadCloser {
 }
 
 // LastCmdStdErrStr is a shortcut to just get the output as string
-func (f *Filecoin) LastCmdStdErrStr() string {
+func (f *Filecoin) LastCmdStdErrStr() (string, error) {
 	buf := new(bytes.Buffer)
 	out := f.LastCmdStdErr()
 	if _, err := buf.ReadFrom(out); err != nil {
-		return "Problem reading from LastCmdStdErr buffer"
+		return "", err
 	}
-	return buf.String()
+	return buf.String(), nil
 }
 
 // RunCmdWithStdin runs `args` against Filecoin process `f`, a testbedi.Output and an error are returned.

--- a/tools/fast/process_action_options.go
+++ b/tools/fast/process_action_options.go
@@ -108,10 +108,18 @@ func AOPayer(payer address.Address) ActionOption {
 	}
 }
 
-// AOValidAt provides the `--validat=<blockheight>` option to actions
+// AOValidAt provides the `--validate=<blockheight>` option to actions
 func AOValidAt(bh *types.BlockHeight) ActionOption {
 	sBH := bh.String()
 	return func() []string {
 		return []string{"--validat", sBH}
+	}
+}
+
+// AOAllowDuplicates provides the --allow-duplicates option to client propose-storage-deal
+func AOAllowDuplicates(allow bool) ActionOption {
+	sAllowDupes := fmt.Sprintf("--allow-duplicates=%t", allow)
+	return func() []string {
+		return []string{sAllowDupes}
 	}
 }

--- a/tools/fast/series/import_and_store.go
+++ b/tools/fast/series/import_and_store.go
@@ -30,7 +30,7 @@ func ImportAndStoreWithDuration(ctx context.Context, client *fast.Filecoin, ask 
 	}
 
 	// Client makes a deal
-	deal, err := client.ClientProposeStorageDeal(ctx, dcid, ask.Miner, ask.ID, duration, false)
+	deal, err := client.ClientProposeStorageDeal(ctx, dcid, ask.Miner, ask.ID, duration)
 	if err != nil {
 		return cid.Undef, nil, err
 	}


### PR DESCRIPTION
# Problem
Closes #3150 , FAST `ClientProposeDeal` was ignoring the allowDuplicates flag.  Discovered while writing an integration test for another story.

# Solution
- Pass --allow-duplicates as a parameter according to the flag.  
- Update `TestDuplicateDeals` from old-style daemon test to FAST, so it now uses this function `ClientProposeDeal`.

with @ingar 