### PR TITLE
Integrate PeerTracker and GraphsyncFetcher

### DIFF
--- a/net/graphsync_fetcher.go
+++ b/net/graphsync_fetcher.go
@@ -177,7 +177,7 @@ func (gsf *GraphSyncFetcher) fetchRemainingTipsets(ctx context.Context, starting
 	return out, nil
 }
 
-// fetchBlocks requests a single set of cids as individual bocks, fetching
+// fetchBlocks requests a single set of cids as individual blocks, fetching
 // non-recursively
 func (gsf *GraphSyncFetcher) fetchBlocks(ctx context.Context, cids []cid.Cid, from peer.ID) error {
 	selector := gsf.ssb.Matcher().Node()

--- a/net/graphsync_fetcher_test.go
+++ b/net/graphsync_fetcher_test.go
@@ -38,6 +38,8 @@ func TestGraphsyncFetcher(t *testing.T) {
 	ctx := context.Background()
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 	bv := th.NewFakeBlockValidator()
+	pid0 := th.RequireIntPeerID(t, 0)
+	builder := chain.NewBuilder(t, address.Undef)
 
 	ssb := selector.NewSelectorSpecBuilder(ipldfree.NodeBuilder())
 	layer1Selector, err := ssb.Matcher().Selector()
@@ -49,26 +51,34 @@ func TestGraphsyncFetcher(t *testing.T) {
 		))
 	})).Selector()
 	require.NoError(t, err)
