### PR TITLE
Improve logging and error messages around graphsync chain fetch.

### DIFF
--- a/chain/message_store.go
+++ b/chain/message_store.go
@@ -43,7 +43,7 @@ func (ms *MessageStore) LoadMessages(ctx context.Context, c cid.Cid) ([]*types.S
 	var out types.MessageCollection
 	err := ms.ipldStore.Get(ctx, c, &out)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not load message collection with cid: %s", c.String())
+		return nil, errors.Wrapf(err, "failed to load messages %s", c.String())
 	}
 	return []*types.SignedMessage(out), nil
 }
@@ -63,7 +63,7 @@ func (ms *MessageStore) LoadReceipts(ctx context.Context, c cid.Cid) ([]*types.M
 	var out types.ReceiptCollection
 	err := ms.ipldStore.Get(ctx, c, &out)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not load receipt collection with cid: %s", c.String())
+		return nil, errors.Wrapf(err, "failed to load receipts %s", c.String())
 	}
 	return []*types.MessageReceipt(out), nil
 }

--- a/chain/syncer.go
+++ b/chain/syncer.go
@@ -157,11 +157,11 @@ func (syncer *Syncer) syncOne(ctx context.Context, parent, next types.TipSet) er
 		blk := next.At(i)
 		msgs, err := syncer.messageProvider.LoadMessages(ctx, blk.Messages)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "syncing tip %s failed loading message list %s for block %s", next.Key(), blk.Messages, blk.Cid())
 		}
 		rcpts, err := syncer.messageProvider.LoadReceipts(ctx, blk.MessageReceipts)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "syncing tip %s failed loading receipts list %s for block %s", next.Key(), blk.MessageReceipts, blk.Cid())
 		}
 		nextMessages = append(nextMessages, msgs)
 		nextReceipts = append(nextReceipts, rcpts)

--- a/node/node.go
+++ b/node/node.go
@@ -570,7 +570,7 @@ func (node *Node) Start(ctx context.Context) error {
 			trusted := true
 			err := node.Syncer.HandleNewTipSet(context.Background(), ci, trusted)
 			if err != nil {
-				log.Infof("error handling blocks: %s", ci.Head.String())
+				log.Infof("error handling tipset from hello %s: %s", ci, err)
 				return
 			}
 			// For now, consider the initial bootstrap done after the syncer has (synchronously)

--- a/types/chain_info.go
+++ b/types/chain_info.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -21,6 +23,11 @@ func NewChainInfo(peer peer.ID, head TipSetKey, height uint64) *ChainInfo {
 		Height:  height,
 		Trusted: true,
 	}
+}
+
+// Returns a human-readable string representation of a chain info
+func (i *ChainInfo) String() string {
+	return fmt.Sprintf("{peer=%s height=%d head=%s}", i.Peer, i.Height, i.Head)
 }
 
 // CISlice is for sorting chain infos


### PR DESCRIPTION
Re #3220. This doesn't actually fix anything, but points to the failure a bit better.

Result:
```
15:20:41.370  INFO net.graphs: fetching initial tipset { bafy2bzacebf4rvcnwk5e3aox4nj75sfspf3evpw3vbh4zy65so7khipy76m7w bafy2bzaceboxgks2bx3wn7wjwrsulzwnohlf27ywk3aqzpxsmogvg3aztssli } from peer QmXhxqTKzBKHA5FcMuiKZv8YaMPwpbKGXHRVZcFB2DX9XY graphsync_fetcher.go:109
15:20:41.370  INFO net.graphs: fetching chain from height 7712, block bafy2bzacebf4rvcnwk5e3aox4nj75sfspf3evpw3vbh4zy65so7khipy76m7w, peer QmXhxqTKzBKHA5FcMuiKZv8YaMPwpbKGXHRVZcFB2DX9XY, 1 levels graphsync_fetcher.go:145
15:20:41.370  INFO net.graphs: fetching chain from height 7710, block bafy2bzacedynkwwaywseknh5szbf5jryuiendddzvq2vcxbbrymuaosc22d6m, peer QmXhxqTKzBKHA5FcMuiKZv8YaMPwpbKGXHRVZcFB2DX9XY, 4 levels graphsync_fetcher.go:145
15:20:41.371  INFO net.graphs: fetching chain from height 7705, block bafy2bzacec7nuqqjneucw5kdpucjvzdir43c5taoy5y6uaaxlnjevzb7fbypw, peer QmXhxqTKzBKHA5FcMuiKZv8YaMPwpbKGXHRVZcFB2DX9XY, 16 levels graphsync_fetcher.go:145
15:20:41.374  INFO net.graphs: fetching chain from height 7671, block bafy2bzacedq5brt53tism5tivgd2zgm2b543bqyaxl4qihu4p4qu6jw5jbnbi, peer QmXhxqTKzBKHA5FcMuiKZv8YaMPwpbKGXHRVZcFB2DX9XY, 64 levels graphsync_fetcher.go:145
15:20:41.384  INFO net.graphs: fetching chain from height 7568, block bafy2bzaceahuvggn4hoodezvoonukxljzn4mxgtrzykaqagpzhftwuyf3nqmm, peer QmXhxqTKzBKHA5FcMuiKZv8YaMPwpbKGXHRVZcFB2DX9XY, 64 levels graphsync_fetcher.go:145
...
15:20:42.009  INFO net.graphs: fetching chain from height 123, block bafy2bzacedo6d53dvu6onnajjjrhg6gxrfsct7qlvsjmjkthzbxhgzwc6v5eo, peer QmXhxqTKzBKHA5FcMuiKZv8YaMPwpbKGXHRVZcFB2DX9XY, 64 levels graphsync_fetcher.go:145
15:20:42.021  INFO       node: error handling tipset from hello {peer=QmXhxqTKzBKHA5FcMuiKZv8YaMPwpbKGXHRVZcFB2DX9XY height=7712 head={ bafy2bzacebf4rvcnwk5e3aox4nj75sfspf3evpw3vbh4zy65so7khipy76m7w bafy2bzaceboxgks2bx3wn7wjwrsulzwnohlf27ywk3aqzpxsmogvg3aztssli }}: syncing tip { bafy2bzaceaut5hsrsyi7otaguxdleow2rzsdd6gnsob5xvo7bwxy7i56nfscq bafy2bzacebbkohbitfb5qhbctggcwuxyevsgnibbypb5sg3xuz5vm6psok7vw bafy2bzacebyikd7kn7ounjjhrovmvqq6a3z45hk6xkkutjf4kw3t4lcabm27q } failed loading receipts list bafy2bzaced73akpx6hvnmqx7eqmeda577pvby427z5scik2uxrroyanrvwb22 for block bafy2bzacebyikd7kn7ounjjhrovmvqq6a3z45hk6xkkutjf4kw3t4lcabm27q: failed to load receipts bafy2bzaced73akpx6hvnmqx7eqmeda577pvby427z5scik2uxrroyanrvwb22: blockservice: key not found node.go:573
```

FYI @hannahhoward @frrist @ZenGround0 