### PR TITLE
Network deployment tests

### DIFF
--- a/functional-tests/network-deployment/README.md
+++ b/functional-tests/network-deployment/README.md
@@ -1,0 +1,68 @@
+Network Deployment Tests
+========================
+
+These tests can be run against a deployed kittyhawk network to verify
+expected behavior.
+
+All tests can be run by invoking the `test` command with the `-deployment <network>`
+flag from the project root. A `go-filecoin` binary should be built and located in the
+project root (`go run ./build build-filecoin`).
+
+```
+$ go run ./build test -deployment nightly -unit false
+```
+
+Their are currently four suported networks: `nightly`, `staging`, `users`, and `local`.
+
+The `local` network is primarly used to help during development as the network will run
+with a `5s` block time and smaller 1KiB sectors.
+
+## Writing Tests
+
+A deployment test is any test with a call to `tf.Deployment(t)`. The call to `tf.Deployment`
+returns the network name the test should be configured for. This value can be passed into
+`fastesting.NewDeploymentEnvironment` so everything is configured correctly.
+
+Due to the large setup cost (chain syncing / processing) the same process can be used for
+related tests as long as no state between tests is shared (creating a miner in one, and using it
+in another).
+
+```
+package networkdeployment_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/tools/fast/fastesting"
+)
+
+func TestFoo(t *testing.T) {
+	network := tf.DeploymentTest(t)
+
+	ctx := context.Background()
+	ctx, env := fastesting.NewDeploymentEnvironment(ctx, t, network, fast.FilecoinOpts{})
+
+	// Teardown will shutdown all running processes the environment knows about
+	// and cleanup anything the environment setup. This includes the directory
+	// the environment was created to use.
+	defer func() {
+		err := env.Teardown(ctx)
+		require.NoError(t, err)
+	}()
+
+	node := env.RequireNewNodeWithFunds()
+
+	 // Tests can reuse the same enviroment or even a shared process. Tests should not depend
+	 // on output of any other test such as a created miner, etc
+
+	 t.Run("Do something with node", func(t *testing.T) {
+	 })
+
+	 t.Run("Do something else with node", func(t *testing.T) {
+	 })
+```

--- a/functional-tests/network-deployment/bootstrap_test.go
+++ b/functional-tests/network-deployment/bootstrap_test.go
@@ -1,0 +1,98 @@
+package networkdeployment_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/tools/fast/fastesting"
+
+	pr "github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
+)
+
+// TestBootstrap verifies information about the bootstrap peers
+func TestBootstrap(t *testing.T) {
+	network := tf.DeploymentTest(t)
+
+	ctx := context.Background()
+	ctx, env := fastesting.NewDeploymentEnvironment(ctx, t, network, fast.FilecoinOpts{})
+	defer func() {
+		err := env.Teardown(ctx)
+		require.NoError(t, err)
+	}()
+
+	client := env.RequireNewNodeStarted()
+
+	t.Run("Check that we are connected to bootstrap peers", func(t *testing.T) {
+		maddrChan := make(chan multiaddr.Multiaddr, 16)
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		go func() {
+			defer close(maddrChan)
+			protop2p := multiaddr.ProtocolWithCode(multiaddr.P_P2P)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(5 * time.Second):
+					peers, err := client.SwarmPeers(ctx)
+					assert.NoError(t, err)
+
+					for _, peer := range peers {
+						transport, err := multiaddr.NewMultiaddr(peer.Addr)
+						require.NoError(t, err)
+
+						// /ipfs/<ID>
+						peercomp, err := multiaddr.NewComponent(protop2p.Name, peer.Peer)
+						require.NoError(t, err)
+
+						fullmaddr := transport.Encapsulate(peercomp)
+						maddrChan <- fullmaddr
+					}
+				}
+			}
+		}()
+
+		bootstrapAddrs := networkBootstrapPeers(network)
+		require.NotEmpty(t, bootstrapAddrs)
+
+		bootstrapPeers, err := createResolvedPeerInfoMap(ctx, bootstrapAddrs)
+		require.NoError(t, err)
+
+		for maddr := range maddrChan {
+			pinfo, err := pr.AddrInfoFromP2pAddr(maddr)
+			require.NoError(t, err)
+
+			if _, ok := bootstrapPeers[pinfo.ID]; !ok {
+				continue
+			}
+
+			// pinfo will have only a single address as it comes from a single multiaddr
+			require.NotEmpty(t, pinfo.Addrs)
+			addr := pinfo.Addrs[0]
+
+			t.Logf("Looking at addr %s", addr)
+			for _, a := range bootstrapPeers[pinfo.ID].Addrs {
+				if addr.Equal(a) {
+					t.Logf("Found addr for peer %s", pinfo.ID)
+					delete(bootstrapPeers, pinfo.ID)
+				}
+			}
+
+			if len(bootstrapPeers) == 0 {
+				cancel()
+			}
+
+			for peerID := range bootstrapPeers {
+				t.Logf("Still waiting for %s", peerID)
+			}
+		}
+	})
+}

