### PR TITLE
Prepare consensus for messages out of blocks

### DIFF
--- a/chain/store_test.go
+++ b/chain/store_test.go
@@ -203,10 +203,11 @@ func initSyncTest(t *testing.T,
 	calcGenBlk.StateRoot = dstP.genStateRoot
 	chainDS := r.ChainDatastore()
 	chainStore := chain.NewStore(chainDS, cst, &state.TreeStateLoader{}, calcGenBlk.Cid())
+	messageStore := chain.NewMessageStore(cst)
 
 	fetcher := th.NewTestFetcher()
 	fetcher.AddSourceBlocks(calcGenBlk)
-	syncer := chain.NewSyncer(con, chainStore, fetcher) // note we use same cst for on and offline for tests
+	syncer := chain.NewSyncer(con, chainStore, messageStore, fetcher) // note we use same cst for on and offline for tests
 
 	// Initialize stores to contain dstP.genesis block and state
 	calcGenTS := th.RequireNewTipSet(t, calcGenBlk)

--- a/chain/syncer_integration_test.go
+++ b/chain/syncer_integration_test.go
@@ -51,7 +51,7 @@ func TestLoadFork(t *testing.T) {
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but
 	// *not* as the store, to which the syncer must ensure to put blocks.
 	eval := &chain.FakeStateEvaluator{}
-	syncer := chain.NewSyncer(eval, store, builder)
+	syncer := chain.NewSyncer(eval, store, builder, builder)
 
 	base := builder.AppendManyOn(3, genesis)
 	left := builder.AppendManyOn(4, base)
@@ -79,7 +79,7 @@ func TestLoadFork(t *testing.T) {
 	newStore := chain.NewStore(repo.ChainDatastore(), &cborStore, &state.TreeStateLoader{}, genesis.At(0).Cid())
 	require.NoError(t, newStore.Load(ctx))
 	fakeFetcher := th.NewTestFetcher()
-	offlineSyncer := chain.NewSyncer(eval, newStore, fakeFetcher)
+	offlineSyncer := chain.NewSyncer(eval, newStore, builder, fakeFetcher)
 
 	assert.True(t, newStore.HasTipSetAndState(ctx, left.Key()))
 	assert.False(t, newStore.HasTipSetAndState(ctx, right.Key()))
@@ -164,6 +164,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 	require.NoError(t, cst.Get(ctx, info.GenesisCid, &calcGenBlk))
 
 	chainStore := chain.NewStore(r.ChainDatastore(), cst, &state.TreeStateLoader{}, calcGenBlk.Cid())
+	messageStore := chain.NewMessageStore(cst)
 
 	verifier := &verification.FakeVerifier{
 		VerifyPoStValid: true,
@@ -190,7 +191,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 		VerifyPoStValid: true,
 	}
 	con = consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &consensus.MarketView{}, calcGenBlk.Cid(), verifier, th.BlockTimeTest)
-	syncer := chain.NewSyncer(con, chainStore, blockSource)
+	syncer := chain.NewSyncer(con, chainStore, messageStore, blockSource)
 	baseTS := requireHeadTipset(t, chainStore) // this is the last block of the bootstrapping chain creating miners
 	require.Equal(t, 1, baseTS.Len())
 	bootstrapStateRoot := baseTS.ToSlice()[0].StateRoot

--- a/chain/syncer_test.go
+++ b/chain/syncer_test.go
@@ -190,7 +190,7 @@ func TestFarFutureTipsets(t *testing.T) {
 		genesis := builder.RequireTipSet(store.GetHead())
 		farHead := builder.AppendManyOn(chain.FinalityLimit+1, genesis)
 
-		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder)
+		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, builder)
 		assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), true))
 	})
 
@@ -199,7 +199,7 @@ func TestFarFutureTipsets(t *testing.T) {
 		genesis := builder.RequireTipSet(store.GetHead())
 		farHead := builder.AppendManyOn(chain.FinalityLimit+1, genesis)
 
-		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder)
+		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, builder)
 		err := syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), false)
 		assert.Error(t, err)
 	})
@@ -217,7 +217,7 @@ func TestNoUncessesaryFetch(t *testing.T) {
 	// A new syncer unable to fetch blocks from the network can handle a tipset that's already
 	// in the store and linked to genesis.
 	emptyFetcher := chain.NewBuilder(t, address.Undef)
-	newSyncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, emptyFetcher)
+	newSyncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, emptyFetcher)
 	assert.NoError(t, newSyncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), head.Key(), heightFromTip(t, head)), true))
 }
 
@@ -404,7 +404,7 @@ func setup(ctx context.Context, t *testing.T) (*chain.Builder, *chain.Store, *ch
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but
 	// *not* as the store, to which the syncer must ensure to put blocks.
 	eval := &chain.FakeStateEvaluator{}
-	syncer := chain.NewSyncer(eval, store, builder)
+	syncer := chain.NewSyncer(eval, store, builder, builder)
 
 	return builder, store, syncer
 }

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -328,7 +328,7 @@ type FakeStateEvaluator struct {
 }
 
 // RunStateTransition delegates to StateBuilder.ComputeState.
