### PR TITLE
Replace warning on duplicate peer tracking with informative message.

### DIFF
--- a/chain/message_store.go
+++ b/chain/message_store.go
@@ -43,7 +43,7 @@ func (ms *MessageStore) LoadMessages(ctx context.Context, c cid.Cid) ([]*types.S
 	var out types.MessageCollection
 	err := ms.ipldStore.Get(ctx, c, &out)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not load message collection with cid: %s", c.String())
+		return nil, errors.Wrapf(err, "failed to load messages %s", c.String())
 	}
 	return []*types.SignedMessage(out), nil
 }
@@ -63,7 +63,7 @@ func (ms *MessageStore) LoadReceipts(ctx context.Context, c cid.Cid) ([]*types.M
 	var out types.ReceiptCollection
 	err := ms.ipldStore.Get(ctx, c, &out)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not load receipt collection with cid: %s", c.String())
+		return nil, errors.Wrapf(err, "failed to load receipts %s", c.String())
 	}
 	return []*types.MessageReceipt(out), nil
 }

--- a/chain/syncer.go
+++ b/chain/syncer.go
@@ -157,11 +157,11 @@ func (syncer *Syncer) syncOne(ctx context.Context, parent, next types.TipSet) er
 		blk := next.At(i)
 		msgs, err := syncer.messageProvider.LoadMessages(ctx, blk.Messages)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "syncing tip %s failed loading message list %s for block %s", next.Key(), blk.Messages, blk.Cid())
 		}
 		rcpts, err := syncer.messageProvider.LoadReceipts(ctx, blk.MessageReceipts)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "syncing tip %s failed loading receipts list %s for block %s", next.Key(), blk.MessageReceipts, blk.Cid())
 		}
 		nextMessages = append(nextMessages, msgs)
 		nextReceipts = append(nextReceipts, rcpts)

--- a/net/peer_tracker.go
+++ b/net/peer_tracker.go
@@ -34,11 +34,10 @@ func (tracker *PeerTracker) Track(ci *types.ChainInfo) {
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
 
-	pidKey := peer.IDB58Encode(ci.Peer)
-	if _, tracking := tracker.peers[pidKey]; tracking {
-		logPeerTracker.Warningf("unexpected duplicate track on peer: %s", pidKey)
-	}
+	pidKey := ci.Peer.Pretty()
+	_, tracking := tracker.peers[pidKey]
 	tracker.peers[pidKey] = ci
+	logPeerTracker.Infof("Tracking %s, new=%t, count=%d", ci, !tracking, len(tracker.peers))
 }
 
 // List returns the chain info of the currently tracked peers.  The info
@@ -63,8 +62,9 @@ func (tracker *PeerTracker) Remove(pid peer.ID) {
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
 
-	pidKey := peer.IDB58Encode(pid)
+	pidKey := pid.Pretty()
 	if _, tracking := tracker.peers[pidKey]; tracking {
+		logPeerTracker.Infof("Dropping peer %s", pidKey)
 		delete(tracker.peers, pidKey)
 	}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -570,7 +570,7 @@ func (node *Node) Start(ctx context.Context) error {
 			trusted := true
 			err := node.Syncer.HandleNewTipSet(context.Background(), ci, trusted)
 			if err != nil {
-				log.Infof("error handling blocks: %s", ci.Head.String())
+				log.Infof("error handling tipset from hello %s: %s", ci, err)
 				return
 			}
 			// For now, consider the initial bootstrap done after the syncer has (synchronously)

--- a/types/chain_info.go
+++ b/types/chain_info.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -21,6 +23,11 @@ func NewChainInfo(peer peer.ID, head TipSetKey, height uint64) *ChainInfo {
 		Height:  height,
 		Trusted: true,
 	}
+}
+
+// Returns a human-readable string representation of a chain info
+func (i *ChainInfo) String() string {
+	return fmt.Sprintf("{peer=%s height=%d head=%s}", i.Peer, i.Height, i.Head)
 }
 
 // CISlice is for sorting chain infos


### PR DESCRIPTION
I don't know exactly why we receive this callback for the same peer multiple times, but it's frequent and not a warning-level problem.

Closes #3128. cc @ZenGround0 