### PR TITLE
Remove LastPoSt from miner state

### DIFF
--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -168,7 +168,6 @@ type State struct {
 	// ProvingPeriodEnd is the block height at the end of the current proving period.
 	// This is the last round in which a proof will be considered to be on-time.
 	ProvingPeriodEnd *types.BlockHeight
-	LastPoSt         *types.BlockHeight
 
 	// The amount of space proven to the network by this miner in the
 	// latest proving period.
@@ -941,7 +940,6 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, poStProofs []types.PoStProof, fa
 
 		// transition to the next proving period
 		state.ProvingPeriodEnd = state.ProvingPeriodEnd.Add(types.NewBlockHeight(ProvingPeriodDuration(state.SectorSize)))
-		state.LastPoSt = chainHeight
 
 		// Update miner power to the amount of data actually proved
 		// during the last proving period.

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -1546,7 +1546,6 @@ func mustGetMinerState(st state.Tree, vms vm.StorageMap, a address.Address) *Sta
 }
 
 type minerEnvBuilder struct {
-	lastPoSt         *types.BlockHeight
 	provingPeriodEnd *types.BlockHeight
 	message          string
 	sectorSet        SectorSet
@@ -1557,7 +1556,6 @@ type minerEnvBuilder struct {
 func (b *minerEnvBuilder) build() (exec.VMContext, *verification.FakeVerifier, *Actor) {
 	minerState := NewState(address.TestAddress, address.TestAddress, peer.ID(""), b.sectorSize)
 	minerState.SectorCommitments = b.sectorSet
-	minerState.LastPoSt = b.lastPoSt
 	minerState.ProvingPeriodEnd = b.provingPeriodEnd
 
 	if b.sectorSet == nil {


### PR DESCRIPTION
## Problem
`LastPoSt` is no longer being used to determine if a miner is active or not (#3195).  We are using `SectorCommitments` and `ProvingPeriodEnd` instead. 

## Solution
Remove `LastPoSt` from the miner state.

Resolves #2947