### PR TITLE
Replace syncing modes with trusted boolean value

### DIFF
--- a/chain/store_test.go
+++ b/chain/store_test.go
@@ -192,7 +192,10 @@ func requireSetTestChain(t *testing.T, con consensus.Protocol, mockStateRoots bo
 	}
 }
 
-func initSyncTest(t *testing.T, con consensus.Protocol, genFunc func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error), cst *hamt.CborIpldStore, bs bstore.Blockstore, r repo.Repo, dstP *SyncerTestParams, syncMode chain.SyncMode) (*chain.Syncer, *chain.Store, repo.Repo, *th.TestFetcher) {
+func initSyncTest(t *testing.T,
+	con consensus.Protocol,
+	genFunc func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error),
+	cst *hamt.CborIpldStore, bs bstore.Blockstore, r repo.Repo, dstP *SyncerTestParams) (*chain.Syncer, *chain.Store, repo.Repo, *th.TestFetcher) {
 	ctx := context.Background()
 
 	calcGenBlk, err := genFunc(cst, bs) // flushes state
@@ -203,7 +206,7 @@ func initSyncTest(t *testing.T, con consensus.Protocol, genFunc func(cst *hamt.C
 
 	fetcher := th.NewTestFetcher()
 	fetcher.AddSourceBlocks(calcGenBlk)
-	syncer := chain.NewSyncer(con, chainStore, fetcher, syncMode) // note we use same cst for on and offline for tests
+	syncer := chain.NewSyncer(con, chainStore, fetcher) // note we use same cst for on and offline for tests
 
 	// Initialize stores to contain dstP.genesis block and state
 	calcGenTS := th.RequireNewTipSet(t, calcGenBlk)
@@ -233,7 +236,7 @@ func initStoreTest(ctx context.Context, t *testing.T, dstP *SyncerTestParams) {
 	initGenesisWrapper := func(cst *hamt.CborIpldStore, bs bstore.Blockstore) (*types.Block, error) {
 		return initGenesis(dstP.minerAddress, dstP.minerOwnerAddress, dstP.minerPeerID, cst, bs)
 	}
-	initSyncTest(t, con, initGenesisWrapper, cst, bs, r, dstP, chain.Syncing)
+	initSyncTest(t, con, initGenesisWrapper, cst, bs, r, dstP)
 	requireSetTestChain(t, con, true, dstP)
 }
 

--- a/chain/syncer.go
+++ b/chain/syncer.go
@@ -78,12 +78,12 @@ type syncStateEvaluator interface {
 // tipset in the incoming chain, and assumptions regarding the existence of
 // grandparent state in the store.
 type Syncer struct {
-	// This mutex ensures at most one call to HandleNewTipset executes at
+	// This mutex ensures at most one call to HandleNewTipSet executes at
 	// any time.  This is important because at least two sections of the
 	// code otherwise have races:
 	// 1. syncOne assumes that chainStore.Head() does not change when
 	// comparing tipset weights and updating the store
-	// 2. HandleNewTipset assumes that calls to widen and then syncOne
+	// 2. HandleNewTipSet assumes that calls to widen and then syncOne
 	// are not run concurrently with other calls to widen to ensure
 	// that the syncer always finds the heaviest existing tipset.
 	mu sync.Mutex
@@ -289,13 +289,13 @@ func (syncer *Syncer) widen(ctx context.Context, ts types.TipSet) (types.TipSet,
 	return wts, nil
 }
 
-// HandleNewTipset extends the Syncer's chain store with the given tipset if they
+// HandleNewTipSet extends the Syncer's chain store with the given tipset if they
 // represent a valid extension. It limits the length of new chains it will
 // attempt to validate and caches invalid blocks it has encountered to
 // help prevent DOS.
-func (syncer *Syncer) HandleNewTipset(ctx context.Context, ci *types.ChainInfo, trusted bool) (err error) {
+func (syncer *Syncer) HandleNewTipSet(ctx context.Context, ci *types.ChainInfo, trusted bool) (err error) {
 	logSyncer.Debugf("Begin fetch and sync of chain with head %v", ci.Head)
-	ctx, span := trace.StartSpan(ctx, "Syncer.HandleNewTipset")
+	ctx, span := trace.StartSpan(ctx, "Syncer.HandleNewTipSet")
 	span.AddAttributes(trace.StringAttribute("tipset", ci.Head.String()))
 	defer tracing.AddErrorEndSpan(ctx, span, &err)
 

--- a/chain/syncer.go
+++ b/chain/syncer.go
@@ -3,7 +3,6 @@ package chain
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
@@ -23,10 +22,6 @@ var reorgCnt *metrics.Int64Counter
 func init() {
 	reorgCnt = metrics.NewInt64Counter("chain/reorg_count", "The number of reorgs that have occurred.")
 }
-
-// The amount of time the syncer will wait while fetching the blocks of a
-// tipset over the network.
-var blkWaitTime = 30 * time.Second
 
 // FinalityLimit is the maximum number of blocks ahead of the current consensus
 // chain height to accept once in caught up mode

--- a/chain/syncer_integration_test.go
+++ b/chain/syncer_integration_test.go
@@ -58,8 +58,8 @@ func TestLoadFork(t *testing.T) {
 	right := builder.AppendManyOn(3, base)
 
 	// Sync the two branches, which stores all blocks in the underlying stores.
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo("", left.Key(), heightFromTip(t, left)), true))
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo("", right.Key(), heightFromTip(t, right)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo("", left.Key(), heightFromTip(t, left)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo("", right.Key(), heightFromTip(t, right)), true))
 	verifyHead(t, store, left)
 
 	// The syncer/store assume that the fetcher populates the underlying block store such that
@@ -105,11 +105,11 @@ func TestLoadFork(t *testing.T) {
 	// without getting old blocks from network. i.e. the store index has been trimmed
 	// of non-heaviest chain blocks.
 
-	err = offlineSyncer.HandleNewTipset(ctx, types.NewChainInfo("", newRight.Key(), heightFromTip(t, newRight)), true)
+	err = offlineSyncer.HandleNewTipSet(ctx, types.NewChainInfo("", newRight.Key(), heightFromTip(t, newRight)), true)
 	assert.Error(t, err)
 
 	// The left chain is ok without any fetching though.
-	assert.NoError(t, offlineSyncer.HandleNewTipset(ctx, types.NewChainInfo("", left.Key(), heightFromTip(t, left)), true))
+	assert.NoError(t, offlineSyncer.HandleNewTipSet(ctx, types.NewChainInfo("", left.Key(), heightFromTip(t, left)), true))
 }
 
 // Syncer handles MarketView weight comparisons.
@@ -243,7 +243,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 
 	// Sync first tipset, should have weight 22 + starting
 	sharedCids := requirePutBlocks(t, blockSource, f1b1, f2b1)
-	err = syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), sharedCids, uint64(f1b1.Height)), true)
+	err = syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), sharedCids, uint64(f1b1.Height)), true)
 	require.NoError(t, err)
 	assertHead(t, chainStore, tsShared)
 	measuredWeight, err := wFun(requireHeadTipset(t, chainStore))
