### PR TITLE
FAST Updates

### DIFF
--- a/commands/client_daemon_test.go
+++ b/commands/client_daemon_test.go
@@ -103,7 +103,12 @@ func TestDuplicateDeals(t *testing.T) {
 	askPrice := big.NewFloat(0.5)
 	expiry := big.NewInt(int64(10000))
 
-	ask, err := series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, askPrice, expiry)
+	pparams, err := minerDaemon.Protocol(ctx)
+	require.NoError(t, err)
+
+	sectorSize := pparams.SupportedSectorSizes[0]
+
+	ask, err := series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, askPrice, expiry, sectorSize)
 	require.NoError(t, err)
 
 	_, err = minerClientMakeDealWithAllowDupes(ctx, t, true, minerDaemon, clientDaemon, ask.ID, duration)
@@ -289,7 +294,13 @@ func TestSelfDialStorageGoodError(t *testing.T) {
 	collateral := big.NewInt(int64(1))
 	price := big.NewFloat(float64(0.001))
 	expiry := big.NewInt(int64(500))
-	ask, err := series.CreateStorageMinerWithAsk(ctx, miningNode, collateral, price, expiry)
+
+	pparams, err := miningNode.Protocol(ctx)
+	require.NoError(t, err)
+
+	sectorSize := pparams.SupportedSectorSizes[0]
+
+	ask, err := series.CreateStorageMinerWithAsk(ctx, miningNode, collateral, price, expiry, sectorSize)
 	minerCreateDoneCh <- struct{}{}
 	require.NoError(t, err)
 

--- a/commands/deals_daemon_test.go
+++ b/commands/deals_daemon_test.go
@@ -53,7 +53,13 @@ func TestDealsRedeem(t *testing.T) {
 	collateral := big.NewInt(int64(1))
 	price := big.NewFloat(float64(1))
 	expiry := big.NewInt(int64(10000))
-	_, err := series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, price, expiry)
+
+	pparams, err := minerDaemon.Protocol(ctx)
+	require.NoError(t, err)
+
+	sectorSize := pparams.SupportedSectorSizes[0]
+
+	_, err = series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, price, expiry, sectorSize)
 	require.NoError(t, err)
 
 	f := files.NewBytesFile([]byte("HODLHODLHODL"))
