### PR TITLE
fix(net): fix bug w/ message fetching via graphsync

### DIFF
--- a/net/graphsync_fetcher.go
+++ b/net/graphsync_fetcher.go
@@ -214,10 +214,13 @@ func (gsf *GraphSyncFetcher) fetchBlocksRecursively(ctx context.Context, baseCid
 	//   - with exactly the first parent block, repeat again for its parents
 	//   - continue up to recursion depth
 	selector := gsf.ssb.ExploreRecursive(recursionDepth, gsf.ssb.ExploreFields(func(efsb selectorbuilder.ExploreFieldsSpecBuilder) {
-		efsb.Insert("messages", gsf.ssb.Matcher())
-		efsb.Insert("messageReceipts", gsf.ssb.Matcher())
 		efsb.Insert("parents", gsf.ssb.ExploreUnion(
-			gsf.ssb.ExploreAll(gsf.ssb.Matcher()),
+			gsf.ssb.ExploreAll(
+				gsf.ssb.ExploreFields(func(efsb selectorbuilder.ExploreFieldsSpecBuilder) {
+					efsb.Insert("messages", gsf.ssb.Matcher())
+					efsb.Insert("messageReceipts", gsf.ssb.Matcher())
+				}),
+			),
 			gsf.ssb.ExploreIndex(0, gsf.ssb.ExploreRecursiveEdge()),
 		))
 	})).Node()


### PR DESCRIPTION
Preliminary fix for #3220

The test (integration test) is crappy but proves the fix. BTW, it requires a very specific combination of things to fail -- the height of 22 is intentional as it's
first layer + 1 recursive layer + 4 recursive layers +16 recursive layers