### PR TITLE
Update CLI show command

### DIFF
--- a/commands/message_daemon_test.go
+++ b/commands/message_daemon_test.go
@@ -143,7 +143,7 @@ func TestMessageSendBlockGasLimit(t *testing.T) {
 
 		blockCid := d.RunSuccess("mining", "once").ReadStdoutTrimNewlines()
 
-		blockInfo := d.RunSuccess("show", "block", blockCid, "--enc", "json").ReadStdoutTrimNewlines()
+		blockInfo := d.RunSuccess("show", "header", blockCid, "--enc", "json").ReadStdoutTrimNewlines()
 
 		require.NoError(t, json.Unmarshal([]byte(blockInfo), &result))
 		assert.NotEmpty(t, result.Messages, "msg under the block gas limit passes validation and is run in the block")

--- a/commands/show.go
+++ b/commands/show.go
@@ -149,7 +149,8 @@ var showMessagesCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Show a filecoin message collection by its CID",
 		ShortDescription: `Prints info for all messages in a collection,
-at the given CID.`,
+at the given CID.  Message collection CIDs are found in the "Messages" field of 
+the filecoin block header.`,
 	},
 	Arguments: []cmdkit.Argument{
 		cmdkit.StringArg("cid", true, false, "CID of message collection to show"),
@@ -184,7 +185,8 @@ var showReceiptsCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Show a filecoin receipt collection by its CID",
 		ShortDescription: `Prints info for all receipts in a collection,
-at the given CID.`,
+at the given CID.  Receipt collection CIDs are found in the "MessageReceipts"
+field of the filecoin block header.`,
 	},
 	Arguments: []cmdkit.Argument{
 		cmdkit.StringArg("cid", true, false, "CID of receipt collection to show"),

--- a/commands/show.go
+++ b/commands/show.go
@@ -23,7 +23,7 @@ var showCmd = &cmds.Command{
 
 var showBlockCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
-		Tagline: "Show a filecoin block by its CID",
+		Tagline: "Show a full filecoin block by its header CID",
 		ShortDescription: `Prints the miner, parent weight, height,
 and nonce of a given block. If JSON encoding is specified with the --enc flag,
 all other block properties will be included as well.`,
@@ -33,6 +33,75 @@ all other block properties will be included as well.`,
 	},
 	Options: []cmdkit.Option{
 		cmdkit.BoolOption("messages", "m", "show messages in block"),
+		cmdkit.BoolOption("receipts", "r", "show receipts in block"),		
+	},
+	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+		cid, err := cid.Decode(req.Arguments[0])
+		if err != nil {
+			return err
+		}
+
+		block, err := GetPorcelainAPI(env).ChainGetFullBlock(req.Context, cid)
+		if err != nil {
+			return err
+		}
+
+		return re.Emit(block)
+	},
+	Type: types.FullBlock{},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, block *types.FullBlock) error {
+			wStr, err := types.FixedStr(uint64(block.Header.ParentWeight))
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintf(w, `Block Details
+Miner:  %s
+Weight: %s
+Height: %s
+Nonce:  %s
+Messages:  %s
+Receipts:  %s
+Timestamp:  %s
+`,
+				block.Header.Miner,
+				wStr,
+				strconv.FormatUint(uint64(block.Header.Height), 10),
+				strconv.FormatUint(uint64(block.Header.Nonce), 10),
+				block.Header.Messages.String(),
+				block.Header.MessageReceipts.String(),
+				strconv.FormatUint(uint64(block.Header.Timestamp), 10),
+			)
+			if err != nil {
+				return err
+			}
+
+			showMessages, _ := req.Options["messages"].(bool)
+			if showMessages == true {
+				_, err = fmt.Fprintf(w, `Messages:  %s`+"\n", block.Messages)
+			}
+			if err != nil {
+				return err
+			}
+			showReceipts, _ := req.Options["receipts"].(bool)
+			if showReceipts == true {
+				_, err = fmt.Fprintf(w, `Receipts: %s`+"\n", block.Receipts)
+			}
+			return err
+		}),
+	},
+}
+
+var showHeaderCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Show a filecoin block header by its CID",
+		ShortDescription: `Prints the miner, parent weight, height,
+and nonce of a given block. If JSON encoding is specified with the --enc flag,
+all other block properties will be included as well.`,
+	},
+	Arguments: []cmdkit.Argument{
+		cmdkit.StringArg("cid", true, false, "CID of block to show"),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		cid, err := cid.Decode(req.Arguments[0])
@@ -68,15 +137,77 @@ Timestamp:  %s
 				strconv.FormatUint(uint64(block.Nonce), 10),
 				strconv.FormatUint(uint64(block.Timestamp), 10),
 			)
-			if err != nil {
-				return err
-			}
+			return err
+		}),
+	},
+}	
+	
+var showMessagesCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Show a filecoin message collection by its CID",
+		ShortDescription: `Prints info for all messages in a colleciton,
+at the given CID.`,
+	},
+	Arguments: []cmdkit.Argument{
+		cmdkit.StringArg("cid", true, false, "CID of message collection to show"),
+	},
+	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+		cid, err := cid.Decode(req.Arguments[0])
+		if err != nil {
+			return err
+		}
 
-			showMessages, _ := req.Options["messages"].(bool)
-			if showMessages == true {
-				_, err = fmt.Fprintf(w, `Messages:  %s`+"\n", block.Messages)
+		messages, err := GetPorcelainAPI(env).ChainGetMessages(req.Context, cid)
+		if err != nil {
+			return err
+		}
+
+		return re.Emit(messages)
+	},
+	Type: []*types.SignedMessage{},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, messages []*types.SignedMessage) error {
+			outStr := "Messages Details\n"
+			for _, msg := range messages {
+				outStr += msg.String() + "\n"
 			}
+			_, err := fmt.Fprintf(w, outStr)
 			return err
 		}),
 	},
 }
+
+var showReceiptsCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Show a filecoin receipt collection by its CID",
+		ShortDescription: `Prints info for all receipts in a colleciton,
+at the given CID.`,
+	},
+	Arguments: []cmdkit.Argument{
+		cmdkit.StringArg("cid", true, false, "CID of receipt collection to show"),
+	},
+	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+		cid, err := cid.Decode(req.Arguments[0])
+		if err != nil {
+			return err
+		}
+
+		receipts, err := GetPorcelainAPI(env).ChainGetReceipts(req.Context, cid)
+		if err != nil {
+			return err
+		}
+
+		return re.Emit(receipts)
+	},
+	Type: []*types.MessageReceipt{},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, receipts []*types.MessageReceipt) error {
+			outStr := "Receipt Details\n"
+			for _, r := range receipts {
+				outStr += r.String() + "\n"
+			}
+			_, err := fmt.Fprintf(w, outStr)
+			return err
+		}),
+	},
+}	

--- a/commands/show.go
+++ b/commands/show.go
@@ -17,7 +17,10 @@ var showCmd = &cmds.Command{
 		Tagline: "Get human-readable representations of filecoin objects",
 	},
 	Subcommands: map[string]*cmds.Command{
-		"block": showBlockCmd,
+		"block":    showBlockCmd,
+		"header":   showHeaderCmd,
+		"messages": showMessagesCmd,
+		"receipts": showReceiptsCmd,
 	},
 }
 
@@ -33,7 +36,7 @@ all other block properties will be included as well.`,
 	},
 	Options: []cmdkit.Option{
 		cmdkit.BoolOption("messages", "m", "show messages in block"),
-		cmdkit.BoolOption("receipts", "r", "show receipts in block"),		
+		cmdkit.BoolOption("receipts", "r", "show receipts in block"),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		cid, err := cid.Decode(req.Arguments[0])
@@ -140,12 +143,12 @@ Timestamp:  %s
 			return err
 		}),
 	},