@@ -278,7 +278,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 
 	f1H, err := f1.Height()
 	require.NoError(t, err)
-	err = syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), f1Cids, uint64(f1H)), true)
+	err = syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), f1Cids, uint64(f1H)), true)
 	require.NoError(t, err)
 
 	assertHead(t, chainStore, f1)
@@ -307,7 +307,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 
 	f2H, err := f2.Height()
 	require.NoError(t, err)
-	err = syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), f2Cids, f2H), true)
+	err = syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), f2Cids, f2H), true)
 	require.NoError(t, err)
 
 	assertHead(t, chainStore, f2)

--- a/chain/syncer_integration_test.go
+++ b/chain/syncer_integration_test.go
@@ -278,7 +278,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 
 	f1H, err := f1.Height()
 	require.NoError(t, err)
-	err = syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), f1Cids, uint64(f1H)), true)
+	err = syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), f1Cids, f1H), true)
 	require.NoError(t, err)
 
 	assertHead(t, chainStore, f1)

--- a/chain/syncer_integration_test.go
+++ b/chain/syncer_integration_test.go
@@ -51,7 +51,7 @@ func TestLoadFork(t *testing.T) {
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but
 	// *not* as the store, to which the syncer must ensure to put blocks.
 	eval := &chain.FakeStateEvaluator{}
-	syncer := chain.NewSyncer(eval, store, builder, chain.Syncing)
+	syncer := chain.NewSyncer(eval, store, builder)
 
 	base := builder.AppendManyOn(3, genesis)
 	left := builder.AppendManyOn(4, base)
@@ -79,7 +79,7 @@ func TestLoadFork(t *testing.T) {
 	newStore := chain.NewStore(repo.ChainDatastore(), &cborStore, &state.TreeStateLoader{}, genesis.At(0).Cid())
 	require.NoError(t, newStore.Load(ctx))
 	fakeFetcher := th.NewTestFetcher()
-	offlineSyncer := chain.NewSyncer(eval, newStore, fakeFetcher, chain.Syncing)
+	offlineSyncer := chain.NewSyncer(eval, newStore, fakeFetcher)
 
 	assert.True(t, newStore.HasTipSetAndState(ctx, left.Key()))
 	assert.False(t, newStore.HasTipSetAndState(ctx, right.Key()))
@@ -190,7 +190,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 		VerifyPoStValid: true,
 	}
 	con = consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &consensus.MarketView{}, calcGenBlk.Cid(), verifier, th.BlockTimeTest)
-	syncer := chain.NewSyncer(con, chainStore, blockSource, chain.Syncing)
+	syncer := chain.NewSyncer(con, chainStore, blockSource)
 	baseTS := requireHeadTipset(t, chainStore) // this is the last block of the bootstrapping chain creating miners
 	require.Equal(t, 1, baseTS.Len())
 	bootstrapStateRoot := baseTS.ToSlice()[0].StateRoot