--- a/functional-tests/network-deployment/logging_test.go
+++ b/functional-tests/network-deployment/logging_test.go
@@ -1,0 +1,10 @@
+package networkdeployment_test
+
+import (
+	logging "github.com/ipfs/go-log"
+	oldlogging "github.com/whyrusleeping/go-logging"
+)
+
+func init() {
+	logging.SetAllLoggers(oldlogging.INFO)
+}

--- a/functional-tests/network-deployment/miner_workflow_test.go
+++ b/functional-tests/network-deployment/miner_workflow_test.go
@@ -1,0 +1,185 @@
+package networkdeployment_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io"
+	"io/ioutil"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-ipfs-files"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/tools/fast/fastesting"
+	"github.com/filecoin-project/go-filecoin/tools/fast/series"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+func TestMinerWorkflow(t *testing.T) {
+	network := tf.DeploymentTest(t)
+
+	ctx := context.Background()
+	ctx, env := fastesting.NewDeploymentEnvironment(ctx, t, network, fast.FilecoinOpts{})
+	defer func() {
+		err := env.Teardown(ctx)
+		require.NoError(t, err)
+	}()
+
+	miner := env.RequireNewNodeWithFunds()
+	client := env.RequireNewNodeWithFunds()
+
+	t.Run("Verify mining", func(t *testing.T) {
+		askCollateral := big.NewInt(10)
+		askPrice := big.NewFloat(0.000000001)
+		askExpiry := big.NewInt(128)
+		dealExpiry := uint64(32)
+
+		pparams, err := miner.Protocol(ctx)
+		require.NoError(t, err)
+
+		sinfo := pparams.SupportedSectors[0]
+
+		//
+		// Verify that a miner can be created with an ask
+		//
+
+		t.Logf("Sector Size: %s", sinfo.Size)
+
+		// Create a miner on the miner node
+		ask, err := series.CreateStorageMinerWithAsk(ctx, miner, askCollateral, askPrice, askExpiry, sinfo.Size)
+		require.NoError(t, err)
+
+		t.Logf("Miner  %s", ask.Miner)
+		t.Logf("Ask ID %d", ask.ID)
+
+		//
+		// Verify that a deal can be proposed
+		//
+
+		// Connect the client and the miner
+		err = series.Connect(ctx, client, miner)
+		require.NoError(t, err)
+
+		// Store some data with the miner with the given ask, returns the cid for
+		// the imported data, and the deal which was created
+		var data bytes.Buffer
+		dataReader := io.LimitReader(rand.Reader, int64(sinfo.MaxPieceSize.Uint64()))
+		dataReader = io.TeeReader(dataReader, &data)
+		dcid, deal, err := series.ImportAndStoreWithDuration(ctx, client, ask, dealExpiry, files.NewReaderFile(dataReader))
+		require.NoError(t, err)
+
+		t.Logf("Piece ID %s", dcid)
+		t.Logf("Deal ID  %s", deal.ProposalCid)
+
+		// Wait for the deal to be complete
+
+		start := time.Now()
+		_, err = series.WaitForDealState(ctx, client, deal, storagedeal.Complete)
+		require.NoError(t, err)
+
+		elapsed := time.Since(start)
+		t.Logf("Storage deal took %s to move to `Complete` state", elapsed)
+
+		//
+		// Verify that deal shows up on both the miner and the client
+		//
+
+		_, err = series.FindDealByID(ctx, client, deal.ProposalCid)
+		require.NoError(t, err, "Could not find deal on client")
+
+		_, err = series.FindDealByID(ctx, miner, deal.ProposalCid)
+		require.NoError(t, err, "Could not find deal on miner")
+
+		//
+		// Verify that the deal piece can be retrieved
+		//
+
+		// Retrieve the stored piece of data
+		reader, err := client.RetrievalClientRetrievePiece(ctx, dcid, ask.Miner)
+		require.NoError(t, err)
+
+		// Verify that it's all the same
+		retrievedData, err := ioutil.ReadAll(reader)
+		require.NoError(t, err)
+		require.Equal(t, data.Bytes(), retrievedData)
+
+		//
+		// Verify that the deal voucher can be redeemed at the end of the deal
+		//
+
+		vouchers, err := client.ClientPayments(ctx, deal.ProposalCid)
+		require.NoError(t, err)
+
+		lastVoucher := vouchers[len(vouchers)-1]
+
+		t.Logf("Vocuher Channel %s", lastVoucher.Channel.String())
+		t.Logf("Voucher Amount  %s", lastVoucher.Amount.String())
+		t.Logf("Voucher ValidAt %s", lastVoucher.ValidAt.String())
+
+		err = series.WaitForBlockHeight(ctx, miner, &lastVoucher.ValidAt)
+		require.NoError(t, err)
+
+		var addr address.Address
+		err = miner.ConfigGet(ctx, "wallet.defaultAddress", &addr)
+		require.NoError(t, err)
+
+		balanceBefore, err := miner.WalletBalance(ctx, addr)
+		require.NoError(t, err)
+
+		t.Logf("Balance Before %s", balanceBefore)
+
+		mcid, err := miner.DealsRedeem(ctx, deal.ProposalCid, fast.AOPrice(big.NewFloat(1.0)), fast.AOLimit(300))
+		require.NoError(t, err)
+
+		t.Logf("Redeem mcid    %s", mcid)
+
+		result, err := miner.MessageWait(ctx, mcid)
+		require.NoError(t, err)
+
+		t.Logf("Redeem msg gas %s", result.Receipt.GasAttoFIL)
+
+		balanceAfter, err := miner.WalletBalance(ctx, addr)
+		require.NoError(t, err)
+
+		t.Logf("Balance After  %s", balanceAfter)
+
+		// We add the receipt back to the after balance to "undo" the gas costs, then subtract the before balance
+		// what is left is the change as a result of redeeming the voucher
+		assert.Equal(t, lastVoucher.Amount, balanceAfter.Add(result.Receipt.GasAttoFIL).Sub(balanceBefore))
+
+		//
+		// Verify that the miners power has increased
+		//
+
+		minfo, err := series.WaitForChainMessage(ctx, miner, func(ctx context.Context, node *fast.Filecoin, msg *types.SignedMessage) (bool, error) {
+			if msg.Method == "submitPoSt" && msg.To == ask.Miner {
+				return true, nil
+			}
+
+			return false, nil
+		})
+		require.NoError(t, err)
+
+		t.Logf("submitPoSt message        %s", minfo.MsgCid)
+		t.Logf("submitPoSt found in block %s", minfo.BlockCid)
+
+		resp, err := miner.MessageWait(ctx, minfo.MsgCid)
+		require.NoError(t, err)
+		assert.Equal(t, 0, int(resp.Receipt.ExitCode))
+
+		mpower, err := miner.MinerPower(ctx, ask.Miner)
+		require.NoError(t, err)
+
+		// We should have a single sector of power
+		assert.Equal(t, &mpower.Power, sinfo.Size)
+	})
+}

