### PR TITLE
Do not update os env with new path

### DIFF
--- a/tools/iptb-plugins/filecoin/local/filecoinutil.go
+++ b/tools/iptb-plugins/filecoin/local/filecoinutil.go
@@ -61,10 +61,6 @@ func (l *Localfilecoin) env() ([]string, error) {
 	envs = filecoin.UpdateOrAppendEnv(envs, "GO_FILECOIN_LOG_JSON", l.logJSON)
 	envs = filecoin.UpdateOrAppendEnv(envs, "PATH", newPath)
 
-	if err := os.Setenv("PATH", newPath); err != nil {
-		return []string{}, err
-	}
-
 	return envs, nil
 }
 

--- a/tools/iptb-plugins/filecoin/local/localfilecoin.go
+++ b/tools/iptb-plugins/filecoin/local/localfilecoin.go
@@ -310,7 +310,12 @@ func (l *Localfilecoin) RunCmd(ctx context.Context, stdin io.Reader, args ...str
 		return nil, fmt.Errorf("error getting env: %s", err)
 	}
 
-	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	firstArg := args[0]
+	if firstArg == "go-filecoin" {
+		firstArg = l.binPath
+	}
+
+	cmd := exec.CommandContext(ctx, firstArg, args[1:]...)
 	cmd.Env = env
 	cmd.Stdin = stdin
 


### PR DESCRIPTION
Updating the os env results in the PATH increases in size on each call
which after many calls will exceed the limit of exec resulting in an
error to execute any exec commands.