### PR TITLE
Update submodules before generating checksums

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,12 +393,12 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=$AWS_ECR_SECRET_ACCESS_KEY
             eval $(aws --region us-east-1 ecr --no-include-email get-login)
       - checkout
+      - update_submodules
       - generate_rust_submodules_checksums
       - attach_workspace:
           at: "."
       - restore_cache:
           key: v1-proof-params-{{ arch }}-{{ checksum "/tmp/rust-fil-proofs-checksum.txt" }}
-      - update_submodules
       - run:
           name: build a base image
           command: |


### PR DESCRIPTION
After https://github.com/filecoin-project/go-filecoin/pull/3201 we have to ensure that we are initializing everything up-front. I believe this wasn't true prior, so having the out of order actions did not matter. All other calls to `generate_rust_submodules_checksums` are proceeded by a call to `update_submodules`.