### PR TITLE
Enhanced Graphsync Mocker

### DIFF
--- a/chain/message_store_test.go
+++ b/chain/message_store_test.go
@@ -2,7 +2,6 @@ package chain_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/ipfs/go-hamt-ipld"
@@ -43,7 +42,7 @@ func TestMessageStoreMessagesHappy(t *testing.T) {
 
 func TestMessageStoreReceiptsHappy(t *testing.T) {
 	ctx := context.Background()
-	mr := NewReceiptMaker()
+	mr := types.NewReceiptMaker()
 
 	receipts := []*types.MessageReceipt{
 		mr.NewReceipt(),
@@ -59,20 +58,4 @@ func TestMessageStoreReceiptsHappy(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, receipts, rtReceipts)
-}
-
-type ReceiptMaker struct {
-	seq uint
-}
-
-// NewReceiptMaker creates a new receipt maker
-func NewReceiptMaker() *ReceiptMaker {
-	return &ReceiptMaker{0}
-}
-
-// NewReceipt creates a new distinct receipt.
-func (rm *ReceiptMaker) NewReceipt() *types.MessageReceipt {
-	seq := rm.seq
-	rm.seq++
-	return &types.MessageReceipt{Return: [][]byte{[]byte(fmt.Sprintf("%d", seq))}}
 }

--- a/consensus/message_validation.go
+++ b/consensus/message_validation.go
@@ -1,0 +1,40 @@
+package consensus
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// MessageSyntaxValidator defines an interface used to validate collections
+// of messages and receipts syntax
+type MessageSyntaxValidator interface {
+	ValidateMessagesSyntax(ctx context.Context, messages []*types.SignedMessage) error
+	ValidateReceiptsSyntax(ctx context.Context, receipts []*types.MessageReceipt) error
+}
+
+// TODO: Define a message semantics validator if necessary
+// See: https://github.com/filecoin-project/go-filecoin/issues/3312
+
+// DefaultMessageSyntaxValidator implements the MessageSyntaxValidator interface.
+type DefaultMessageSyntaxValidator struct {
+}
+
+// NewDefaultMessageSyntaxValidator returns a new DefaultMessageSyntaxValidator.
+func NewDefaultMessageSyntaxValidator() *DefaultMessageSyntaxValidator {
+	return &DefaultMessageSyntaxValidator{}
+}
+
+// ValidateMessagesSyntax validates a set of messages are correctly formed.
+// TODO: Create a real implementation
+// See: https://github.com/filecoin-project/go-filecoin/issues/3312
+func (dv *DefaultMessageSyntaxValidator) ValidateMessagesSyntax(ctx context.Context, messages []*types.SignedMessage) error {
+	return nil
+}
+
+// ValidateReceiptsSyntax validates a set of receipts are correctly formed.
+// TODO: Create a real implementation
+// See: https://github.com/filecoin-project/go-filecoin/issues/3312
+func (dv *DefaultMessageSyntaxValidator) ValidateReceiptsSyntax(ctx context.Context, receipts []*types.MessageReceipt) error {
+	return nil
+}

--- a/net/graphsync_fetcher.go
+++ b/net/graphsync_fetcher.go
@@ -274,6 +274,7 @@ func (gsf *GraphSyncFetcher) loadAndVerify(ctx context.Context, key types.TipSet
 			}
 			if !ok {
 				incomplete = append(incomplete, blk.Cid())
+				break
 			}
 		}
 	}

--- a/net/graphsync_fetcher_test.go
+++ b/net/graphsync_fetcher_test.go
@@ -3,6 +3,7 @@ package net_test
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"reflect"
@@ -256,13 +257,34 @@ func TestGraphsyncFetcher(t *testing.T) {
 	})
 
 	t.Run("blocks present but messages don't decode", func(t *testing.T) {
+		mgs := newMockableGraphsync(ctx, bs, t)
+		block := requireSimpleValidBlock(t, 3, address.Undef)
+		block.Messages = notDecodableBlock.Cid()
+		key := types.NewTipSetKey(block.Cid())
+		notDecodableLoader := simpleLoader([]format.Node{block.ToNode(), notDecodableBlock, types.ReceiptCollection{}.ToNode()})
+		mgs.stubResponseWithLoader(pid0, layer1Selector, notDecodableLoader, block.Cid())
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, &fakePeerTracker{})
 
+		done := doneAt(key)
+		ts, err := fetcher.FetchTipSets(ctx, key, pid0, done)
+		require.Errorf(t, err, "fetched data (cid %s) was not a message collection", notDecodableBlock.Cid())
+		require.Nil(t, ts)
 	})
 