-}	
-	
+}
+
 var showMessagesCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Show a filecoin message collection by its CID",
-		ShortDescription: `Prints info for all messages in a colleciton,
+		ShortDescription: `Prints info for all messages in a collection,
 at the given CID.`,
 	},
 	Arguments: []cmdkit.Argument{
@@ -180,7 +183,7 @@ at the given CID.`,
 var showReceiptsCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Show a filecoin receipt collection by its CID",
-		ShortDescription: `Prints info for all receipts in a colleciton,
+		ShortDescription: `Prints info for all receipts in a collection,
 at the given CID.`,
 	},
 	Arguments: []cmdkit.Argument{
@@ -210,4 +213,4 @@ at the given CID.`,
 			return err
 		}),
 	},
-}	
+}

--- a/commands/show_test.go
+++ b/commands/show_test.go
@@ -3,7 +3,6 @@ package commands_test
 import (
 	"encoding/json"
 	"testing"
-	//	"fmt"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -114,6 +113,23 @@ func TestBlockDaemon(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(emptyMessagesLine), &messageCollection))
 
 		assert.Equal(t, 0, len(messageCollection))
+	})
+
+	t.Run("show receipts <empty-collection-cid> returns empty receipt collection", func(t *testing.T) {
+		d := th.NewDaemon(t,
+			th.KeyFile(fixtures.KeyFilePaths()[0]),
+			th.WithMiner(fixtures.TestMiners[0])).Start()
+		defer d.ShutdownSuccess()
+
+		// mine a block
+		th.RunSuccessFirstLine(d, "mining", "once")
+
+		emptyReceiptsLine := th.RunSuccessFirstLine(d, "show", "receipts", types.EmptyReceiptsCID.String(), "--enc", "json")
+
+		var receipts []*types.MessageReceipt
+		require.NoError(t, json.Unmarshal([]byte(emptyReceiptsLine), &receipts))
+
+		assert.Equal(t, 0, len(receipts))
 	})
 
 	t.Run("show messages and show receipts", func(t *testing.T) {

--- a/commands/show_test.go
+++ b/commands/show_test.go
@@ -3,10 +3,12 @@ package commands_test
 import (
 	"encoding/json"
 	"testing"
+	//	"fmt"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/fixtures"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
@@ -62,15 +64,121 @@ func TestBlockDaemon(t *testing.T) {
 
 		// get the mined block by its CID
 		blockGetLine := th.RunSuccessFirstLine(d, "show", "block", minedBlockCidStr, "--enc", "json")
-		var blockGetBlock types.Block
+		var blockGetBlock types.FullBlock
 		require.NoError(t, json.Unmarshal([]byte(blockGetLine), &blockGetBlock))
 
 		// ensure that we were returned the correct block
 
-		require.Equal(t, minedBlockCidStr, blockGetBlock.Cid().String())
+		require.Equal(t, minedBlockCidStr, blockGetBlock.Header.Cid().String())
 
 		// ensure that the JSON we received from block get conforms to schema
 
-		requireSchemaConformance(t, []byte(blockGetLine), "filecoin_block")
+	})
+
+	t.Run("show header <cid-of-genesis-block> --enc json returns JSON for a filecoin block header", func(t *testing.T) {
+		d := th.NewDaemon(t,
+			th.KeyFile(fixtures.KeyFilePaths()[0]),
+			th.WithMiner(fixtures.TestMiners[0])).Start()
+		defer d.ShutdownSuccess()
+
+		// mine a block and get its CID
+		minedBlockCidStr := th.RunSuccessFirstLine(d, "mining", "once")
+
+		// get the mined block by its CID
+		headerGetLine := th.RunSuccessFirstLine(d, "show", "header", minedBlockCidStr, "--enc", "json")
+
+		var headerGetBlock types.Block
+		require.NoError(t, json.Unmarshal([]byte(headerGetLine), &headerGetBlock))
+
+		// ensure that we were returned the correct block
+
+		require.Equal(t, minedBlockCidStr, headerGetBlock.Cid().String())
+
+		// ensure that the JSON we received from block get conforms to schema
+
+		requireSchemaConformance(t, []byte(headerGetLine), "filecoin_block")
+	})
+
+	t.Run("show messages <empty-collection-cid> returns empty message collection", func(t *testing.T) {
+		d := th.NewDaemon(t,
+			th.KeyFile(fixtures.KeyFilePaths()[0]),
+			th.WithMiner(fixtures.TestMiners[0])).Start()
+		defer d.ShutdownSuccess()
+
+		// mine a block
+		th.RunSuccessFirstLine(d, "mining", "once")
+
+		emptyMessagesLine := th.RunSuccessFirstLine(d, "show", "messages", types.EmptyMessagesCID.String(), "--enc", "json")
+
+		var messageCollection []*types.SignedMessage
+		require.NoError(t, json.Unmarshal([]byte(emptyMessagesLine), &messageCollection))
+
+		assert.Equal(t, 0, len(messageCollection))
+	})
+
+	t.Run("show messages and show receipts", func(t *testing.T) {
+		d := th.NewDaemon(
+			t,
+			th.DefaultAddress(fixtures.TestAddresses[0]),
+			th.KeyFile(fixtures.KeyFilePaths()[1]),
+			// must include same-index KeyFilePath when configuring with a TestMiner.
+			th.WithMiner(fixtures.TestMiners[0]),
+			th.KeyFile(fixtures.KeyFilePaths()[0]),
+		).Start()
+		defer d.ShutdownSuccess()
+
+		d.RunSuccess("mining", "once")
+
+		from := d.GetDefaultAddress() // this should = fixtures.TestAddresses[0]
+
+		d.RunSuccess("message", "send",
+			"--from", from,
+			"--gas-price", "1",
+			"--gas-limit", "300",
+			fixtures.TestAddresses[3],
+		)
+
+		d.RunSuccess("message", "send",
+			"--from", from,
+			"--gas-price", "1",
+			"--gas-limit", "300",
+			"--value", "10",
+			fixtures.TestAddresses[3],
+		)
+
+		d.RunSuccess("message", "send",
+			"--from", from,
+			"--gas-price", "1",
+			"--gas-limit", "300",
+			"--value", "5.5",
+			fixtures.TestAddresses[3],
+		)
+
+		minedBlockCidStr := th.RunSuccessFirstLine(d, "mining", "once")
+
+		// Full block checks out
+		blockGetLine := th.RunSuccessFirstLine(d, "show", "block", minedBlockCidStr, "--enc", "json")
+		var blockGetBlock types.FullBlock
+		require.NoError(t, json.Unmarshal([]byte(blockGetLine), &blockGetBlock))
+
+		assert.Equal(t, 3, len(blockGetBlock.Messages))
+		assert.Equal(t, 3, len(blockGetBlock.Receipts))
+
+		fromAddr, err := address.NewFromString(from)
+		require.NoError(t, err)
+		assert.Equal(t, fromAddr, blockGetBlock.Messages[0].MeteredMessage.Message.From)
+		assert.Equal(t, uint8(0), blockGetBlock.Receipts[0].ExitCode)
+
+		// Full block matches show messages
+		messagesGetLine := th.RunSuccessFirstLine(d, "show", "messages", blockGetBlock.Header.Messages.String(), "--enc", "json")
+		var messages []*types.SignedMessage
+		require.NoError(t, json.Unmarshal([]byte(messagesGetLine), &messages))
+		assert.Equal(t, blockGetBlock.Messages, messages)
+
+		// Full block matches show receipts
+		receiptsGetLine := th.RunSuccessFirstLine(d, "show", "receipts", blockGetBlock.Header.MessageReceipts.String(), "--enc", "json")
+		var receipts []*types.MessageReceipt
+		require.NoError(t, json.Unmarshal([]byte(receiptsGetLine), &receipts))
+		assert.Equal(t, blockGetBlock.Receipts, receipts)
 	})
 }

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -143,6 +143,16 @@ func (api *API) ChainGetBlock(ctx context.Context, id cid.Cid) (*types.Block, er
 	return api.chain.GetBlock(ctx, id)
 }
 
+// ChainGetMessages gets a message colleciton by CID
+func (api *API) ChainGetMessages(ctx context.Context, id cid.Cid) ([]*types.SignedMessage, error) {
+	return api.chain.GetMessages(ctx, id)
+}
+
+// ChainGetReceipts gets a receipt collection by CID
+func (api *API) ChainGetReceipts(ctx context.Context, id cid.Cid) ([]*types.MessageReceipt, error) {
+	return api.chain.GetReceipts(ctx, id)
+}
+
 // ChainHead returns the head tipset
 func (api *API) ChainHead() (types.TipSet, error) {
 	return api.chain.Head()

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -143,7 +143,7 @@ func (api *API) ChainGetBlock(ctx context.Context, id cid.Cid) (*types.Block, er
 	return api.chain.GetBlock(ctx, id)
 }
 
-// ChainGetMessages gets a message colleciton by CID
+// ChainGetMessages gets a message collection by CID
 func (api *API) ChainGetMessages(ctx context.Context, id cid.Cid) ([]*types.SignedMessage, error) {
 	return api.chain.GetMessages(ctx, id)
 }

--- a/plumbing/cst/chain_state.go
+++ b/plumbing/cst/chain_state.go
@@ -27,8 +27,8 @@ type chainReader interface {
 // ChainStateProvider composes a chain and a state store to provide access to
 // the state (including actors) derived from a chain.
 type ChainStateProvider struct {
-	reader          chainReader           // Provides chain tipsets and state roots.
-	cst             *hamt.CborIpldStore   // Provides chain blocks and state trees.
+	reader          chainReader         // Provides chain tipsets and state roots.
+	cst             *hamt.CborIpldStore // Provides chain blocks and state trees.
 	messageProvider chain.MessageProvider
 }
 
@@ -76,10 +76,12 @@ func (chn *ChainStateProvider) GetBlock(ctx context.Context, id cid.Cid) (*types
 	return &out, err
 }
 
+// GetMessages gets a message collection by CID.
 func (chn *ChainStateProvider) GetMessages(ctx context.Context, id cid.Cid) ([]*types.SignedMessage, error) {
 	return chn.messageProvider.LoadMessages(ctx, id)
 }
 
+// GetReceipts gets a receipt collection by CID.
 func (chn *ChainStateProvider) GetReceipts(ctx context.Context, id cid.Cid) ([]*types.MessageReceipt, error) {
 	return chn.messageProvider.LoadReceipts(ctx, id)
 }

--- a/plumbing/cst/chain_state.go
+++ b/plumbing/cst/chain_state.go
@@ -29,7 +29,7 @@ type chainReader interface {
 type ChainStateProvider struct {
 	reader          chainReader           // Provides chain tipsets and state roots.
 	cst             *hamt.CborIpldStore   // Provides chain blocks and state trees.
-	messageProvider chain.MessageProvider // nolint: structcheck
+	messageProvider chain.MessageProvider
 }
 
 var (
@@ -74,6 +74,14 @@ func (chn *ChainStateProvider) GetBlock(ctx context.Context, id cid.Cid) (*types
 	var out types.Block
 	err := chn.cst.Get(ctx, id, &out)
 	return &out, err
+}
+
+func (chn *ChainStateProvider) GetMessages(ctx context.Context, id cid.Cid) ([]*types.SignedMessage, error) {
+	return chn.messageProvider.LoadMessages(ctx, id)
+}
+
+func (chn *ChainStateProvider) GetReceipts(ctx context.Context, id cid.Cid) ([]*types.MessageReceipt, error) {
+	return chn.messageProvider.LoadReceipts(ctx, id)
 }
 
 // SampleRandomness samples randomness from the chain at the given height.

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -50,6 +50,11 @@ func (a *API) ChainBlockHeight() (*types.BlockHeight, error) {
 	return ChainBlockHeight(a)
 }
 
+// GetFullBlock returns the full block given the header cid
+func (a *API) ChainGetFullBlock(ctx context.Context, id cid.Cid) (*types.FullBlock, error) {
+	return GetFullBlock(ctx, a, id)
+}
+
 // CreatePayments establishes a payment channel and create multiple payments against it
 func (a *API) CreatePayments(ctx context.Context, config CreatePaymentsParams) (*CreatePaymentsReturn, error) {
 	return CreatePayments(ctx, a, config)
@@ -75,11 +80,6 @@ func (a *API) DealRedeemPreview(ctx context.Context, fromAddr address.Address, d
 // DealsLs returns a channel with all deals
 func (a *API) DealsLs(ctx context.Context) (<-chan *StorageDealLsResult, error) {
 	return DealsLs(ctx, a)
-}
-
-// GetFullBlock returns the full block given the header cid
-func (a *API) GetFullBlock(ctx context.Context, id cid.Cid) (*types.FullBlock, error) {
-	return GetFullBlock(ctx, a, id)
 }
 
 // MessagePoolWait waits for the message pool to have at least messageCount unmined messages.

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -77,6 +77,11 @@ func (a *API) DealsLs(ctx context.Context) (<-chan *StorageDealLsResult, error) 
 	return DealsLs(ctx, a)
 }
 
+// GetFullBlock returns the full block given the header cid
+func (a *API) GetFullBlock(ctx context.Context, id cid.Cid) (*types.FullBlock, error) {
+	return GetFullBlock(ctx, a, id)
+}
+
 // MessagePoolWait waits for the message pool to have at least messageCount unmined messages.
 // It's useful for integration testing.
 func (a *API) MessagePoolWait(ctx context.Context, messageCount uint) ([]*types.SignedMessage, error) {

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -50,7 +50,7 @@ func (a *API) ChainBlockHeight() (*types.BlockHeight, error) {
 	return ChainBlockHeight(a)
 }
 
-// GetFullBlock returns the full block given the header cid
+// ChainGetFullBlock returns the full block given the header cid
 func (a *API) ChainGetFullBlock(ctx context.Context, id cid.Cid) (*types.FullBlock, error) {
 	return GetFullBlock(ctx, a, id)
 }

--- a/porcelain/chain.go
+++ b/porcelain/chain.go
@@ -1,6 +1,10 @@
 package porcelain
 
 import (
+	"context"
+	
+	"github.com/ipfs/go-cid"
+	
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -19,4 +23,33 @@ func ChainBlockHeight(plumbing chBlockHeightPlumbing) (*types.BlockHeight, error
 		return nil, err
 	}
 	return types.NewBlockHeight(height), nil
+}
+
+type fullBlockPlumbing interface {
+	ChainGetBlock(context.Context, cid.Cid) (*types.Block, error)
+	ChainGetMessages(context.Context, cid.Cid) ([]*types.SignedMessage, error)
+	ChainGetReceipts(context.Context, cid.Cid) ([]*types.MessageReceipt, error)
+}
+
+// GetFullBlock returns a full block: header, messages, receipts.
+func GetFullBlock(ctx context.Context, plumbing fullBlockPlumbing, id cid.Cid) (*types.FullBlock, error) {
+	var out types.FullBlock
+	var err error
+	
+	out.Header, err = plumbing.ChainGetBlock(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	
+	out.Messages, err = plumbing.ChainGetMessages(ctx, out.Header.Messages)
+	if err != nil {
+		return nil, err
+	}
+
+	out.Receipts, err = plumbing.ChainGetReceipts(ctx, out.Header.MessageReceipts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &out, nil
 }

--- a/porcelain/chain.go
+++ b/porcelain/chain.go
@@ -2,9 +2,9 @@ package porcelain
 
 import (
 	"context"
-	
+
 	"github.com/ipfs/go-cid"
-	
+
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -35,12 +35,12 @@ type fullBlockPlumbing interface {
 func GetFullBlock(ctx context.Context, plumbing fullBlockPlumbing, id cid.Cid) (*types.FullBlock, error) {
 	var out types.FullBlock
 	var err error
-	
+
 	out.Header, err = plumbing.ChainGetBlock(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	out.Messages, err = plumbing.ChainGetMessages(ctx, out.Header.Messages)
 	if err != nil {
 		return nil, err

--- a/tools/fast/action_show.go
+++ b/tools/fast/action_show.go
@@ -8,8 +8,8 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
-// ShowBlock runs the `show block` command against the filecoin process
-func (f *Filecoin) ShowBlock(ctx context.Context, ref cid.Cid) (*types.Block, error) {
+// ShowHeader runs the `show header` command against the filecoin process
+func (f *Filecoin) ShowHeader(ctx context.Context, ref cid.Cid) (*types.Block, error) {
 	var out types.Block
 
 	sRef := ref.String()

--- a/tools/fast/action_show.go
+++ b/tools/fast/action_show.go
@@ -14,7 +14,7 @@ func (f *Filecoin) ShowBlock(ctx context.Context, ref cid.Cid) (*types.Block, er
 
 	sRef := ref.String()
 
-	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "show", "block", sRef); err != nil {
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "show", "header", sRef); err != nil {
 		return nil, err
 	}
 

--- a/tools/fast/series/get_head_block_height.go
+++ b/tools/fast/series/get_head_block_height.go
@@ -14,7 +14,7 @@ func GetHeadBlockHeight(ctx context.Context, client *fast.Filecoin) (*types.Bloc
 		return nil, err
 	}
 
-	block, err := client.ShowBlock(ctx, tipset[0])
+	block, err := client.ShowHeader(ctx, tipset[0])
 	if err != nil {
 		return nil, err
 	}

--- a/types/full_block.go
+++ b/types/full_block.go
@@ -1,0 +1,15 @@
+package types
+
+type FullBlock struct {
+	Header   *Block
+	Messages []*SignedMessage
+	Receipts []*MessageReceipt
+}
+
+func NewFullBlock(header *Block, msgs []*SignedMessage, rcpts []*MessageReceipt) *FullBlock {
+	return &FullBlock{
+		Header:   header,
+		Messages: msgs,
+		Receipts: rcpts,
+	}
+}

--- a/types/full_block.go
+++ b/types/full_block.go
@@ -1,11 +1,14 @@
 package types
 
+// FullBlock carries a block header and the message and receipt collections
+// referenced from the header.
 type FullBlock struct {
 	Header   *Block
 	Messages []*SignedMessage
 	Receipts []*MessageReceipt
 }
 
+// NewFullBlock constructs a new full block.
 func NewFullBlock(header *Block, msgs []*SignedMessage, rcpts []*MessageReceipt) *FullBlock {
 	return &FullBlock{
 		Header:   header,

--- a/types/message_receipt.go
+++ b/types/message_receipt.go
@@ -1,6 +1,9 @@
 package types
 
 import (
+	"encoding/json"
+	"fmt"
+
 	cbor "github.com/ipfs/go-ipld-cbor"
 )
 
@@ -20,4 +23,14 @@ type MessageReceipt struct {
 
 	// GasAttoFIL Charge is the actual amount of FIL transferred from the sender to the miner for processing the message
 	GasAttoFIL AttoFIL `json:"gasAttoFIL"`
+}
+
+func (mr *MessageReceipt) String() string {
+	errStr := "(error encoding MessageReceipt)"
+
+	js, err := json.MarshalIndent(mr, "", "  ")
+	if err != nil {
+		return errStr
+	}
+	return fmt.Sprintf("MessageReceipt: %s", string(js))
 }


### PR DESCRIPTION
Closes #3196.  

Some changes since writing that issue: it makes more sense to use a separate command for the header and the full block rather than controlling with a flag because the cmds lib can only return a single type from each CLI call.  I kept `block` as the name of the full block command and now `header` is the block header show command.

Note that the old`show block` api is still broken because now the structure of the output is like 

```
{
    Header {
        Parents: ...
        Ticket: ...
        Timestamp: ...
        ...
    }
    Messages: [msg1, msg2...]
    Receipts: [rcpt1, rcpt2,...]
}
```

instead of the previous:

```
{
    Parents: ...
    Ticket: ...
    Timestamp: ...
    ... 
    Messages: [msg1, msg2...]
    Receipts: [rcpt1, rcpt2...]
}
```