### PR TITLE
register block syntax validation on pubsub

### DIFF
--- a/consensus/block_validation.go
+++ b/consensus/block_validation.go
@@ -70,9 +70,9 @@ func (dv *DefaultBlockValidator) ValidateSemantic(ctx context.Context, child *ty
 }
 
 // ValidateSyntax validates a single block is correctly formed.
+// TODO this is an incomplete implementation #3277
 func (dv *DefaultBlockValidator) ValidateSyntax(ctx context.Context, blk *types.Block) error {
-	// TODO special handling for genesis block
-	// figure out in: https://github.com/filecoin-project/go-filecoin/issues/3121
+	// TODO special handling for genesis block #3121
 	if blk.Height == 0 {
 		return nil
 	}
@@ -94,7 +94,7 @@ func (dv *DefaultBlockValidator) ValidateSyntax(ctx context.Context, blk *types.
 			return fmt.Errorf("block %s has nil ticket", blk.Cid().String())
 		}
 	}
-	// TODO validate block signature: 1054
+	// TODO validate block signature #1054
 	return nil
 }
 

--- a/net/validators.go
+++ b/net/validators.go
@@ -13,18 +13,17 @@ import (
 
 var blockTopicLogger = logging.Logger("net/block_validator")
 
-// BlockTopicValidator may be registered on go-libp2p-pubsub to validate
-// pubsub messages on the BlockTopic.
+// BlockTopicValidator may be registered on go-libp2p-pubsub to validate pubsub messages on the
+// BlockTopic.
 type BlockTopicValidator struct {
 	validator pubsub.Validator
 	opts      []pubsub.ValidatorOpt
 }
 
-// NewBlockTopicValidator retruns a BlockTopicValidator using `bv` for
-// message validation
+// NewBlockTopicValidator retruns a BlockTopicValidator using `bv` for message validation
 func NewBlockTopicValidator(bv consensus.BlockSyntaxValidator, opts ...pubsub.ValidatorOpt) *BlockTopicValidator {
 	return &BlockTopicValidator{
-		opts: nil,
+		opts: opts,
 		validator: func(ctx context.Context, p peer.ID, msg *pubsub.Message) bool {
 			blk, err := types.DecodeBlock(msg.GetData())
 			if err != nil {
@@ -45,14 +44,12 @@ func (btv *BlockTopicValidator) Topic() string {
 	return BlockTopic
 }
 
-// Validator returns a validation method matching the Validator pubsub
-// function signature.
+// Validator returns a validation method matching the Validator pubsub function signature.
 func (btv *BlockTopicValidator) Validator() pubsub.Validator {
 	return btv.validator
 }
 
-// Opts returns the pubsub ValidatorOpts the BlockTopicValidator is configured
-// to use.
+// Opts returns the pubsub ValidatorOpts the BlockTopicValidator is configured to use.
 func (btv *BlockTopicValidator) Opts() []pubsub.ValidatorOpt {
 	return btv.opts
 }

--- a/net/validators.go
+++ b/net/validators.go
@@ -1,0 +1,58 @@
+package net
+
+import (
+	"context"
+
+	logging "github.com/ipfs/go-log"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-pubsub"
+
+	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+var blockTopicLogger = logging.Logger("net/block_validator")
+
+// BlockTopicValidator may be registered on go-libp2p-pubsub to validate
+// pubsub messages on the BlockTopic.
+type BlockTopicValidator struct {
+	validator pubsub.Validator
+	opts      []pubsub.ValidatorOpt
+}
+
+// NewBlockTopicValidator retruns a BlockTopicValidator using `bv` for
+// message validation
+func NewBlockTopicValidator(bv consensus.BlockSyntaxValidator, opts ...pubsub.ValidatorOpt) *BlockTopicValidator {
+	return &BlockTopicValidator{
+		opts: nil,
+		validator: func(ctx context.Context, p peer.ID, msg *pubsub.Message) bool {
+			blk, err := types.DecodeBlock(msg.GetData())
+			if err != nil {
+				blockTopicLogger.Debugf("block from peer: %s failed to decode: %s", p.String(), err.Error())
+				return false
+			}
+			if err := bv.ValidateSyntax(ctx, blk); err != nil {
+				blockTopicLogger.Debugf("block: %s from peer: %s failed to validate: %s", blk.Cid().String(), p.String(), err.Error())
+				return false
+			}
+			return true
+		},
+	}
+}
+
+// Topic returns the topic string BlockTopic
+func (btv *BlockTopicValidator) Topic() string {
+	return BlockTopic
+}
+
+// Validator returns a validation method matching the Validator pubsub
+// function signature.
+func (btv *BlockTopicValidator) Validator() pubsub.Validator {
+	return btv.validator
+}
+
+// Opts returns the pubsub ValidatorOpts the BlockTopicValidator is configured
+// to use.
+func (btv *BlockTopicValidator) Opts() []pubsub.ValidatorOpt {
+	return btv.opts
+}

--- a/net/validators_test.go
+++ b/net/validators_test.go
@@ -1,0 +1,64 @@
+package net_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/net"
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+func TestBlockTopicValidator(t *testing.T) {
+	tf.UnitTest(t)
+	ctx := context.Background()
+
+	mbv := th.NewMockBlockValidator()
+	tv := net.NewBlockTopicValidator(mbv, nil)
+	builder := chain.NewBuilder(t, address.Undef)
+	pid1 := th.RequireIntPeerID(t, 1)
+
+	goodBlk := builder.BuildOnBlock(nil, func(b *chain.BlockBuilder) {})
+	badBlk := builder.BuildOnBlock(nil, func(b *chain.BlockBuilder) {
+		b.IncHeight(1)
+	})
+
+	mbv.StubSyntaxValidationForBlock(badBlk, fmt.Errorf("invalid block"))
+
+	validator := tv.Validator()
+
+	assert.Equal(t, net.BlockTopic, tv.Topic())
+	assert.Nil(t, tv.Opts())
+	assert.True(t, validator(ctx, pid1, blkToPubSub(goodBlk)))
+	assert.False(t, validator(ctx, pid1, blkToPubSub(badBlk)))
+	assert.False(t, validator(ctx, pid1, nonBlkPubSubMsg()))
+
+}
+
+// convert a types.Block to a pubsub message
+func blkToPubSub(blk *types.Block) *pubsub.Message {
+	pbm := &pubsub_pb.Message{
+		Data: blk.ToNode().RawData(),
+	}
+	return &pubsub.Message{
+		Message: pbm,
+	}
+}
+
+// returns a pubsub message that will not decode to a types.Block
+func nonBlkPubSubMsg() *pubsub.Message {
+	pbm := &pubsub_pb.Message{
+		Data: []byte("meow"),
+	}
+	return &pubsub.Message{
+		Message: pbm,
+	}
+}

--- a/net/validators_test.go
+++ b/net/validators_test.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p-pubsub/pb"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/net"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
@@ -19,8 +23,8 @@ import (
 
 func TestBlockTopicValidator(t *testing.T) {
 	tf.UnitTest(t)
-	ctx := context.Background()
 
+	ctx := context.Background()
 	mbv := th.NewMockBlockValidator()
 	tv := net.NewBlockTopicValidator(mbv, nil)
 	builder := chain.NewBuilder(t, address.Undef)
@@ -36,11 +40,89 @@ func TestBlockTopicValidator(t *testing.T) {
 	validator := tv.Validator()
 
 	assert.Equal(t, net.BlockTopic, tv.Topic())
-	assert.Nil(t, tv.Opts())
 	assert.True(t, validator(ctx, pid1, blkToPubSub(goodBlk)))
 	assert.False(t, validator(ctx, pid1, blkToPubSub(badBlk)))
 	assert.False(t, validator(ctx, pid1, nonBlkPubSubMsg()))
+}
 
+func TestBlockPubSubValidation(t *testing.T) {
+	tf.IntegrationTest(t)
+	ctx := context.Background()
+
+	// setup a mock network and generate a host
+	mn := mocknet.New(ctx)
+	host1, err := mn.GenPeer()
+	require.NoError(t, err)
+
+	// create a fake clock to trigger block validation failures
+	now := time.Unix(1234567890, 0)
+	mclock := th.NewFakeSystemClock(now)
+	// block time will be 1 second
+	blocktime := time.Second * 1
+
+	// setup a block validator and a topic validator
+	bv := consensus.NewDefaultBlockValidator(blocktime, mclock)
+	btv := net.NewBlockTopicValidator(bv)
+
+	// setup a floodsub instance on the host and register the topic validator
+	fsub1, err := pubsub.NewFloodSub(ctx, host1, pubsub.WithMessageSigning(false))
+	require.NoError(t, err)
+	err = fsub1.RegisterTopicValidator(btv.Topic(), btv.Validator(), btv.Opts()...)
+	require.NoError(t, err)
+
+	// subscribe to the block validator topic
+	sub1, err := fsub1.Subscribe(btv.Topic())
+	require.NoError(t, err)
+
+	// generate a miner address for blocks
+	miner := address.NewForTestGetter()()
+
+	// create an invalid block
+	invalidBlk := &types.Block{
+		Height:    1,
+		Timestamp: types.Uint64(now.Add(time.Second * 60).Unix()), // invalid timestamp, 60 seconds in future
+		StateRoot: types.NewCidForTestGetter()(),
+		Miner:     miner,
+		Tickets:   []types.Ticket{{VRFProof: []byte{0}}},
+	}
+	// publish the invalid block
+	err = fsub1.Publish(btv.Topic(), invalidBlk.ToNode().RawData())
+	assert.NoError(t, err)
+
+	// see FIXME below (#3285)
+	time.Sleep(time.Millisecond * 100)
+
+	// create a valid block
+	validBlk := &types.Block{
+		Height:    1,
+		Timestamp: types.Uint64(now.Unix()), // valid because it was publish "now".
+		StateRoot: types.NewCidForTestGetter()(),
+		Miner:     miner,
+		Tickets:   []types.Ticket{{VRFProof: []byte{0}}},
+	}
+	// publish the invalid block
+	err = fsub1.Publish(btv.Topic(), validBlk.ToNode().RawData())
+	assert.NoError(t, err)
+
+	// FIXME: #3285
+	// Floodsub makes no guarantees on the order of messages, this means the block we
+	// get here is nondeterministic. For now we do our best to let the invalid block propagate first
+	// by sleeping (*wince*), but it could be the case that the valid block arrives first - meaning this
+	// test could pass incorrectly since we don't know if the invalid block is in the channel and we
+	// have no easy way of checking since Next blocks if the channel is empty. A solution here
+	// could be to create a metrics registry in the block validator code and assert that it has seen
+	// one invalid block and one valid block.
+	// If this test ever flakes we know there is an issue with libp2p since the block validator has
+	// a test and sine TestBlockTopicValidator tests the plumbing of this code.
+	received, err := sub1.Next(ctx)
+	assert.NoError(t, err, "Receieved an invalid block over pubsub, seee issue #3285 for help debugging")
+
+	// decode the block from pubsub
+	maybeBlk, err := types.DecodeBlock(received.GetData())
+	require.NoError(t, err)
+
+	// assert this block is the valid one
+	assert.Equal(t, validBlk.Cid().String(), maybeBlk.Cid().String())
 }
 
 // convert a types.Block to a pubsub message

--- a/net/validators_test.go
+++ b/net/validators_test.go
@@ -25,7 +25,7 @@ func TestBlockTopicValidator(t *testing.T) {
 	tf.UnitTest(t)
 
 	ctx := context.Background()
-	mbv := th.NewMockBlockValidator()
+	mbv := th.NewStubBlockValidator()
 	tv := net.NewBlockTopicValidator(mbv, nil)
 	builder := chain.NewBuilder(t, address.Undef)
 	pid1 := th.RequireIntPeerID(t, 1)
@@ -114,6 +114,8 @@ func TestBlockPubSubValidation(t *testing.T) {
 	// one invalid block and one valid block.
 	// If this test ever flakes we know there is an issue with libp2p since the block validator has
 	// a test and sine TestBlockTopicValidator tests the plumbing of this code.
+	// This test should be reimplemented by starting an in-process node using something like GenNode
+	// refer to #3285 for details.
 	received, err := sub1.Next(ctx)
 	assert.NoError(t, err, "Receieved an invalid block over pubsub, seee issue #3285 for help debugging")
 

--- a/node/node.go
+++ b/node/node.go
@@ -442,6 +442,11 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to set up network")
 	}
+	// register block validation on floodsub
+	btv := net.NewBlockTopicValidator(blkValid)
+	if err := fsub.RegisterTopicValidator(btv.Topic(), btv.Validator(), btv.Opts()...); err != nil {
+		return nil, errors.Wrap(err, "failed to register block validator")
+	}
 
 	backend, err := wallet.NewDSBackend(nc.Repo.WalletDatastore())
 	if err != nil {

--- a/testhelpers/consensus.go
+++ b/testhelpers/consensus.go
@@ -145,6 +145,43 @@ func (fbv *FakeBlockValidator) ValidateSyntax(ctx context.Context, blk *types.Bl
 	return nil
 }
 
+// MockBlockValidator is a mockable block validator.
+type MockBlockValidator struct {
+	syntaxStubs   map[cid.Cid]error
+	semanticStubs map[cid.Cid]error
+}
+
+// NewMockBlockValidator creates a MockBlockValidator that allows errors to configured
+// for blocks passed to the Validate* methods.
+func NewMockBlockValidator() *MockBlockValidator {
+	return &MockBlockValidator{
+		syntaxStubs:   make(map[cid.Cid]error),
+		semanticStubs: make(map[cid.Cid]error),
+	}
+}
+
+// ValidateSemantic returns nil or error for stubbed block `child`.
+func (mbv *MockBlockValidator) ValidateSemantic(ctx context.Context, child *types.Block, parents *types.TipSet) error {
+	return mbv.semanticStubs[child.Cid()]
+}
+
+// ValidateSyntax return nil or error for stubbed block `blk`.
+func (mbv *MockBlockValidator) ValidateSyntax(ctx context.Context, blk *types.Block) error {
+	return mbv.syntaxStubs[blk.Cid()]
+}
+
+// StubSyntaxValidationForBlock stubs an error when the ValidateSyntax is called
+// on the with the given block.
+func (mbv *MockBlockValidator) StubSyntaxValidationForBlock(blk *types.Block, err error) {
+	mbv.syntaxStubs[blk.Cid()] = err
+}
+
+// StubSemanticValidationForBlock stubs an error when the ValidateSemantic is called
+// on the with the given child block.
+func (mbv *MockBlockValidator) StubSemanticValidationForBlock(child *types.Block, err error) {
+	mbv.semanticStubs[child.Cid()] = err
+}
+
 // NewTestProcessor creates a processor with a test validator and test rewarder
 func NewTestProcessor() *consensus.DefaultProcessor {
 	return consensus.NewConfiguredProcessor(&TestSignedMessageValidator{}, &TestBlockRewarder{})

--- a/testhelpers/consensus.go
+++ b/testhelpers/consensus.go
@@ -145,40 +145,40 @@ func (fbv *FakeBlockValidator) ValidateSyntax(ctx context.Context, blk *types.Bl
 	return nil
 }
 
-// MockBlockValidator is a mockable block validator.
-type MockBlockValidator struct {
+// StubBlockValidator is a mockable block validator.
+type StubBlockValidator struct {
 	syntaxStubs   map[cid.Cid]error
 	semanticStubs map[cid.Cid]error
 }
 
-// NewMockBlockValidator creates a MockBlockValidator that allows errors to configured
+// NewStubBlockValidator creates a StubBlockValidator that allows errors to configured
 // for blocks passed to the Validate* methods.
-func NewMockBlockValidator() *MockBlockValidator {
-	return &MockBlockValidator{
+func NewStubBlockValidator() *StubBlockValidator {
+	return &StubBlockValidator{
 		syntaxStubs:   make(map[cid.Cid]error),
 		semanticStubs: make(map[cid.Cid]error),
 	}
 }
 
 // ValidateSemantic returns nil or error for stubbed block `child`.
-func (mbv *MockBlockValidator) ValidateSemantic(ctx context.Context, child *types.Block, parents *types.TipSet) error {
+func (mbv *StubBlockValidator) ValidateSemantic(ctx context.Context, child *types.Block, parents *types.TipSet) error {
 	return mbv.semanticStubs[child.Cid()]
 }
 
 // ValidateSyntax return nil or error for stubbed block `blk`.
-func (mbv *MockBlockValidator) ValidateSyntax(ctx context.Context, blk *types.Block) error {
+func (mbv *StubBlockValidator) ValidateSyntax(ctx context.Context, blk *types.Block) error {
 	return mbv.syntaxStubs[blk.Cid()]
 }
 
 // StubSyntaxValidationForBlock stubs an error when the ValidateSyntax is called
 // on the with the given block.
-func (mbv *MockBlockValidator) StubSyntaxValidationForBlock(blk *types.Block, err error) {
+func (mbv *StubBlockValidator) StubSyntaxValidationForBlock(blk *types.Block, err error) {
 	mbv.syntaxStubs[blk.Cid()] = err
 }
 
 // StubSemanticValidationForBlock stubs an error when the ValidateSemantic is called
 // on the with the given child block.
-func (mbv *MockBlockValidator) StubSemanticValidationForBlock(child *types.Block, err error) {
+func (mbv *StubBlockValidator) StubSemanticValidationForBlock(child *types.Block, err error) {
 	mbv.semanticStubs[child.Cid()] = err
 }
 


### PR DESCRIPTION
### What
This PR does the following things: 
- adds a block syntax validator to the node pubsub and closes #2783. I have created #3277 as a placeholder for bringing block validation inline with the spec.
- also adds a mockable block validator, the topic validator uses this in its unit test.
- adds an integration that could be improved in #3285 
- adds metrics to track the number of decode and syntax failures.