### PR TITLE
Add "mining add-piece" command

### DIFF
--- a/commands/mining.go
+++ b/commands/mining.go
@@ -215,11 +215,17 @@ var stringEncoderMap = cmds.EncoderMap{
 	}),
 }
 
+// MiningAddPieceResult is a wrapper around the uint64 sectorID
+type MiningAddPieceResult struct {
+	SectorID uint64
+}
+
 var miningAddPieceCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
-		Tagline: "Add a piece from a local file",
+		Tagline: "Add data directly to a staged sector",
 		ShortDescription: `
-Stages a piece (a local file) into a staged sector. 
+Adds a piece (a local file) to a staged sector.  This is used
+to add data outside of a deal.
 `,
 	},
 	Arguments: []cmdkit.Argument{
@@ -241,12 +247,12 @@ Stages a piece (a local file) into a staged sector.
 			return err
 		}
 
-		return re.Emit(sectorID)
+		return re.Emit(MiningAddPieceResult{SectorID: sectorID})
 	},
-	Type: uint64(0),
+	Type: MiningAddPieceResult{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, sectorId uint64) error {
-			fmt.Fprintf(w, "piece staged in sector %d\n", sectorId) // nolint: errcheck
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, result MiningAddPieceResult) error {
+			fmt.Fprintf(w, "piece staged in sector %d\n", result.SectorID) // nolint: errcheck
 			return nil
 		}),
 	},

