### PR TITLE
Track block, message and tipset size when processing.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1142,6 +1142,7 @@ golang.org/x/tools v0.0.0-20190725161231-2e34cfcb95cb h1:Zi4or4sGkVpI7V5TX4JDMHJ
 golang.org/x/tools v0.0.0-20190725161231-2e34cfcb95cb/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/tools v0.0.0-20190726230722-1bd56024c620 h1:R1KpHac1wFOWMlo5t+90wDLZ3e6dtEDcwvHB+qA1etk=
 golang.org/x/tools v0.0.0-20190726230722-1bd56024c620/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools v0.0.0-20190813142322-97f12d73768f h1:nQv5Lx4ucsmk8T4jkEQKJu7YLkYXy/PLoZgTpnIrkuI=
 golang.org/x/tools v0.0.0-20190813142322-97f12d73768f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190212162355-a5947ffaace3 h1:P6iTFmrTQqWrqLZPX1VMzCUbCRCAUXSUsSpkEOvWzJ0=
 golang.org/x/xerrors v0.0.0-20190212162355-a5947ffaace3/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/metrics/bucket.go
+++ b/metrics/bucket.go
@@ -1,0 +1,51 @@
+package metrics
+
+import (
+	"context"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+// NewInt64ByteBucket creates a Int64Bucket with units of bytes and a default set of aggregation
+// bounds from .25 kilobytes to 10 megabytes.
+func NewInt64ByteBucket(name, desc string, tagKeys ...tag.Key) *Int64Bucket {
+	defaultBounds := []float64{250, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000, 5000000, 10000000}
+	return NewInt64BucketWithBounds(name, desc, stats.UnitBytes, defaultBounds, tagKeys...)
+}
+
+// NewInt64BucketWithBounds creates a Int64Bucket wrapping an opencensus int64 measurement.
+func NewInt64BucketWithBounds(name, desc, unit string, bounds []float64, tagKeys ...tag.Key) *Int64Bucket {
+	log.Infof("registering avg counter: %s - %s", name, desc)
+	measure := stats.Int64(name, desc, unit)
+	iView := &view.View{
+		Name:        name,
+		Measure:     measure,
+		Description: desc,
+		TagKeys:     tagKeys,
+		Aggregation: view.Distribution(bounds...),
+	}
+	if err := view.Register(iView); err != nil {
+		// a panic here indicates a developer error when creating a view.
+		// Since this method is called in init() methods, this panic when hit
+		// will cause running the program to fail immediately.
+		panic(err)
+	}
+
+	return &Int64Bucket{
+		measureCt: measure,
+		view:      iView,
+	}
+}
+
+// Int64Bucket wraps an opencensus int64 measure that is uses as a distribution.
+type Int64Bucket struct {
+	measureCt *stats.Int64Measure
+	view      *view.View
+}
+
+// Add adds `m` to the values tracked by Int64Bucket.
+func (c *Int64Bucket) Add(ctx context.Context, m int64) {
+	stats.Record(ctx, c.measureCt.M(m))
+}

--- a/types/tipset_test.go
+++ b/types/tipset_test.go
@@ -82,6 +82,16 @@ func TestTipSet(t *testing.T) {
 		assert.Equal(t, 3, t3.Len())
 	})
 
+	t.Run("size", func(t *testing.T) {
+		var expSize uint64
+		t3 := RequireNewTipSet(t, b1, b2, b3)
+		expSize += requireBlockSize(t, b1)
+		expSize += requireBlockSize(t, b2)
+		expSize += requireBlockSize(t, b3)
+		assert.Equal(t, expSize, t3.Size())
+
+	})
+
 	t.Run("key", func(t *testing.T) {
 		assert.Equal(t, NewTipSetKey(b1.Cid()), RequireNewTipSet(t, b1).Key())
 		assert.Equal(t, NewTipSetKey(b1.Cid(), b2.Cid(), b3.Cid()),
@@ -200,4 +210,13 @@ func makeTestBlocks(t *testing.T) (*Block, *Block, *Block) {
 	b2 := block(t, []byte{2}, 1, cid1, parentWeight, 2, "2")
 	b3 := block(t, []byte{3}, 1, cid1, parentWeight, 3, "3")
 	return b1, b2, b3
+}
+
+func requireBlockSize(t *testing.T, b *Block) uint64 {
+	s, err := b.ToNode().Size()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+
 }


### PR DESCRIPTION
This PR adds metrics to track the block, message, and tipset sizes when processing as well as tipset size and duration when fetching.

This PR allows for the amount of data fetched to be compared with the amount of data processed. These metrics can be used when profiling chain syncing and processing times.