### PR TITLE
add seal-now command

### DIFF
--- a/commands/message.go
+++ b/commands/message.go
@@ -81,9 +81,9 @@ var msgSendCmd = &cmds.Command{
 			return err
 		}
 
-		method := ""
-		if len(req.Arguments) > 1 {
-			method = req.Arguments[1]
+		method, ok := req.Options["method"].(string)
+		if !ok {
+			method = ""
 		}
 
 		if preview {

--- a/commands/message.go
+++ b/commands/message.go
@@ -81,9 +81,9 @@ var msgSendCmd = &cmds.Command{
 			return err
 		}
 
-		method, ok := req.Options["method"].(string)
-		if !ok {
-			method = ""
+		method := ""
+		if len(req.Arguments) > 1 {
+			method = req.Arguments[1]
 		}
 
 		if preview {

--- a/commands/mining.go
+++ b/commands/mining.go
@@ -19,11 +19,12 @@ var miningCmd = &cmds.Command{
 		Tagline: "Manage all mining operations for a node",
 	},
 	Subcommands: map[string]*cmds.Command{
-		"address": miningAddrCmd,
-		"once":    miningOnceCmd,
-		"start":   miningStartCmd,
-		"status":  miningStatusCmd,
-		"stop":    miningStopCmd,
+		"address":  miningAddrCmd,
+		"once":     miningOnceCmd,
+		"start":    miningStartCmd,
+		"status":   miningStatusCmd,
+		"stop":     miningStopCmd,
+		"seal-now": miningSealCmd,
 	},
 }
 
@@ -158,6 +159,19 @@ var miningStopCmd = &cmds.Command{
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		GetBlockAPI(env).MiningStop(req.Context)
 		return re.Emit("Stopped mining")
+	},
+	Encoders: stringEncoderMap,
+}
+
+var miningSealCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Start sealing all staged sectors or create and seal a new sector",
+	},
+	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+		if err := GetPorcelainAPI(env).SealNow(req.Context); err != nil {
+			return err
+		}
+		return re.Emit("sealing started")
 	},
 	Encoders: stringEncoderMap,
 }

