### PR TITLE
Protocol command returns max piece size

### DIFF
--- a/commands/client_daemon_test.go
+++ b/commands/client_daemon_test.go
@@ -106,9 +106,9 @@ func TestDuplicateDeals(t *testing.T) {
 	pparams, err := minerDaemon.Protocol(ctx)
 	require.NoError(t, err)
 
-	sectorSize := pparams.SupportedSectorSizes[0]
+	sinfo := pparams.SupportedSectors[0]
 
-	ask, err := series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, askPrice, expiry, sectorSize)
+	ask, err := series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, askPrice, expiry, sinfo.Size)
 	require.NoError(t, err)
 
 	_, err = minerClientMakeDealWithAllowDupes(ctx, t, true, minerDaemon, clientDaemon, ask.ID, duration)
@@ -298,9 +298,9 @@ func TestSelfDialStorageGoodError(t *testing.T) {
 	pparams, err := miningNode.Protocol(ctx)
 	require.NoError(t, err)
 
-	sectorSize := pparams.SupportedSectorSizes[0]
+	sinfo := pparams.SupportedSectors[0]
 
-	ask, err := series.CreateStorageMinerWithAsk(ctx, miningNode, collateral, price, expiry, sectorSize)
+	ask, err := series.CreateStorageMinerWithAsk(ctx, miningNode, collateral, price, expiry, sinfo.Size)
 	minerCreateDoneCh <- struct{}{}
 	require.NoError(t, err)
 

--- a/commands/deals_daemon_test.go
+++ b/commands/deals_daemon_test.go
@@ -57,9 +57,9 @@ func TestDealsRedeem(t *testing.T) {
 	pparams, err := minerDaemon.Protocol(ctx)
 	require.NoError(t, err)
 
-	sectorSize := pparams.SupportedSectorSizes[0]
+	sinfo := pparams.SupportedSectors[0]
 
-	_, err = series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, price, expiry, sectorSize)
+	_, err = series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, price, expiry, sinfo.Size)
 	require.NoError(t, err)
 
 	f := files.NewBytesFile([]byte("HODLHODLHODL"))
