### PR TITLE
Have miner confirm that payment conditions are valid before continuing with payment deal

### DIFF
--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -60,9 +60,9 @@ func (a *API) CreatePayments(ctx context.Context, config CreatePaymentsParams) (
 	return CreatePayments(ctx, a, config)
 }
 
-// ValidateStoragePaymentCondition validates that the given condition is a payment condition and has the right values
-func (a *API) ValidateStoragePaymentCondition(ctx context.Context, condition *types.Predicate, minerAddr address.Address, commP types.CommP, pieceSize *types.BytesAmount) error {
-	return ValidateStoragePaymentCondition(ctx, condition, minerAddr, commP, pieceSize)
+// ValidatePaymentVoucherCondition validates that the given condition is a payment condition and has the right values
+func (a *API) ValidatePaymentVoucherCondition(ctx context.Context, condition *types.Predicate, minerAddr address.Address, commP types.CommP, pieceSize *types.BytesAmount) error {
+	return ValidatePaymentVoucherCondition(ctx, condition, minerAddr, commP, pieceSize)
 }
 
 // DealGet returns a single deal matching a given cid or an error

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -60,6 +60,11 @@ func (a *API) CreatePayments(ctx context.Context, config CreatePaymentsParams) (
 	return CreatePayments(ctx, a, config)
 }
 
+// ValidateStoragePaymentCondition validates that the given condition is a payment condition and has the right values
+func (a *API) ValidateStoragePaymentCondition(ctx context.Context, condition *types.Predicate, minerAddr address.Address, commP types.CommP, pieceSize *types.BytesAmount) error {
+	return ValidateStoragePaymentCondition(ctx, condition, minerAddr, commP, pieceSize)
+}
+
 // DealGet returns a single deal matching a given cid or an error
 func (a *API) DealGet(ctx context.Context, proposalCid cid.Cid) (*storagedeal.Deal, error) {
 	return DealGet(ctx, a, proposalCid)

--- a/protocol/storage/client.go
+++ b/protocol/storage/client.go
@@ -126,7 +126,7 @@ func (smc *Client) ProposeDeal(ctx context.Context, miner address.Address, data 
 
 	// Generating the piece commitment is a computationally expensive operation and can take
 	// many minutes depending on the size of the piece.
-	res, err := proofs.GeneratePieceCommitment(proofs.GeneratePieceCommitmentRequest{
+	pieceCommitmentResponse, err := proofs.GeneratePieceCommitment(proofs.GeneratePieceCommitmentRequest{
 		PieceReader: pieceReader,
 		PieceSize:   types.NewBytesAmount(pieceSize),
 	})
@@ -194,7 +194,7 @@ func (smc *Client) ProposeDeal(ctx context.Context, miner address.Address, data 
 			Value:           totalCost,
 			Duration:        duration,
 			MinerAddress:    miner,
-			CommP:           res.CommP,
+			CommP:           pieceCommitmentResponse.CommP,
 			PaymentInterval: VoucherInterval,
 			PieceSize:       types.NewBytesAmount(pieceSize),
 			ChannelExpiry:   *chainHeight.Add(types.NewBlockHeight(duration + ChannelExpiryInterval)),

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	cbor "github.com/ipfs/go-ipld-cbor"
+	"github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log"
 	dag "github.com/ipfs/go-merkledag"
 	uio "github.com/ipfs/go-unixfs/io"
@@ -27,6 +28,7 @@ import (
 	cbu "github.com/filecoin-project/go-filecoin/cborutil"
 	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/porcelain"
+	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/repo"
@@ -88,6 +90,8 @@ type minerPorcelain interface {
 
 	DealGet(context.Context, cid.Cid) (*storagedeal.Deal, error)
 	DealPut(*storagedeal.Deal) error
+
+	ValidateStoragePaymentCondition(ctx context.Context, condition *types.Predicate, minerAddr address.Address, commP types.CommP, pieceSize *types.BytesAmount) error
 
 	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
 	MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error)
@@ -448,6 +452,13 @@ func (sm *Miner) processStorageDeal(proposalCid cid.Cid) {
 		return
 	}
 
+	// Before adding piece, confirm that client has generated payment conditions correctly now that
+	// we can compute CommP
+	if err := sm.validatePieceCommitments(ctx, d, rootIpldNode, dagService); err != nil {
+		fail("payment error", fmt.Sprintf("failed to add piece: %s", err))
+		return
+	}
+
 	r, err := uio.NewDagReader(ctx, rootIpldNode, dagService)
 	if err != nil {
 		fail("internal error", fmt.Sprintf("failed to add piece: %s", err))
@@ -482,6 +493,32 @@ func (sm *Miner) processStorageDeal(proposalCid cid.Cid) {
 	if err := sm.saveDealsAwaitingSeal(); err != nil {
 		log.Errorf("could not save deal awaiting seal: %s", err)
 	}
+}
+
+func (sm *Miner) validatePieceCommitments(ctx context.Context, deal *storagedeal.Deal, rootIpldNode format.Node, serv format.NodeGetter) error {
+	pieceReader, err := uio.NewDagReader(ctx, rootIpldNode, serv)
+	if err != nil {
+		return err
+	}
+
+	// Generating the piece commitment is a computationally expensive operation and can take
+	// many minutes depending on the size of the piece.
+	pieceCommitmentResponse, err := proofs.GeneratePieceCommitment(proofs.GeneratePieceCommitmentRequest{
+		PieceReader: pieceReader,
+		PieceSize:   types.NewBytesAmount(deal.Proposal.Size.Uint64()),
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to generate pieceCommitmentResponse commitment")
+	}
+
+	for _, voucher := range deal.Proposal.Payment.Vouchers {
+		err := porcelain.ValidateStoragePaymentCondition(ctx, voucher.Condition, sm.minerAddr, pieceCommitmentResponse.CommP, deal.Proposal.Size)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (sm *Miner) loadDealsAwaitingSeal() error {

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -91,7 +91,7 @@ type minerPorcelain interface {
 	DealGet(context.Context, cid.Cid) (*storagedeal.Deal, error)
 	DealPut(*storagedeal.Deal) error
 
-	ValidateStoragePaymentCondition(ctx context.Context, condition *types.Predicate, minerAddr address.Address, commP types.CommP, pieceSize *types.BytesAmount) error
+	ValidatePaymentVoucherCondition(ctx context.Context, condition *types.Predicate, minerAddr address.Address, commP types.CommP, pieceSize *types.BytesAmount) error
 
 	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
 	MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error)
@@ -512,7 +512,7 @@ func (sm *Miner) validatePieceCommitments(ctx context.Context, deal *storagedeal
 	}
 
 	for _, voucher := range deal.Proposal.Payment.Vouchers {
-		err := porcelain.ValidateStoragePaymentCondition(ctx, voucher.Condition, sm.minerAddr, pieceCommitmentResponse.CommP, deal.Proposal.Size)
+		err := porcelain.ValidatePaymentVoucherCondition(ctx, voucher.Condition, sm.minerAddr, pieceCommitmentResponse.CommP, deal.Proposal.Size)
 		if err != nil {
 			return err
 		}

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -798,7 +798,7 @@ func (mtp *minerTestPorcelain) ChainSampleRandomness(ctx context.Context, sample
 	return bytes, nil
 }
 
-func (mtp *minerTestPorcelain) ValidateStoragePaymentCondition(ctx context.Context, condition *types.Predicate, minerAddr address.Address, commP types.CommP, pieceSize *types.BytesAmount) error {
+func (mtp *minerTestPorcelain) ValidatePaymentVoucherCondition(ctx context.Context, condition *types.Predicate, minerAddr address.Address, commP types.CommP, pieceSize *types.BytesAmount) error {
 	return nil
 }
 

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -798,6 +798,10 @@ func (mtp *minerTestPorcelain) ChainSampleRandomness(ctx context.Context, sample
 	return bytes, nil
 }
 
+func (mtp *minerTestPorcelain) ValidateStoragePaymentCondition(ctx context.Context, condition *types.Predicate, minerAddr address.Address, commP types.CommP, pieceSize *types.BytesAmount) error {
+	return nil
+}
+
 func (mtp *minerTestPorcelain) MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error {
 	return nil
 }


### PR DESCRIPTION
closes #2572

### Problem

A miner does quite a bit of validation of payment data prior to accepting the deal. Unfortunately, the miner cannot confirm the client has specified the correct commitment until they are in possession of the client's data.

### Solution

Once the client has exported their data, have the miner generate a piece commitment from it. Then have the miner validate all the payments go the the right method on the right miner with the right CommP and piece size.