### PR TITLE
Update circleci docker container to circleci/golang:1.12.1-stretch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
 
   deps_linux:
     docker:
-      - image: circleci/golang:1.12.1
+      - image: circleci/golang:1.12.1-stretch
     working_directory: /go/src/github.com/filecoin-project/go-filecoin
     resource_class: xlarge
     steps:
@@ -178,7 +178,7 @@ jobs:
 
   build_linux:
     docker:
-      - image: circleci/golang:1.12.1
+      - image: circleci/golang:1.12.1-stretch
     working_directory: /go/src/github.com/filecoin-project/go-filecoin
     resource_class: xlarge
     parameters:
@@ -234,7 +234,7 @@ jobs:
 
   unit_test_linux:
     docker:
-      - image: circleci/golang:1.12.1
+      - image: circleci/golang:1.12.1-stretch
     parallelism: 3
     working_directory: /go/src/github.com/filecoin-project/go-filecoin
     resource_class: large
@@ -266,7 +266,7 @@ jobs:
 
   integration_test_linux:
     docker:
-      - image: circleci/golang:1.12.1
+      - image: circleci/golang:1.12.1-stretch
     parallelism: 3
     working_directory: /go/src/github.com/filecoin-project/go-filecoin
     resource_class: xlarge
@@ -300,7 +300,7 @@ jobs:
 
   functional_test_linux:
     docker:
-      - image: circleci/golang:1.12.1
+      - image: circleci/golang:1.12.1-stretch
     parallelism: 4
     working_directory: /go/src/github.com/filecoin-project/go-filecoin
     resource_class: xlarge
@@ -338,7 +338,7 @@ jobs:
 
   publish_release:
     docker:
-      - image: circleci/golang:1.12.1
+      - image: circleci/golang:1.12.1-stretch
     resource_class: small
     parameters:
       <<: *nightly_param
@@ -364,7 +364,7 @@ jobs:
 
   build_docker_img:
     docker:
-      - image: circleci/golang:1.12.1
+      - image: circleci/golang:1.12.1-stretch
     resource_class: xlarge
     parameters:
       <<: *nightly_param
@@ -455,7 +455,7 @@ jobs:
 
   trigger_nightly_devnet_deploy:
     docker:
-      - image: circleci/golang:1.12.1
+      - image: circleci/golang:1.12.1-stretch
     resource_class: small
     steps:
       - setup_remote_docker
@@ -491,7 +491,7 @@ jobs:
       <<: *user_devnet_param
       <<: *test_devnet_param
     docker:
-      - image: circleci/golang:1.12.1
+      - image: circleci/golang:1.12.1-stretch
     resource_class: small
     steps:
       - checkout


### PR DESCRIPTION
This is a bit of a hail-mary to move us past this current issue. We unfortunately still have no idea what is causing the panics to occur as only containers built in circleci has this issue. 

I'm hoping locking into `stretch` will fix this in the short term, as the rust proofs are built from a [`debian:stretch` base image](https://github.com/filecoin-project/rust-fil-proofs/blob/master/Dockerfile-ci#L5), and I was successful in building go-filecoin from `golang:1.12.1-stretch` and coping it into a `busybox:1-glibc` container.

The docker file I used was a slightly modified version  I created for the new k8s deployments.

https://github.com/filecoin-project/go-filecoin/blob/feat/devnet-fast-k8s/Dockerfile.devnet.base

I'm hoping because circleci uses this [same image to build their `circleci/golang:1.12.1-stretch`](https://github.com/CircleCI-Public/circleci-dockerfiles/blob/ce5a26df3b256dad024122a0016b4dd19cc1ccc8/golang/images/1.12.1-stretch/Dockerfile#L5) container everything should be built in the same environment.