--- a/chain/syncer_test.go
+++ b/chain/syncer_test.go
@@ -18,6 +18,14 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
+func heightFromTip(t *testing.T, tip types.TipSet) uint64 {
+	h, err := tip.Height()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
 func TestOneBlock(t *testing.T) {
 	tf.UnitTest(t)
 	ctx := context.Background()
@@ -25,7 +33,7 @@ func TestOneBlock(t *testing.T) {
 	genesis := builder.RequireTipSet(store.GetHead())
 
 	t1 := builder.AppendOn(genesis, 1)
-	assert.NoError(t, syncer.HandleNewTipset(ctx, t1.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t1.Key(), heightFromTip(t, t1)), true))
 
 	verifyTip(t, store, t1, t1.At(0).StateRoot)
 	verifyHead(t, store, t1)
@@ -38,7 +46,7 @@ func TestMultiBlockTip(t *testing.T) {
 	genesis := builder.RequireTipSet(store.GetHead())
 
 	tip := builder.AppendOn(genesis, 2)
-	assert.NoError(t, syncer.HandleNewTipset(ctx, tip.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), tip.Key(), heightFromTip(t, tip)), true))
 
 	verifyTip(t, store, tip, builder.StateForKey(tip.Key()))
 	verifyHead(t, store, tip)
@@ -51,13 +59,15 @@ func TestTipSetIncremental(t *testing.T) {
 	genesis := builder.RequireTipSet(store.GetHead())
 
 	t1 := builder.AppendOn(genesis, 1)
+
 	t2 := builder.AppendOn(genesis, 1)
-	assert.NoError(t, syncer.HandleNewTipset(ctx, t1.Key(), peer.ID("")))
+
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t1.Key(), heightFromTip(t, t1)), true))
 
 	verifyTip(t, store, t1, builder.StateForKey(t1.Key()))
 	verifyHead(t, store, t1)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, t2.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t2.Key(), heightFromTip(t, t2)), true))
 	verifyTip(t, store, t2, builder.StateForKey(t2.Key()))
 
 	merged := types.RequireNewTipSet(t, t1.At(0), t2.At(0))
@@ -72,23 +82,26 @@ func TestChainIncremental(t *testing.T) {
 	genesis := builder.RequireTipSet(store.GetHead())
 
 	t1 := builder.AppendOn(genesis, 2)
+
 	t2 := builder.AppendOn(t1, 3)
+
 	t3 := builder.AppendOn(t2, 1)
+
 	t4 := builder.AppendOn(t3, 2)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, t1.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t1.Key(), heightFromTip(t, t1)), true))
 	verifyTip(t, store, t1, builder.StateForKey(t1.Key()))
 	verifyHead(t, store, t1)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, t2.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t2.Key(), heightFromTip(t, t2)), true))
 	verifyTip(t, store, t2, builder.StateForKey(t2.Key()))
 	verifyHead(t, store, t2)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, t3.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t3.Key(), heightFromTip(t, t3)), true))
 	verifyTip(t, store, t3, builder.StateForKey(t3.Key()))
 	verifyHead(t, store, t3)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, t4.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t4.Key(), heightFromTip(t, t4)), true))
 	verifyTip(t, store, t4, builder.StateForKey(t4.Key()))
 	verifyHead(t, store, t4)
 }
@@ -104,7 +117,7 @@ func TestChainJump(t *testing.T) {
 	t3 := builder.AppendOn(t2, 1)
 	t4 := builder.AppendOn(t3, 2)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, t4.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t4.Key(), heightFromTip(t, t4)), true))
 	verifyTip(t, store, t1, builder.StateForKey(t1.Key()))
 	verifyTip(t, store, t2, builder.StateForKey(t2.Key()))
 	verifyTip(t, store, t3, builder.StateForKey(t3.Key()))
@@ -127,12 +140,12 @@ func TestIgnoreLightFork(t *testing.T) {
 	t4 := builder.AppendOn(t3, 1)
 
 	// Sync heaviest branch first.
-	assert.NoError(t, syncer.HandleNewTipset(ctx, t4.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t4.Key(), heightFromTip(t, t4)), true))
 	verifyTip(t, store, t4, builder.StateForKey(t4.Key()))
 	verifyHead(t, store, t4)
 
 	// Lighter fork is processed but not change head.
-	assert.NoError(t, syncer.HandleNewTipset(ctx, forkHead.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), forkHead.Key(), heightFromTip(t, forkHead)), true))
 	verifyTip(t, store, forkHead, builder.StateForKey(forkHead.Key()))
 	verifyHead(t, store, t4)
 }
@@ -156,12 +169,12 @@ func TestAcceptHeavierFork(t *testing.T) {
 	fork2 := builder.AppendOn(fork1, 1)
 	fork3 := builder.AppendOn(fork2, 1)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, main4.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), main4.Key(), heightFromTip(t, main4)), true))
 	verifyTip(t, store, main4, builder.StateForKey(main4.Key()))
 	verifyHead(t, store, main4)
 
-	// Heavier fork updates head
-	assert.NoError(t, syncer.HandleNewTipset(ctx, fork3.Key(), peer.ID("")))
+	// Heavier fork updates hea3
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), fork3.Key(), heightFromTip(t, fork3)), true))
 	verifyTip(t, store, fork1, builder.StateForKey(fork1.Key()))
 	verifyTip(t, store, fork2, builder.StateForKey(fork2.Key()))
 	verifyTip(t, store, fork3, builder.StateForKey(fork3.Key()))
@@ -178,7 +191,7 @@ func TestFarFutureTipsets(t *testing.T) {
 		farHead := builder.AppendManyOn(chain.FinalityLimit+1, genesis)
 
 		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, chain.Syncing)
-		assert.NoError(t, syncer.HandleNewTipset(ctx, farHead.Key(), peer.ID("")))
+		assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), true))
 	})
 
 	t.Run("rejects when caught up", func(t *testing.T) {
@@ -187,7 +200,8 @@ func TestFarFutureTipsets(t *testing.T) {
 		farHead := builder.AppendManyOn(chain.FinalityLimit+1, genesis)
 
 		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, chain.CaughtUp)
-		err := syncer.HandleNewTipset(ctx, farHead.Key(), peer.ID(""))
+		// TODO(frrist): you will want to set reusted to false here
+		err := syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), true)
 		assert.Error(t, err)
 	})
 }
