### PR TITLE
Peer Tracker #3054

### DIFF
--- a/net/peer_tracker.go
+++ b/net/peer_tracker.go
@@ -1,0 +1,81 @@
+package net
+
+import (
+	"sync"
+
+	logging "github.com/ipfs/go-log"
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
+
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+var logPeerTracker = logging.Logger("peer-tracker")
+
+// PeerTracker is used to record a subset of peers. Its methods are thread safe.
+// It is designed to plug directly into libp2p disconnect notifications to
+// automatically register dropped connections.
+type PeerTracker struct {
+	// mu protects peers
+	mu sync.RWMutex
+	// peers maps stringified peer.IDs to info about their chains
+	peers map[string]*types.ChainInfo
+}
+
+// NewPeerTracker creates a peer tracker.
+func NewPeerTracker() *PeerTracker {
+	return &PeerTracker{
+		peers: make(map[string]*types.ChainInfo),
+	}
+}
+
+// Track adds information about a given peer.ID
+func (tracker *PeerTracker) Track(ci *types.ChainInfo) {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	pidKey := peer.IDB58Encode(ci.Peer)
+	if _, tracking := tracker.peers[pidKey]; tracking {
+		logPeerTracker.Warningf("unexpected duplicate track on peer: %s", pidKey)
+	}
+	tracker.peers[pidKey] = ci
+}
+
+// List returns the chain info of the currently tracked peers.  The info
+// tracked by the tracker can change arbitrarily after this is called -- there
+// is no guarantee that the peers returned will be tracked when they are used
+// by the caller and no guarantee that the chain info is up to date.
+func (tracker *PeerTracker) List() []*types.ChainInfo {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	var tracked []*types.ChainInfo
+	for _, ci := range tracker.peers {
+		tracked = append(tracked, ci)
+	}
+	out := make([]*types.ChainInfo, len(tracked))
+	copy(out, tracked)
+	return out
+}
+
+// Remove removes a peer ID from the tracker.
+func (tracker *PeerTracker) Remove(pid peer.ID) {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	pidKey := peer.IDB58Encode(pid)
+	if _, tracking := tracker.peers[pidKey]; tracking {
+		delete(tracker.peers, pidKey)
+	}
+}
+
+// TrackerRegisterDisconnect registers a tracker remove operation as a libp2p
+// "Disconnected" network event callback.
+func TrackerRegisterDisconnect(ntwk network.Network, tracker *PeerTracker) {
+	notifee := &network.NotifyBundle{}
+	notifee.DisconnectedF = func(network network.Network, conn network.Conn) {
+		pid := conn.RemotePeer()
+		tracker.Remove(pid)
+	}
+	ntwk.Notify(notifee)
+}

--- a/net/peer_tracker_test.go
+++ b/net/peer_tracker_test.go
@@ -1,0 +1,110 @@
+package net_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/net"
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+func TestPeerTrackerTracks(t *testing.T) {
+	tf.UnitTest(t)
+
+	tracker := net.NewPeerTracker()
+	pid0 := th.RequireIntPeerID(t, 0)
+	pid1 := th.RequireIntPeerID(t, 1)
+	pid3 := th.RequireIntPeerID(t, 3)
+	pid7 := th.RequireIntPeerID(t, 7)
+
+	ci0 := types.NewChainInfo(pid0, types.NewTipSetKey(types.SomeCid()), 6)
+	ci1 := types.NewChainInfo(pid1, types.NewTipSetKey(), 0)
+	ci3 := types.NewChainInfo(pid3, types.NewTipSetKey(), 0)
+	ci7 := types.NewChainInfo(pid7, types.NewTipSetKey(), 0)
+
+	tracker.Track(ci0)
+	tracker.Track(ci1)
+	tracker.Track(ci3)
+	tracker.Track(ci7)
+
+	tracked := tracker.List()
+	sort.Sort(types.CISlice(tracked))
+	expected := []*types.ChainInfo{ci0, ci1, ci3, ci7}
+	sort.Sort(types.CISlice(expected))
+	assert.Equal(t, expected, tracked)
+}
+
+func TestPeerTrackerRemove(t *testing.T) {
+	tf.UnitTest(t)
+
+	tracker := net.NewPeerTracker()
+	pid0 := th.RequireIntPeerID(t, 0)
+	pid1 := th.RequireIntPeerID(t, 1)
+	pid3 := th.RequireIntPeerID(t, 3)
+	pid7 := th.RequireIntPeerID(t, 7)
+
+	ci0 := types.NewChainInfo(pid0, types.NewTipSetKey(types.SomeCid()), 6)
+	ci1 := types.NewChainInfo(pid1, types.NewTipSetKey(), 0)
+	ci3 := types.NewChainInfo(pid3, types.NewTipSetKey(), 0)
+	ci7 := types.NewChainInfo(pid7, types.NewTipSetKey(), 0)
+
+	tracker.Track(ci0)
+	tracker.Track(ci1)
+	tracker.Track(ci3)
+	tracker.Track(ci7)
+
+	tracker.Remove(pid1)
+	tracker.Remove(pid3)
+	tracker.Remove(pid7)
+
+	tracked := tracker.List()
+	expected := []*types.ChainInfo{ci0}
+	assert.Equal(t, expected, tracked)
+}
+
+func TestPeerTrackerNetworkDisconnect(t *testing.T) {
+	tf.UnitTest(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mn, err := mocknet.FullMeshConnected(ctx, 4)
+	require.NoError(t, err)
+
+	self := mn.Hosts()[0]
+	a := mn.Hosts()[1]
+	b := mn.Hosts()[2]
+	c := mn.Hosts()[3]
+
+	selfID := self.ID()
+	aID := a.ID()
+	bID := b.ID()
+	cID := c.ID()
+
+	aCI := types.NewChainInfo(aID, types.NewTipSetKey(), 0)
+	bCI := types.NewChainInfo(bID, types.NewTipSetKey(), 0)
+
+	// self is the tracking node
+	// self tracks peers a and b
+	// self does not track peer c
+	tracker := net.NewPeerTracker()
+	tracker.Track(aCI)
+	tracker.Track(bCI)
+
+	// register tracker OnDisconnect callback in self's network
+	net.TrackerRegisterDisconnect(self.Network(), tracker)
+
+	// disconnect from tracked a and untracked c
+	require.NoError(t, mn.DisconnectPeers(selfID, aID))
+	require.NoError(t, mn.DisconnectPeers(selfID, cID))
+
+	tracked := tracker.List()
+	assert.Equal(t, []*types.ChainInfo{bCI}, tracked)
+}

--- a/protocol/hello/hello.go
+++ b/protocol/hello/hello.go
@@ -33,13 +33,13 @@ var log = logging.Logger("/fil/hello")
 
 // Message is the data structure of a single message in the hello protocol.
 type Message struct {
-	HeaviestTipSetCids   []cid.Cid
+	HeaviestTipSetCids   types.TipSetKey
 	HeaviestTipSetHeight uint64
 	GenesisHash          cid.Cid
 	CommitSha            string
 }
 
-type syncCallback func(from peer.ID, cids []cid.Cid, height uint64)
+type helloCallback func(ci *types.ChainInfo)
 
 type getTipSetFunc func() (types.TipSet, error)
 
@@ -52,8 +52,8 @@ type Handler struct {
 
 	genesis cid.Cid
 
-	// chainSyncCB is called when new peers tell us about their chain
-	chainSyncCB syncCallback
+	// callBack is called when new peers tell us about their chain
+	callBack helloCallback
 
 	//  is used to retrieve the current heaviest tipset
 	// for filling out our hello messages.
@@ -65,11 +65,11 @@ type Handler struct {
 
 // New creates a new instance of the hello protocol and registers it to
 // the given host, with the provided callbacks.
-func New(h host.Host, gen cid.Cid, syncCallback syncCallback, getHeaviestTipSet getTipSetFunc, net string, commitSha string) *Handler {
+func New(h host.Host, gen cid.Cid, helloCallback helloCallback, getHeaviestTipSet getTipSetFunc, net string, commitSha string) *Handler {
 	hello := &Handler{
 		host:              h,
 		genesis:           gen,
-		chainSyncCB:       syncCallback,
+		callBack:          helloCallback,
 		getHeaviestTipSet: getHeaviestTipSet,
 		net:               net,
 		commitSha:         commitSha,
@@ -126,7 +126,8 @@ func (h *Handler) processHelloMessage(from peer.ID, msg *Message) error {
 		return ErrWrongVersion
 	}
 
-	h.chainSyncCB(from, msg.HeaviestTipSetCids, msg.HeaviestTipSetHeight)
+	ci := types.NewChainInfo(from, msg.HeaviestTipSetCids, msg.HeaviestTipSetHeight)
+	h.callBack(ci)
 	return nil
 }
 
@@ -142,7 +143,7 @@ func (h *Handler) getOurHelloMessage() *Message {
 
 	return &Message{
 		GenesisHash:          h.genesis,
-		HeaviestTipSetCids:   heaviest.Key().ToSlice(),
+		HeaviestTipSetCids:   heaviest.Key(),
 		HeaviestTipSetHeight: height,
 		CommitSha:            h.commitSha,
 	}

--- a/testhelpers/net.go
+++ b/testhelpers/net.go
@@ -3,7 +3,9 @@ package testhelpers
 import (
 	"context"
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -18,6 +20,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 	mh "github.com/multiformats/go-multihash"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/types"
 )
@@ -120,6 +123,17 @@ func RandPeerID() (peer.ID, error) {
 	}
 	h, _ := mh.Sum(buf, mh.SHA2_256, -1)
 	return peer.ID(h), nil
+}
+
+// RequireIntPeerID takes in an integer and creates a unique peer id for it.
+func RequireIntPeerID(t *testing.T, i int64) peer.ID {
+	buf := make([]byte, 16)
+	n := binary.PutVarint(buf, i)
+	h, err := mh.Sum(buf[:n], mh.ID, -1)
+	require.NoError(t, err)
+	pid, err := peer.IDFromBytes(h)
+	require.NoError(t, err)
+	return pid
 }
 
 // TestFetcher is an object with the same method set as Fetcher plus a method

--- a/types/chain_info.go
+++ b/types/chain_info.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+// ChainInfo is used to track metadata about a peer and its chain.
+type ChainInfo struct {
+	Peer    peer.ID
+	Head    TipSetKey
+	Height  uint64
+	Trusted bool
+}
+
+// NewChainInfo creates a chain info from a peer id a head tipset key and a
+// chain height.
+func NewChainInfo(peer peer.ID, head TipSetKey, height uint64) *ChainInfo {
+	return &ChainInfo{
+		Peer:    peer,
+		Head:    head,
+		Height:  height,
+		Trusted: true,
+	}
+}
+
+// CISlice is for sorting chain infos
+type CISlice []*ChainInfo
+
+// Len returns the number of chain infos in the slice.
+func (cis CISlice) Len() int { return len(cis) }
+
+// Swap swaps chain infos.
+func (cis CISlice) Swap(i, j int) { cis[i], cis[j] = cis[j], cis[i] }
+
+// Less compares chain infos on peer ID.  There should only ever be one chain
+// info per peer in a CISlice.
+func (cis CISlice) Less(i, j int) bool { return string(cis[i].Peer) < string(cis[j].Peer) }


### PR DESCRIPTION
I changed the name from "manager" to "tracker" because our first draft of this is a passive listener to the actual management done by libp2p and the hello protocol.

- [x] peer tracking object & tests (commit 1)
- [x] integration into hello protocol and node's networking stack & tests (commit 2)