--- a/functional-tests/network-deployment/relay_check_test.go
+++ b/functional-tests/network-deployment/relay_check_test.go
@@ -1,0 +1,321 @@
+package networkdeployment_test
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/fixtures"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/tools/fast/fastesting"
+
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-circuit"
+	pr "github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/routing"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multiaddr-dns"
+)
+
+// TestRelayCheck is a two part test
+// 1) Check that the relay peers are advertising their addresses under
+//    the correct dht key
+// 2) Check that a node behind a NAT aquires a circuit relay address from
+//    one of the relay peers
+func TestRelayCheck(t *testing.T) {
+	network := tf.DeploymentTest(t)
+
+	ctx := context.Background()
+	ctx, env := fastesting.NewDeploymentEnvironment(ctx, t, network, fast.FilecoinOpts{})
+	defer func() {
+		err := env.Teardown(ctx)
+		require.NoError(t, err)
+	}()
+
+	client := env.RequireNewNodeStarted()
+
+	// In this test we query the dht looking for providers of the relay key
+	// and verify that all of the expected providers show up at some point.
+	t.Run("Check for relay providers", func(t *testing.T) {
+		dhtKey, err := cid.Decode("zb2rhZ6FpTqFZyiAtpQFRKmybPMjq5A7oPHfmD5WeBko5kRAo")
+		require.NoError(t, err)
+
+		maddrChan := make(chan multiaddr.Multiaddr, 16)
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		eventChan, err := scanDhtProviders(ctx, t, client, dhtKey)
+		require.NoError(t, err)
+
+		go func() {
+			defer close(maddrChan)
+			for event := range eventChan {
+				// There is only a single PeerInfo in the response see command `findprovs`.
+				pinfo := event.Responses[0]
+
+				// For some reason if a peer responses to a query, it will not include its
+				// own addresses. This might be a bug. However, all it means is that we need
+				// to take at least two arounds from two different peers, which is largely
+				// just luck of the draw.
+				if len(pinfo.Addrs) == 0 {
+					t.Logf("No addresses returned for peer %s", pinfo.ID)
+					continue
+				}
+
+				t.Logf("Found record for peer %s", pinfo.ID)
+
+				// Converts the pinfo into a set of addresses
+				maddrs, err := pr.AddrInfoToP2pAddrs(pinfo)
+				if err != nil {
+					t.Logf("Failed to get maddrs")
+					continue
+				}
+
+				for _, maddr := range maddrs {
+					maddrChan <- maddr
+				}
+			}
+		}()
+
+		relayPeersAddrs := networkRelayPeers(network)
+		require.NotEmpty(t, relayPeersAddrs)
+
+		// To verify that all of the relay peers are advertising correctly we need to
+		// see one of their addresses come through when we query the relay provider key.
+		// Below we construct a peer.ID mapping to a PeerInfo that contains addresses we
+		// expect to see.
+		// The address we expect to see is either the dns4 multiaddr from relayPeersAddrs,
+		// or the resolved ip4 address.
+		relayPeers, err := createResolvedPeerInfoMap(ctx, relayPeersAddrs)
+		require.NoError(t, err)
+
+		for maddr := range maddrChan {
+			pinfo, err := pr.AddrInfoFromP2pAddr(maddr)
+			require.NoError(t, err)
+
+			if _, ok := relayPeers[pinfo.ID]; !ok {
+				continue
+			}
+
+			// pinfo will have only a single address as it comes from a single multiaddr
+			require.NotEmpty(t, pinfo.Addrs)
+			addr := pinfo.Addrs[0]
+
+			t.Logf("Looking at addr %s", addr)
+			for _, a := range relayPeers[pinfo.ID].Addrs {
+				if addr.Equal(a) {
+					t.Logf("Found addr for peer %s", pinfo.ID)
+					delete(relayPeers, pinfo.ID)
+				}
+			}
+
+			if len(relayPeers) == 0 {
+				cancel()
+			}
+
+			for peerID := range relayPeers {
+				t.Logf("Still waiting for %s", peerID)
+			}
+		}
+	})
+
+	// In this test we want to verify that we retrieve a circuit relay address
+	// from one of our expected relay providers.
+	t.Run("Has circuit address", func(t *testing.T) {
+		details, err := client.ID(ctx)
+		require.NoError(t, err)
+
+		maddrChan := make(chan multiaddr.Multiaddr, 16)
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		go func() {
+			defer close(maddrChan)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(5 * time.Second):
+					details, err := client.ID(ctx)
+					assert.NoError(t, err)
+
+					for _, maddr := range details.Addresses {
+						maddrChan <- maddr
+					}
+				}
+			}
+		}()
+
+		relayPeersAddrs := networkRelayPeers(network)
+		require.NotEmpty(t, relayPeersAddrs)
+
+		relayPeers, err := createResolvedPeerInfoMap(ctx, relayPeersAddrs)
+		require.NoError(t, err)
+
+		// To verify that we have a circuit address from one of our relays we need to
+		// strip off the circuit component, and compare the address to the known addresses
+		// of our relays
+
+		protop2p := multiaddr.ProtocolWithCode(multiaddr.P_P2P)
+		protocircuit := multiaddr.ProtocolWithCode(relay.P_CIRCUIT)
+
+		// /ipfs/<ID>
+		peercomp, err := multiaddr.NewComponent(protop2p.Name, details.ID.String())
+		require.NoError(t, err)
+
+		// /p2p-circuit
+		relaycomp, err := multiaddr.NewComponent(protocircuit.Name, "")
+		require.NoError(t, err)
+
+		// /p2p-circuit/ipfs/<ID>
+		relaypeer := relaycomp.Encapsulate(peercomp)
+
+		for maddr := range maddrChan {
+			if _, err := maddr.ValueForProtocol(relay.Protocol.Code); err != nil {
+				continue
+			}
+
+			t.Logf("Found circuit addr %s", maddr)
+
+			relayaddr := maddr.Decapsulate(relaypeer)
+			pinfo, err := pr.AddrInfoFromP2pAddr(relayaddr)
+			require.NoError(t, err)
+
+			if _, ok := relayPeers[pinfo.ID]; !ok {
+				continue
+			}
+
+			// pinfo will have only a single address as it comes from a single multiaddr
+			require.NotEmpty(t, pinfo.Addrs)
+			addr := pinfo.Addrs[0]
+
+			if _, ok := relayPeers[pinfo.ID]; !ok {
+				t.Logf("Found circuit address %s from unexpected peer %s", maddr, pinfo.ID)
+				continue
+			}
+
+			for _, a := range relayPeers[pinfo.ID].Addrs {
+				if addr.Equal(a) {
+					t.Logf("Addr relays through %s", pinfo.ID)
+					cancel()
+					break
+				}
+			}
+		}
+	})
+}
+
+func createResolvedPeerInfoMap(ctx context.Context, addrs []string) (map[pr.ID]*pr.AddrInfo, error) {
+	protop2p := multiaddr.ProtocolWithCode(multiaddr.P_P2P)
+
+	relayPeers := make(map[pr.ID]*pr.AddrInfo)
+	for _, addr := range addrs {
+		maddr, err := multiaddr.NewMultiaddr(addr)
+		if err != nil {
+			return nil, err
+		}
+
+		pinfo, err := pr.AddrInfoFromP2pAddr(maddr)
+		if err != nil {
+			return nil, err
+		}
+
+		// PeerInfo stores just the transport of the multiaddr and removes the peer
+		// component from the end. However, when we resolve the dns4 address to ip4
+		// we get back the full address, so we want to strip the peer component
+		// for consistently
+
+		// This is the /ipfs/<peer-id> component
+		peercomp, err := multiaddr.NewComponent(protop2p.Name, pinfo.ID.String())
+		if err != nil {
+			return nil, err
+		}
+
+		rmaddrs, err := madns.Resolve(ctx, maddr)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, maddr := range rmaddrs {
+			pinfo.Addrs = append(pinfo.Addrs, maddr.Decapsulate(peercomp))
+		}
+
+		relayPeers[pinfo.ID] = pinfo
+	}
+
+	return relayPeers, nil
+}
+
+// scanDhtProviders runs a `findprovs` at least every 5 seconds and reads through all
+// of the events looking for `notif.Provider` events. These events contain PeerInfo
+// which we convert into a slice of multiaddrs and publish on our maddrChan.
+func scanDhtProviders(ctx context.Context, t *testing.T, node *fast.Filecoin, dhtKey cid.Cid) (<-chan routing.QueryEvent, error) {
+	eventChan := make(chan routing.QueryEvent, 16)
+
+	go func() {
+		defer close(eventChan)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(5 * time.Second):
+				t.Logf("Finding Providers for %s", dhtKey)
+				decoder, err := node.DHTFindProvs(ctx, dhtKey)
+				if err != nil {
+					t.Logf("Failed to run `findprovs`: %s", err)
+					continue
+				}
+
+				// Read all of the events from `findprovs`
+				for {
+					var event routing.QueryEvent
+					if err := decoder.Decode(&event); err != nil {
+						if err == io.EOF {
+							break
+						}
+
+						t.Logf("Decode failed %s", err)
+						continue
+					}
+
+					if event.Type == routing.Provider {
+						if len(event.Responses) == 0 {
+							t.Logf("No responses for provider event")
+							continue
+						}
+
+						eventChan <- event
+					}
+				}
+			}
+		}
+	}()
+
+	return eventChan, nil
+}
+
+// returns the list of peer address for the network bootstrap peers
+func networkBootstrapPeers(network string) []string {
+	// Currently all bootstrap addresses are relay peers
+
+	switch network {
+	case "nightly":
+		return fixtures.DevnetNightlyBootstrapAddrs
+	case "staging":
+		return fixtures.DevnetStagingBootstrapAddrs
+	case "user":
+		return fixtures.DevnetUserBootstrapAddrs
+	}
+
+	return []string{}
+}
+
+// returns the list of peer address for network relay peers
+func networkRelayPeers(network string) []string {
+	return networkBootstrapPeers(network)
+}

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect
 	github.com/multiformats/go-multiaddr v0.0.4