@@ -199,13 +213,13 @@ func TestNoUncessesaryFetch(t *testing.T) {
 	genesis := builder.RequireTipSet(store.GetHead())
 
 	head := builder.AppendManyOn(4, genesis)
-	assert.NoError(t, syncer.HandleNewTipset(ctx, head.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), head.Key(), heightFromTip(t, head)), true))
 
 	// A new syncer unable to fetch blocks from the network can handle a tipset that's already
 	// in the store and linked to genesis.
 	emptyFetcher := chain.NewBuilder(t, address.Undef)
 	newSyncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, emptyFetcher, chain.Syncing)
-	assert.NoError(t, newSyncer.HandleNewTipset(ctx, head.Key(), peer.ID("")))
+	assert.NoError(t, newSyncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), head.Key(), heightFromTip(t, head)), true))
 }
 
 // Syncer must track state of subsets of parent tipsets tracked in the store
@@ -231,23 +245,24 @@ func TestSubsetParent(t *testing.T) {
 	// Set up chain with {A1, A2} -> {B1, B2, B3}
 	tipA1A2 := builder.AppendOn(genesis, 2)
 	tipB1B2B3 := builder.AppendOn(tipA1A2, 3)
-	require.NoError(t, syncer.HandleNewTipset(ctx, tipB1B2B3.Key(), peer.ID("")))
+	require.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), tipB1B2B3.Key(), heightFromTip(t, tipB1B2B3)), true))
 
 	// Sync one tipset with a parent equal to a subset of an existing
 	// tipset in the store: {B1, B2} -> {C1, C2}
 	tipB1B2 := types.RequireNewTipSet(t, tipB1B2B3.At(0), tipB1B2B3.At(1))
 	tipC1C2 := builder.AppendOn(tipB1B2, 2)
-	assert.NoError(t, syncer.HandleNewTipset(ctx, tipC1C2.Key(), peer.ID("")))
+
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), tipC1C2.Key(), heightFromTip(t, tipC1C2)), true))
 
 	// Sync another tipset with a parent equal to a subset of the tipset
 	// just synced: C1 -> D1
 	tipC1 := types.RequireNewTipSet(t, tipC1C2.At(0))
 	tipD1OnC1 := builder.AppendOn(tipC1, 1)
-	assert.NoError(t, syncer.HandleNewTipset(ctx, tipD1OnC1.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), tipD1OnC1.Key(), heightFromTip(t, tipD1OnC1)), true))
 
 	// A full parent also works fine: {C1, C2} -> D1
 	tipD1OnC1C2 := builder.AppendOn(tipC1C2, 1)
-	assert.NoError(t, syncer.HandleNewTipset(ctx, tipD1OnC1C2.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), tipD1OnC1C2.Key(), heightFromTip(t, tipD1OnC1C2)), true))
 }
 
 // Check that the syncer correctly adds widened chain ancestors to the store.
@@ -268,12 +283,12 @@ func TestWidenChainAncestor(t *testing.T) {
 	link2UnionSubset := types.RequireNewTipSet(t, link2.At(0), link2Alt.At(0))
 
 	// Sync the subset of link2 first
-	assert.NoError(t, syncer.HandleNewTipset(ctx, link2UnionSubset.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), link2UnionSubset.Key(), heightFromTip(t, link2UnionSubset)), true))
 	verifyTip(t, store, link2UnionSubset, builder.StateForKey(link2UnionSubset.Key()))
 	verifyHead(t, store, link2UnionSubset)
 
 	// Sync chain with head at link4
-	require.NoError(t, syncer.HandleNewTipset(ctx, link4.Key(), peer.ID("")))
+	require.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), link4.Key(), heightFromTip(t, link4)), true))
 	verifyTip(t, store, link4, builder.StateForKey(link4.Key()))
 	verifyHead(t, store, link4)
 
@@ -319,10 +334,10 @@ func TestHeaviestIsWidenedAncestor(t *testing.T) {
 	forkLink3 := builder.AppendOn(forkLink2, 1)
 
 	// Sync main chain
-	assert.NoError(t, syncer.HandleNewTipset(ctx, link4.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), link4.Key(), heightFromTip(t, link4)), true))
 
 	// Sync fork chain
-	assert.NoError(t, syncer.HandleNewTipset(ctx, forkLink3.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), forkLink3.Key(), heightFromTip(t, forkLink3)), true))
 
 	// Assert that widened chain is the new head
 	wideBlocks := link2.ToSlice()
@@ -343,7 +358,7 @@ func TestBlocksNotATipSetRejected(t *testing.T) {
 	b2 := builder.AppendBlockOnBlocks(b1)
 
 	badKey := types.NewTipSetKey(b1.Cid(), b2.Cid())
-	err := syncer.HandleNewTipset(ctx, badKey, peer.ID(""))
+	err := syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), badKey, uint64(b1.Height)), true)
 	assert.Error(t, err)
 
 	_, err = store.GetTipSet(badKey)
@@ -365,11 +380,11 @@ func TestBlockNotLinkedRejected(t *testing.T) {
 
 	// The syncer fails to fetch this block so cannot sync it.
 	b1 := shadowBuilder.AppendOn(genesis, 1)
-	assert.Error(t, syncer.HandleNewTipset(ctx, b1.Key(), peer.ID("")))
+	assert.Error(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), b1.Key(), heightFromTip(t, b1)), true))
 
 	// Make the same block available from the syncer's builder
 	builder.AppendBlockOn(genesis)