-func (e *FakeStateEvaluator) RunStateTransition(ctx context.Context, tip types.TipSet, ancestors []types.TipSet, stateID cid.Cid) (cid.Cid, error) {
+func (e *FakeStateEvaluator) RunStateTransition(ctx context.Context, tip types.TipSet, messages [][]*types.SignedMessage, receipts [][]*types.MessageReceipt, ancestors []types.TipSet, stateID cid.Cid) (cid.Cid, error) {
 	return e.ComputeState(stateID, tipMessages(tip))
 }
 

--- a/consensus/expected_test.go
+++ b/consensus/expected_test.go
@@ -106,7 +106,14 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		tipSet := types.RequireNewTipSet(t, blocks...)
 
-		_, err = exp.RunStateTransition(ctx, tipSet, []types.TipSet{pTipSet}, blocks[0].StateRoot)
+		var emptyMessages [][]*types.SignedMessage
+		var emptyReceipts [][]*types.MessageReceipt
+		for i := 0; i < len(blocks); i++ {
+			emptyMessages = append(emptyMessages, []*types.SignedMessage{})
+			emptyReceipts = append(emptyReceipts, []*types.MessageReceipt{})
+		}
+
+		_, err = exp.RunStateTransition(ctx, tipSet, emptyMessages, emptyReceipts, []types.TipSet{pTipSet}, blocks[0].StateRoot)
 		assert.NoError(t, err)
 	})
 
@@ -126,7 +133,14 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		tipSet := types.RequireNewTipSet(t, blocks...)
 
-		_, err = exp.RunStateTransition(ctx, tipSet, []types.TipSet{pTipSet}, genesisBlock.StateRoot)
+		var emptyMessages [][]*types.SignedMessage
+		var emptyReceipts [][]*types.MessageReceipt
+		for i := 0; i < len(blocks); i++ {
+			emptyMessages = append(emptyMessages, []*types.SignedMessage{})
+			emptyReceipts = append(emptyReceipts, []*types.MessageReceipt{})
+		}
+
+		_, err = exp.RunStateTransition(ctx, tipSet, emptyMessages, emptyReceipts, []types.TipSet{pTipSet}, genesisBlock.StateRoot)
 		assert.EqualError(t, err, "can't check for winning ticket: Couldn't get minerPower: something went wrong with the miner power")
 	})
 }

--- a/consensus/protocol.go
+++ b/consensus/protocol.go
@@ -34,7 +34,7 @@ type Protocol interface {
 
 	// RunStateTransition returns the state root CID resulting from applying the input ts to the
 	// prior `stateID`.  It returns an error if the transition is invalid.
-	RunStateTransition(ctx context.Context, ts types.TipSet, ancestors []types.TipSet, stateID cid.Cid) (cid.Cid, error)
+	RunStateTransition(ctx context.Context, ts types.TipSet, tsMessages [][]*types.SignedMessage, tsReceipts [][]*types.MessageReceipt, ancestors []types.TipSet, stateID cid.Cid) (cid.Cid, error)
 
 	// ValidateSyntax validates a single block is correctly formed.
 	ValidateSyntax(ctx context.Context, b *types.Block) error

--- a/node/node.go
+++ b/node/node.go
@@ -433,7 +433,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 	fcWallet := wallet.New(backend)
 
 	// only the syncer gets the storage which is online connected
-	chainSyncer := chain.NewSyncer(nodeConsensus, chainStore, fetcher)
+	chainSyncer := chain.NewSyncer(nodeConsensus, chainStore, messageStore, fetcher)
 	msgPool := core.NewMessagePool(nc.Repo.Config().Mpool, consensus.NewIngestionValidator(chainState, nc.Repo.Config().Mpool))
 	inbox := core.NewInbox(msgPool, core.InboxMaxAgeTipsets, chainStore, messageStore)
 

--- a/plumbing/msg/waiter.go
+++ b/plumbing/msg/waiter.go
@@ -216,7 +216,16 @@ func (w *Waiter) receiptFromTipSet(ctx context.Context, msgCid cid.Cid, ts types
 		return nil, err
 	}
 
-	res, err := consensus.NewDefaultProcessor().ProcessTipSet(ctx, st, vm.NewStorageMap(w.bs), ts, ancestors)
+	var tsMessages [][]*types.SignedMessage
+	for i := 0; i < ts.Len(); i++ {
+		blk := ts.At(i)
+		// TODO #3103 this is a temporary way to force the consensus interface.
+		// Once we separate messages out from blocks we'll need to read from
+		// the message collection store.
+		tsMessages = append(tsMessages, blk.Messages)
+	}
+
+	res, err := consensus.NewDefaultProcessor().ProcessTipSet(ctx, st, vm.NewStorageMap(w.bs), ts, tsMessages, ancestors)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This follows onto PR #3168, making changes that will be needed to the consensus and processor interfaces for message separation.

Please do not review until #3168 is in as it is based on that branch.