+	github.com/multiformats/go-multiaddr-dns v0.0.3
 	github.com/multiformats/go-multiaddr-net v0.0.1
 	github.com/multiformats/go-multibase v0.0.1
 	github.com/multiformats/go-multihash v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -1142,6 +1142,7 @@ golang.org/x/tools v0.0.0-20190725161231-2e34cfcb95cb h1:Zi4or4sGkVpI7V5TX4JDMHJ
 golang.org/x/tools v0.0.0-20190725161231-2e34cfcb95cb/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/tools v0.0.0-20190726230722-1bd56024c620 h1:R1KpHac1wFOWMlo5t+90wDLZ3e6dtEDcwvHB+qA1etk=
 golang.org/x/tools v0.0.0-20190726230722-1bd56024c620/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools v0.0.0-20190813142322-97f12d73768f h1:nQv5Lx4ucsmk8T4jkEQKJu7YLkYXy/PLoZgTpnIrkuI=
 golang.org/x/tools v0.0.0-20190813142322-97f12d73768f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190212162355-a5947ffaace3 h1:P6iTFmrTQqWrqLZPX1VMzCUbCRCAUXSUsSpkEOvWzJ0=
 golang.org/x/xerrors v0.0.0-20190212162355-a5947ffaace3/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/testhelpers/testflags/flags.go
