### PR TITLE
Updated to tagged graphsync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/ipfs/go-ds-badger v0.0.5
 	github.com/ipfs/go-ds-leveldb v0.0.2 // indirect
 	github.com/ipfs/go-fs-lock v0.0.1
-	github.com/ipfs/go-graphsync v0.0.0-20190806205338-f506993bcc90
+	github.com/ipfs/go-graphsync v0.0.1-filecoin
 	github.com/ipfs/go-hamt-ipld v0.0.1
 	github.com/ipfs/go-ipfs-blockstore v0.0.1
 	github.com/ipfs/go-ipfs-chunker v0.0.1
@@ -62,7 +62,7 @@ require (
 	github.com/ipfs/go-path v0.0.1
 	github.com/ipfs/go-unixfs v0.0.1
 	github.com/ipfs/iptb v1.3.8-0.20190401234037-98ccf4228a73
-	github.com/ipld/go-ipld-prime v0.0.0-20190730002952-369bb56ad071
+	github.com/ipld/go-ipld-prime v0.0.1-filecoin
 	github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jbenet/goprocess v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -338,6 +338,8 @@ github.com/ipfs/go-graphsync v0.0.0-20190730081500-edbfd0323fdf h1:W7GMZUIea+nDr
 github.com/ipfs/go-graphsync v0.0.0-20190730081500-edbfd0323fdf/go.mod h1:Mc/swk1M2pyFi60f+urOPJo7K6lTnS9NMF5dJNjrffE=
 github.com/ipfs/go-graphsync v0.0.0-20190806205338-f506993bcc90 h1:Ow8i70zrww6+U9b68b7TOyivaMNk79hz59WB2qjXLgQ=
 github.com/ipfs/go-graphsync v0.0.0-20190806205338-f506993bcc90/go.mod h1:kWwu6mFFtlqD6PM4rU3PutXlwanwg+Sefkd5eWHpFio=
+github.com/ipfs/go-graphsync v0.0.1-filecoin h1:Z8TyQw9mhlRFeMiN+/2xgBMkPp0EU1SnA/BhT5VUyTQ=
+github.com/ipfs/go-graphsync v0.0.1-filecoin/go.mod h1:ICL/OYl1sg5VTjM+jVwuNGyScs/wzs+cpeyl1HdOXyc=
 github.com/ipfs/go-hamt-ipld v0.0.1 h1:dOS1Bp9hyZUozI4Y7rC+FJqitur00tWlIFmLLgNev38=
 github.com/ipfs/go-hamt-ipld v0.0.1/go.mod h1:WrX60HHX2SeMb602Z1s9Ztnf/4fzNHzwH9gxNTVpEmk=
 github.com/ipfs/go-ipfs-blockstore v0.0.1 h1:O9n3PbmTYZoNhkgkEyrXTznbmktIXif62xLX+8dPHzc=
@@ -412,6 +414,8 @@ github.com/ipld/go-ipld-prime v0.0.0-20190727004028-8623c7a03978 h1:idRwgPC9oCGn
 github.com/ipld/go-ipld-prime v0.0.0-20190727004028-8623c7a03978/go.mod h1:bDDSvVz7vaK12FNvMeRYnpRFkSUPNQOiCYQezMD/P3w=
 github.com/ipld/go-ipld-prime v0.0.0-20190730002952-369bb56ad071 h1:+jRGf/jb5MnxBsLYczZF0u5pr3nzfbS8pPt/49Yxekw=
 github.com/ipld/go-ipld-prime v0.0.0-20190730002952-369bb56ad071/go.mod h1:bDDSvVz7vaK12FNvMeRYnpRFkSUPNQOiCYQezMD/P3w=
+github.com/ipld/go-ipld-prime v0.0.1-filecoin h1:jK1bUG/z73GNeKrNlVfdexkEIIWp0BEsBVjHkh9WvXo=
+github.com/ipld/go-ipld-prime v0.0.1-filecoin/go.mod h1:bDDSvVz7vaK12FNvMeRYnpRFkSUPNQOiCYQezMD/P3w=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/jackpal/gateway v1.0.4 h1:LS5EHkLuQ6jzaHwULi0vL+JO0mU/n4yUtK8oUjHHOlM=

--- a/net/graphsync_fetcher_test.go
+++ b/net/graphsync_fetcher_test.go
@@ -22,6 +22,7 @@ import (
 	ipldfree "github.com/ipld/go-ipld-prime/impl/free"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
+	selectorbuilder "github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	"github.com/libp2p/go-libp2p-core/peer"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/assert"
@@ -43,13 +44,13 @@ func TestGraphsyncFetcher(t *testing.T) {
 	pid0 := th.RequireIntPeerID(t, 0)
 	builder := chain.NewBuilder(t, address.Undef)
 
-	ssb := selector.NewSelectorSpecBuilder(ipldfree.NodeBuilder())
-	layer1Selector, err := ssb.ExploreFields(func(efsb selector.ExploreFieldsSpecBuilder) {
+	ssb := selectorbuilder.NewSelectorSpecBuilder(ipldfree.NodeBuilder())
+	layer1Selector, err := ssb.ExploreFields(func(efsb selectorbuilder.ExploreFieldsSpecBuilder) {
 		efsb.Insert("messages", ssb.Matcher())
 		efsb.Insert("messageReceipts", ssb.Matcher())
 	}).Selector()
 	require.NoError(t, err)
-	gsSelector, err := ssb.ExploreRecursive(1, ssb.ExploreFields(func(efsb selector.ExploreFieldsSpecBuilder) {
+	gsSelector, err := ssb.ExploreRecursive(1, ssb.ExploreFields(func(efsb selectorbuilder.ExploreFieldsSpecBuilder) {
 		efsb.Insert("messages", ssb.Matcher())
 		efsb.Insert("messageReceipts", ssb.Matcher())
 		efsb.Insert("parents", ssb.ExploreUnion(
@@ -58,7 +59,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		))
 	})).Selector()
 	require.NoError(t, err)
-	gsSelectorRound2, err := ssb.ExploreRecursive(4, ssb.ExploreFields(func(efsb selector.ExploreFieldsSpecBuilder) {
+	gsSelectorRound2, err := ssb.ExploreRecursive(4, ssb.ExploreFields(func(efsb selectorbuilder.ExploreFieldsSpecBuilder) {
 		efsb.Insert("messages", ssb.Matcher())
 		efsb.Insert("messageReceipts", ssb.Matcher())
 		efsb.Insert("parents", ssb.ExploreUnion(


### PR DESCRIPTION
# Goals

Updates to a tagged version of Graphsync that relies on a tagged version of go-ipld-prime (which is based on master, as opposed to a branch)

# Implementation

Update versions. One utility class -- the selector builder -- was moved to a different package so there are a couple changes.

# For discussion

**Why the prerelease in the version name?**

Put this there cause it seems very likely we will need to merge a few bug fixes to one of these libraries prior to release and I'd like to not have a bunch of actual version updates till we have the release -- which will be the first production release for both these libraries.

Also don't want to mess with Eric Mehre's timeline on go-ipld-prime.