### PR TITLE
Client validates PIP

### DIFF
--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -1260,15 +1260,22 @@ func TestVerifyPIP(t *testing.T) {
 		msgParams := actor.MustConvertParams(commP, pieceSize, firstSectorID, pip)
 		message := types.NewMessage(address.TestAddress, address.TestAddress2, 0, types.ZeroAttoFIL, "verifyPieceInclusion", msgParams)
 
+		comm1 := th.MakeCommitments()
+		comm2 := th.MakeCommitments()
+
+		commitments := NewSectorSet()
+		commitments.Add(1, types.Commitments{CommR: comm1.CommR})
+		commitments.Add(2, types.Commitments{CommR: comm2.CommR})
+
 		minerState := *NewState(address.TestAddress, address.TestAddress, peer.ID(""), types.OneKiBSectorSize)
-		minerState.SectorCommitments = nil
+		minerState.SectorCommitments = commitments
 
 		vmctx := th.NewFakeVMContext(message, minerState)
 		miner := Actor{}
 
 		code, err := miner.VerifyPieceInclusion(vmctx, commP, pieceSize, firstSectorID, pip)
 
-		require.Error(t, err, "not active")
+		require.EqualError(t, err, "miner not active")
 		require.NotEqual(t, uint8(0), code)
 	})
 
@@ -1298,7 +1305,7 @@ func TestVerifyPIP(t *testing.T) {
 
 		code, err := miner.VerifyPieceInclusion(vmctx, commP, pieceSize, firstSectorID, pip)
 
-		require.Error(t, err, "miner is tardy")
+		require.EqualError(t, err, "miner is tardy")
 		require.NotEqual(t, uint8(0), code)
 	})
 

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -1256,6 +1256,22 @@ func TestVerifyPIP(t *testing.T) {
 		require.Nil(t, verifier.LastReceivedVerifyPieceInclusionProofRequest, "should have never called the verifier")
 	})
 
