### PR TITLE
Add CommD, CommR, CommRStar to ProofInfo

### DIFF
--- a/functional-tests/retrieval
+++ b/functional-tests/retrieval
@@ -174,13 +174,13 @@ message_wait "${STORAGE_MN_MINER_SET_PRICE_MSG_CID}" "${STORAGE_MN_REPO_DIR}"
 
 echo ""
 echo "client proposes a storage deal, which transfers file 1..."
-./go-filecoin client propose-storage-deal "${STORAGE_MN_MINER_FIL_ADDR}" "${PIECE_1_CID}" 0 5 \
-  --repodir="$CL_REPO_DIR" \
+PROPOSAL1_CID=$(./go-filecoin client propose-storage-deal "${STORAGE_MN_MINER_FIL_ADDR}" "${PIECE_1_CID}" 0 5 --repodir="$CL_REPO_DIR" --enc=json |  jq -r '.ProposalCid["/"]')
+echo "proposal 1 cid: $PROPOSAL1_CID"
 
 echo ""
 echo "client proposes a storage deal, which transfers piece 2..."
-./go-filecoin client propose-storage-deal "${STORAGE_MN_MINER_FIL_ADDR}" "${PIECE_2_CID}" 0 5 \
-  --repodir="$CL_REPO_DIR" \
+PROPOSAL2_CID=$(./go-filecoin client propose-storage-deal "${STORAGE_MN_MINER_FIL_ADDR}" "${PIECE_2_CID}" 0 5 --repodir="$CL_REPO_DIR" --enc=json |  jq -r '.ProposalCid["/"]')
+echo "proposal 2 cid: $PROPOSAL2_CID"
 
 echo ""
 echo "wait for commitSector sent by miner owner to be included in a block viewable by all nodes..."
@@ -193,6 +193,14 @@ echo "wait for submitPoSt, too..."
 wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${CL_REPO_DIR}" "${COMMIT_SECTOR_AND_POST_TIMEOUT}"
 wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${BOOTSTRAP_MN_REPO_DIR}" "${COMMIT_SECTOR_AND_POST_TIMEOUT}"
 wait_for_message_in_chain_by_method_and_sender submitPoSt "${STORAGE_MN_MINER_OWNER_FIL_ADDR}" "${STORAGE_MN_REPO_DIR}" "${COMMIT_SECTOR_AND_POST_TIMEOUT}"
+
+echo ""
+echo "storage deal 1 status:"
+./go-filecoin client query-storage-deal "${PROPOSAL1_CID}" --repodir="$CL_REPO_DIR" --enc=json |  jq .
+
+echo ""
+echo "storage deal 2 status:"
+./go-filecoin client query-storage-deal "${PROPOSAL2_CID}" --repodir="$CL_REPO_DIR" --enc=json |  jq .
 
 echo ""
 echo ""

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -587,6 +587,9 @@ func (sm *Miner) onCommitSuccess(ctx context.Context, dealCid cid.Cid, sector *s
 		resp.ProofInfo = &storagedeal.ProofInfo{
 			SectorID:          sector.SectorID,
 			CommitmentMessage: commitMessageCid,
+			CommD:             sector.CommD[:],
+			CommR:             sector.CommR[:],
+			CommRStar:         sector.CommRStar[:],
 		}
 		if pieceInfo != nil {
 			resp.ProofInfo.PieceInclusionProof = pieceInfo.InclusionProof

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -309,6 +309,9 @@ func TestOnCommitmentSent(t *testing.T) {
 		assert.Equal(t, sector.SectorID, dealResponse.ProofInfo.SectorID, "sector id should match committed sector")
 		assert.Equal(t, msgCid, dealResponse.ProofInfo.CommitmentMessage, "CommitmentMessage should be cid of commitSector messsage")
 		assert.Equal(t, sector.Pieces[0].InclusionProof, dealResponse.ProofInfo.PieceInclusionProof, "PieceInclusionProof should be proof generated after sealing")
+		assert.Equal(t, sector.CommD[:], dealResponse.ProofInfo.CommD)
+		assert.Equal(t, sector.CommR[:], dealResponse.ProofInfo.CommR)
+		assert.Equal(t, sector.CommRStar[:], dealResponse.ProofInfo.CommRStar)
 	})
 
 	t.Run("OnCommit doesn't fail when piece info is missing", func(t *testing.T) {
@@ -909,8 +912,15 @@ func testSectorMetadata(pieceRef cid.Cid) *sectorbuilder.SealedSectorMetadata {
 	copy(commD[:], []byte{9, 9, 9, 9})
 	pip := []byte{3, 3, 3, 3, 3}
 
+	// Make some values that aren't the zero value
+	var commR types.CommR
+	copy(commR[:], []byte{1, 2, 3, 4})
+
+	var commRStar types.CommRStar
+	copy(commRStar[:], []byte{5, 6, 7, 8})
+
 	piece := &sectorbuilder.PieceInfo{Ref: pieceRef, Size: 10999, InclusionProof: pip}
-	return &sectorbuilder.SealedSectorMetadata{SectorID: sectorID, CommD: commD, Pieces: []*sectorbuilder.PieceInfo{piece}}
+	return &sectorbuilder.SealedSectorMetadata{SectorID: sectorID, CommD: commD, CommR: commR, CommRStar: commRStar, Pieces: []*sectorbuilder.PieceInfo{piece}}
 }
 
 func testSignedDealProposal(porcelainAPI *minerTestPorcelain, vouchers []*types.PaymentVoucher, size uint64) *storagedeal.SignedDealProposal {

--- a/protocol/storage/storagedeal/types.go
+++ b/protocol/storage/storagedeal/types.go
@@ -129,6 +129,15 @@ type ProofInfo struct {
 	// Sector id allows us to find the committed sector metadata on chain
 	SectorID uint64
 
+	// CommD of the sector
+	CommD []byte
+
+	// CommR of the replica
+	CommR []byte
+
+	// CommRStar of the replica
+	CommRStar []byte
+
 	// CommitmentMessage is the cid of the message that committed the sector. It's used to track when the sector goes on chain.
 	CommitmentMessage cid.Cid
 


### PR DESCRIPTION
## Problem
Miners and storage clients would like more data when inspecting the storage deals they are involved in.

## Solution
Add `CommD`, `CommR`, and `CommRStar` to the payload returned from the `query-storage-deal` command.

## Example payload
(with `--enc=json`)
```json
{
  "State": 7,
  "Message": "",
  "ProposalCid": {
    "/": "bafy2bzaceadaomv5z2otqnchg5yrsckgtokcv4o5b2aks7geqycmw4neqdkti"
  },
  "ProofInfo": {
    "SectorID": 1,
    "CommD": "7y3qof2Ym+JmBL4HNsx5B4MXhszKsxzViekWs5Vl3zs=",
    "CommR": "3CGQ/QY08SvqY9hHolzKk+533k2WospIhJTtPYJF/XI=",
    "CommRStar": "pTZ5o4J/w+cQUPuTWyTD1fe8ptw2WP7Xa1fMFnzesU4=",
    "CommitmentMessage": {
      "/": "bafy2bzacedanjszzvuixgw4sykaiwficfud7c6tij3mvpvmz3bz2wdhgezjtc"
    },
    "PieceInclusionProof": "EAAAAAAAAABRTi4JhUuDkSEh8epLy2hzutjP+UjGTh5jiYV8PG9YAw=="
  },
  "Signature": "c2lnbmF0dXJycmVlZQ=="
}
```

resolve #3085