### PR TITLE
Set graphsync logger to info

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 
 	logging.SetLogLevel("dht", "error")          // nolint: errcheck
 	logging.SetLogLevel("bitswap", "error")      // nolint: errcheck
+	logging.SetLogLevel("graphsync", "info")     // nolint: errcheck
 	logging.SetLogLevel("heartbeat", "error")    // nolint: errcheck
 	logging.SetLogLevel("blockservice", "error") // nolint: errcheck
 	logging.SetLogLevel("peerqueue", "error")    // nolint: errcheck


### PR DESCRIPTION
Graphsync is very spammy with the debug logs producing 30k-60k logs in 5 minutes per host on nightly. This might indicate a larger issue but the spam is so bad that it fills our elastic search instance to the point that we can gather no logs.

We reduced bitswap to error only as well, so I believe we will want to do the same here.

Almost all of which seem to be this line: https://github.com/ipfs/go-graphsync/blob/405d87c1c392c326e529929f18fd648ab2e3d07e/requestmanager/asyncloader/responsecache/responsecache.go#L84