+++ b/testhelpers/testflags/flags.go
@@ -11,6 +11,20 @@ var integrationTest = flag.Bool("integration", true, "Run the integration go tes
 var unitTest = flag.Bool("unit", true, "Run the unit go tests")
 var functionalTest = flag.Bool("functional", false, "Run the functional go tests")
 var sectorBuilderTest = flag.Bool("sectorbuilder", false, "Run the sector builder tests")
+var deploymentTest = flag.String("deployment", "", "Run the deployment tests against a network")
+
+// DeploymentTest will run the test its called from iff the `-deployment` flag
+// is passed when calling `go test`. Otherwise the test will be skipped. DeploymentTest
+// will run the test its called from in parallel.
+// The network under test will be returned.
+func DeploymentTest(t *testing.T) string {
+	if len(*deploymentTest) == 0 {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	return *deploymentTest
+}
 
 // FunctionalTest will run the test its called from iff the `-functional` flag
 // is passed when calling `go test`. Otherwise the test will be skipped. FunctionalTest

--- a/tools/fast/action_deals.go
+++ b/tools/fast/action_deals.go
@@ -10,15 +10,11 @@ import (
 )
 
 // DealsList runs the `deals list` command against the filecoin process
-func (f *Filecoin) DealsList(ctx context.Context, client bool, miner bool) (*json.Decoder, error) {
+func (f *Filecoin) DealsList(ctx context.Context, options ...ActionOption) (*json.Decoder, error) {
 	args := []string{"go-filecoin", "deals", "list"}
 
-	if client {
-		args = append(args, "--client")
-	}
-
-	if miner {
-		args = append(args, "--miner")
+	for _, option := range options {
+		args = append(args, option()...)
 	}
 
 	return f.RunCmdLDJSONWithStdin(ctx, nil, args...)

--- a/tools/fast/bin/localnet/main.go
+++ b/tools/fast/bin/localnet/main.go
@@ -27,6 +27,7 @@ import (
 	logging "github.com/ipfs/go-log"
 	"github.com/mitchellh/go-homedir"
 
+	"github.com/filecoin-project/go-filecoin/commands"
 	"github.com/filecoin-project/go-filecoin/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 	"github.com/filecoin-project/go-filecoin/tools/fast/environment"
@@ -351,6 +352,25 @@ func main() {
 	}
 
 	fmt.Println("Finished!")
+	var nodeDetails []*commands.IDDetails
+	nodes := env.Processes()
+	for _, node := range nodes {
+		details, err := node.ID(ctx)
+		if err != nil {
+			exitcode = handleError(err, "failed to fetch details of node")
+			return
+		}
+
+		nodeDetails = append(nodeDetails, details)
+	}
+
+	fmt.Printf("Genesis %s\n", genesisURI)
+	for i, details := range nodeDetails {
+		for _, addr := range details.Addresses {
+			fmt.Printf("node %d addr: %s\n", i, addr)
+		}
+	}
+
 	fmt.Println("Ctrl-C to exit")
 
 	<-exit

--- a/tools/fast/environment/environment_memory_genesis.go
+++ b/tools/fast/environment/environment_memory_genesis.go
@@ -78,9 +78,6 @@ func NewMemoryGenesis(funds *big.Int, location string, proofsMode types.ProofsMo
 // Filecoin processes default wallet address.
 // GetFunds will cause the genesis node to send 1000 filecoin to process `p`.
 func (e *MemoryGenesis) GetFunds(ctx context.Context, p *fast.Filecoin) error {
-	e.processesMu.Lock()
-	defer e.processesMu.Unlock()
-
 	e.log.Infof("GetFunds for process: %s", p.String())
 	return series.SendFilecoinDefaults(ctx, e.Processes()[0], p, 1000)
 }
@@ -240,7 +237,7 @@ func (e *MemoryGenesis) buildGenesis(funds *big.Int) error {
 		Miners: []*gengen.CreateStorageMinerConfig{
 			{
 				Owner:               0,
-				NumCommittedSectors: 1,
+				NumCommittedSectors: 128,
 			},
 		},
 		ProofsMode: e.proofsMode,

--- a/tools/fast/fastesting/deployment.go
+++ b/tools/fast/fastesting/deployment.go
@@ -1,0 +1,184 @@
+package fastesting
+
+import (
+	"context"
+	"io/ioutil"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-ipfs-files"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/testhelpers"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/tools/fast/environment"
+	"github.com/filecoin-project/go-filecoin/tools/fast/series"
+	localplugin "github.com/filecoin-project/go-filecoin/tools/iptb-plugins/filecoin/local"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// DeploymentEnvironment provides common setup for writing tests which will run against
+// a deployed network using FAST
+type DeploymentEnvironment struct {
+	environment.Environment
+
+	t   *testing.T
+	ctx context.Context
+
+	pluginName string
+	pluginOpts map[string]string
+
+	postInitFn func(context.Context, *fast.Filecoin) error
+
+	fastenvOpts fast.FilecoinOpts
+}
+
+// NewDeploymentEnvironment creates a DeploymentEnvironment with a basic setup for writing
+// tests using the FAST library. DeploymentEnvironment also supports testing locally using
+// the `local` network which will handle setting up a mining node and updating bootstrap
+// peers. The local network runs at 5 second blocktimes.
+func NewDeploymentEnvironment(ctx context.Context, t *testing.T, network string, fastenvOpts fast.FilecoinOpts) (context.Context, *DeploymentEnvironment) {
+
+	// Create a directory for the test using the test name (mostly for FAST)
+	// Replace the forward slash as tempdir can't handle them
+	dir, err := ioutil.TempDir("", strings.Replace(t.Name(), "/", ".", -1))
+	require.NoError(t, err)
+
+	if network == "local" {
+		return makeLocal(ctx, t, dir, fastenvOpts)
+	}
+
+	return makeDevnet(ctx, t, network, dir, fastenvOpts)
+}
+
+func makeLocal(ctx context.Context, t *testing.T, dir string, fastenvOpts fast.FilecoinOpts) (context.Context, *DeploymentEnvironment) {
+	// Create an environment to connect to the devnet
+	env, err := environment.NewMemoryGenesis(big.NewInt(1000000), dir, types.TestProofsMode)
+	require.NoError(t, err)
+
+	defer func() {
+		dumpEnvOutputOnFail(t, env.Processes())
+	}()
+
+	// Setup options for nodes.
+	options := make(map[string]string)
+	options[localplugin.AttrLogJSON] = "0"
+	options[localplugin.AttrLogLevel] = "5"
+	options[localplugin.AttrFilecoinBinary] = testhelpers.MustGetFilecoinBinary()
+
+	genesisURI := env.GenesisCar()
+	genesisMiner, err := env.GenesisMiner()
+	require.NoError(t, err)
+
+	fastenvOpts.InitOpts = append([]fast.ProcessInitOption{fast.POGenesisFile(genesisURI)}, fastenvOpts.InitOpts...)
+	fastenvOpts.DaemonOpts = append([]fast.ProcessDaemonOption{fast.POBlockTime(time.Second * 5)}, fastenvOpts.DaemonOpts...)
+
+	ctx = series.SetCtxSleepDelay(ctx, time.Second*5)
+
+	// Setup the first node which is used to help coordinate the other nodes by providing
+	// funds, mining for the network, etc
+	genesis, err := env.NewProcess(ctx, localplugin.PluginName, options, fastenvOpts)
+	require.NoError(t, err)
+
+	err = series.SetupGenesisNode(ctx, genesis, genesisMiner.Address, files.NewReaderFile(genesisMiner.Owner))
+	require.NoError(t, err)
+
+	err = genesis.MiningStart(ctx)
+	require.NoError(t, err)
+
+	details, err := genesis.ID(ctx)
+	require.NoError(t, err)
+
+	return ctx, &DeploymentEnvironment{
+		Environment: env,
+		t:           t,
+		ctx:         ctx,
+		pluginName:  localplugin.PluginName,
+		pluginOpts:  options,
+		fastenvOpts: fastenvOpts,
+		postInitFn: func(ctx context.Context, node *fast.Filecoin) error {
+			config, err := node.Config()
+			if err != nil {
+				return err
+			}
+
+			config.Bootstrap.Addresses = []string{details.Addresses[0].String()}
+			config.Bootstrap.MinPeerThreshold = 1
+			config.Bootstrap.Period = "10s"
+
+			return node.WriteConfig(config)
+		},
+	}
+}
+
+func makeDevnet(ctx context.Context, t *testing.T, network string, dir string, fastenvOpts fast.FilecoinOpts) (context.Context, *DeploymentEnvironment) {
+	// Create an environment that includes a genesis block with 1MM FIL
+	env, err := environment.NewDevnet(network, dir)
+	require.NoError(t, err)
+
+	defer func() {
+		dumpEnvOutputOnFail(t, env.Processes())
+	}()
+
+	// Setup options for nodes.
+	options := make(map[string]string)
+	options[localplugin.AttrLogJSON] = "0"                                        // Enable JSON logs
+	options[localplugin.AttrLogLevel] = "5"                                       // Set log level to Debug
+	options[localplugin.AttrFilecoinBinary] = testhelpers.MustGetFilecoinBinary() // Get the filecoin binary
+
+	genesisURI := env.GenesisCar()
+
+	fastenvOpts.InitOpts = append(fastenvOpts.InitOpts, fast.POGenesisFile(genesisURI), fast.PODevnet(network))
+
+	ctx = series.SetCtxSleepDelay(ctx, time.Second*30)
+
+	return ctx, &DeploymentEnvironment{
+		Environment: env,
+		t:           t,
+		ctx:         ctx,
+		pluginName:  localplugin.PluginName,
+		pluginOpts:  options,
+		fastenvOpts: fastenvOpts,
+		postInitFn: func(ctx context.Context, node *fast.Filecoin) error {
+			return nil
+		},
+	}
+}
+
+// RequireNewNodeStarted builds a new node using RequireNewNode, then initializes
+// and starts it
+func (env *DeploymentEnvironment) RequireNewNodeStarted() *fast.Filecoin {
+	p, err := env.NewProcess(env.ctx, env.pluginName, env.pluginOpts, env.fastenvOpts)
+	require.NoError(env.t, err)
+
+	err = series.InitAndStart(env.ctx, p, env.postInitFn)
+	require.NoError(env.t, err)
+
+	return p
+}
+
+// RequireNewNodeWithFunds builds a new node using RequireNewNodeStarted, then
+// sends it funds from the environment GenesisMiner node
+func (env *DeploymentEnvironment) RequireNewNodeWithFunds() *fast.Filecoin {
+	p := env.RequireNewNodeStarted()
+
+	err := env.GetFunds(env.ctx, p)
+	require.NoError(env.t, err)
+
+	return p
+}
+
+// Teardown stops all of the nodes and cleans up the environment. If the test failed,
+// it will also print the last output of each process by calling `DumpLastOutput`.
+// Output is logged using the Log method on the testing.T
+func (env *DeploymentEnvironment) Teardown(ctx context.Context) error {
+	env.DumpEnvOutputOnFail()
+	return env.Environment.Teardown(ctx)
+}
+
+// DumpEnvOutputOnFail calls `DumpLastOutput for each process if the test failed.
+func (env *DeploymentEnvironment) DumpEnvOutputOnFail() {
+	dumpEnvOutputOnFail(env.t, env.Processes())
+}

--- a/tools/fast/process.go
+++ b/tools/fast/process.go
@@ -115,6 +115,8 @@ func (f *Filecoin) InitDaemon(ctx context.Context, args ...string) (testbedi.Out
 		}
 	}
 
+	f.Log.Infof("InitDaemon: %s %s", f.core.Dir(), args)
+
 	return f.core.Init(ctx, args...)
 }
 
@@ -129,6 +131,8 @@ func (f *Filecoin) StartDaemon(ctx context.Context, wait bool, args ...string) (
 			args = append(args, opt()...)
 		}
 	}
+
+	f.Log.Infof("StartDaemon: %s %s", f.core.Dir(), args)
 
 	out, err := f.core.Start(ctx, wait, args...)
 	if err != nil {

--- a/tools/fast/process_options.go
+++ b/tools/fast/process_options.go
@@ -31,6 +31,13 @@ func POAutoSealIntervalSeconds(seconds int) ProcessInitOption {
 	}
 }
 
+// PODevnet provides the `--devnet-<net>` option to process at init
+func PODevnet(net string) ProcessInitOption {
+	return func() []string {
+		return []string{fmt.Sprintf("--devnet-%s", net)}
+	}
+}
+
 // PODevnetStaging provides the `--devnet-staging` option to process at init
 func PODevnetStaging() ProcessInitOption {
 	return func() []string {

--- a/tools/fast/series/find_deal_by_id.go
+++ b/tools/fast/series/find_deal_by_id.go
@@ -1,0 +1,33 @@
+package series
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/filecoin-project/go-filecoin/commands"
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/ipfs/go-cid"
+)
+
+// FindDealByID looks for a deal using `DealsList` and returns the result where id matches the ProposalCid of
+// the deal.
+func FindDealByID(ctx context.Context, client *fast.Filecoin, id cid.Cid) (commands.DealsListResult, error) {
+	dec, err := client.DealsList(ctx)
+	if err != nil {
+		return commands.DealsListResult{}, err
+	}
+
+	var dl commands.DealsListResult
+
+	for dec.More() {
+		if err := dec.Decode(&dl); err != nil {
+			return commands.DealsListResult{}, err
+		}
+
+		if dl.ProposalCid == id {
+			return dl, nil
+		}
+	}
+
+	return commands.DealsListResult{}, fmt.Errorf("No deal found")
+}

--- a/tools/fast/series/wait_for_chain_message.go
+++ b/tools/fast/series/wait_for_chain_message.go
@@ -1,0 +1,79 @@
+package series
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/filecoin-project/go-filecoin/tools/fast"
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/ipfs/go-cid"
+)
+
+// MsgInfo contains the BlockCid for the message MsgCid
+type MsgInfo struct {
+	BlockCid cid.Cid
+	MsgCid   cid.Cid
+}
+
+// MsgSearchFn is the function signature used to find a message
+type MsgSearchFn func(context.Context, *fast.Filecoin, *types.SignedMessage) (bool, error)
+
+// WaitForChainMessage iterates over the chain until the provided function `fn` returns true.
+func WaitForChainMessage(ctx context.Context, node *fast.Filecoin, fn MsgSearchFn) (*MsgInfo, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-CtxSleepDelay(ctx):
+			dec, err := node.ChainLs(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			for dec.More() {
+				var blks []types.Block
+				err := dec.Decode(&blks)
+				if err != nil {
+					if err == io.EOF {
+						break
+					}
+
+					return nil, err
+				}
+
+				if msgInfo, err := findMessageInBlockSlice(ctx, node, blks, fn); err == nil {
+					return msgInfo, nil
+				}
+			}
+		}
+	}
+}
+
+func findMessageInBlockSlice(ctx context.Context, node *fast.Filecoin, blks []types.Block, fn MsgSearchFn) (*MsgInfo, error) {
+	for _, blk := range blks {
+		msgs, err := node.ShowMessages(ctx, blk.Messages)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, msg := range msgs {
+			found, err := fn(ctx, node, msg)
+			if err != nil {
+				return nil, err
+			}
+
+			if found {
+				blockCid := blk.Cid()
+				msgCid, _ := msg.Cid()
+
+				return &MsgInfo{
+					BlockCid: blockCid,
+					MsgCid:   msgCid,
+				}, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("Message not found")
+}


### PR DESCRIPTION
This PR provides us a fairly simple way to write functional tests that can be run against a deployed network, and support local development.

Due to bootstrapping issues I've added a `fastesting.NewDeploymentEnvironment` which provides the barebones to support both the deployed networks as well as local development.
