### PR TITLE
sign and verify deal response

### DIFF
--- a/plumbing/strgdls/store_test.go
+++ b/plumbing/strgdls/store_test.go
@@ -46,13 +46,15 @@ func TestDealStoreRoundTrip(t *testing.T) {
 			ValidAt: *validAt,
 		}}}
 
-	proposal := &storagedeal.Proposal{
-		PieceRef:     pieceRefCid,
-		Size:         size,
-		TotalPrice:   totalPrice,
-		Duration:     duration,
-		MinerAddress: minerAddr,
-		Payment:      payment,
+	proposal := &storagedeal.SignedProposal{
+		Proposal: storagedeal.Proposal{
+			PieceRef:     pieceRefCid,
+			Size:         size,
+			TotalPrice:   totalPrice,
+			Duration:     duration,
+			MinerAddress: minerAddr,
+			Payment:      payment,
+		},
 	}
 
 	proposalCid, err := convert.ToCid(proposal)
@@ -64,12 +66,14 @@ func TestDealStoreRoundTrip(t *testing.T) {
 	storageDeal := &storagedeal.Deal{
 		Miner:    minerAddr,
 		Proposal: proposal,
-		Response: &storagedeal.Response{
-			State:       storagedeal.Accepted,
-			Message:     responseMessage,
-			ProposalCid: proposalCid,
-			ProofInfo:   &storagedeal.ProofInfo{CommitmentMessage: messageCid},
-			Signature:   []byte("signature"),
+		Response: &storagedeal.SignedResponse{
+			Response: storagedeal.Response{
+				State:       storagedeal.Accepted,
+				Message:     responseMessage,
+				ProposalCid: proposalCid,
+				ProofInfo:   &storagedeal.ProofInfo{CommitmentMessage: messageCid},
+			},
+			Signature: []byte("signature"),
 		},
 	}
 

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -126,7 +126,7 @@ func (a *API) MinerGetOwnerAddress(ctx context.Context, minerAddr address.Addres
 	return MinerGetOwnerAddress(ctx, a, minerAddr)
 }
 
-// MinerGetWorkerAddress queries for the owner address of the given miner
+// MinerGetWorkerAddress queries for the worker address of the given miner
 func (a *API) MinerGetWorkerAddress(ctx context.Context, minerAddr address.Address) (address.Address, error) {
 	return MinerGetWorkerAddress(ctx, a, minerAddr)
 }

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -126,6 +126,11 @@ func (a *API) MinerGetOwnerAddress(ctx context.Context, minerAddr address.Addres
 	return MinerGetOwnerAddress(ctx, a, minerAddr)
 }
 
+// MinerGetWorkerAddress queries for the owner address of the given miner
+func (a *API) MinerGetWorkerAddress(ctx context.Context, minerAddr address.Address) (address.Address, error) {
+	return MinerGetWorkerAddress(ctx, a, minerAddr)
+}
+
 // MinerGetSectorSize queries for the sector size of the given miner.
 func (a *API) MinerGetSectorSize(ctx context.Context, minerAddr address.Address) (*types.BytesAmount, error) {
 	return MinerGetSectorSize(ctx, a, minerAddr)

--- a/porcelain/miner.go
+++ b/porcelain/miner.go
@@ -281,6 +281,16 @@ func MinerGetOwnerAddress(ctx context.Context, plumbing minerQueryAndDeserialize
 	return address.NewFromBytes(res[0])
 }
 
+// MinerGetWorkerAddress queries for the worker address of the given miner
+func MinerGetWorkerAddress(ctx context.Context, plumbing minerQueryAndDeserialize, minerAddr address.Address) (address.Address, error) {
+	res, err := plumbing.MessageQuery(ctx, address.Undef, minerAddr, "getWorker")
+	if err != nil {
+		return address.Undef, err
+	}
+
+	return address.NewFromBytes(res[0])
+}
+
 // queryAndDeserialize is a convenience method. It sends a query message to a
 // miner and, based on the method return-type, deserializes to the appropriate
 // ABI type.

--- a/porcelain/miner_test.go
+++ b/porcelain/miner_test.go
@@ -413,13 +413,13 @@ func TestMinerPreviewSetPrice(t *testing.T) {
 	})
 }
 
-type minerGetOwnerPlumbing struct{}
+type minerQueryAndDeserializePlumbing struct{}
 
-func (mgop *minerGetOwnerPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error) {
+func (mgop *minerQueryAndDeserializePlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error) {
 	return [][]byte{address.TestAddress.Bytes()}, nil
 }
 
-func (mgop *minerGetOwnerPlumbing) ActorGetSignature(ctx context.Context, actorAddr address.Address, method string) (*exec.FunctionSignature, error) {
+func (mgop *minerQueryAndDeserializePlumbing) ActorGetSignature(ctx context.Context, actorAddr address.Address, method string) (*exec.FunctionSignature, error) {
 	if method == "getSectorSize" {
 		return &exec.FunctionSignature{
 			Params: nil,
@@ -433,7 +433,15 @@ func (mgop *minerGetOwnerPlumbing) ActorGetSignature(ctx context.Context, actorA
 func TestMinerGetOwnerAddress(t *testing.T) {
 	tf.UnitTest(t)
 
-	addr, err := MinerGetOwnerAddress(context.Background(), &minerGetOwnerPlumbing{}, address.TestAddress2)
+	addr, err := MinerGetOwnerAddress(context.Background(), &minerQueryAndDeserializePlumbing{}, address.TestAddress2)
+	assert.NoError(t, err)
+	assert.Equal(t, address.TestAddress, addr)
+}
+
+func TestMinerGetWorkerAddress(t *testing.T) {
+	tf.UnitTest(t)
+
+	addr, err := MinerGetWorkerAddress(context.Background(), &minerQueryAndDeserializePlumbing{}, address.TestAddress2)
 	assert.NoError(t, err)
 	assert.Equal(t, address.TestAddress, addr)
 }
@@ -441,7 +449,7 @@ func TestMinerGetOwnerAddress(t *testing.T) {
 func TestMinerGetPower(t *testing.T) {
 	tf.UnitTest(t)
 
-	power, err := MinerGetPower(context.Background(), &minerGetOwnerPlumbing{}, address.TestAddress2)
+	power, err := MinerGetPower(context.Background(), &minerQueryAndDeserializePlumbing{}, address.TestAddress2)
 	assert.NoError(t, err)
 	assert.Equal(t, "2", power.Total.String())
 	assert.Equal(t, "2", power.Power.String())

--- a/porcelain/miner_test.go
+++ b/porcelain/miner_test.go
@@ -416,7 +416,18 @@ func TestMinerPreviewSetPrice(t *testing.T) {
 type minerQueryAndDeserializePlumbing struct{}
 
 func (mgop *minerQueryAndDeserializePlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error) {
-	return [][]byte{address.TestAddress.Bytes()}, nil
+	switch method {
+	case "getOwner":
+		return [][]byte{address.TestAddress.Bytes()}, nil
+	case "getWorker":
+		return [][]byte{address.TestAddress2.Bytes()}, nil
+	case "getPower":
+		return [][]byte{types.NewBytesAmount(2).Bytes()}, nil
+	case "getTotalStorage":
+		return [][]byte{types.NewBytesAmount(4).Bytes()}, nil
+	default:
+		return nil, fmt.Errorf("unsupported method: %s", method)
+	}
 }
 
 func (mgop *minerQueryAndDeserializePlumbing) ActorGetSignature(ctx context.Context, actorAddr address.Address, method string) (*exec.FunctionSignature, error) {
@@ -443,7 +454,7 @@ func TestMinerGetWorkerAddress(t *testing.T) {
 
 	addr, err := MinerGetWorkerAddress(context.Background(), &minerQueryAndDeserializePlumbing{}, address.TestAddress2)
 	assert.NoError(t, err)
-	assert.Equal(t, address.TestAddress, addr)
+	assert.Equal(t, address.TestAddress2, addr)
 }
 
 func TestMinerGetPower(t *testing.T) {
@@ -451,7 +462,7 @@ func TestMinerGetPower(t *testing.T) {
 
 	power, err := MinerGetPower(context.Background(), &minerQueryAndDeserializePlumbing{}, address.TestAddress2)
 	assert.NoError(t, err)
-	assert.Equal(t, "2", power.Total.String())
+	assert.Equal(t, "4", power.Total.String())
 	assert.Equal(t, "2", power.Power.String())
 }
 

--- a/porcelain/storagedeals_test.go
+++ b/porcelain/storagedeals_test.go
@@ -43,8 +43,10 @@ func TestDealGet(t *testing.T) {
 	cidGetter := types.NewCidForTestGetter()
 	dealCid := cidGetter()
 	expectedDeal := &storagedeal.Deal{
-		Response: &storagedeal.Response{
-			ProposalCid: dealCid,
+		Response: &storagedeal.SignedResponse{
+			Response: storagedeal.Response{
+				ProposalCid: dealCid,
+			},
 		},
 	}
 
@@ -65,8 +67,10 @@ func TestDealGetNotFound(t *testing.T) {
 	dealCid := cidGetter()
 	badCid := cidGetter()
 	expectedDeal := &storagedeal.Deal{
-		Response: &storagedeal.Response{
-			ProposalCid: dealCid,
+		Response: &storagedeal.SignedResponse{
+			Response: storagedeal.Response{
+				ProposalCid: dealCid,
+			},
 		},
 	}
 
@@ -105,9 +109,11 @@ func (trp *testRedeemPlumbing) DealGet(_ context.Context, c cid.Cid) (*storagede
 	require.Equal(trp.t, trp.dealCid, c)
 
 	deal := &storagedeal.Deal{
-		Proposal: &storagedeal.Proposal{
-			Payment: storagedeal.PaymentInfo{
-				Vouchers: trp.vouchers,
+		Proposal: &storagedeal.SignedProposal{
+			Proposal: storagedeal.Proposal{
+				Payment: storagedeal.PaymentInfo{
+					Vouchers: trp.vouchers,
+				},
 			},
 		},
 	}

--- a/protocol/storage/api.go
+++ b/protocol/storage/api.go
@@ -22,13 +22,13 @@ func NewAPI(storageClient *Client) API {
 
 // ProposeStorageDeal calls the storage client ProposeDeal function
 func (a *API) ProposeStorageDeal(ctx context.Context, data cid.Cid, miner address.Address,
-	askid uint64, duration uint64, allowDuplicates bool) (*storagedeal.Response, error) {
+	askid uint64, duration uint64, allowDuplicates bool) (*storagedeal.SignedResponse, error) {
 
 	return a.sc.ProposeDeal(ctx, miner, data, askid, duration, allowDuplicates)
 }
 
 // QueryStorageDeal calls the storage client QueryDeal function
-func (a *API) QueryStorageDeal(ctx context.Context, prop cid.Cid) (*storagedeal.Response, error) {
+func (a *API) QueryStorageDeal(ctx context.Context, prop cid.Cid) (*storagedeal.SignedResponse, error) {
 	return a.sc.QueryDeal(ctx, prop)
 }
 

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -390,13 +390,14 @@ func (sm *Miner) rejectProposal(p *storagedeal.Proposal, reason string) (*storag
 	return resp, nil
 }
 
-func (sm *Miner) updateDealResponse(ctx context.Context, proposalCid cid.Cid, f func(*storagedeal.Response)) error {
+// updateDealResponse retrieves a deal, operates on its response with a provided callback then signs the deal and stores it.
+func (sm *Miner) updateDealResponse(ctx context.Context, proposalCid cid.Cid, callback func(*storagedeal.Response)) error {
 	deal, err := sm.porcelainAPI.DealGet(ctx, proposalCid)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get retrieve deal with proposal CID %s", proposalCid.String())
 	}
 
-	f(deal.Response)
+	callback(deal.Response)
 
 	if err = deal.Response.Sign(sm.porcelainAPI, sm.workerAddr); err != nil {
 		return errors.Wrap(err, "could not sign deal response")

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -563,7 +563,7 @@ func (sm *Miner) signDealResponse(resp *storagedeal.Response) error {
 		return err
 	}
 
-	resp.Signature, err = sm.porcelainAPI.SignBytes(respBytes, sm.ownerAddr)
+	resp.Signature, err = sm.porcelainAPI.SignBytes(respBytes, sm.workerAddr)
 	return err
 }
 

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -817,6 +817,10 @@ func (mtp *minerTestPorcelain) MinerCalculateLateFee(ctx context.Context, minerA
 	return types.ZeroAttoFIL, nil
 }
 
+func (mtp *minerTestPorcelain) SignBytes(data []byte, addr address.Address) (types.Signature, error) {
+	return addr.Bytes(), nil
+}
+
 func newTestMiner(api *minerTestPorcelain) *Miner {
 	return &Miner{
 		porcelainAPI: api,

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -55,7 +55,7 @@ func TestReceiveStorageProposal(t *testing.T) {
 		_, err := miner.receiveStorageProposal(context.Background(), proposal)
 		require.NoError(t, err)
 
-		// one deal should be stored and it should have been accepted
+		// one deal should be stored and it should have been accepted and signed
 		require.Len(t, porcelainAPI.deals, 1)
 		for _, deal := range porcelainAPI.deals {
 			assert.Equal(t, storagedeal.Accepted, deal.Response.State)

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -668,6 +668,7 @@ type minerTestPorcelain struct {
 	config          *cfg.Config
 	payerAddress    address.Address
 	targetAddress   address.Address
+	workerAddress   address.Address
 	channelID       *types.ChannelID
 	messageCid      *cid.Cid
 	signer          types.MockSigner
@@ -687,9 +688,11 @@ var _ minerPorcelain = (*minerTestPorcelain)(nil)
 type messageHandlerMap map[string]func(address.Address, types.AttoFIL, ...interface{}) ([][]byte, error)
 
 func newMinerTestPorcelain(t *testing.T, minerPriceString string) *minerTestPorcelain {
-	mockSigner, ki := types.NewMockSignersAndKeyInfo(1)
+	mockSigner, ki := types.NewMockSignersAndKeyInfo(2)
 	payerAddr, err := ki[0].Address()
 	require.NoError(t, err, "Could not create payer address")
+	workerAddr, err := ki[1].Address()
+	require.NoError(t, err, "Could not create worker address")
 
 	addressGetter := address.NewForTestGetter()
 	cidGetter := types.NewCidForTestGetter()
@@ -704,6 +707,7 @@ func newMinerTestPorcelain(t *testing.T, minerPriceString string) *minerTestPorc
 		config:          config,
 		payerAddress:    payerAddr,
 		targetAddress:   addressGetter(),
+		workerAddress:   workerAddr,
 		channelID:       types.NewChannelID(73),
 		messageCid:      &messageCid,
 		signer:          mockSigner,
@@ -800,7 +804,7 @@ func (mtp *minerTestPorcelain) MinerCalculateLateFee(ctx context.Context, minerA
 }
 
 func (mtp *minerTestPorcelain) SignBytes(data []byte, addr address.Address) (types.Signature, error) {
-	return addr.Bytes(), nil
+	return mtp.signer.SignBytes(data, addr)
 }
 
 func newTestMiner(api *minerTestPorcelain) *Miner {

--- a/protocol/storage/storagedeal/types.go
+++ b/protocol/storage/storagedeal/types.go
@@ -11,8 +11,9 @@ import (
 func init() {
 	cbor.RegisterCborType(PaymentInfo{})
 	cbor.RegisterCborType(Proposal{})
+	cbor.RegisterCborType(SignedProposal{})
 	cbor.RegisterCborType(Response{})
-	cbor.RegisterCborType(SignedDealProposal{})
+	cbor.RegisterCborType(SignedResponse{})
 	cbor.RegisterCborType(ProofInfo{})
 	cbor.RegisterCborType(QueryRequest{})
 	cbor.RegisterCborType(Deal{})
@@ -73,8 +74,8 @@ func (dp *Proposal) Marshal() ([]byte, error) {
 	return cbor.DumpObject(dp)
 }
 
-// NewSignedProposal signs Proposal with address `addr` and returns a SignedDealProposal.
-func (dp *Proposal) NewSignedProposal(addr address.Address, signer types.Signer) (*SignedDealProposal, error) {
+// NewSignedProposal signs Proposal with address `addr` and returns a SignedProposal.
+func (dp *Proposal) NewSignedProposal(addr address.Address, signer types.Signer) (*SignedProposal, error) {
 	data, err := dp.Marshal()
 	if err != nil {
 		return nil, err
@@ -84,14 +85,14 @@ func (dp *Proposal) NewSignedProposal(addr address.Address, signer types.Signer)
 	if err != nil {
 		return nil, err
 	}
-	return &SignedDealProposal{
+	return &SignedProposal{
 		Proposal:  *dp,
 		Signature: sig,
 	}, nil
 }
 
-// SignedDealProposal is a deal proposal signed by the proposing client
-type SignedDealProposal struct {
+// SignedProposal is a deal proposal signed by the proposing client
+type SignedProposal struct {
 	Proposal
 	// Signature is the signature of the client proposing the deal.
 	Signature types.Signature
@@ -111,15 +112,19 @@ type Response struct {
 	// ProofInfo is a collection of information needed to convince the client that
 	// the miner has sealed the data into a sector.
 	ProofInfo *ProofInfo
+}
+
+// SignedResponse is a signed wrapper around response
+type SignedResponse struct {
+	Response
 
 	// Signature is a signature from the miner over the response
 	Signature types.Signature
 }
 
 // Sign signs this response
-func (r *Response) Sign(signer types.Signer, addr address.Address) error {
-	r.Signature = nil
-	respBytes, err := cbor.DumpObject(r)
+func (r *SignedResponse) Sign(signer types.Signer, addr address.Address) error {
+	respBytes, err := cbor.DumpObject(r.Response)
 	if err != nil {
 		return err
 	}
@@ -129,11 +134,8 @@ func (r *Response) Sign(signer types.Signer, addr address.Address) error {
 }
 
 // VerifySignature verifies the signature of this response
-func (r *Response) VerifySignature(addr address.Address) (bool, error) {
-	var responseCopy Response
-	responseCopy = *r
-	responseCopy.Signature = nil
-	respBytes, err := cbor.DumpObject(responseCopy)
+func (r *SignedResponse) VerifySignature(addr address.Address) (bool, error) {
+	respBytes, err := cbor.DumpObject(r.Response)
 	if err != nil {
 		return false, err
 	}
@@ -144,9 +146,9 @@ func (r *Response) VerifySignature(addr address.Address) (bool, error) {
 // Deal is a storage deal struct
 type Deal struct {
 	Miner    address.Address
-	Proposal *Proposal
-	Response *Response
 	CommP    types.CommP
+	Proposal *SignedProposal
+	Response *SignedResponse
 }
 
 // ProofInfo contains the details about a seal proof, that the client needs to know to verify that his deal was posted on chain.

--- a/protocol/storage/storagedeal/types.go
+++ b/protocol/storage/storagedeal/types.go
@@ -116,6 +116,31 @@ type Response struct {
 	Signature types.Signature
 }
 
+// Sign signs this response
+func (r *Response) Sign(signer types.Signer, addr address.Address) error {
+	r.Signature = nil
+	respBytes, err := cbor.DumpObject(r)
+	if err != nil {
+		return err
+	}
+
+	r.Signature, err = signer.SignBytes(respBytes, addr)
+	return err
+}
+
+// VerifySignature verifies the signature of this response
+func (r *Response) VerifySignature(addr address.Address) (bool, error) {
+	var responseCopy Response
+	responseCopy = *r
+	responseCopy.Signature = nil
+	respBytes, err := cbor.DumpObject(responseCopy)
+	if err != nil {
+		return false, err
+	}
+
+	return types.IsValidSignature(respBytes, addr, r.Signature), nil
+}
+
 // Deal is a storage deal struct
 type Deal struct {
 	Miner    address.Address


### PR DESCRIPTION
closes #1211

### Problem

The storage miner's deal response has contained a `Signature` field for some time, but we've never actually populated it. It's critical that the miner signs the deal, because the response forms a contract that can be posted on chain for deal arbitration.

### Solution

Sign the deal proposal when the deal is accepted, when it's rejected, and when it's updated. Also have the client check the signature whenever a deal response is received.

### Refactors

This PR refactors `protocols/storage/miner` to abstract just the processing of the deal. This allows us to test the deal acceptance and deal rejection.

This PR also adds porcelain to retrieve the miner worker address because that is the address used to sign the response.