+	t.Run("PIP is invalid if miner isn't proving anything", func(t *testing.T) {
+		msgParams := actor.MustConvertParams(commP, pieceSize, firstSectorID, pip)
+		message := types.NewMessage(address.TestAddress, address.TestAddress2, 0, types.ZeroAttoFIL, "verifyPieceInclusion", msgParams)
+
+		minerState := *NewState(address.TestAddress, address.TestAddress, peer.ID(""), types.OneKiBSectorSize)
+		minerState.SectorCommitments = nil
+
+		vmctx := th.NewFakeVMContext(message, minerState)
+		miner := Actor{}
+
+		code, err := miner.VerifyPieceInclusion(vmctx, commP, pieceSize, firstSectorID, pip)
+
+		require.Error(t, err, "not active")
+		require.NotEqual(t, uint8(0), code)
+	})
+
 	t.Run("PIP is invalid if miner is tardy/slashable", func(t *testing.T) {
 		msgParams := actor.MustConvertParams(commP, pieceSize, firstSectorID, pip)
 		message := types.NewMessage(address.TestAddress, address.TestAddress2, 0, types.ZeroAttoFIL, "verifyPieceInclusion", msgParams)

--- a/commands/deals_daemon_test.go
+++ b/commands/deals_daemon_test.go
@@ -79,7 +79,7 @@ func TestDealsRedeem(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait until deal is accepted so miner has redeemable vouchers.
-	err = series.WaitForDealState(ctx, clientDaemon, dealResponse, storagedeal.Staged)
+	_, err = series.WaitForDealState(ctx, clientDaemon, dealResponse, storagedeal.Staged)
 	require.NoError(t, err)
 
 	// Wait until deal period is complete.

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -225,6 +225,7 @@ func (a *API) ClientListAsks(ctx context.Context) <-chan Ask {
 	return ClientListAsks(ctx, a)
 }
 
+// ClientValidateDeal checks to see that a storage deal is in the `Complete` state, and that its PIP is valid
 func (a *API) ClientValidateDeal(ctx context.Context, proposalCid cid.Cid, proofInfo *storagedeal.ProofInfo) error {
 	return ClientVerifyStorageDeal(ctx, a, proposalCid, proofInfo)
 }

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -225,6 +225,10 @@ func (a *API) ClientListAsks(ctx context.Context) <-chan Ask {
 	return ClientListAsks(ctx, a)
 }
 
+func (a *API) ClientValidateDeal(ctx context.Context, proposalCid cid.Cid, proofInfo *storagedeal.ProofInfo) error {
+	return ClientVerifyStorageDeal(ctx, a, proposalCid, proofInfo)
+}
+
 // CalculatePoSt invokes the sector builder to calculate a proof-of-spacetime.
 func (a *API) CalculatePoSt(ctx context.Context, sortedCommRs proofs.SortedCommRs, seed types.PoStChallengeSeed) ([]types.PoStProof, []uint64, error) {
 	return CalculatePoSt(ctx, a, sortedCommRs, seed)

--- a/porcelain/client.go
+++ b/porcelain/client.go
@@ -2,15 +2,16 @@ package porcelain
 
 import (
 	"context"
-	"fmt"
+	"math/big"
+
+	"github.com/ipfs/go-cid"
+	"github.com/pkg/errors"
+
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
-	"github.com/ipfs/go-cid"
-	"github.com/pkg/errors"
-	"math/big"
 
 	cbor "github.com/ipfs/go-ipld-cbor"
 )
@@ -100,13 +101,11 @@ type cvsdPlumbing interface {
 	MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error)
 }
 
+// ClientVerifyStorageDeal check to see that a storage deal is in the `Complete` state, and that its PIP is valid
+// returns nil if successful
 func ClientVerifyStorageDeal(ctx context.Context, plumbing cvsdPlumbing, proposalCid cid.Cid, proofInfo *storagedeal.ProofInfo) error {
 	// Get the deal out of local storage.  This Deal was stored when we made the
 	// proposal, and has never been updated
-	fmt.Printf("getting deal\n")
-
-	fmt.Printf("ProofInfo: %+v\n", proofInfo)
-
 	deal, err := plumbing.DealGet(ctx, proposalCid)
 	if err != nil {
 		return errors.Wrap(err, "failed to get deal")
@@ -119,16 +118,10 @@ func ClientVerifyStorageDeal(ctx context.Context, plumbing cvsdPlumbing, proposa
 		proofInfo.PieceInclusionProof,
 	}
 
-	fmt.Printf("params to verify: %v", params)
-
-	result, err := plumbing.MessageQuery(ctx, address.Undef, deal.Miner, "doVerifyPieceInclusion", params...)
+	_, err = plumbing.MessageQuery(ctx, address.Undef, deal.Miner, "doVerifyPieceInclusion", params...)
 	if err != nil {
-		fmt.Printf("verify error: %v", err)
-
 		return err
 	}
-
-	fmt.Printf("result from verify: %v", result)
 
 	return nil
 }

--- a/protocol/storage/client.go
+++ b/protocol/storage/client.go
@@ -231,7 +231,7 @@ func (smc *Client) ProposeDeal(ctx context.Context, miner address.Address, data 
 
 	// Note: currently the miner requests the data out of band
 
-	if err := smc.recordResponse(ctx, &response, miner, proposal, res.CommP); err != nil {
+	if err := smc.recordResponse(ctx, &response, miner, proposal, pieceCommitmentResponse.CommP); err != nil {
 		return nil, errors.Wrap(err, "failed to track response")
 	}
 	smc.log.Debugf("proposed deal for: %s, %v\n", miner.String(), proposal)

--- a/protocol/storage/client.go
+++ b/protocol/storage/client.go
@@ -231,7 +231,7 @@ func (smc *Client) ProposeDeal(ctx context.Context, miner address.Address, data 
 
 	// Note: currently the miner requests the data out of band
 
-	if err := smc.recordResponse(ctx, &response, miner, proposal); err != nil {
+	if err := smc.recordResponse(ctx, &response, miner, proposal, res.CommP); err != nil {
 		return nil, errors.Wrap(err, "failed to track response")
 	}
 	smc.log.Debugf("proposed deal for: %s, %v\n", miner.String(), proposal)
@@ -239,7 +239,7 @@ func (smc *Client) ProposeDeal(ctx context.Context, miner address.Address, data 
 	return &response, nil
 }
 
-func (smc *Client) recordResponse(ctx context.Context, resp *storagedeal.Response, miner address.Address, p *storagedeal.Proposal) error {
+func (smc *Client) recordResponse(ctx context.Context, resp *storagedeal.Response, miner address.Address, p *storagedeal.Proposal, commP types.CommP) error {
 	proposalCid, err := convert.ToCid(p)
 	if err != nil {
 		return errors.New("failed to get cid of proposal")
@@ -259,6 +259,7 @@ func (smc *Client) recordResponse(ctx context.Context, resp *storagedeal.Respons
 		Miner:    miner,
 		Proposal: p,
 		Response: resp,
+		CommP:    commP,
 	})
 }
 

--- a/protocol/storage/storagedeal/types.go
+++ b/protocol/storage/storagedeal/types.go
@@ -121,6 +121,7 @@ type Deal struct {
 	Miner    address.Address
 	Proposal *Proposal
 	Response *Response
+	CommP    types.CommP
 }
 
 // ProofInfo contains the details about a seal proof, that the client needs to know to verify that his deal was posted on chain.

--- a/tools/fast/action_client.go
+++ b/tools/fast/action_client.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/filecoin-project/go-filecoin/commands"
 	"io"
 
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/commands"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 
 	"github.com/ipfs/go-cid"

--- a/tools/fast/action_client.go
+++ b/tools/fast/action_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/filecoin-project/go-filecoin/commands"
 	"io"
 
 	"github.com/filecoin-project/go-filecoin/address"
@@ -62,6 +63,17 @@ func (f *Filecoin) ClientQueryStorageDeal(ctx context.Context, prop cid.Cid) (*s
 	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "client", "query-storage-deal", prop.String()); err != nil {
 		return nil, err
 	}
+	return &out, nil
+}
+
+// ClientVerifyStorageDeal runs the client verify-storage-deal command against the filecoin process.
+func (f *Filecoin) ClientVerifyStorageDeal(ctx context.Context, prop cid.Cid) (*commands.VerifyStorageDealResult, error) {
+	var out commands.VerifyStorageDealResult
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "client", "verify-storage-deal", prop.String()); err != nil {
+		return nil, err
+	}
+
 	return &out, nil
 }
 

--- a/tools/fast/bin/localnet/main.go
+++ b/tools/fast/bin/localnet/main.go
@@ -292,7 +292,7 @@ func main() {
 	}
 
 	for _, deal := range deals {
-		err = series.WaitForDealState(ctx, genesis, deal, storagedeal.Complete)
+		_, err = series.WaitForDealState(ctx, genesis, deal, storagedeal.Complete)
 		if err != nil {
 			exitcode = handleError(err, "failed series.WaitForDealState;")
 			return

--- a/tools/fast/series/wait_for_deal_state.go
+++ b/tools/fast/series/wait_for_deal_state.go
@@ -9,12 +9,12 @@ import (
 
 // WaitForDealState will query the storage deal until its state matches the
 // passed in `state`, or the context is canceled.
-func WaitForDealState(ctx context.Context, client *fast.Filecoin, deal *storagedeal.Response, state storagedeal.State) error {
+func WaitForDealState(ctx context.Context, client *fast.Filecoin, deal *storagedeal.Response, state storagedeal.State) (dr *storagedeal.Response, err error) {
 	for {
 		// Client waits around for the deal to be sealed
-		dr, err := client.ClientQueryStorageDeal(ctx, deal.ProposalCid)
+		dr, err = client.ClientQueryStorageDeal(ctx, deal.ProposalCid)
 		if err != nil {
-			return err
+			return
 		}
 
 		if dr.State == state {
@@ -24,5 +24,5 @@ func WaitForDealState(ctx context.Context, client *fast.Filecoin, deal *storaged
 		CtxSleepDelay(ctx)
 	}
 
-	return nil
+	return
 }

--- a/tools/fast/series/wait_for_deal_state.go
+++ b/tools/fast/series/wait_for_deal_state.go
@@ -9,20 +9,18 @@ import (
 
 // WaitForDealState will query the storage deal until its state matches the
 // passed in `state`, or the context is canceled.
-func WaitForDealState(ctx context.Context, client *fast.Filecoin, deal *storagedeal.Response, state storagedeal.State) (dr *storagedeal.Response, err error) {
+func WaitForDealState(ctx context.Context, client *fast.Filecoin, deal *storagedeal.Response, state storagedeal.State) (*storagedeal.Response, error) {
 	for {
 		// Client waits around for the deal to be sealed
-		dr, err = client.ClientQueryStorageDeal(ctx, deal.ProposalCid)
+		dr, err := client.ClientQueryStorageDeal(ctx, deal.ProposalCid)
 		if err != nil {
-			return
+			return nil, err
 		}
 
 		if dr.State == state {
-			break
+			return dr, nil
 		}
 
 		CtxSleepDelay(ctx)
 	}
-
-	return
 }

--- a/tools/fast/tests/retrieval_test.go
+++ b/tools/fast/tests/retrieval_test.go
@@ -119,9 +119,6 @@ func TestRetrievalLocalNetwork(t *testing.T) {
 	RunRetrievalTest(ctx, t, miner, client, sectorSize)
 }
 
-// Current issue:
-// miner state LastPoSt is nil during deal finalization, so verifyPieceInclusion will never succeed
-
 // TestRetrieval exercises storing and retreiving with the filecoin protocols on a kittyhawk deployed
 // devnet.
 func TestRetrievalDevnet(t *testing.T) {


### PR DESCRIPTION
## Problem
PIP generation is happening during deal creation, but it isn't being verified.

## Solution
Add a new client command, `verify-deal-proposal`, that checks that the returned deal from the storage miner is in the [`Complete`](https://github.com/filecoin-project/go-filecoin/blob/fe3d41143e81d461d8f049f0ac739b391b5aa342/protocol/storage/storagedeal/state.go#L33) state, and that the PIP returned in the [`ProofInfo`](https://github.com/filecoin-project/go-filecoin/blob/fe3d41143e81d461d8f049f0ac739b391b5aa342/protocol/storage/storagedeal/types.go#L113) is valid.

## Note
This command doesn't cancel the payment channel if the PIP is invalid; the client must call `paych cancel` with the channel id, which is stored in the proposal.

Resolves #2676 