--- a/commands/mining_daemon_test.go
+++ b/commands/mining_daemon_test.go
@@ -46,7 +46,7 @@ func TestMiningGenBlock(t *testing.T) {
 }
 
 func TestMiningSealNow(t *testing.T) {
-	tf.FunctionalTest(t)
+	//tf.FunctionalTest(t)
 
 	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{
 		InitOpts:   []fast.ProcessInitOption{fast.POAutoSealIntervalSeconds(1)},
@@ -75,11 +75,6 @@ func TestMiningSealNow(t *testing.T) {
 	miningAddress, err := minerNode.MiningAddress(ctx)
 	require.NoError(t, err)
 
-	// get initial power
-	initialPower, err := minerNode.MinerPower(ctx, miningAddress)
-	require.NoError(t, err)
-	assert.Equal(t, types.ZeroBytes, initialPower)
-
 	// start sealing
 	err = minerNode.SealNow(ctx)
 	require.NoError(t, err)
@@ -90,9 +85,8 @@ func TestMiningSealNow(t *testing.T) {
 		power, err := minerNode.MinerPower(ctx, miningAddress)
 		require.NoError(t, err)
 
-		if power.Power.GreaterThan(&initialPower.Power) {
-			// seal was successful
-			assert.True(t, types.NewBytesAmount(1024).Equal(&power.Power))
+		if power.Power.GreaterThan(types.ZeroBytes) {
+			// miner has gained power, so seal was successful
 			return
 		}
 		time.Sleep(time.Second)

--- a/commands/mining_daemon_test.go
+++ b/commands/mining_daemon_test.go
@@ -46,7 +46,7 @@ func TestMiningGenBlock(t *testing.T) {
 }
 
 func TestMiningSealNow(t *testing.T) {
-	//tf.FunctionalTest(t)
+	tf.FunctionalTest(t)
 
 	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{
 		InitOpts:   []fast.ProcessInitOption{fast.POAutoSealIntervalSeconds(1)},

--- a/commands/mining_daemon_test.go
+++ b/commands/mining_daemon_test.go
@@ -1,14 +1,20 @@
 package commands_test
 
 import (
+	"context"
+	"github.com/filecoin-project/go-filecoin/tools/fast/series"
 	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/fixtures"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/tools/fast/fastesting"
 )
 
 func parseInt(t *testing.T, s string) *big.Int {
@@ -36,4 +42,57 @@ func TestMiningGenBlock(t *testing.T) {
 	sum := new(big.Int)
 
 	assert.Equal(t, sum.Add(beforeBalance, big.NewInt(1000)), afterBalance)
+}
+
+func TestMiningSealNow(t *testing.T) {
+	tf.FunctionalTest(t)
+
+	// Give the deal time to complete
+	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{
+		InitOpts:   []fast.ProcessInitOption{fast.POAutoSealIntervalSeconds(1)},
+		DaemonOpts: []fast.ProcessDaemonOption{fast.POBlockTime(50 * time.Millisecond)},
+	})
+	defer func() {
+		require.NoError(t, env.Teardown(ctx))
+	}()
+
+	genesisNode := env.GenesisMiner
+	require.NoError(t, genesisNode.MiningStart(ctx))
+	defer func() {
+		require.NoError(t, genesisNode.MiningStop(ctx))
+	}()
+
+	minerNode := env.RequireNewNodeWithFunds(1000)
+
+	// Connect the clientNode and the minerNode
+	require.NoError(t, series.Connect(ctx, genesisNode, minerNode))
+
+	// Calls MiningOnce on genesis (client). This also starts the Miner.
+	_, err := series.CreateStorageMinerWithAsk(ctx, minerNode, big.NewInt(500), big.NewFloat(0.0001), big.NewInt(3000))
+	require.NoError(t, err)
+
+	// get address of miner so we can check power
+	miningAddress, err := minerNode.MiningAddress(ctx)
+	require.NoError(t, err)
+
+	// get initial power
+	initialPower, err := minerNode.MinerPower(ctx, miningAddress)
+	require.NoError(t, err)
+
+	// start sealing
+	err = minerNode.SealNow(ctx)
+	require.NoError(t, err)
+
+	// wait up to three minutes for miner to gain power from sealing
+	for i := 0; i < 180; i++ {
+		power, err := minerNode.MinerPower(ctx, miningAddress)
+		require.NoError(t, err)
+
+		if power.Power.GreaterThan(&initialPower.Power) {
+			// seal was successful
+			return
+		}
+		time.Sleep(time.Second)
+	}
+	assert.Fail(t, "timed out waiting for miner to gain power from sealing")
 }

--- a/commands/mining_daemon_test.go
+++ b/commands/mining_daemon_test.go
@@ -52,6 +52,7 @@ func TestMiningSealNow(t *testing.T) {
 		InitOpts:   []fast.ProcessInitOption{fast.POAutoSealIntervalSeconds(1)},
 		DaemonOpts: []fast.ProcessDaemonOption{fast.POBlockTime(50 * time.Millisecond)},
 	})
+	env.RunAsyncMiner()
 	defer func() {
 		require.NoError(t, env.Teardown(ctx))
 	}()

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -240,6 +240,11 @@ func (a *API) CalculatePoSt(ctx context.Context, sortedCommRs proofs.SortedCommR
 	return CalculatePoSt(ctx, a, sortedCommRs, seed)
 }
 
+// SealNow forces the sectorbuilder to either seal the staged sectors it has or create a new one and seal it immediately
+func (a *API) SealNow(ctx context.Context) error {
+	return SealNow(ctx, a)
+}
+
 // PingMinerWithTimeout pings a storage or retrieval miner, waiting the given
 // timeout and returning desciptive errors.
 func (a *API) PingMinerWithTimeout(

--- a/porcelain/sectorbuilder.go
+++ b/porcelain/sectorbuilder.go
@@ -1,12 +1,16 @@
 package porcelain
 
 import (
+	"bytes"
 	"context"
-	"errors"
 
 	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
 	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multihash"
+
+	"github.com/pkg/errors"
 )
 
 type sbPlumbing interface {
@@ -28,4 +32,34 @@ func CalculatePoSt(ctx context.Context, plumbing sbPlumbing, sortedCommRs proofs
 		return nil, nil, err
 	}
 	return res.Proofs, res.Faults, nil
+}
+
+// SealNow forces the sectorbuilder to either seal the staged sectors it has or create a new one and seal it immediately
+func SealNow(ctx context.Context, plumbing sbPlumbing) error {
+	if plumbing.SectorBuilder() == nil {
+		return errors.New("must be mining to seal sectors")
+	}
+
+	stagedSectors, err := plumbing.SectorBuilder().GetAllStagedSectors()
+	if err != nil {
+		return errors.Wrap(err, "could not retrieved staged sectors")
+	}
+
+	// if no sectors are staged, add a 1 byte piece to ensure at least one seal
+	if len(stagedSectors) == 0 {
+		data := []byte{0}
+		hash, err := multihash.Sum(data, multihash.SHA2_256, -1)
+		if err != nil {
+			return errors.Wrap(err, "could not create cid for piece")
+		}
+		pieceRef := cid.NewCidV1(cid.DagCBOR, hash)
+		_, err = plumbing.SectorBuilder().AddPiece(ctx, pieceRef, 1, bytes.NewReader(data))
+		if err != nil {
+			return errors.Wrap(err, "could not add piece to trigger sealing")
+		}
+
+	}
+
+	// start sealing on all existing staged sectors
+	return plumbing.SectorBuilder().SealAllStagedSectors(ctx)
 }

--- a/porcelain/sectorbuilder_test.go
+++ b/porcelain/sectorbuilder_test.go
@@ -1,0 +1,94 @@
+package porcelain_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/filecoin-project/go-filecoin/porcelain"
+	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
+	"github.com/filecoin-project/go-sectorbuilder"
+)
+
+func TestSealNow(t *testing.T) {
+	t.Run("adds piece and triggers sealing when staged sectors is empty", func(t *testing.T) {
+		p := newTestSectorBuilderPlumbing(0)
+
+		err := SealNow(context.Background(), p)
+		require.NoError(t, err)
+
+		// adds a piece
+		assert.Equal(t, 1, p.sectorbuilder.addPieceCount)
+
+		// seals sectors
+		assert.Equal(t, 1, p.sectorbuilder.sealAllSectorsCount)
+	})
+
+	t.Run("does not add a piece when staged sectors exist", func(t *testing.T) {
+		p := newTestSectorBuilderPlumbing(4)
+
+		err := SealNow(context.Background(), p)
+		require.NoError(t, err)
+
+		// adds a piece
+		assert.Equal(t, 0, p.sectorbuilder.addPieceCount)
+
+		// seals sectors
+		assert.Equal(t, 1, p.sectorbuilder.sealAllSectorsCount)
+	})
+}
+
+func newTestSectorBuilderPlumbing(stagedSectors int) *testSectorBuilderPlumbing {
+	sb := &testSectorBuilder{numStagedSectors: stagedSectors}
+	return &testSectorBuilderPlumbing{
+		sectorbuilder: sb,
+	}
+}
+
+type testSectorBuilderPlumbing struct {
+	sectorbuilder *testSectorBuilder
+}
+
+func (tsbp *testSectorBuilderPlumbing) SectorBuilder() sectorbuilder.SectorBuilder {
+	return tsbp.sectorbuilder
+}
+
+type testSectorBuilder struct {
+	addPieceCount       int
+	sealAllSectorsCount int
+	numStagedSectors    int
+}
+
+func (tsb *testSectorBuilder) AddPiece(ctx context.Context, pieceRef cid.Cid, pieceSize uint64, pieceReader io.Reader) (sectorID uint64, err error) {
+	tsb.addPieceCount++
+	return 0, nil
+}
+
+func (tsb *testSectorBuilder) ReadPieceFromSealedSector(pieceCid cid.Cid) (io.Reader, error) {
+	return nil, nil
+}
+
+func (tsb *testSectorBuilder) SealAllStagedSectors(ctx context.Context) error {
+	tsb.sealAllSectorsCount++
+	return nil
+}
+
+func (tsb *testSectorBuilder) GetAllStagedSectors() ([]go_sectorbuilder.StagedSectorMetadata, error) {
+	return make([]go_sectorbuilder.StagedSectorMetadata, tsb.numStagedSectors), nil
+}
+
+func (tsb *testSectorBuilder) SectorSealResults() <-chan sectorbuilder.SectorSealResult {
+	return nil
+}
+
+func (tsb *testSectorBuilder) GeneratePoSt(sectorbuilder.GeneratePoStRequest) (sectorbuilder.GeneratePoStResponse, error) {
+	return sectorbuilder.GeneratePoStResponse{}, nil
+}
+
+func (tsb *testSectorBuilder) Close() error {
+	return nil
+}

--- a/porcelain/sectorbuilder_test.go
+++ b/porcelain/sectorbuilder_test.go
@@ -34,7 +34,7 @@ func TestSealNow(t *testing.T) {
 		err := SealNow(context.Background(), p)
 		require.NoError(t, err)
 
-		// adds a piece
+		// does not add a piece
 		assert.Equal(t, 0, p.sectorbuilder.addPieceCount)
 
 		// seals sectors

--- a/proofs/sectorbuilder/interface.go
+++ b/proofs/sectorbuilder/interface.go
@@ -2,6 +2,7 @@ package sectorbuilder
 
 import (
 	"context"
+	"github.com/filecoin-project/go-sectorbuilder"
 	"io"
 
 	"github.com/ipfs/go-cid"
@@ -32,6 +33,9 @@ type SectorBuilder interface {
 
 	// SealAllStagedSectors seals any non-empty staged sectors.
 	SealAllStagedSectors(ctx context.Context) error
+
+	// GetAllStagedSectors returns a slice of all staged sector metadata for the sector builder, or an error.
+	GetAllStagedSectors() ([]go_sectorbuilder.StagedSectorMetadata, error)
 
 	// SectorSealResults returns an unbuffered channel that is sent a value
 	// whenever sealing completes. All calls to SectorSealResults will get the

--- a/proofs/sectorbuilder/interface.go
+++ b/proofs/sectorbuilder/interface.go
@@ -2,9 +2,9 @@ package sectorbuilder
 
 import (
 	"context"
-	"github.com/filecoin-project/go-sectorbuilder"
 	"io"
 
+	"github.com/filecoin-project/go-sectorbuilder"
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 

--- a/proofs/sectorbuilder/rustsectorbuilder.go
+++ b/proofs/sectorbuilder/rustsectorbuilder.go
@@ -70,7 +70,7 @@ func NewRustSectorBuilder(cfg RustSectorBuilderConfig) (*RustSectorBuilder, erro
 	}
 
 	// load staged sector metadata and use it to initialize the poller
-	metadata, err := sb.stagedSectors()
+	metadata, err := sb.GetAllStagedSectors()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load staged sectors")
 	}
@@ -232,8 +232,8 @@ func (sb *RustSectorBuilder) SealAllStagedSectors(ctx context.Context) error {
 	return go_sectorbuilder.SealAllStagedSectors(sb.ptr)
 }
 
-// stagedSectors returns a slice of all staged sector metadata for the sector builder, or an error.
-func (sb *RustSectorBuilder) stagedSectors() ([]go_sectorbuilder.StagedSectorMetadata, error) {
+// GetAllStagedSectors returns a slice of all staged sector metadata for the sector builder, or an error.
+func (sb *RustSectorBuilder) GetAllStagedSectors() ([]go_sectorbuilder.StagedSectorMetadata, error) {
 	return go_sectorbuilder.GetAllStagedSectors(sb.ptr)
 }
 

--- a/tools/fast/action_mining.go
+++ b/tools/fast/action_mining.go
@@ -69,3 +69,17 @@ func (f *Filecoin) MiningStatus(ctx context.Context) (commands.MiningStatusResul
 
 	return out, nil
 }
+
+// SealNow adds a staged sector if none exists and then triggers sealing on it
+func (f *Filecoin) SealNow(ctx context.Context) error {
+	out, err := f.RunCmdWithStdin(ctx, nil, "go-filecoin", "mining", "seal-now")
+	if err != nil {
+		return err
+	}
+
+	if out.ExitCode() > 0 {
+		return fmt.Errorf("filecoin command: %s, exited with non-zero exitcode: %d", out.Args(), out.ExitCode())
+	}
+
+	return nil
+}


### PR DESCRIPTION
closes #3044 

### Problem

Some storage miners are only interested in gaining mining power, and don't want to have to wait for storage deals (or fake storage deals) to start committing sectors. Currently sector sealing doesn't begin until a piece has been added to a sector.

### Solution

The SectorBuilder only lets us trigger sealing on sectors that are already staged. If a miner has not accepted a storage deal, there will be no sectors to stage. We check to see if any staged sectors exist. If not, we add a 1 byte piece to the sector builder to generate a staged sector. In either case we call `sectorbuilder.SealAllStagedSectors` to trigger the sealing process.

This PR includes a functional test to demonstrate that calling `mining seal-now` results in additional storage power without a storage deal taking place.