### PR TITLE
Pin busybox to 1.30.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN set -x \
 
 
 # Now comes the actual target image, which aims to be as small as possible.
-FROM busybox:1-glibc AS filecoin
+FROM busybox:1.30.1-glibc AS filecoin
 MAINTAINER Filecoin Dev Team
 
 # Get the filecoin binary, entrypoint script, and TLS CAs from the build container.

--- a/Dockerfile.ci.faucet
+++ b/Dockerfile.ci.faucet
@@ -1,4 +1,4 @@
-FROM busybox:1-glibc
+FROM busybox:1.30.1-glibc
 MAINTAINER Filecoin Dev Team
 
 # Get the binary, entrypoint script, and TLS CAs from the build container.

--- a/Dockerfile.ci.filecoin
+++ b/Dockerfile.ci.filecoin
@@ -1,4 +1,4 @@
-FROM busybox:1-glibc AS filecoin
+FROM busybox:1.30.1-glibc AS filecoin
 MAINTAINER Filecoin Dev Team
 
 # Get the filecoin binary, entrypoint script, and TLS CAs from the build container.

--- a/Dockerfile.ci.genesis
+++ b/Dockerfile.ci.genesis
@@ -1,4 +1,4 @@
-FROM busybox:1-glibc
+FROM busybox:1.30.1-glibc
 MAINTAINER Filecoin Dev Team
 
 # Get the binary, entrypoint script, and TLS CAs from the build container.

--- a/Dockerfile.faucet
+++ b/Dockerfile.faucet
@@ -39,7 +39,7 @@ RUN set -x \
 
 
 # Now comes the actual target image, which aims to be as small as possible.
-FROM busybox:1-glibc
+FROM busybox:1.30.1-glibc
 MAINTAINER Filecoin Dev Team
 
 # Get the binary, entrypoint script, and TLS CAs from the build container.

--- a/Dockerfile.genesis
+++ b/Dockerfile.genesis
@@ -36,7 +36,7 @@ RUN set -x \
 
 
 # Now comes the actual target image, which aims to be as small as possible.
-FROM busybox:1-glibc
+FROM busybox:1.30.1-glibc
 MAINTAINER Filecoin Dev Team
 
 # Get the binary, entrypoint script, and TLS CAs from the build container.


### PR DESCRIPTION
Busybox 1.31.0 was released 14 days ago which happens to coincide with these issues we are facing with nightly. After forcing an update locally I was able to reproduce the issue.

Pinning the image back to 1.30.1 fixes it. I looked through the 1.31.0 change log and did not find anything that popped out at me.