@@ -229,9 +229,9 @@ func TestDealsShow(t *testing.T) {
 	pparams, err := minerNode.Protocol(ctx)
 	require.NoError(t, err)
 
-	sectorSize := pparams.SupportedSectorSizes[0]
+	sinfo := pparams.SupportedSectors[0]
 
-	ask, err := series.CreateStorageMinerWithAsk(ctx, minerNode, collateral, price, expiry, sectorSize)
+	ask, err := series.CreateStorageMinerWithAsk(ctx, minerNode, collateral, price, expiry, sinfo.Size)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, minerNode.MiningStop(ctx))
@@ -398,10 +398,10 @@ func setupDeal(
 	pparams, err := minerNode.Protocol(ctx)
 	require.NoError(t, err)
 
-	sectorSize := pparams.SupportedSectorSizes[0]
+	sinfo := pparams.SupportedSectors[0]
 
 	// Calls MiningOnce on genesis (client). This also starts the Miner.
-	ask, err := series.CreateStorageMinerWithAsk(ctx, minerNode, collateral, price, expiry, sectorSize)
+	ask, err := series.CreateStorageMinerWithAsk(ctx, minerNode, collateral, price, expiry, sinfo.Size)
 	require.NoError(t, err)
 	require.NoError(t, minerNode.MiningStop(ctx))
 

--- a/commands/miner.go
+++ b/commands/miner.go
@@ -68,7 +68,7 @@ additional sectors.`,
 			return err
 		}
 
-		sectorSize, err := optionalSectorSizeWithDefault(req.Options["sectorsize"], pp.SupportedSectorSizes[0])
+		sectorSize, err := optionalSectorSizeWithDefault(req.Options["sectorsize"], pp.SupportedSectors[0].Size)
 		if err != nil {
 			return err
 		}
@@ -79,9 +79,9 @@ additional sectors.`,
 		// supported.
 		// https://github.com/filecoin-project/specs/pull/318
 		if !pp.IsSupportedSectorSize(sectorSize) {
-			supportedStrs := make([]string, len(pp.SupportedSectorSizes))
-			for i, ss := range pp.SupportedSectorSizes {
-				supportedStrs[i] = ss.String()
+			supportedStrs := make([]string, len(pp.SupportedSectors))
+			for i, si := range pp.SupportedSectors {
+				supportedStrs[i] = si.Size.String()
 			}
 			return fmt.Errorf("unsupported sector size: %s (supported sizes: %s)", sectorSize, strings.Join(supportedStrs, ", "))
 		}

--- a/commands/mining_daemon_test.go
+++ b/commands/mining_daemon_test.go
@@ -72,9 +72,9 @@ func TestMiningSealNow(t *testing.T) {
 	pparams, err := minerNode.Protocol(ctx)
 	require.NoError(t, err)
 
-	sectorSize := pparams.SupportedSectorSizes[0]
+	sinfo := pparams.SupportedSectors[0]
 
-	_, err = series.CreateStorageMinerWithAsk(ctx, minerNode, big.NewInt(500), big.NewFloat(0.0001), big.NewInt(3000), sectorSize)
+	_, err = series.CreateStorageMinerWithAsk(ctx, minerNode, big.NewInt(500), big.NewFloat(0.0001), big.NewInt(3000), sinfo.Size)
 	require.NoError(t, err)
 
 	// get address of miner so we can check power

--- a/commands/protocol.go
+++ b/commands/protocol.go
@@ -8,8 +8,6 @@ import (
 	"github.com/ipfs/go-ipfs-cmds"
 
 	"github.com/filecoin-project/go-filecoin/porcelain"
-	"github.com/filecoin-project/go-filecoin/types"
-	"github.com/filecoin-project/go-sectorbuilder"
 )
 
 var protocolCmd = &cmds.Command{
@@ -31,16 +29,11 @@ var protocolCmd = &cmds.Command{
 				return err
 			}
 
-			sectorSize := types.OneKiBSectorSize
-			if pp.ProofsMode == types.LiveProofsMode {
-				sectorSize = types.TwoHundredFiftySixMiBSectorSize
-			}
-
-			maxUserBytes := types.NewBytesAmount(go_sectorbuilder.GetMaxUserBytesPerStagedSector(sectorSize.Uint64()))
-
-			_, err = fmt.Fprintf(w, "\t%s (%s writeable)\n", readableBytesAmount(float64(sectorSize.Uint64())), readableBytesAmount(float64(maxUserBytes.Uint64())))
-			if err != nil {
-				return err
+			for _, sectorInfo := range pp.SupportedSectors {
+				_, err = fmt.Fprintf(w, "\t%s (%s writeable)\n", readableBytesAmount(float64(sectorInfo.Size.Uint64())), readableBytesAmount(float64(sectorInfo.MaxPieceSize.Uint64())))
+				if err != nil {
+					return err
+				}
 			}
 
 			return nil

--- a/porcelain/protocol_test.go
+++ b/porcelain/protocol_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/filecoin-project/go-sectorbuilder"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,11 +45,14 @@ func TestProtocolParams(t *testing.T) {
 			autoSealInterval: 120,
 		}
 
+		sectorSize := types.OneKiBSectorSize
+		maxUserBytes := types.NewBytesAmount(go_sectorbuilder.GetMaxUserBytesPerStagedSector(sectorSize.Uint64()))
+
 		expected := &porcelain.ProtocolParams{
-			AutoSealInterval:     120,
-			ProofsMode:           types.TestProofsMode,
-			SupportedSectorSizes: []*types.BytesAmount{types.OneKiBSectorSize},
-			BlockTime:            protocolTestParamBlockTime,
+			AutoSealInterval: 120,
+			ProofsMode:       types.TestProofsMode,
+			SupportedSectors: []porcelain.SectorInfo{{sectorSize, maxUserBytes}},
+			BlockTime:        protocolTestParamBlockTime,
 		}
 
 		out, err := porcelain.ProtocolParameters(context.TODO(), plumbing)

--- a/tools/fast/action_miner_test.go
+++ b/tools/fast/action_miner_test.go
@@ -54,9 +54,9 @@ func requireMinerClientMakeADeal(ctx context.Context, t *testing.T, minerDaemon,
 	pparams, err := minerDaemon.Protocol(ctx)
 	require.NoError(t, err)
 
-	sectorSize := pparams.SupportedSectorSizes[0]
+	sinfo := pparams.SupportedSectors[0]
 
-	_, err = series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, price, expiry, sectorSize)
+	_, err = series.CreateStorageMinerWithAsk(ctx, minerDaemon, collateral, price, expiry, sinfo.Size)
 	require.NoError(t, err)
 
 	f := files.NewBytesFile([]byte("HODLHODLHODL"))


### PR DESCRIPTION
Moves the max piece size into the json response so that it can be used from FAST.

Resolves #3229