-	assert.NoError(t, syncer.HandleNewTipset(ctx, b1.Key(), peer.ID("")))
+	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), b1.Key(), heightFromTip(t, b1)), true))
 }
 
 ///// Set-up /////

--- a/chain/syncer_test.go
+++ b/chain/syncer_test.go
@@ -190,7 +190,7 @@ func TestFarFutureTipsets(t *testing.T) {
 		genesis := builder.RequireTipSet(store.GetHead())
 		farHead := builder.AppendManyOn(chain.FinalityLimit+1, genesis)
 
-		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, chain.Syncing)
+		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder)
 		assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), true))
 	})
 
@@ -199,9 +199,8 @@ func TestFarFutureTipsets(t *testing.T) {
 		genesis := builder.RequireTipSet(store.GetHead())
 		farHead := builder.AppendManyOn(chain.FinalityLimit+1, genesis)
 
-		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, chain.CaughtUp)
-		// TODO(frrist): you will want to set reusted to false here
-		err := syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), true)
+		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder)
+		err := syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), false)
 		assert.Error(t, err)
 	})
 }
@@ -218,7 +217,7 @@ func TestNoUncessesaryFetch(t *testing.T) {
 	// A new syncer unable to fetch blocks from the network can handle a tipset that's already
 	// in the store and linked to genesis.
 	emptyFetcher := chain.NewBuilder(t, address.Undef)
-	newSyncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, emptyFetcher, chain.Syncing)
+	newSyncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, emptyFetcher)
 	assert.NoError(t, newSyncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), head.Key(), heightFromTip(t, head)), true))
 }
 
@@ -405,7 +404,7 @@ func setup(ctx context.Context, t *testing.T) (*chain.Builder, *chain.Store, *ch
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but
 	// *not* as the store, to which the syncer must ensure to put blocks.
 	eval := &chain.FakeStateEvaluator{}
-	syncer := chain.NewSyncer(eval, store, builder, chain.Syncing)
+	syncer := chain.NewSyncer(eval, store, builder)
 
 	return builder, store, syncer
 }

--- a/chain/syncer_test.go
+++ b/chain/syncer_test.go
@@ -33,7 +33,7 @@ func TestOneBlock(t *testing.T) {
 	genesis := builder.RequireTipSet(store.GetHead())
 
 	t1 := builder.AppendOn(genesis, 1)
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t1.Key(), heightFromTip(t, t1)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), t1.Key(), heightFromTip(t, t1)), true))
 
 	verifyTip(t, store, t1, t1.At(0).StateRoot)
 	verifyHead(t, store, t1)
@@ -46,7 +46,7 @@ func TestMultiBlockTip(t *testing.T) {
 	genesis := builder.RequireTipSet(store.GetHead())
 
 	tip := builder.AppendOn(genesis, 2)
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), tip.Key(), heightFromTip(t, tip)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), tip.Key(), heightFromTip(t, tip)), true))
 
 	verifyTip(t, store, tip, builder.StateForKey(tip.Key()))
 	verifyHead(t, store, tip)
@@ -62,12 +62,12 @@ func TestTipSetIncremental(t *testing.T) {
 
 	t2 := builder.AppendOn(genesis, 1)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t1.Key(), heightFromTip(t, t1)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), t1.Key(), heightFromTip(t, t1)), true))
 
 	verifyTip(t, store, t1, builder.StateForKey(t1.Key()))
 	verifyHead(t, store, t1)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t2.Key(), heightFromTip(t, t2)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), t2.Key(), heightFromTip(t, t2)), true))
 	verifyTip(t, store, t2, builder.StateForKey(t2.Key()))
 
 	merged := types.RequireNewTipSet(t, t1.At(0), t2.At(0))
@@ -89,19 +89,19 @@ func TestChainIncremental(t *testing.T) {
 
 	t4 := builder.AppendOn(t3, 2)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t1.Key(), heightFromTip(t, t1)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), t1.Key(), heightFromTip(t, t1)), true))
 	verifyTip(t, store, t1, builder.StateForKey(t1.Key()))
 	verifyHead(t, store, t1)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t2.Key(), heightFromTip(t, t2)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), t2.Key(), heightFromTip(t, t2)), true))
 	verifyTip(t, store, t2, builder.StateForKey(t2.Key()))
 	verifyHead(t, store, t2)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t3.Key(), heightFromTip(t, t3)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), t3.Key(), heightFromTip(t, t3)), true))
 	verifyTip(t, store, t3, builder.StateForKey(t3.Key()))
 	verifyHead(t, store, t3)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t4.Key(), heightFromTip(t, t4)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), t4.Key(), heightFromTip(t, t4)), true))
 	verifyTip(t, store, t4, builder.StateForKey(t4.Key()))
 	verifyHead(t, store, t4)
 }
@@ -117,7 +117,7 @@ func TestChainJump(t *testing.T) {
 	t3 := builder.AppendOn(t2, 1)
 	t4 := builder.AppendOn(t3, 2)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t4.Key(), heightFromTip(t, t4)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), t4.Key(), heightFromTip(t, t4)), true))
 	verifyTip(t, store, t1, builder.StateForKey(t1.Key()))
 	verifyTip(t, store, t2, builder.StateForKey(t2.Key()))
 	verifyTip(t, store, t3, builder.StateForKey(t3.Key()))
