### PR TITLE
Feat/set miner worker 2959

### DIFF
--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -123,7 +123,7 @@ type Ask struct {
 // State is the miner actors storage.
 type State struct {
 	// Owner is the address of the account that owns this miner. Income and returned
-	// collateral are paid to this address. This address is also allowed to change the
+	// collateral are paid to this address. This address is also allowed todd change the
 	// worker address for the miner.
 	Owner address.Address
 

--- a/commands/main.go
+++ b/commands/main.go
@@ -329,8 +329,8 @@ func isConnectionRefused(err error) bool {
 	return syscallErr.Err == syscall.ECONNREFUSED
 }
 
-var priceOption = cmdkit.StringOption("gas-price", "Price (FIL e.g. 0.00013) to pay for each GasUnits consumed mining this message")
-var limitOption = cmdkit.Uint64Option("gas-limit", "Maximum number of GasUnits this message is allowed to consume")
+var priceOption = cmdkit.StringOption("gas-price", "Price (FIL e.g. 0.00013) to pay for each GasUnit consumed mining this message")
+var limitOption = cmdkit.Uint64Option("gas-limit", "Maximum GasUnits this message is allowed to consume")
 var previewOption = cmdkit.BoolOption("preview", "Preview the Gas cost of this command without actually executing it")
 
 func parseGasOptions(req *cmds.Request) (types.AttoFIL, types.GasUnits, bool, error) {

--- a/commands/miner.go
+++ b/commands/miner.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/ipfs/go-cid"
-	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
-	cmds "github.com/ipfs/go-ipfs-cmds"
+	"github.com/ipfs/go-ipfs-cmdkit"
+	"github.com/ipfs/go-ipfs-cmds"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
 

--- a/commands/miner.go
+++ b/commands/miner.go
@@ -543,9 +543,13 @@ var minerWorkerAddressCmd = &cmds.Command{
 		ShortDescription: "Show the address of the miner worker",
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
-		minerAddr, err := getMinerAddress(env)
+		ret, err := GetPorcelainAPI(env).ConfigGet("mining.minerAddress")
 		if err != nil {
 			return errors.Wrap(err, "problem getting miner address")
+		}
+		minerAddr, ok := ret.(address.Address)
+		if !ok {
+			return errors.New("problem converting miner address")
 		}
 		workerAddr, err := GetPorcelainAPI(env).MinerGetWorkerAddress(req.Context, minerAddr)
 		if err != nil {
@@ -563,16 +567,4 @@ var minerWorkerAddressCmd = &cmds.Command{
 			return nil
 		}),
 	},
-}
-
-func getMinerAddress(env cmds.Environment) (address.Address, error) {
-	retVal, err := GetPorcelainAPI(env).ConfigGet("mining.minerAddress")
-	if err != nil {
-		return address.Undef, err
-	}
-	minerAddr, ok := retVal.(address.Address)
-	if !ok {
-		return address.Undef, err
-	}
-	return minerAddr, nil
 }

--- a/commands/miner.go
+++ b/commands/miner.go
@@ -495,7 +495,7 @@ ProvingSet: %s
 
 // MinerWorkerResult is a struct containing the result of a MinerWorker or MinerSetWorker command.
 type MinerWorkerResult struct {
-	WorkerAddress address.Address `json:"WorkerAddress"`
+	WorkerAddress address.Address `json:"workerAddress"`
 }
 
 var minerSetWorkerAddressCmd = &cmds.Command{

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -76,21 +76,24 @@ func TestMinerHelp(t *testing.T) {
 			assert.Contains(t, result, elem)
 		}
 	})
-	t.Run("worker --help shows worker help", func(t *testing.T) {
+	t.Run("set-worker --help shows set-worker help", func(t *testing.T) {
 		expected := []string{
-			"go-filecoin miner worker <newAddress> - Set the address of the miner worker",
-			"go-filecoin miner worker [--gas-price=<gas-price>] [--gas-limit=<gas-limit>] [--] <newAddress>",
-			"<newAddress> - The address of the new miner worker.",
-			"--gas-price string - Price (FIL e.g. 0.00013) to pay for each GasUnits consumed mining this message.",
-			" --gas-limit uint64 - Maximum number of GasUnits this message is allowed to consume.",
-			" Sets the address of the miner worker to the provided address. The new address must be that of a worker that has already been created. When a miner is created, this address defaults to the miner owner. Use this command to change the default.",
+			"go-filecoin miner set-worker <new-address> - Set the address of the miner worker",
+			"go-filecoin miner set-worker [--gas-price=<gas-price>] [--gas-limit=<gas-limit>] [--] <new-address>",
+			"<new-address> - The address of the new miner worker.",
+			"--gas-price string - Price (FIL e.g. 0.00013) to pay per GasUnit consumed mining this message.",
+			" --gas-limit uint64 - Maximum GasUnits this message is allowed to consume.",
+			"Set the address of the miner worker to the provided address. When a miner is created, this address defaults to the miner owner. Use this command to change the default.",
 		}
-		result := runHelpSuccess(t, "miner", "worker", "--help")
+		result := runHelpSuccess(t, "miner", "set-worker", "--help")
 		for _, elem := range expected {
 			assert.Contains(t, result, elem)
 		}
 	})
-
+	t.Run("worker --help shows worker help", func(t *testing.T) {
+		result := runHelpSuccess(t, "miner", "worker", "--help")
+		assert.Contains(t, result, "go-filecoin miner worker - Get the address of the miner worker")
+	})
 }
 
 func runHelpSuccess(t *testing.T, args ...string) string {

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/protocol/retrieval"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -105,6 +106,7 @@ func newDefaultBootstrapConfig() *BootstrapConfig {
 // MiningConfig holds all configuration options related to mining.
 type MiningConfig struct {
 	MinerAddress            address.Address `json:"minerAddress"`
+	WorkerAddress           address.Address `json:"workerAddress"`
 	AutoSealIntervalSeconds uint            `json:"autoSealIntervalSeconds"`
 	StoragePrice            types.AttoFIL   `json:"storagePrice"`
 }
@@ -112,6 +114,7 @@ type MiningConfig struct {
 func newDefaultMiningConfig() *MiningConfig {
 	return &MiningConfig{
 		MinerAddress:            address.Undef,
+		WorkerAddress:           address.Undef,
 		AutoSealIntervalSeconds: 120,
 		StoragePrice:            types.ZeroAttoFIL,
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -105,7 +105,6 @@ func newDefaultBootstrapConfig() *BootstrapConfig {
 // MiningConfig holds all configuration options related to mining.
 type MiningConfig struct {
 	MinerAddress            address.Address `json:"minerAddress"`
-	WorkerAddress           address.Address `json:"workerAddress"`
 	AutoSealIntervalSeconds uint            `json:"autoSealIntervalSeconds"`
 	StoragePrice            types.AttoFIL   `json:"storagePrice"`
 }
@@ -113,7 +112,6 @@ type MiningConfig struct {
 func newDefaultMiningConfig() *MiningConfig {
 	return &MiningConfig{
 		MinerAddress:            address.Undef,
-		WorkerAddress:           address.Undef,
 		AutoSealIntervalSeconds: 120,
 		StoragePrice:            types.ZeroAttoFIL,
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/protocol/retrieval"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 

--- a/node/node.go
+++ b/node/node.go
@@ -1094,7 +1094,6 @@ func (node *Node) initStorageFaultSlasherForNode(ctx context.Context, workerAddr
 	node.StorageFaultSlasher = storage.NewFaultSlasher(
 		node.PorcelainAPI,
 		node.Outbox,
-		workerAddress,
 		storage.DefaultFaultSlasherGasPrice,
 		storage.DefaultFaultSlasherGasLimit)
 	return nil

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -260,3 +260,8 @@ func (a *API) PingMinerWithTimeout(
 ) error {
 	return PingMinerWithTimeout(ctx, minerPID, timeout, a)
 }
+
+// MinerSetWorkerAddress sets the miner worker address to the provided address
+func (a *API) MinerSetWorkerAddress(ctx context.Context, toAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits) error {
+	return MinerSetWorkerAddress(ctx, a, toAddr, gasPrice, gasLimit)
+}

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -262,6 +262,6 @@ func (a *API) PingMinerWithTimeout(
 }
 
 // MinerSetWorkerAddress sets the miner worker address to the provided address
-func (a *API) MinerSetWorkerAddress(ctx context.Context, toAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits) error {
+func (a *API) MinerSetWorkerAddress(ctx context.Context, toAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits) (cid.Cid, error) {
 	return MinerSetWorkerAddress(ctx, a, toAddr, gasPrice, gasLimit)
 }

--- a/porcelain/miner.go
+++ b/porcelain/miner.go
@@ -510,30 +510,45 @@ func MinerGetCollateral(ctx context.Context, plumbing mgaAPI, minerAddr address.
 	return types.NewAttoFILFromBytes(rets[0]), nil
 }
 
-// mmswaAPI is the subset of the plumbing.API that MinerSetWorkerAddress uses.
-type mmswaAPI interface {
+// mswaAPI is the subset of the plumbing.API that MinerSetWorkerAddress uses.
+type mswaAPI interface {
+	ConfigGet(dottedPath string) (interface{}, error)
 	ConfigSet(dottedKey string, jsonString string) error
 	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
 	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error
+	MinerGetOwnerAddress(ctx context.Context, minerAddr address.Address) (address.Address, error)
 }
 
 // MinerSetWorkerAddress sets the worker address of the miner actor to the provided new address,
 // waits for the message to appear on chain and then sets miner.workerAddr config to the new address.
 func MinerSetWorkerAddress(
 	ctx context.Context,
-	plumbing mmswaAPI,
-	minerOwnerAddr,
-	minerActorAddr,
+	plumbing mswaAPI,
 	workerAddr address.Address,
 	gasPrice types.AttoFIL,
 	gasLimit types.GasUnits,
 ) error {
-	// message send
-	smsgCid, err := plumbing.MessageSend(ctx, minerOwnerAddr, minerActorAddr, types.ZeroAttoFIL, gasPrice, gasLimit, "changeWorker", workerAddr)
+
+	minerAddr, err := getAddrConfig(plumbing, "mining.minerAddr")
+	if err != nil {
+		return errors.Wrap(err, "could not get miner owner address")
+	}
+
+	minerWorkerAddr, err := getAddrConfig(plumbing, "mining.minerWorkerAddr")
+	if err != nil {
+		return errors.Wrap(err, "could not get miner owner address")
+	}
+
+	minerOwnerAddr, err := plumbing.MinerGetOwnerAddress(ctx, minerAddr)
+	if err != nil {
+		return errors.Wrap(err, "could not get miner address")
+	}
+
+	smsgCid, err := plumbing.MessageSend(ctx, minerOwnerAddr, minerWorkerAddr, types.ZeroAttoFIL, gasPrice, gasLimit, "changeWorker", workerAddr)
 	if err != nil {
 		return err
 	}
-	// message wait
+
 	err = plumbing.MessageWait(ctx, smsgCid, func(blk *types.Block, smsg *types.SignedMessage, receipt *types.MessageReceipt) error {
 		if receipt.ExitCode != uint8(0) {
 			return vmErrors.VMExitCodeToError(receipt.ExitCode, storagemarket.Errors)
@@ -543,6 +558,19 @@ func MinerSetWorkerAddress(
 	if err != nil {
 		return err
 	}
+
 	// set config
 	return plumbing.ConfigSet("mining.workerAddr", workerAddr.String())
+}
+
+func getAddrConfig(plumbing mswaAPI, dottedKey string) (address.Address, error) {
+	ret, err := plumbing.ConfigGet(dottedKey)
+	if err != nil {
+		return address.Undef, errors.Wrap(err, fmt.Sprintf("could not get %s", dottedKey))
+	}
+	configAddr, ok := ret.(address.Address)
+	if !ok {
+		return address.Undef, errors.New(fmt.Sprintf("Problem converting %s to address", configAddr))
+	}
+	return configAddr, nil
 }

--- a/porcelain/miner.go
+++ b/porcelain/miner.go
@@ -544,5 +544,5 @@ func MinerSetWorkerAddress(
 		return err
 	}
 	// set config
-	return plumbing.ConfigSet("miner.workerAddr", workerAddr.String())
+	return plumbing.ConfigSet("mining.workerAddr", workerAddr.String())
 }

--- a/porcelain/miner.go
+++ b/porcelain/miner.go
@@ -527,14 +527,13 @@ func MinerSetWorkerAddress(
 	gasLimit types.GasUnits,
 ) (cid.Cid, error) {
 
-	ret, err := plumbing.ConfigGet("mining.minerAddress")
+	retVal, err := plumbing.ConfigGet("mining.minerAddress")
 	if err != nil {
 		return cid.Undef, err
 	}
-
-	minerAddr, ok := ret.(address.Address)
+	minerAddr, ok := retVal.(address.Address)
 	if !ok {
-		return cid.Undef, errors.New("Problem getting miner address")
+		return cid.Undef, errors.New("problem converting miner address")
 	}
 
 	minerOwnerAddr, err := plumbing.MinerGetOwnerAddress(ctx, minerAddr)

--- a/porcelain/miner_test.go
+++ b/porcelain/miner_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/filecoin-project/go-leb128"
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
-	"github.com/libp2p/go-libp2p-peer"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
@@ -24,12 +22,7 @@ import (
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/wallet"
-	"github.com/filecoin-project/go-leb128"
-	"github.com/ipfs/go-cid"
-	cbor "github.com/ipfs/go-ipld-cbor"
-	"github.com/libp2p/go-libp2p-core/peer"
 
-	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -617,7 +610,7 @@ func (mswap *minerSetWorkerAddressPlumbing) MessageSend(ctx context.Context, fro
 	if mswap.msgFail {
 		return cid.Cid{}, errors.New("MsgFail")
 	}
-	mswap.msgCid = types.SomeCid()
+	mswap.msgCid = types.EmptyMessagesCID
 	return mswap.msgCid, nil
 }
 

--- a/porcelain/miner_test.go
+++ b/porcelain/miner_test.go
@@ -279,7 +279,7 @@ func TestMinerSetPrice(t *testing.T) {
 		price := types.NewAttoFILFromFIL(50)
 		_, err := MinerSetPrice(ctx, plumbing, address.Undef, address.Undef, types.NewGasPrice(0), types.NewGasUnits(0), price, big.NewInt(0))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "Test error in MessageSend")
+		assert.Contains(t, err.Error(), "test error in MessageSend")
 
 		configPrice, err := plumbing.config.Get("mining.storagePrice")
 		require.NoError(t, err)
@@ -348,7 +348,7 @@ func TestMinerSetPrice(t *testing.T) {
 
 		_, err := MinerSetPrice(ctx, plumbing, address.Undef, address.Undef, types.NewGasPrice(0), types.NewGasUnits(0), price, big.NewInt(0))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "Test error in MessageWait")
+		assert.Contains(t, err.Error(), "test error in MessageWait")
 	})
 
 	t.Run("returns interesting information about adding the ask", func(t *testing.T) {

--- a/porcelain/miner_test.go
+++ b/porcelain/miner_test.go
@@ -652,7 +652,7 @@ func TestMinerSetWorkerAddress(t *testing.T) {
 			minerAddr:  minerAddr,
 		}
 
-		err := MinerSetWorkerAddress(context.Background(), plumbing, workerAddr, gprice, glimit)
+		_, err := MinerSetWorkerAddress(context.Background(), plumbing, workerAddr, gprice, glimit)
 		assert.NoError(t, err)
 		assert.Equal(t, workerAddr.String(), plumbing.workerAddr.String())
 	})
@@ -668,11 +668,6 @@ func TestMinerSetWorkerAddress(t *testing.T) {
 			error:    "MsgFail",
 		},
 		{
-			name:     "When MessageWait fails, returns the error and does not set worker address",
-			plumbing: &minerSetWorkerAddressPlumbing{msgWaitFail: true},
-			error:    "MsgWaitFail",
-		},
-		{
 			name:     "When ConfigGet fails, returns the error and does not set worker address",
 			plumbing: &minerSetWorkerAddressPlumbing{cfgFail: true},
 			error:    "CfgFail",
@@ -686,7 +681,7 @@ func TestMinerSetWorkerAddress(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			err := MinerSetWorkerAddress(context.Background(), test.plumbing, workerAddr, gprice, glimit)
+			_, err := MinerSetWorkerAddress(context.Background(), test.plumbing, workerAddr, gprice, glimit)
 			assert.Error(t, err, test.error)
 			assert.Empty(t, test.plumbing.workerAddr)
 		})

--- a/porcelain/miner_test.go
+++ b/porcelain/miner_test.go
@@ -243,7 +243,7 @@ func TestMinerSetPrice(t *testing.T) {
 		price := types.NewAttoFILFromFIL(50)
 		_, err := MinerSetPrice(ctx, plumbing, address.Undef, address.Undef, types.NewGasPrice(0), types.NewGasUnits(0), price, big.NewInt(0))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "Test error in ConfigGet")
+		assert.Contains(t, err.Error(), "test error in ConfigGet")
 	})
 
 	t.Run("reports error when setting into config", func(t *testing.T) {
@@ -254,7 +254,7 @@ func TestMinerSetPrice(t *testing.T) {
 		price := types.NewAttoFILFromFIL(50)
 		_, err := MinerSetPrice(ctx, plumbing, address.Undef, address.Undef, types.NewGasPrice(0), types.NewGasUnits(0), price, big.NewInt(0))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "Test error in ConfigSet")
+		assert.Contains(t, err.Error(), "test error in ConfigSet")
 	})
 
 	t.Run("sets price into config", func(t *testing.T) {

--- a/tools/fast/action_miner.go
+++ b/tools/fast/action_miner.go
@@ -110,3 +110,29 @@ func (f *Filecoin) MinerProvingPeriod(ctx context.Context, miner address.Address
 
 	return out, nil
 }
+
+// MinerWorker runs the `miner worker` command against the filecoin process
+func (f *Filecoin) MinerWorker(ctx context.Context) (address.Address, error) {
+	var out address.Address
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "miner", "worker"); err != nil {
+		return address.Undef, err
+	}
+	return out, nil
+}
+
+// MinerSetWorker runs the `miner set-worker` command against the filecoin process
+func (f *Filecoin) MinerSetWorker(ctx context.Context, newAddr address.Address, options ...ActionOption) error {
+	var out string
+
+	args := []string{"go-filecoin", "miner", "set-worker", newAddr.String()}
+
+	for _, option := range options {
+		args = append(args, option()...)
+	}
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
+		return err
+	}
+	return nil
+}

--- a/tools/fast/action_miner.go
+++ b/tools/fast/action_miner.go
@@ -122,8 +122,8 @@ func (f *Filecoin) MinerWorker(ctx context.Context) (commands.MinerWorkerResult,
 }
 
 // MinerSetWorker runs the `miner set-worker` command against the filecoin process
-func (f *Filecoin) MinerSetWorker(ctx context.Context, newAddr address.Address, options ...ActionOption) (commands.MinerWorkerResult, error) {
-	var out commands.MinerWorkerResult
+func (f *Filecoin) MinerSetWorker(ctx context.Context, newAddr address.Address, options ...ActionOption) (cid.Cid, error) {
+	var out cid.Cid
 
 	args := []string{"go-filecoin", "miner", "set-worker", newAddr.String()}
 

--- a/tools/fast/action_miner.go
+++ b/tools/fast/action_miner.go
@@ -112,18 +112,18 @@ func (f *Filecoin) MinerProvingPeriod(ctx context.Context, miner address.Address
 }
 
 // MinerWorker runs the `miner worker` command against the filecoin process
-func (f *Filecoin) MinerWorker(ctx context.Context) (address.Address, error) {
-	var out address.Address
+func (f *Filecoin) MinerWorker(ctx context.Context) (commands.MinerWorkerResult, error) {
+	var out commands.MinerWorkerResult
 
 	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "miner", "worker"); err != nil {
-		return address.Undef, err
+		return out, err
 	}
 	return out, nil
 }
 
 // MinerSetWorker runs the `miner set-worker` command against the filecoin process
-func (f *Filecoin) MinerSetWorker(ctx context.Context, newAddr address.Address, options ...ActionOption) error {
-	var out string
+func (f *Filecoin) MinerSetWorker(ctx context.Context, newAddr address.Address, options ...ActionOption) (commands.MinerWorkerResult, error) {
+	var out commands.MinerWorkerResult
 
 	args := []string{"go-filecoin", "miner", "set-worker", newAddr.String()}
 
@@ -132,7 +132,7 @@ func (f *Filecoin) MinerSetWorker(ctx context.Context, newAddr address.Address, 
 	}
 
 	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
-		return err
+		return out, err
 	}
-	return nil
+	return out, nil
 }


### PR DESCRIPTION
Part of #2959 

Creates two commands, 
`miner worker` which displays the miner worker address, and already had a porcelain API function associated with it, requiring only the hookup to the CLI.

`miner set-worker <new-address>` which sets the new worker address. 

## Example output:
### miner worker
**$ go-filecoin  miner worker --help**
```
USAGE
  ./go-filecoin miner worker - Show the address of the miner worker

SYNOPSIS
  ./go-filecoin miner worker

DESCRIPTION

  Show the address of the miner worker
```

**$ go-filecoin miner worker**
```
t1nhudgskmseowv7rp4e6scxsmlt3qoysvpn73tuy
```

### miner set-worker
**$ go-filecoin miner set-worker --help**

```
USAGE
  ./go-filecoin miner set-worker <new-address> - Set the address of the miner worker

SYNOPSIS
  ./go-filecoin miner set-worker [--gas-price=<gas-price>] [--gas-limit=<gas-limit>] [--] <new-address>

ARGUMENTS

  <new-address> - The address of the new miner worker.

OPTIONS

  --gas-price string - Price (FIL e.g. 0.00013) to pay for each GasUnit consumed mining this message.
  --gas-limit uint64 - Maximum GasUnits this message is allowed to consume.

DESCRIPTION

  Set the address of the miner worker to the provided address. When a miner is created, this address defaults to the miner owner. Use this command to change the default.
```

**$ go-filecoin miner set-worker t1nhudgskmseowv7rp4e6scxsmlt3qoysvpn73tuy --gas-price=1.0 --gas-limit=300**

```
Changed worker to 't1nhudgskmseowv7rp4e6scxsmlt3qoysvpn73tuy'
```