--- a/commands/mining.go
+++ b/commands/mining.go
@@ -197,7 +197,7 @@ var miningStopCmd = &cmds.Command{
 
 var miningSealCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
-		Tagline: "Start sealing all staged sectors or create and seal a new sector",
+		Tagline: "Start sealing all staged sectors",
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		if err := GetPorcelainAPI(env).SealNow(req.Context); err != nil {
@@ -236,12 +236,12 @@ Stages a piece (a local file) into a staged sector.
 			return fmt.Errorf("given file was not a files.File")
 		}
 
-		sectorId, err := GetPorcelainAPI(env).AddPiece(req.Context, fi)
+		sectorID, err := GetPorcelainAPI(env).AddPiece(req.Context, fi)
 		if err != nil {
 			return err
 		}
 
-		return re.Emit(sectorId)
+		return re.Emit(sectorID)
 	},
 	Type: uint64(0),
 	Encoders: cmds.EncoderMap{

--- a/commands/mining_daemon_test.go
+++ b/commands/mining_daemon_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/go-filecoin/types"
 	files "github.com/ipfs/go-ipfs-files"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,6 +16,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 	"github.com/filecoin-project/go-filecoin/tools/fast/fastesting"
 	"github.com/filecoin-project/go-filecoin/tools/fast/series"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 func parseInt(t *testing.T, s string) *big.Int {

--- a/commands/mining_daemon_test.go
+++ b/commands/mining_daemon_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-filecoin/types"
+	files "github.com/ipfs/go-ipfs-files"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -45,7 +46,7 @@ func TestMiningGenBlock(t *testing.T) {
 	assert.Equal(t, sum.Add(beforeBalance, big.NewInt(1000)), afterBalance)
 }
 
-func TestMiningSealNow(t *testing.T) {
+func TestMiningAddPieceAndSealNow(t *testing.T) {
 	tf.FunctionalTest(t)
 
 	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{
@@ -84,6 +85,10 @@ func TestMiningSealNow(t *testing.T) {
 	defer func() {
 		require.NoError(t, minerNode.MiningStop(ctx))
 	}()
+
+	// add a piece
+	_, err = minerNode.AddPiece(ctx, files.NewBytesFile([]byte("HODL")))
+	require.NoError(t, err)
 
 	// Since the miner does not yet have power, we still need the genesis node to mine
 	// the miner's commitSector and the submitPoSt messages

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -241,7 +241,7 @@ func (a *API) CalculatePoSt(ctx context.Context, sortedCommRs proofs.SortedCommR
 	return CalculatePoSt(ctx, a, sortedCommRs, seed)
 }
 
-// SealNow forces the sectorbuilder to either seal the staged sectors it has
+// SealNow forces the sectorbuilder to seal the staged sectors it has
 func (a *API) SealNow(ctx context.Context) error {
 	return SealNow(ctx, a)
 }

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -241,7 +241,7 @@ func (a *API) CalculatePoSt(ctx context.Context, sortedCommRs proofs.SortedCommR
 	return CalculatePoSt(ctx, a, sortedCommRs, seed)
 }
 
-// SealNow forces the sectorbuilder to either seal the staged sectors it has or create a new one and seal it immediately
+// SealNow forces the sectorbuilder to either seal the staged sectors it has
 func (a *API) SealNow(ctx context.Context) error {
 	return SealNow(ctx, a)
 }

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -2,6 +2,7 @@ package porcelain
 
 import (
 	"context"
+	"io"
 	"math/big"
 	"time"
 
@@ -243,6 +244,11 @@ func (a *API) CalculatePoSt(ctx context.Context, sortedCommRs proofs.SortedCommR
 // SealNow forces the sectorbuilder to either seal the staged sectors it has or create a new one and seal it immediately
 func (a *API) SealNow(ctx context.Context) error {
 	return SealNow(ctx, a)
+}
+
+// AddPiece adds a piece to a staged sector
+func (a *API) AddPiece(ctx context.Context, reader io.Reader) (uint64, error) {
+	return AddPiece(ctx, a, reader)
 }
 
 // PingMinerWithTimeout pings a storage or retrieval miner, waiting the given

--- a/porcelain/sectorbuilder.go
+++ b/porcelain/sectorbuilder.go
@@ -67,7 +67,7 @@ func AddPiece(ctx context.Context, plumbing sbPlumbing, pieceReader io.Reader) (
 	return sectorID, nil
 }
 
-// SealNow forces the sectorbuilder to either seal the staged sectors it has or create a new one and seal it immediately
+// SealNow forces the sectorbuilder to seal the staged sectors it has, if any
 func SealNow(ctx context.Context, plumbing sbPlumbing) error {
 	if plumbing.SectorBuilder() == nil {
 		return errors.New("must be mining to seal sectors")
@@ -78,7 +78,7 @@ func SealNow(ctx context.Context, plumbing sbPlumbing) error {
 		return errors.Wrap(err, "could not retrieved staged sectors")
 	}
 
-	// if no sectors are staged, nothing to do
+	// nothing to do if no sectors are staged
 	if len(stagedSectors) == 0 {
 		return nil
 	}

--- a/porcelain/sectorbuilder.go
+++ b/porcelain/sectorbuilder.go
@@ -3,18 +3,24 @@ package porcelain
 import (
 	"bytes"
 	"context"
+	"io"
+
+	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+	"github.com/multiformats/go-multihash"
 
 	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
 	"github.com/filecoin-project/go-filecoin/types"
-	"github.com/ipfs/go-cid"
-	"github.com/multiformats/go-multihash"
 
 	"github.com/pkg/errors"
 )
 
 type sbPlumbing interface {
 	SectorBuilder() sectorbuilder.SectorBuilder
+	DAGImportData(context.Context, io.Reader) (ipld.Node, error)
+	DAGCat(context.Context, cid.Cid) (io.Reader, error)
+	DAGGetFileSize(ctx context.Context, c cid.Cid) (uint64, error)
 }
 
 // CalculatePoSt invokes the sector builder to calculate a proof-of-spacetime.
@@ -32,6 +38,34 @@ func CalculatePoSt(ctx context.Context, plumbing sbPlumbing, sortedCommRs proofs
 		return nil, nil, err
 	}
 	return res.Proofs, res.Faults, nil
+}
+
+func AddPiece(ctx context.Context, plumbing sbPlumbing, pieceReader io.Reader) (uint64, error) {
+	if plumbing.SectorBuilder() == nil {
+		return 0, errors.New("must be mining to add piece")
+	}
+
+	node, err := plumbing.DAGImportData(ctx, pieceReader)
+	if err != nil {
+		return 0, errors.Wrap(err, "could not read piece into local store")
+	}
+
+	dagReader, err := plumbing.DAGCat(ctx, node.Cid())
+	if err != nil {
+		return 0, errors.Wrap(err, "could not obtain reader for piece")
+	}
+
+	size, err := plumbing.DAGGetFileSize(ctx, node.Cid())
+	if err != nil {
+		return 0, errors.Wrap(err, "could not calculate piece size")
+	}
+
+	sectorId, err := plumbing.SectorBuilder().AddPiece(ctx, node.Cid(), size, dagReader)
+	if err != nil {
+		return 0, errors.Wrap(err, "could not add piece")
+	}
+
+	return sectorId, nil
 }
 
 // SealNow forces the sectorbuilder to either seal the staged sectors it has or create a new one and seal it immediately

--- a/porcelain/sectorbuilder.go
+++ b/porcelain/sectorbuilder.go
@@ -73,16 +73,6 @@ func SealNow(ctx context.Context, plumbing sbPlumbing) error {
 		return errors.New("must be mining to seal sectors")
 	}
 
-	stagedSectors, err := plumbing.SectorBuilder().GetAllStagedSectors()
-	if err != nil {
-		return errors.Wrap(err, "could not retrieved staged sectors")
-	}
-
-	// nothing to do if no sectors are staged
-	if len(stagedSectors) == 0 {
-		return nil
-	}
-
 	// start sealing on all existing staged sectors
 	return plumbing.SectorBuilder().SealAllStagedSectors(ctx)
 }

--- a/porcelain/sectorbuilder_test.go
+++ b/porcelain/sectorbuilder_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestSealNow(t *testing.T) {
-	t.Run("triggers sealing if there are staged sectors", func(t *testing.T) {
+	t.Run("triggers sealing", func(t *testing.T) {
 		p := newTestSectorBuilderPlumbing(1)
 
 		err := SealNow(context.Background(), p)
@@ -27,19 +27,6 @@ func TestSealNow(t *testing.T) {
 
 		// seals sectors
 		assert.Equal(t, 1, p.sectorbuilder.sealAllSectorsCount)
-	})
-
-	t.Run("doesn't seal if there are no staged sectors", func(t *testing.T) {
-		p := newTestSectorBuilderPlumbing(0)
-
-		err := SealNow(context.Background(), p)
-		require.NoError(t, err)
-
-		// does not add a piece
-		assert.Equal(t, 0, p.sectorbuilder.addPieceCount)
-
-		// seals sectors
-		assert.Equal(t, 0, p.sectorbuilder.sealAllSectorsCount)
 	})
 }
 

--- a/tools/fast/action_mining.go
+++ b/tools/fast/action_mining.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	files "github.com/ipfs/go-ipfs-files"
+
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/commands"
 	"github.com/filecoin-project/go-filecoin/types"
@@ -81,6 +83,15 @@ func (f *Filecoin) MiningStatus(ctx context.Context) (commands.MiningStatusResul
 		return commands.MiningStatusResult{}, err
 	}
 
+	return out, nil
+}
+
+// AddPiece runs the mining add-piece command
+func (f *Filecoin) AddPiece(ctx context.Context, data files.File) (commands.MiningAddPieceResult, error) {
+	var out commands.MiningAddPieceResult
+	if err := f.RunCmdJSONWithStdin(ctx, data, &out, "go-filecoin", "mining", "add-piece"); err != nil {
+		return out, err
+	}
 	return out, nil
 }
 

--- a/tools/fast/action_mining.go
+++ b/tools/fast/action_mining.go
@@ -95,7 +95,7 @@ func (f *Filecoin) AddPiece(ctx context.Context, data files.File) (commands.Mini
 	return out, nil
 }
 
-// SealNow adds a staged sector if none exists and then triggers sealing on it
+// SealNow seals any staged sectors
 func (f *Filecoin) SealNow(ctx context.Context) error {
 	out, err := f.RunCmdWithStdin(ctx, nil, "go-filecoin", "mining", "seal-now")
 	if err != nil {


### PR DESCRIPTION
## Summary
To allow miners to have more control over self-sealed data, this PR breaks apart the `mining seal-now` command into two parts:
1. `mining add-piece <file>` - adds arbitrary data to a staged sector
1. `mining seal-now` - forces the sealing of any staged sectors

Previously, `seal-now` would generate a staged sector if one didn't exist; now the only way a miner can create a staged sector without accepting a deal is to use `add-piece`.

resolves #3044