@@ -140,12 +140,12 @@ func TestIgnoreLightFork(t *testing.T) {
 	t4 := builder.AppendOn(t3, 1)
 
 	// Sync heaviest branch first.
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), t4.Key(), heightFromTip(t, t4)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), t4.Key(), heightFromTip(t, t4)), true))
 	verifyTip(t, store, t4, builder.StateForKey(t4.Key()))
 	verifyHead(t, store, t4)
 
 	// Lighter fork is processed but not change head.
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), forkHead.Key(), heightFromTip(t, forkHead)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), forkHead.Key(), heightFromTip(t, forkHead)), true))
 	verifyTip(t, store, forkHead, builder.StateForKey(forkHead.Key()))
 	verifyHead(t, store, t4)
 }
@@ -169,12 +169,12 @@ func TestAcceptHeavierFork(t *testing.T) {
 	fork2 := builder.AppendOn(fork1, 1)
 	fork3 := builder.AppendOn(fork2, 1)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), main4.Key(), heightFromTip(t, main4)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), main4.Key(), heightFromTip(t, main4)), true))
 	verifyTip(t, store, main4, builder.StateForKey(main4.Key()))
 	verifyHead(t, store, main4)
 
 	// Heavier fork updates hea3
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), fork3.Key(), heightFromTip(t, fork3)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), fork3.Key(), heightFromTip(t, fork3)), true))
 	verifyTip(t, store, fork1, builder.StateForKey(fork1.Key()))
 	verifyTip(t, store, fork2, builder.StateForKey(fork2.Key()))
 	verifyTip(t, store, fork3, builder.StateForKey(fork3.Key()))
@@ -191,7 +191,7 @@ func TestFarFutureTipsets(t *testing.T) {
 		farHead := builder.AppendManyOn(chain.FinalityLimit+1, genesis)
 
 		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder)
-		assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), true))
+		assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), true))
 	})
 
 	t.Run("rejects when caught up", func(t *testing.T) {
@@ -200,7 +200,7 @@ func TestFarFutureTipsets(t *testing.T) {
 		farHead := builder.AppendManyOn(chain.FinalityLimit+1, genesis)
 
 		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder)
-		err := syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), false)
+		err := syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), false)
 		assert.Error(t, err)
 	})
 }
@@ -212,13 +212,13 @@ func TestNoUncessesaryFetch(t *testing.T) {
 	genesis := builder.RequireTipSet(store.GetHead())
 
 	head := builder.AppendManyOn(4, genesis)
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), head.Key(), heightFromTip(t, head)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), head.Key(), heightFromTip(t, head)), true))
 
 	// A new syncer unable to fetch blocks from the network can handle a tipset that's already
 	// in the store and linked to genesis.
 	emptyFetcher := chain.NewBuilder(t, address.Undef)
 	newSyncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, emptyFetcher)
-	assert.NoError(t, newSyncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), head.Key(), heightFromTip(t, head)), true))
+	assert.NoError(t, newSyncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), head.Key(), heightFromTip(t, head)), true))
 }
 
 // Syncer must track state of subsets of parent tipsets tracked in the store
@@ -244,24 +244,24 @@ func TestSubsetParent(t *testing.T) {
 	// Set up chain with {A1, A2} -> {B1, B2, B3}
 	tipA1A2 := builder.AppendOn(genesis, 2)
 	tipB1B2B3 := builder.AppendOn(tipA1A2, 3)
-	require.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), tipB1B2B3.Key(), heightFromTip(t, tipB1B2B3)), true))
+	require.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), tipB1B2B3.Key(), heightFromTip(t, tipB1B2B3)), true))
 
 	// Sync one tipset with a parent equal to a subset of an existing
 	// tipset in the store: {B1, B2} -> {C1, C2}
 	tipB1B2 := types.RequireNewTipSet(t, tipB1B2B3.At(0), tipB1B2B3.At(1))
 	tipC1C2 := builder.AppendOn(tipB1B2, 2)
 
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), tipC1C2.Key(), heightFromTip(t, tipC1C2)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), tipC1C2.Key(), heightFromTip(t, tipC1C2)), true))
 
 	// Sync another tipset with a parent equal to a subset of the tipset
 	// just synced: C1 -> D1
 	tipC1 := types.RequireNewTipSet(t, tipC1C2.At(0))
 	tipD1OnC1 := builder.AppendOn(tipC1, 1)
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), tipD1OnC1.Key(), heightFromTip(t, tipD1OnC1)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), tipD1OnC1.Key(), heightFromTip(t, tipD1OnC1)), true))
 
 	// A full parent also works fine: {C1, C2} -> D1
 	tipD1OnC1C2 := builder.AppendOn(tipC1C2, 1)
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), tipD1OnC1C2.Key(), heightFromTip(t, tipD1OnC1C2)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), tipD1OnC1C2.Key(), heightFromTip(t, tipD1OnC1C2)), true))
 }
 
 // Check that the syncer correctly adds widened chain ancestors to the store.
@@ -282,12 +282,12 @@ func TestWidenChainAncestor(t *testing.T) {
 	link2UnionSubset := types.RequireNewTipSet(t, link2.At(0), link2Alt.At(0))
 
 	// Sync the subset of link2 first
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), link2UnionSubset.Key(), heightFromTip(t, link2UnionSubset)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), link2UnionSubset.Key(), heightFromTip(t, link2UnionSubset)), true))
 	verifyTip(t, store, link2UnionSubset, builder.StateForKey(link2UnionSubset.Key()))
 	verifyHead(t, store, link2UnionSubset)
 
 	// Sync chain with head at link4