@@ -220,7 +226,12 @@ func TestDealsShow(t *testing.T) {
 	price := big.NewFloat(0.000000001)      // price per byte/block
 	expiry := big.NewInt(24 * 60 * 60 / 30) // ~24 hours
 
-	ask, err := series.CreateStorageMinerWithAsk(ctx, minerNode, collateral, price, expiry)
+	pparams, err := minerNode.Protocol(ctx)
+	require.NoError(t, err)
+
+	sectorSize := pparams.SupportedSectorSizes[0]
+
+	ask, err := series.CreateStorageMinerWithAsk(ctx, minerNode, collateral, price, expiry, sectorSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, minerNode.MiningStop(ctx))
@@ -384,8 +395,13 @@ func setupDeal(
 	collateral := big.NewInt(500)           // FIL
 	expiry := big.NewInt(24 * 60 * 60 / 30) // ~24 hours
 
+	pparams, err := minerNode.Protocol(ctx)
+	require.NoError(t, err)
+
+	sectorSize := pparams.SupportedSectorSizes[0]
+
 	// Calls MiningOnce on genesis (client). This also starts the Miner.
-	ask, err := series.CreateStorageMinerWithAsk(ctx, minerNode, collateral, price, expiry)
+	ask, err := series.CreateStorageMinerWithAsk(ctx, minerNode, collateral, price, expiry, sectorSize)
 	require.NoError(t, err)
 	require.NoError(t, minerNode.MiningStop(ctx))
 

--- a/commands/mining_daemon_test.go
+++ b/commands/mining_daemon_test.go
@@ -69,7 +69,12 @@ func TestMiningSealNow(t *testing.T) {
 	require.NoError(t, series.Connect(ctx, genesisNode, minerNode))
 
 	// Calls MiningOnce on genesis (client). This also starts the Miner.
-	_, err := series.CreateStorageMinerWithAsk(ctx, minerNode, big.NewInt(500), big.NewFloat(0.0001), big.NewInt(3000))
+	pparams, err := minerNode.Protocol(ctx)
+	require.NoError(t, err)
+
+	sectorSize := pparams.SupportedSectorSizes[0]
+
+	_, err = series.CreateStorageMinerWithAsk(ctx, minerNode, big.NewInt(500), big.NewFloat(0.0001), big.NewInt(3000), sectorSize)
 	require.NoError(t, err)
 
 	// get address of miner so we can check power

--- a/tools/fast/action_client.go
+++ b/tools/fast/action_client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/commands"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
+	"github.com/filecoin-project/go-filecoin/types"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-ipfs-files"
@@ -81,4 +82,15 @@ func (f *Filecoin) ClientVerifyStorageDeal(ctx context.Context, prop cid.Cid) (*
 // A json decoer is returned that asks may be decoded from.
 func (f *Filecoin) ClientListAsks(ctx context.Context) (*json.Decoder, error) {
 	return f.RunCmdLDJSONWithStdin(ctx, nil, "go-filecoin", "client", "list-asks")
+}
+
+// ClientPayments runs the client payments command against the filecoin process.
+func (f *Filecoin) ClientPayments(ctx context.Context, deal cid.Cid) ([]types.PaymentVoucher, error) {
+	var out []types.PaymentVoucher
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "client", "payments", deal.String()); err != nil {
+		return nil, err
+	}
+
+	return out, nil
 }

--- a/tools/fast/action_deals.go
+++ b/tools/fast/action_deals.go
@@ -2,6 +2,7 @@ package fast
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/ipfs/go-cid"
 
@@ -9,9 +10,7 @@ import (
 )
 
 // DealsList runs the `deals list` command against the filecoin process
-func (f *Filecoin) DealsList(ctx context.Context, client bool, miner bool) (*commands.DealsListResult, error) {
-	var out commands.DealsListResult
-
+func (f *Filecoin) DealsList(ctx context.Context, client bool, miner bool) (*json.Decoder, error) {
 	args := []string{"go-filecoin", "deals", "list"}
 
 	if client {
@@ -22,11 +21,7 @@ func (f *Filecoin) DealsList(ctx context.Context, client bool, miner bool) (*com
 		args = append(args, "--miner")
 	}
 
-	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
-		return nil, err
-	}
-
-	return &out, nil
+	return f.RunCmdLDJSONWithStdin(ctx, nil, args...)
 }
 
 // DealsRedeem runs the `deals redeem` command against the filecoin process.

--- a/tools/fast/action_dht.go
+++ b/tools/fast/action_dht.go
@@ -2,11 +2,11 @@ package fast
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
-	"github.com/libp2p/go-libp2p-core/routing"
 	"github.com/multiformats/go-multiaddr"
 )
 
@@ -40,14 +40,7 @@ func (f *Filecoin) DHTFindPeer(ctx context.Context, pid peer.ID) ([]multiaddr.Mu
 }
 
 // DHTFindProvs runs the `dht findprovs` command against the filecoin process
-func (f *Filecoin) DHTFindProvs(ctx context.Context, key cid.Cid) ([]routing.QueryEvent, error) {
-	var out []routing.QueryEvent
-
-	args := []string{"go-filecoin", "swarm", "findprovs", key.String()}
-
-	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
-		return nil, err
-	}
-
-	return out, nil
+func (f *Filecoin) DHTFindProvs(ctx context.Context, key cid.Cid) (*json.Decoder, error) {
+	args := []string{"go-filecoin", "dht", "findprovs", key.String()}
+	return f.RunCmdLDJSONWithStdin(ctx, nil, args...)
 }

--- a/tools/fast/action_miner_test.go
+++ b/tools/fast/action_miner_test.go
@@ -50,7 +50,13 @@ func requireMinerClientMakeADeal(ctx context.Context, t *testing.T, minerDaemon,
 	collateral := big.NewInt(int64(1))
 	price := big.NewFloat(float64(1))
 	expiry := big.NewInt(int64(10000))
-	_, err := series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, price, expiry)
+
+	pparams, err := minerDaemon.Protocol(ctx)
+	require.NoError(t, err)
+
+	sectorSize := pparams.SupportedSectorSizes[0]
+
+	_, err = series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, price, expiry, sectorSize)
 	require.NoError(t, err)
 
 	f := files.NewBytesFile([]byte("HODLHODLHODL"))

--- a/tools/fast/action_show.go
+++ b/tools/fast/action_show.go
@@ -20,3 +20,29 @@ func (f *Filecoin) ShowHeader(ctx context.Context, ref cid.Cid) (*types.Block, e
 
 	return &out, nil
 }
+
+// ShowMessages runs the `show messages` command against the filecoin process
+func (f *Filecoin) ShowMessages(ctx context.Context, ref cid.Cid) ([]*types.SignedMessage, error) {
+	var out []*types.SignedMessage
+
+	sRef := ref.String()
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "show", "messages", sRef); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// ShowReceipts runs the `show receipts` command against the filecoin process
+func (f *Filecoin) ShowReceipts(ctx context.Context, ref cid.Cid) ([]*types.MessageReceipt, error) {
+	var out []*types.MessageReceipt
+
+	sRef := ref.String()
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "show", "receipts", sRef); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}

--- a/tools/fast/bin/localnet/main.go
+++ b/tools/fast/bin/localnet/main.go
@@ -273,7 +273,15 @@ func main() {
 			return
 		}
 
-		ask, err := series.CreateStorageMinerWithAsk(ctx, miner, minerCollateral, minerPrice, minerExpiry)
+		pparams, err := miner.Protocol(ctx)
+		if err != nil {
+			exitcode = handleError(err, "failed to get protocol;")
+			return
+		}
+
+		sectorSize := pparams.SupportedSectorSizes[0]
+
+		ask, err := series.CreateStorageMinerWithAsk(ctx, miner, minerCollateral, minerPrice, minerExpiry, sectorSize)
 		if err != nil {
 			exitcode = handleError(err, "failed series.CreateStorageMinerWithAsk;")
 			return

--- a/tools/fast/environment/environment_devnet.go
+++ b/tools/fast/environment/environment_devnet.go
@@ -31,6 +31,9 @@ type Devnet struct {
 
 	processesMu sync.Mutex
 	processes   []*fast.Filecoin
+
+	processCountMu sync.Mutex
+	processCount   int
 }
 
 // NewDevnet builds an environment that uses deployed infrastructure to
@@ -76,11 +79,15 @@ func (e *Devnet) NewProcess(ctx context.Context, processType string, options map
 	e.processesMu.Lock()
 	defer e.processesMu.Unlock()
 
+	e.processCountMu.Lock()
+	defer e.processCountMu.Unlock()
+
 	ns := iptb.NodeSpec{
 		Type:  processType,
-		Dir:   fmt.Sprintf("%s/%d", e.location, len(e.processes)),
+		Dir:   fmt.Sprintf("%s/%d", e.location, e.processCount),
 		Attrs: options,
 	}
+	e.processCount = e.processCount + 1
 
 	e.log.Infof("New Process type: %s, dir: %s", processType, ns.Dir)
 

--- a/tools/fast/environment/environment_memory_genesis.go
+++ b/tools/fast/environment/environment_memory_genesis.go
@@ -43,6 +43,9 @@ type MemoryGenesis struct {
 	processesMu sync.Mutex
 	processes   []*fast.Filecoin
 
+	processCountMu sync.Mutex
+	processCount   int
+
 	proofsMode types.ProofsMode
 }
 
@@ -118,11 +121,15 @@ func (e *MemoryGenesis) NewProcess(ctx context.Context, processType string, opti
 	e.processesMu.Lock()
 	defer e.processesMu.Unlock()
 
+	e.processCountMu.Lock()
+	defer e.processCountMu.Unlock()
+
 	ns := iptb.NodeSpec{
 		Type:  processType,
-		Dir:   fmt.Sprintf("%s/%d", e.location, len(e.processes)),
+		Dir:   fmt.Sprintf("%s/%d", e.location, e.processCount),
 		Attrs: options,
 	}
+	e.processCount = e.processCount + 1
 
 	e.log.Infof("New Process type: %s, dir: %s", processType, ns.Dir)
 

--- a/tools/fast/process_action_options.go
+++ b/tools/fast/process_action_options.go
@@ -123,3 +123,10 @@ func AOAllowDuplicates(allow bool) ActionOption {
 		return []string{sAllowDupes}
 	}
 }
+
+// AOSectorSize provides the `--sectorsize` option to actions
+func AOSectorSize(ba *types.BytesAmount) ActionOption {
+	return func() []string {
+		return []string{"--sectorsize", ba.String()}
+	}
+}

--- a/tools/fast/series/create_miner_with_ask.go
+++ b/tools/fast/series/create_miner_with_ask.go
@@ -6,14 +6,15 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 // CreateStorageMinerWithAsk setups a miner and sets an ask price. The created ask is
 // returned. The node will be mining as well.
-func CreateStorageMinerWithAsk(ctx context.Context, miner *fast.Filecoin, collateral *big.Int, price *big.Float, expiry *big.Int) (porcelain.Ask, error) {
+func CreateStorageMinerWithAsk(ctx context.Context, miner *fast.Filecoin, collateral *big.Int, price *big.Float, expiry *big.Int, sectorSize *types.BytesAmount) (porcelain.Ask, error) {
 
 	// Create miner
-	_, err := miner.MinerCreate(ctx, collateral, fast.AOPrice(big.NewFloat(1.0)), fast.AOLimit(300))
+	_, err := miner.MinerCreate(ctx, collateral, fast.AOSectorSize(sectorSize), fast.AOPrice(big.NewFloat(1.0)), fast.AOLimit(300))
 	if err != nil {
 		return porcelain.Ask{}, err
 	}

--- a/tools/fast/series/ctx_sleep_delay.go
+++ b/tools/fast/series/ctx_sleep_delay.go
@@ -24,13 +24,14 @@ func SetCtxSleepDelay(ctx context.Context, d time.Duration) context.Context {
 }
 
 // CtxSleepDelay is a helper method to make sure people don't call `time.Sleep`
-// themselves in series. It will use the time.Duration in the context, or
-// default to `mining.DefaultBlockTime` from the go-filecoin/mining package.
-func CtxSleepDelay(ctx context.Context) {
+// or `time.After` themselves in series. It will use the time.Duration in the
+// context, or default to `mining.DefaultBlockTime` from the go-filecoin/mining package.
+// A channel is return which will receive a time.Time value after the delay.
+func CtxSleepDelay(ctx context.Context) <-chan time.Time {
 	d, ok := ctx.Value(sleepDelayKey).(time.Duration)
 	if !ok {
 		d = defaultSleepDelay
 	}
 
-	time.Sleep(d)
+	return time.After(d)
 }

--- a/tools/fast/series/init_and_start.go
+++ b/tools/fast/series/init_and_start.go
@@ -6,10 +6,17 @@ import (
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 )
 
-// InitAndStart is a quick way to run Init and Start for a filecoin process.
-func InitAndStart(ctx context.Context, node *fast.Filecoin) error {
+// InitAndStart is a quick way to run Init and Start for a filecoin process. A variadic set of functions
+// can be passed to run between init and the start of the daemon to make configuration changes.
+func InitAndStart(ctx context.Context, node *fast.Filecoin, fns ...func(context.Context, *fast.Filecoin) error) error {
 	if _, err := node.InitDaemon(ctx); err != nil {
 		return err
+	}
+
+	for _, fn := range fns {
+		if err := fn(ctx, node); err != nil {
+			return err
+		}
 	}
 
 	if _, err := node.StartDaemon(ctx, true); err != nil {

--- a/tools/fast/series/wait_for_block_height.go
+++ b/tools/fast/series/wait_for_block_height.go
@@ -21,7 +21,7 @@ func WaitForBlockHeight(ctx context.Context, client *fast.Filecoin, bh *types.Bl
 			break
 		}
 
-		CtxSleepDelay(ctx)
+		<-CtxSleepDelay(ctx)
 	}
 
 	return nil

--- a/tools/fast/series/wait_for_deal_state.go
+++ b/tools/fast/series/wait_for_deal_state.go
@@ -21,6 +21,6 @@ func WaitForDealState(ctx context.Context, client *fast.Filecoin, deal *storaged
 			return dr, nil
 		}
 
-		CtxSleepDelay(ctx)
+		<-CtxSleepDelay(ctx)
 	}
 }


### PR DESCRIPTION
Set of FAST updates 

**New Actions**
- ShowMessages
- ShowReceipts
- ClientPayments

**Features**
- InitAndStart series takes a variadic set of functions to apply between `InitDaemon` and `StartDaemon`. This helps with applying configuration changes before the daemon starts.
- CtxSleepDelay now returns a channel which receives a value after the delay time. This allows the function to be more versatile allowing for use inside of `select` statements.
- CreateStorageMinerWithAsk now requires a sector size for the miner.

**Bugs**
- When tearing down processes with `TeardownProcess`, new processes will not use the same directory as a previous process.
- DHTFindProvs now returns a `*json.Decoder` so more than one value can be parsed from the LDJSON stream.