-	t.Run("blocks present but message receipts don't decode", func(t *testing.T) {
+	t.Run("blocks present but receipts don't decode", func(t *testing.T) {
+		mgs := newMockableGraphsync(ctx, bs, t)
+		block := requireSimpleValidBlock(t, 3, address.Undef)
+		block.MessageReceipts = notDecodableBlock.Cid()
+		key := types.NewTipSetKey(block.Cid())
+		notDecodableLoader := simpleLoader([]format.Node{block.ToNode(), notDecodableBlock, types.MessageCollection{}.ToNode()})
+		mgs.stubResponseWithLoader(pid0, layer1Selector, notDecodableLoader, block.Cid())
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, &fakePeerTracker{})
 
+		done := doneAt(key)
+		ts, err := fetcher.FetchTipSets(ctx, key, pid0, done)
+		require.Errorf(t, err, "fetched data (cid %s) was not a message receipt collection", notDecodableBlock.Cid())
+		require.Nil(t, ts)
 	})
-
 	t.Run("missing single block in multi block tip during recursive fetch", func(t *testing.T) {
 
 	})
@@ -667,7 +689,6 @@ func (fpt *fakePeerTracker) List() []*types.ChainInfo {
 	return fpt.peers
 }
 
-/*
 func simpleBlock() *types.Block {
 	return &types.Block{
 		ParentWeight:    0,
@@ -678,7 +699,7 @@ func simpleBlock() *types.Block {
 	}
 }
 
-func requireSimpleValidBlock(t * testing.T, nonce uint64, miner address.Address) * types.Block {
+func requireSimpleValidBlock(t *testing.T, nonce uint64, miner address.Address) *types.Block {
 	b := simpleBlock()
 	ticket := make(types.Signature, binary.Size(nonce))
 	binary.BigEndian.PutUint64(ticket, nonce)
@@ -686,11 +707,12 @@ func requireSimpleValidBlock(t * testing.T, nonce uint64, miner address.Address)
 	b.Ticket = ticket
 	bytes, err := cbor.DumpObject("null")
 	require.NoError(t, err)
-	b.StateRoot = cid.Prefix{
+	b.StateRoot, _ = cid.Prefix{
 		Version:  1,
 		Codec:    cid.DagCBOR,
 		MhType:   types.DefaultHashFunction,
 		MhLength: -1,
 	}.Sum(bytes)
 	b.Miner = miner
-}*/
+	return b
+}