-	require.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), link4.Key(), heightFromTip(t, link4)), true))
+	require.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), link4.Key(), heightFromTip(t, link4)), true))
 	verifyTip(t, store, link4, builder.StateForKey(link4.Key()))
 	verifyHead(t, store, link4)
 
@@ -333,10 +333,10 @@ func TestHeaviestIsWidenedAncestor(t *testing.T) {
 	forkLink3 := builder.AppendOn(forkLink2, 1)
 
 	// Sync main chain
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), link4.Key(), heightFromTip(t, link4)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), link4.Key(), heightFromTip(t, link4)), true))
 
 	// Sync fork chain
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), forkLink3.Key(), heightFromTip(t, forkLink3)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), forkLink3.Key(), heightFromTip(t, forkLink3)), true))
 
 	// Assert that widened chain is the new head
 	wideBlocks := link2.ToSlice()
@@ -357,7 +357,7 @@ func TestBlocksNotATipSetRejected(t *testing.T) {
 	b2 := builder.AppendBlockOnBlocks(b1)
 
 	badKey := types.NewTipSetKey(b1.Cid(), b2.Cid())
-	err := syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), badKey, uint64(b1.Height)), true)
+	err := syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), badKey, uint64(b1.Height)), true)
 	assert.Error(t, err)
 
 	_, err = store.GetTipSet(badKey)
@@ -379,11 +379,11 @@ func TestBlockNotLinkedRejected(t *testing.T) {
 
 	// The syncer fails to fetch this block so cannot sync it.
 	b1 := shadowBuilder.AppendOn(genesis, 1)
-	assert.Error(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), b1.Key(), heightFromTip(t, b1)), true))
+	assert.Error(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), b1.Key(), heightFromTip(t, b1)), true))
 
 	// Make the same block available from the syncer's builder
 	builder.AppendBlockOn(genesis)
-	assert.NoError(t, syncer.HandleNewTipset(ctx, types.NewChainInfo(peer.ID(""), b1.Key(), heightFromTip(t, b1)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), b1.Key(), heightFromTip(t, b1)), true))
 }
 
 ///// Set-up /////