+	gsSelectorRound2, err := ssb.ExploreRecursive(4, ssb.ExploreFields(func(efsb selector.ExploreFieldsSpecBuilder) {
+		efsb.Insert("parents", ssb.ExploreUnion(
+			ssb.ExploreAll(ssb.Matcher()),
+			ssb.ExploreIndex(0, ssb.ExploreRecursiveEdge()),
+		))
+	})).Selector()
+	require.NoError(t, err)
+	pid1 := th.RequireIntPeerID(t, 1)
+	pid2 := th.RequireIntPeerID(t, 2)
 
 	t.Run("happy path returns correct tipsets", func(t *testing.T) {
-		builder := chain.NewBuilder(t, address.Undef)
 		gen := builder.NewGenesis()
 		final := builder.AppendOn(gen, 3)
 
 		stubs := []requestResponse{
 			{
-				fakeRequest{cidlink.Link{Cid: final.At(0).Cid()}, layer1Selector},
+				fakeRequest{pid0, cidlink.Link{Cid: final.At(0).Cid()}, layer1Selector},
 				fakeResponse{blks: []format.Node{final.At(0).ToNode()}},
 			},
 			{
-				fakeRequest{cidlink.Link{Cid: final.At(1).Cid()}, layer1Selector},
+				fakeRequest{pid0, cidlink.Link{Cid: final.At(1).Cid()}, layer1Selector},
 				fakeResponse{blks: []format.Node{final.At(1).ToNode()}},
 			},
 			{
-				fakeRequest{cidlink.Link{Cid: final.At(2).Cid()}, layer1Selector},
+				fakeRequest{pid0, cidlink.Link{Cid: final.At(2).Cid()}, layer1Selector},
 				fakeResponse{blks: []format.Node{final.At(2).ToNode()}},
 			},
-			{fakeRequest{cidlink.Link{Cid: final.At(0).Cid()}, gsSelector}, fakeResponse{
+			{fakeRequest{pid0, cidlink.Link{Cid: final.At(0).Cid()}, gsSelector}, fakeResponse{
 				responses: []graphsync.ResponseProgress{
 					makeGsResponse("", final.At(0).Cid()),
 					makeGsResponse("parents", final.At(0).Cid()),
@@ -79,7 +89,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		}
 		mgs := &mockableGraphsync{stubs: stubs, t: t, store: bs}
 
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv)
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, &fakePeerTracker{})
 
 		done := func(ts types.TipSet) (bool, error) {
 			if ts.Key().Equals(gen.Key()) {
@@ -88,12 +98,230 @@ func TestGraphsyncFetcher(t *testing.T) {
 			return false, nil
 		}
 
-		ts, err := fetcher.FetchTipSets(ctx, final.Key(), peer.ID("fake"), done)
+		ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
 		require.NoError(t, err, "the request completes successfully")
 		require.Equal(t, 4, len(mgs.receivedRequests), "all expected graphsync requests are made")
 		require.Equal(t, 2, len(ts), "the right number of tipsets is returned")
 		require.True(t, final.Key().Equals(ts[0].Key()), "the initial tipset is correct")
 		require.True(t, gen.Key().Equals(ts[1].Key()), "the remaining tipsets are correct")
+	})
+
+	t.Run("initial request fails on a block but fallback peer succeeds", func(t *testing.T) {
+		gen := builder.NewGenesis()
+		final := builder.AppendOn(gen, 3)
+		height, err := final.Height()
+		require.NoError(t, err)
+		chain1 := types.NewChainInfo(pid1, final.Key(), height)
+		chain2 := types.NewChainInfo(pid2, final.Key(), height)
+		pt := &fakePeerTracker{[]*types.ChainInfo{chain1, chain2}}
+
+		stubs := []requestResponse{
+			{
+				fakeRequest{pid0, cidlink.Link{Cid: final.At(0).Cid()}, layer1Selector},
+				fakeResponse{blks: []format.Node{final.At(0).ToNode()}},
+			},
+			{
+				fakeRequest{pid0, cidlink.Link{Cid: final.At(1).Cid()}, layer1Selector},
+				fakeResponse{nil, []error{fmt.Errorf("Everything failed")}, nil},
+			},
+			{
+				fakeRequest{pid0, cidlink.Link{Cid: final.At(2).Cid()}, layer1Selector},
+				fakeResponse{nil, []error{fmt.Errorf("Everything failed")}, nil},
+			},
+			{
+				fakeRequest{pid1, cidlink.Link{Cid: final.At(1).Cid()}, layer1Selector},
+				fakeResponse{blks: []format.Node{final.At(1).ToNode()}},
+			},
+			{
+				fakeRequest{pid1, cidlink.Link{Cid: final.At(2).Cid()}, layer1Selector},
+				fakeResponse{nil, []error{fmt.Errorf("Everything failed")}, nil},
+			},
+			{
+				fakeRequest{pid2, cidlink.Link{Cid: final.At(2).Cid()}, layer1Selector},
+				fakeResponse{blks: []format.Node{final.At(2).ToNode()}},
+			},
+			{fakeRequest{pid2, cidlink.Link{Cid: final.At(0).Cid()}, gsSelector}, fakeResponse{
+				responses: []graphsync.ResponseProgress{
+					makeGsResponse("", final.At(0).Cid()),
+					makeGsResponse("parents", final.At(0).Cid()),
+					makeGsResponse("parents/0", gen.At(0).Cid()),
+				},
+				blks: []format.Node{final.At(0).ToNode(), gen.At(0).ToNode()},
+			}},
+		}
+		mgs := &mockableGraphsync{stubs: stubs, t: t, store: bs}
+
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, pt)
+
+		done := func(ts types.TipSet) (bool, error) {
+			if ts.Key().Equals(gen.Key()) {
+				return true, nil
+			}
+			return false, nil
+		}
+
+		ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
+		require.NoError(t, err, "the request completes successfully")
+		require.Equal(t, 7, len(mgs.receivedRequests), "all expected graphsync requests are made")
+		require.Equal(t, pid0, mgs.receivedRequests[0].p, "asks first peer for everything in first tipset")
+		require.Equal(t, pid0, mgs.receivedRequests[1].p, "asks first peer for everything in first tipset")
+		require.Equal(t, pid0, mgs.receivedRequests[2].p, "asks first peer for everything in first tipset")
+		require.Equal(t, pid1, mgs.receivedRequests[3].p, "asks second peer for failed responses in first tipset")
+		require.Equal(t, pid1, mgs.receivedRequests[4].p, "asks second peer for failed responses in first tipset")
+		require.Equal(t, pid2, mgs.receivedRequests[5].p, "asks third peer for failed responses in first tipset")
+		require.Equal(t, pid2, mgs.receivedRequests[6].p, "asks third peer for when continuing the query")
+		require.Equal(t, 2, len(ts), "the right number of tipsets is returned")
+		require.True(t, final.Key().Equals(ts[0].Key()), "the initial tipset is correct")
+		require.True(t, gen.Key().Equals(ts[1].Key()), "the remaining tipsets are correct")
+	})
+
+	t.Run("initial request fails and no other peers succeed", func(t *testing.T) {
+		gen := builder.NewGenesis()
+		final := builder.AppendOn(gen, 3)
+		height, err := final.Height()
+		require.NoError(t, err)
+		chain1 := types.NewChainInfo(pid1, final.Key(), height)
+		chain2 := types.NewChainInfo(pid2, final.Key(), height)
+		pt := &fakePeerTracker{[]*types.ChainInfo{chain1, chain2}}
+
+		stubs := []requestResponse{
+			{
+				fakeRequest{pid0, cidlink.Link{Cid: final.At(0).Cid()}, layer1Selector},
+				fakeResponse{blks: []format.Node{final.At(0).ToNode()}},
+			},
+			{
+				fakeRequest{pid0, cidlink.Link{Cid: final.At(1).Cid()}, layer1Selector},
+				fakeResponse{nil, []error{fmt.Errorf("Everything failed")}, nil},
+			},
+			{
+				fakeRequest{pid0, cidlink.Link{Cid: final.At(2).Cid()}, layer1Selector},
+				fakeResponse{nil, []error{fmt.Errorf("Everything failed")}, nil},
+			},
+			{
+				fakeRequest{pid1, cidlink.Link{Cid: final.At(1).Cid()}, layer1Selector},
+				fakeResponse{nil, []error{fmt.Errorf("Everything failed")}, nil},
+			},
+			{
+				fakeRequest{pid1, cidlink.Link{Cid: final.At(2).Cid()}, layer1Selector},
+				fakeResponse{nil, []error{fmt.Errorf("Everything failed")}, nil},
+			},
+			{
+				fakeRequest{pid2, cidlink.Link{Cid: final.At(1).Cid()}, layer1Selector},
+				fakeResponse{nil, []error{fmt.Errorf("Everything failed")}, nil},
+			},
+			{
+				fakeRequest{pid2, cidlink.Link{Cid: final.At(2).Cid()}, layer1Selector},
+				fakeResponse{nil, []error{fmt.Errorf("Everything failed")}, nil},
+			},
+		}
+		mgs := &mockableGraphsync{stubs: stubs, t: t, store: bs}
+
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, pt)
+
+		done := func(ts types.TipSet) (bool, error) {
+			if ts.Key().Equals(gen.Key()) {
+				return true, nil
+			}
+			return false, nil
+		}
+
+		ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
+		require.Equal(t, 7, len(mgs.receivedRequests), "all expected graphsync requests are made")
+		require.Equal(t, pid0, mgs.receivedRequests[0].p)
+		require.Equal(t, pid0, mgs.receivedRequests[1].p)
+		require.Equal(t, pid0, mgs.receivedRequests[2].p)
+		require.Equal(t, pid1, mgs.receivedRequests[3].p)
+		require.Equal(t, pid1, mgs.receivedRequests[4].p)
+		require.Equal(t, pid2, mgs.receivedRequests[5].p)
+		require.Equal(t, pid2, mgs.receivedRequests[6].p)
+		require.Errorf(t, err, "Failed fetching tipset: %s", final.Key().String())
+		require.Nil(t, ts)
+	})
+
+	t.Run("partial response fail during recursive fetch recovers at fail point", func(t *testing.T) {
+		gen := builder.NewGenesis()
+		final := builder.AppendManyOn(5, gen)
+		height, err := final.Height()
+		require.NoError(t, err)
+		chain1 := types.NewChainInfo(pid1, final.Key(), height)
+		chain2 := types.NewChainInfo(pid2, final.Key(), height)
+		pt := &fakePeerTracker{[]*types.ChainInfo{chain1, chain2}}
+
+		middleNodes := make([]format.Node, 4)
+		current := final
+		for i := 0; i < 4; i++ {
+			key, err := current.Parents()
+			require.NoError(t, err)
+			current, err = builder.GetTipSet(key)
+			require.NoError(t, err)
+			middleNodes[i] = current.At(0).ToNode()
+		}
+
+		stubs := []requestResponse{
+			{
+				fakeRequest{pid0, cidlink.Link{Cid: final.At(0).Cid()}, layer1Selector},
+				fakeResponse{blks: []format.Node{final.At(0).ToNode()}},
+			},
+			{fakeRequest{pid0, cidlink.Link{Cid: final.At(0).Cid()}, gsSelector}, fakeResponse{
+				responses: []graphsync.ResponseProgress{
+					makeGsResponse("", final.At(0).Cid()),
+					makeGsResponse("parents", final.At(0).Cid()),
+					makeGsResponse("parents/0", middleNodes[0].Cid()),
+				},
+				blks: []format.Node{final.At(0).ToNode(), middleNodes[0]},
+			}},
+			{fakeRequest{pid0, cidlink.Link{Cid: middleNodes[0].Cid()}, gsSelectorRound2}, fakeResponse{
+				responses: []graphsync.ResponseProgress{
+					makeGsResponse("", middleNodes[0].Cid()),
+					makeGsResponse("parents", middleNodes[0].Cid()),
+					makeGsResponse("parents/0", middleNodes[1].Cid()),
+					makeGsResponse("parents/0/parents", middleNodes[1].Cid()),
+					makeGsResponse("parents/0/parents/0", middleNodes[2].Cid()),
+				},
+				errs: []error{fmt.Errorf("Everything failed")},
+				blks: []format.Node{middleNodes[0], middleNodes[1], middleNodes[2]},
+			}},
+			{fakeRequest{pid1, cidlink.Link{Cid: middleNodes[2].Cid()}, gsSelectorRound2}, fakeResponse{
+				responses: []graphsync.ResponseProgress{
+					makeGsResponse("", middleNodes[2].Cid()),
+					makeGsResponse("parents", middleNodes[2].Cid()),
+					makeGsResponse("parents/0", middleNodes[3].Cid()),
+					makeGsResponse("parents/0/parents", middleNodes[3].Cid()),
+					makeGsResponse("parents/0/parents/0", gen.At(0).Cid()),
+					makeGsResponse("parents/0/parents/0/parents", gen.At(0).Cid()),
+				},
+				blks: []format.Node{middleNodes[2], middleNodes[3], gen.At(0).ToNode()},
+			}},
+		}
+		mgs := &mockableGraphsync{stubs: stubs, t: t, store: bs}
+
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, pt)
+
+		done := func(ts types.TipSet) (bool, error) {
+			if ts.Key().Equals(gen.Key()) {
+				return true, nil
+			}
+			return false, nil
+		}
+
+		ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
+		require.NoError(t, err, "the request completes successfully")
+		require.Equal(t, 4, len(mgs.receivedRequests), "all expected graphsync requests are made")
+		require.Equal(t, pid0, mgs.receivedRequests[0].p)
+		require.Equal(t, pid0, mgs.receivedRequests[1].p)
+		require.Equal(t, pid0, mgs.receivedRequests[2].p)
+		require.Equal(t, pid1, mgs.receivedRequests[3].p)
+		require.Equal(t, 6, len(ts), "the right number of tipsets is returned")
+		expectedTs := final
+		for _, resultTs := range ts {
+			require.True(t, expectedTs.Key().Equals(resultTs.Key()), "the initial tipset is correct")
+			key, err := expectedTs.Parents()
+			require.NoError(t, err)
+			if !key.Empty() {
+				expectedTs, err = builder.GetTipSet(key)
+				require.NoError(t, err)
+			}
+		}
 	})
 
 	t.Run("value returned with non block format", func(t *testing.T) {
@@ -107,13 +335,13 @@ func TestGraphsyncFetcher(t *testing.T) {
 
 		stubs := []requestResponse{
 			{
-				fakeRequest{cidlink.Link{Cid: notABlockCid}, layer1Selector},
+				fakeRequest{pid0, cidlink.Link{Cid: notABlockCid}, layer1Selector},
 				fakeResponse{blks: []format.Node{notABlockObj}},
 			},
 		}
 		mgs := &mockableGraphsync{stubs: stubs, t: t, store: bs}
 
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv)
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, &fakePeerTracker{})
 
 		done := func(ts types.TipSet) (bool, error) {
 			if ts.Key().Equals(originalCids) {
@@ -121,7 +349,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 			}
 			return false, nil
 		}
-		ts, err := fetcher.FetchTipSets(ctx, originalCids, peer.ID("fake"), done)
+		ts, err := fetcher.FetchTipSets(ctx, originalCids, pid0, done)
 		require.Errorf(t, err, "fetched data (cid %s) was not a block", notABlockCid.String())
 		require.Nil(t, ts)
 	})
@@ -162,6 +390,7 @@ func TestRealWorldGraphsyncFetchAcrossNetwork(t *testing.T) {
 	bridge2 := ipldbridge.NewIPLDBridge()
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 	bv := th.NewFakeBlockValidator()
+	pt := net.NewPeerTracker()
 
 	localLoader := func(lnk ipld.Link, lnkCtx ipld.LinkContext) (io.Reader, error) {
 		asCidLink, ok := lnk.(cidlink.Link)
@@ -192,7 +421,8 @@ func TestRealWorldGraphsyncFetchAcrossNetwork(t *testing.T) {
 	}
 
 	localGraphsync := graphsync.New(ctx, gsnet1, bridge1, localLoader, localStorer)
-	fetcher := net.NewGraphSyncFetcher(ctx, localGraphsync, bs, bv)
+
+	fetcher := net.NewGraphSyncFetcher(ctx, localGraphsync, bs, bv, pt)
 
 	remoteLoader := func(lnk ipld.Link, lnkCtx ipld.LinkContext) (io.Reader, error) {
 		cid := lnk.(cidlink.Link).Cid
@@ -227,6 +457,7 @@ func TestRealWorldGraphsyncFetchAcrossNetwork(t *testing.T) {
 }
 
 type fakeRequest struct {
+	p        peer.ID
 	root     ipld.Link
 	selector selector.Selector
 }
@@ -250,6 +481,10 @@ type mockableGraphsync struct {
 }
 
 func (mgs *mockableGraphsync) toChans(mr fakeResponse) (<-chan graphsync.ResponseProgress, <-chan error) {
+	for _, block := range mr.blks {
+		requireBlockStorePut(mgs.t, mgs.store, block)
+	}
+
 	errChan := make(chan error, len(mr.errs))
 	for _, err := range mr.errs {
 		errChan <- err
@@ -262,9 +497,6 @@ func (mgs *mockableGraphsync) toChans(mr fakeResponse) (<-chan graphsync.Respons
 	}
 	close(responseChan)
 
-	for _, block := range mr.blks {
-		requireBlockStorePut(mgs.t, mgs.store, block)
-	}
 	return responseChan, errChan
 }
 
@@ -273,14 +505,14 @@ func (mgs *mockableGraphsync) Request(ctx context.Context, p peer.ID, root ipld.
 	if err != nil {
 		return mgs.toChans(fakeResponse{nil, []error{fmt.Errorf("Invalid selector")}, nil})
 	}
-	request := fakeRequest{root, parsed}
+	request := fakeRequest{p, root, parsed}
 	mgs.receivedRequests = append(mgs.receivedRequests, request)
 	for _, stub := range mgs.stubs {
 		if reflect.DeepEqual(stub.request, request) {
 			return mgs.toChans(stub.response)
 		}
 	}
-	return mgs.toChans(fakeResponse{nil, []error{fmt.Errorf("Failed Request")}, nil})
+	return mgs.toChans(fakeResponse{nil, []error{fmt.Errorf("Missing Mocked Request")}, nil})
 }
 
 func makeGsResponse(path string, blockCid cid.Cid) graphsync.ResponseProgress {
@@ -293,4 +525,12 @@ func makeGsResponse(path string, blockCid cid.Cid) graphsync.ResponseProgress {
 			Link: cidlink.Link{Cid: blockCid},
 		},
 	}
+}
+
+type fakePeerTracker struct {
+	peers []*types.ChainInfo
+}
+
+func (fpt *fakePeerTracker) List() []*types.ChainInfo {
+	return fpt.peers
 }

--- a/net/graphsync_fetcher_test.go
+++ b/net/graphsync_fetcher_test.go
@@ -169,7 +169,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		require.Equal(t, pid1, mgs.receivedRequests[3].p, "asks second peer for failed responses in first tipset")
 		require.Equal(t, pid1, mgs.receivedRequests[4].p, "asks second peer for failed responses in first tipset")
 		require.Equal(t, pid2, mgs.receivedRequests[5].p, "asks third peer for failed responses in first tipset")
-		require.Equal(t, pid2, mgs.receivedRequests[6].p, "asks third peer for when continuing the query")
+		require.Equal(t, pid2, mgs.receivedRequests[6].p, "asks third peer for remaining tipsets")
 		require.Equal(t, 2, len(ts), "the right number of tipsets is returned")
 		require.True(t, final.Key().Equals(ts[0].Key()), "the initial tipset is correct")
 		require.True(t, gen.Key().Equals(ts[1].Key()), "the remaining tipsets are correct")


### PR DESCRIPTION
# Goals

Integrate the peer tracker with the graphsync fetcher to provide fallback resiliency if peer goes
offline during a fetch

# Implementation

- During a request:
  - track which peers we've already tried to request from
  - every time a request fails:
    - query the peer tracker for peers we haven't tried yet
    - if we find one we haven't tried, retry with that peer.  if any full tipsets were fetched, verify them and start at the first incomplete tipset
    - if we exhaust all peers we know about, fail with a message about the tipset we failed on
- multiple unit tests of different potential error cases during fetching process

# For Discussion

This is getting to be a very complicated and stateful iteration. We have to deal with:
  - tracking peers we've tried
  - tracking which peer we trying currently
  - gradually increasing our recursion depth
  - building a tipset list
  - lots and lots of error checking, all of which aborts the function
  - checking every tipset to see if we're done yet

I'm not entirely sure how to simplify all of it. I starting tracking a small bit of that state independently with the requestPeerFinder. I wonder if other parts could be broken out to abstract parts of the state tracking.

fix #3177 