--- a/node/node.go
+++ b/node/node.go
@@ -22,8 +22,8 @@ import (
 	gsstoreutil "github.com/ipfs/go-graphsync/storeutil"
 	"github.com/ipfs/go-hamt-ipld"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
-	"github.com/ipfs/go-ipfs-exchange-interface"
-	"github.com/ipfs/go-ipfs-exchange-offline"
+	exchange "github.com/ipfs/go-ipfs-exchange-interface"
+	offline "github.com/ipfs/go-ipfs-exchange-offline"
 	offroute "github.com/ipfs/go-ipfs-routing/offline"
 	logging "github.com/ipfs/go-log"
 	"github.com/ipfs/go-merkledag"
@@ -33,8 +33,8 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 	p2pmetrics "github.com/libp2p/go-libp2p-core/metrics"
 	"github.com/libp2p/go-libp2p-core/routing"
-	"github.com/libp2p/go-libp2p-kad-dht"
-	"github.com/libp2p/go-libp2p-kad-dht/opts"
+	dht "github.com/libp2p/go-libp2p-kad-dht"
+	dhtopts "github.com/libp2p/go-libp2p-kad-dht/opts"
 	libp2pps "github.com/libp2p/go-libp2p-pubsub"
 	rhost "github.com/libp2p/go-libp2p/p2p/host/routed"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
@@ -390,6 +390,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 	// setup block validation
 	// TODO when #2961 is resolved do the needful here.
 	blkValid := consensus.NewDefaultBlockValidator(nc.BlockTime, clock.NewSystemClock())
+	messageValid := consensus.NewDefaultMessageSyntaxValidator()
 
 	// set up peer tracking
 	peerTracker := net.NewPeerTracker()
@@ -405,7 +406,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 	loader := gsstoreutil.LoaderForBlockstore(bs)
 	storer := gsstoreutil.StorerForBlockstore(bs)
 	gsync := graphsync.New(ctx, graphsyncNetwork, bridge, loader, storer)
-	fetcher := net.NewGraphSyncFetcher(ctx, gsync, bs, blkValid, peerTracker)
+	fetcher := net.NewGraphSyncFetcher(ctx, gsync, bs, blkValid, messageValid, peerTracker)
 
 	ipldCborStore := hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
 	genCid, err := readGenesisCid(nc.Repo.Datastore())

--- a/types/message.go
+++ b/types/message.go
@@ -117,6 +117,16 @@ func (msg *Message) Equals(other *Message) bool {
 // MessageCollection tracks a group of messages and assigns it a cid.
 type MessageCollection []*SignedMessage
 
+// DecodeMessages decodes raw bytes into an array of signed messages
+func DecodeMessages(b []byte) ([]*SignedMessage, error) {
+	var out MessageCollection
+	if err := cbor.DecodeInto(b, &out); err != nil {
+		return nil, err
+	}
+
+	return []*SignedMessage(out), nil
+}
+
 // TODO #3078 the panics here and in types.Block should go away.  We need to
 // keep them in order to use the ipld cborstore with the default hash function
 // because we need to implement hamt.cidProvider which doesn't handle errors.
@@ -139,6 +149,16 @@ func (mC MessageCollection) ToNode() ipld.Node {
 
 // ReceiptCollection tracks a group of receipts and assigns it a cid.
 type ReceiptCollection []*MessageReceipt
+
+// DecodeReceipts decodes raw bytes into an array of message receipts
+func DecodeReceipts(b []byte) ([]*MessageReceipt, error) {
+	var out ReceiptCollection
+	if err := cbor.DecodeInto(b, &out); err != nil {
+		return nil, err
+	}
+
+	return []*MessageReceipt(out), nil
+}
 
 // Cid returns the cid of the receipt collection.
 func (rC ReceiptCollection) Cid() cid.Cid {

--- a/types/testing_messages.go
+++ b/types/testing_messages.go
@@ -2,8 +2,9 @@ package types
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/address"
 )
@@ -66,4 +67,21 @@ func EmptyReceipts(n int) []*MessageReceipt {
 		out[i] = &MessageReceipt{}
 	}
 	return out
+}
+
+// ReceiptMaker generates unique receipts
+type ReceiptMaker struct {
+	seq uint
+}
+
+// NewReceiptMaker creates a new receipt maker
+func NewReceiptMaker() *ReceiptMaker {
+	return &ReceiptMaker{0}
+}
+
+// NewReceipt creates a new distinct receipt.
+func (rm *ReceiptMaker) NewReceipt() *MessageReceipt {
+	seq := rm.seq
+	rm.seq++
+	return &MessageReceipt{Return: [][]byte{[]byte(fmt.Sprintf("%d", seq))}}
 }


### PR DESCRIPTION
# Goals

Build a more flexibile mock graphsync that is easy to construct responses against, and interoperates well with a chain

# Implementation

The basic idea here is this -- and I want to check that this is ok -- actually execute IPLD selector queries, backed by a CID loader, which by default just loads from the specified chain builder (but obviously with no network involved). The loader can also be overloaded to error on some cids, or to return undecodable blocks on some cids

# Discussion

Admittedly, this moves us just a bit a way from a unit test in the sense that we are actually counting on selector logic. The upside to this is:
1. It makes sure IPLD selector queries are constructed correctly (which to me makes the test more meaningful)
2. It makes for a very succinct mocking syntax (net more deletions than additions than deletions in this PR!)

Open to lots of revision feedback but would appreciate a quick up or down on whether this general approach is ok before I write a bunch of tests against it.