--- a/node/block.go
+++ b/node/block.go
@@ -28,7 +28,10 @@ func (node *Node) AddNewBlock(ctx context.Context, b *types.Block) (err error) {
 
 	log.Debugf("syncing new block: %s", b.Cid().String())
 
-	if err := node.Syncer.HandleNewTipSet(ctx, types.NewChainInfo(node.Host().ID(), types.NewTipSetKey(blkCid), uint64(b.Height)), true); err != nil {
+	// TODO Implement principled trusting of ChainInfo's
+	// to address in #2674
+	trusted := true
+	if err := node.Syncer.HandleNewTipSet(ctx, types.NewChainInfo(node.Host().ID(), types.NewTipSetKey(blkCid), uint64(b.Height)), trusted); err != nil {
 		return err
 	}
 
@@ -58,7 +61,10 @@ func (node *Node) processBlock(ctx context.Context, pubSubMsg pubsub.Message) (e
 	// Don't be too quick to change that, though: the syncer re-fetching the block
 	// is currently critical to reliable validation.
 	// See https://github.com/filecoin-project/go-filecoin/issues/2962
-	err = node.Syncer.HandleNewTipSet(ctx, types.NewChainInfo(from, types.NewTipSetKey(blk.Cid()), uint64(blk.Height)), true)
+	// TODO Implement principled trusting of ChainInfo's
+	// to address in #2674
+	trusted := true
+	err = node.Syncer.HandleNewTipSet(ctx, types.NewChainInfo(from, types.NewTipSetKey(blk.Cid()), uint64(blk.Height)), trusted)
 	if err != nil {
 		return errors.Wrap(err, "processing block from network")
 	}

--- a/node/block.go
+++ b/node/block.go
@@ -27,7 +27,8 @@ func (node *Node) AddNewBlock(ctx context.Context, b *types.Block) (err error) {
 	}
 
 	log.Debugf("syncing new block: %s", b.Cid().String())
-	if err := node.Syncer.HandleNewTipset(ctx, types.NewTipSetKey(blkCid), node.Host().ID()); err != nil {
+
+	if err := node.Syncer.HandleNewTipset(ctx, types.NewChainInfo(node.Host().ID(), types.NewTipSetKey(blkCid), uint64(b.Height)), true); err != nil {
 		return err
 	}
 
@@ -57,7 +58,7 @@ func (node *Node) processBlock(ctx context.Context, pubSubMsg pubsub.Message) (e
 	// Don't be too quick to change that, though: the syncer re-fetching the block
 	// is currently critical to reliable validation.
 	// See https://github.com/filecoin-project/go-filecoin/issues/2962
-	err = node.Syncer.HandleNewTipset(ctx, types.NewTipSetKey(blk.Cid()), from)
+	err = node.Syncer.HandleNewTipset(ctx, types.NewChainInfo(from, types.NewTipSetKey(blk.Cid()), uint64(blk.Height)), true)
 	if err != nil {
 		return errors.Wrap(err, "processing block from network")
 	}

--- a/node/block.go
+++ b/node/block.go
@@ -28,7 +28,7 @@ func (node *Node) AddNewBlock(ctx context.Context, b *types.Block) (err error) {
 
 	log.Debugf("syncing new block: %s", b.Cid().String())
 
-	if err := node.Syncer.HandleNewTipset(ctx, types.NewChainInfo(node.Host().ID(), types.NewTipSetKey(blkCid), uint64(b.Height)), true); err != nil {
+	if err := node.Syncer.HandleNewTipSet(ctx, types.NewChainInfo(node.Host().ID(), types.NewTipSetKey(blkCid), uint64(b.Height)), true); err != nil {
 		return err
 	}
 
@@ -58,7 +58,7 @@ func (node *Node) processBlock(ctx context.Context, pubSubMsg pubsub.Message) (e
 	// Don't be too quick to change that, though: the syncer re-fetching the block
 	// is currently critical to reliable validation.
 	// See https://github.com/filecoin-project/go-filecoin/issues/2962
-	err = node.Syncer.HandleNewTipset(ctx, types.NewChainInfo(from, types.NewTipSetKey(blk.Cid()), uint64(blk.Height)), true)
+	err = node.Syncer.HandleNewTipSet(ctx, types.NewChainInfo(from, types.NewTipSetKey(blk.Cid()), uint64(blk.Height)), true)
 	if err != nil {
 		return errors.Wrap(err, "processing block from network")
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -28,7 +28,6 @@ import (
 	circuit "github.com/libp2p/go-libp2p-circuit"
 	"github.com/libp2p/go-libp2p-core/host"
 	p2pmetrics "github.com/libp2p/go-libp2p-core/metrics"
-	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/routing"
 	"github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p-kad-dht/opts"
@@ -92,7 +91,7 @@ type nodeChainReader interface {
 }
 
 type nodeChainSyncer interface {
-	HandleNewTipset(ctx context.Context, tipsetCids types.TipSetKey, from peer.ID) error
+	HandleNewTipset(ctx context.Context, ci *types.ChainInfo, trusted bool) error
 }
 
 // Node represents a full Filecoin node.
@@ -553,7 +552,7 @@ func (node *Node) Start(ctx context.Context) error {
 		// Start up 'hello' handshake service
 		helloCallback := func(ci *types.ChainInfo) {
 			node.PeerTracker.Track(ci)
-			err := node.Syncer.HandleNewTipset(context.Background(), ci.Head, ci.Peer)
+			err := node.Syncer.HandleNewTipset(context.Background(), ci, true)
 			if err != nil {
 				log.Infof("error handling blocks: %s", ci.Head.String())
 				return

--- a/node/node.go
+++ b/node/node.go
@@ -431,7 +431,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 	fcWallet := wallet.New(backend)
 
 	// only the syncer gets the storage which is online connected
-	chainSyncer := chain.NewSyncer(nodeConsensus, chainStore, fetcher, chain.Syncing)
+	chainSyncer := chain.NewSyncer(nodeConsensus, chainStore, fetcher)
 	msgPool := core.NewMessagePool(nc.Repo.Config().Mpool, consensus.NewIngestionValidator(chainState, nc.Repo.Config().Mpool))
 	inbox := core.NewInbox(msgPool, core.InboxMaxAgeTipsets, chainStore)
 

--- a/node/node.go
+++ b/node/node.go
@@ -552,7 +552,10 @@ func (node *Node) Start(ctx context.Context) error {
 		// Start up 'hello' handshake service
 		helloCallback := func(ci *types.ChainInfo) {
 			node.PeerTracker.Track(ci)
-			err := node.Syncer.HandleNewTipSet(context.Background(), ci, true)
+			// TODO Implement principled trusting of ChainInfo's
+			// to address in #2674
+			trusted := true
+			err := node.Syncer.HandleNewTipSet(context.Background(), ci, trusted)
 			if err != nil {
 				log.Infof("error handling blocks: %s", ci.Head.String())
 				return

--- a/node/node.go
+++ b/node/node.go
@@ -91,7 +91,7 @@ type nodeChainReader interface {
 }
 
 type nodeChainSyncer interface {
-	HandleNewTipset(ctx context.Context, ci *types.ChainInfo, trusted bool) error
+	HandleNewTipSet(ctx context.Context, ci *types.ChainInfo, trusted bool) error
 }
 
 // Node represents a full Filecoin node.
@@ -552,7 +552,7 @@ func (node *Node) Start(ctx context.Context) error {
 		// Start up 'hello' handshake service
 		helloCallback := func(ci *types.ChainInfo) {
 			node.PeerTracker.Track(ci)
-			err := node.Syncer.HandleNewTipset(context.Background(), ci, true)
+			err := node.Syncer.HandleNewTipSet(context.Background(), ci, true)
 			if err != nil {
 				log.Infof("error handling blocks: %s", ci.Head.String())
 				return


### PR DESCRIPTION
### What
This PR can be reviewed in 2 steps:
- cd16520 adds a type called `PeerHeadInfo` that contains information about a peer, its current head state and its trustworthiness. `HandleNewTipset` is then modified to accept this type. This is a mechanical change that doesn't effect the code logic.
- bf0e2c3 does a couple things:
    - replaces the syncers `syncMode` with the `Trusted` field in `PeerHeadInfo`. The syncers logic is changed to check if a TipSet exceeds finality if the peer is untrusted.
    - modifies `exceedsFinalityLimit` to accept 2 Uint64's, the current head and the new Head we get from `PeerHeadInfo`. This change simplifies the Fethers callback to a single case.
    - removes the `fetchCtx` as that was mode dependent.