### PR TITLE
Use miner worker address (#2959)

### DIFF
--- a/mining/worker.go
+++ b/mining/worker.go
@@ -187,7 +187,7 @@ func (w *DefaultWorker) Mine(ctx context.Context, base types.TipSet, nullBlkCoun
 	}
 	prCh := createProof(challenge, w.createPoSTFunc)
 
-	//
+	// Read uncached worker address
 	workerAddr, err := w.api.MinerGetWorkerAddress(ctx, w.minerAddr)
 	if err != nil {
 		outCh <- Output{Err: err}

--- a/mining/worker.go
+++ b/mining/worker.go
@@ -70,6 +70,7 @@ type MessageApplier interface {
 
 type workerPorcelainAPI interface {
 	BlockTime() time.Duration
+	MinerGetWorkerAddress(ctx context.Context, minerAddr address.Address) (address.Address, error)
 }
 
 // DefaultWorker runs a mining job.
@@ -79,7 +80,6 @@ type DefaultWorker struct {
 	createPoSTFunc DoSomeWorkFunc
 	minerAddr      address.Address
 	minerOwnerAddr address.Address
-	minerWorker    address.Address
 	workerSigner   consensus.TicketSigner
 
 	// consensus things
@@ -101,7 +101,6 @@ type WorkerParameters struct {
 
 	MinerAddr      address.Address
 	MinerOwnerAddr address.Address
-	MinerWorker    address.Address
 	WorkerSigner   consensus.TicketSigner
 
 	// consensus things
@@ -122,8 +121,9 @@ func NewDefaultWorker(parameters WorkerParameters) *DefaultWorker {
 	w := NewDefaultWorkerWithDeps(parameters,
 		func() {})
 
-	// TODO: create real PoST.
-	// https://github.com/filecoin-project/go-filecoin/issues/1791
+	// TODO:
+	//  What to do about PoST is still under discussion.
+	//  see go-filecoin issue #2223
 	w.createPoSTFunc = w.fakeCreatePoST
 
 	return w
@@ -145,7 +145,6 @@ func NewDefaultWorkerWithDeps(parameters WorkerParameters,
 		createPoSTFunc: createPoST,
 		minerAddr:      parameters.MinerAddr,
 		minerOwnerAddr: parameters.MinerOwnerAddr,
-		minerWorker:    parameters.MinerWorker,
 		workerSigner:   parameters.WorkerSigner,
 	}
 }
@@ -188,6 +187,13 @@ func (w *DefaultWorker) Mine(ctx context.Context, base types.TipSet, nullBlkCoun
 	}
 	prCh := createProof(challenge, w.createPoSTFunc)
 
+	//
+	workerAddr, err := w.api.MinerGetWorkerAddress(ctx, w.minerAddr)
+	if err != nil {
+		outCh <- Output{Err: err}
+		return false
+	}
+
 	var proof types.PoStProof
 	var ticket types.Ticket
 	select {
@@ -200,7 +206,7 @@ func (w *DefaultWorker) Mine(ctx context.Context, base types.TipSet, nullBlkCoun
 			return false
 		}
 		proof := append(types.PoStProof{}, prChRead[:]...)
-		ticket, err = consensus.CreateTicket(proof, w.minerWorker, w.workerSigner)
+		ticket, err = consensus.CreateTicket(proof, workerAddr, w.workerSigner)
 		if err != nil {
 			log.Errorf("failed to create ticket: %s", err)
 			return false
@@ -235,8 +241,9 @@ func (w *DefaultWorker) Mine(ctx context.Context, base types.TipSet, nullBlkCoun
 func createProof(challengeSeed types.PoStChallengeSeed, createPoST DoSomeWorkFunc) <-chan types.PoStChallengeSeed {
 	c := make(chan types.PoStChallengeSeed)
 	go func() {
-		// TODO send new PoST on channel once we can create it
-		//  https://github.com/filecoin-project/go-filecoin/issues/1791
+		// TODO:
+		//  What to do about PoST is still under discussion.
+		//  see go-filecoin issue #2223
 		createPoST()
 		c <- challengeSeed
 	}()

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -59,11 +59,10 @@ func Test_Mine(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		outCh := make(chan mining.Output)
 		worker := mining.NewDefaultWorkerWithDeps(mining.WorkerParameters{
-			API: th.NewDefaultTestWorkerPorcelainAPI(),
+			API: th.NewDefaultTestWorkerPorcelainAPI(blockSignerAddr),
 
 			MinerAddr:      minerAddr,
 			MinerOwnerAddr: minerOwnerAddr,
-			MinerWorker:    blockSignerAddr,
 			WorkerSigner:   mockSigner,
 
 			GetStateTree: getStateTree,
@@ -87,11 +86,10 @@ func Test_Mine(t *testing.T) {
 		doSomeWorkCalled = false
 		ctx, cancel := context.WithCancel(context.Background())
 		worker := mining.NewDefaultWorkerWithDeps(mining.WorkerParameters{
-			API: th.NewDefaultTestWorkerPorcelainAPI(),
+			API: th.NewDefaultTestWorkerPorcelainAPI(blockSignerAddr),
 
 			MinerAddr:      minerAddr,
 			MinerOwnerAddr: minerOwnerAddr,
-			MinerWorker:    blockSignerAddr,
 			WorkerSigner:   mockSigner,
 
 			GetStateTree: makeExplodingGetStateTree(st),
@@ -118,11 +116,10 @@ func Test_Mine(t *testing.T) {
 		doSomeWorkCalled = false
 		ctx, cancel := context.WithCancel(context.Background())
 		worker := mining.NewDefaultWorkerWithDeps(mining.WorkerParameters{
-			API: th.NewDefaultTestWorkerPorcelainAPI(),
+			API: th.NewDefaultTestWorkerPorcelainAPI(blockSignerAddr),
 
 			MinerAddr:      minerAddr,
 			MinerOwnerAddr: minerOwnerAddr,
-			MinerWorker:    blockSignerAddr,
 			WorkerSigner:   mockSigner,
 
 			GetStateTree: getStateTree,
@@ -226,6 +223,7 @@ func TestApplyMessagesForSuccessTempAndPermFailures(t *testing.T) {
 	messages := []*types.SignedMessage{smsg1, smsg2, smsg3, smsg4}
 
 	res, err := consensus.NewDefaultProcessor().ApplyMessagesAndPayRewards(ctx, st, vms, messages, addr1, types.NewBlockHeight(0), nil)
+	require.NotNil(t, res)
 
 	assert.Len(t, res.PermanentFailures, 2)
 	assert.Contains(t, res.PermanentFailures, smsg3)
@@ -261,11 +259,10 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 	messages := chain.NewMessageStore(cst)
 
 	worker := mining.NewDefaultWorkerWithDeps(mining.WorkerParameters{
-		API: th.NewDefaultTestWorkerPorcelainAPI(),
+		API: th.NewDefaultTestWorkerPorcelainAPI(blockSignerAddr),
 
 		MinerAddr:      minerAddr,
 		MinerOwnerAddr: minerOwnerAddr,
-		MinerWorker:    blockSignerAddr,
 		WorkerSigner:   mockSigner,
 
 		GetStateTree: getStateTree,
@@ -317,11 +314,10 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 	messages := chain.NewMessageStore(cst)
 
 	worker := mining.NewDefaultWorkerWithDeps(mining.WorkerParameters{
-		API: th.NewDefaultTestWorkerPorcelainAPI(),
+		API: th.NewDefaultTestWorkerPorcelainAPI(blockSignerAddr),
 
 		MinerAddr:      addrs[4],
 		MinerOwnerAddr: addrs[3],
-		MinerWorker:    blockSignerAddr,
 		WorkerSigner:   mockSigner,
 
 		GetStateTree: getStateTree,
@@ -425,11 +421,10 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 	messages := chain.NewMessageStore(cst)
 
 	worker := mining.NewDefaultWorkerWithDeps(mining.WorkerParameters{
-		API: th.NewDefaultTestWorkerPorcelainAPI(),
+		API: th.NewDefaultTestWorkerPorcelainAPI(blockSignerAddr),
 
 		MinerAddr:      minerAddr,
 		MinerOwnerAddr: minerOwnerAddr,
-		MinerWorker:    blockSignerAddr,
 		WorkerSigner:   mockSigner,
 
 		GetStateTree: getStateTree,
@@ -486,11 +481,10 @@ func TestGenerateWithoutMessages(t *testing.T) {
 	messages := chain.NewMessageStore(cst)
 
 	worker := mining.NewDefaultWorkerWithDeps(mining.WorkerParameters{
-		API: th.NewDefaultTestWorkerPorcelainAPI(),
+		API: th.NewDefaultTestWorkerPorcelainAPI(blockSignerAddr),
 
 		MinerAddr:      addrs[4],
 		MinerOwnerAddr: addrs[3],
-		MinerWorker:    blockSignerAddr,
 		WorkerSigner:   mockSigner,
 
 		GetStateTree: getStateTree,
@@ -539,11 +533,10 @@ func TestGenerateError(t *testing.T) {
 
 	messages := chain.NewMessageStore(cst)
 	worker := mining.NewDefaultWorkerWithDeps(mining.WorkerParameters{
-		API: th.NewDefaultTestWorkerPorcelainAPI(),
+		API: th.NewDefaultTestWorkerPorcelainAPI(blockSignerAddr),
 
 		MinerAddr:      addrs[4],
 		MinerOwnerAddr: addrs[3],
-		MinerWorker:    blockSignerAddr,
 		WorkerSigner:   mockSigner,
 
 		GetStateTree: makeExplodingGetStateTree(st),
@@ -596,7 +589,7 @@ func (st *stateTreeForTest) Flush(ctx context.Context) (cid.Cid, error) {
 	return st.TestFlush(ctx)
 }
 
-func getWeightTest(c context.Context, ts types.TipSet) (uint64, error) {
+func getWeightTest(_ context.Context, ts types.TipSet) (uint64, error) {
 	w, err := ts.ParentWeight()
 	if err != nil {
 		return uint64(0), err

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -167,7 +167,7 @@ func makeNodes(t *testing.T, numNodes int) (address.Address, []*Node) {
 	)
 	seed.GiveKey(t, minerNode, 0)
 	mineraddr, ownerAddr := seed.GiveMiner(t, minerNode, 0)
-	_, err := storage.NewMiner(mineraddr, ownerAddr, ownerAddr, &storage.FakeProver{}, types.OneKiBSectorSize, minerNode, minerNode.Repo.DealsDatastore(), minerNode.PorcelainAPI)
+	_, err := storage.NewMiner(mineraddr, ownerAddr, &storage.FakeProver{}, types.OneKiBSectorSize, minerNode, minerNode.Repo.DealsDatastore(), minerNode.PorcelainAPI)
 	assert.NoError(t, err)
 
 	nodes := []*Node{minerNode}

--- a/node/node.go
+++ b/node/node.go
@@ -917,7 +917,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 		return errors.Wrapf(err, "failed to get mining owner address for miner %s", minerAddr)
 	}
 
-	minerWorkerAddr, err := node.PorcelainAPI.MinerGetWorker(ctx, minerAddr)
+	minerWorkerAddr, err := node.PorcelainAPI.MinerGetWorkerAddress(ctx, minerAddr)
 	if err != nil {
 		return errors.Wrap(err, "could not get worker address from miner actor")
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -1093,7 +1093,6 @@ func initStorageMinerForNode(ctx context.Context, node *Node) (*storage.Miner, a
 	miner, err := storage.NewMiner(
 		minerAddr,
 		ownerAddress,
-		workerAddress,
 		prover,
 		sectorSize,
 		node,

--- a/node/node.go
+++ b/node/node.go
@@ -1198,11 +1198,6 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (mining.Worker, error)
 		return nil, errors.Wrap(err, "failed to get mining address")
 	}
 
-	minerWorker, err := node.PorcelainAPI.MinerGetWorker(ctx, minerAddr)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get key from miner actor")
-	}
-
 	minerOwnerAddr, err := node.PorcelainAPI.MinerGetOwnerAddress(ctx, minerAddr)
 	if err != nil {
 		log.Errorf("could not get owner address of miner actor")
@@ -1213,7 +1208,6 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (mining.Worker, error)
 
 		MinerAddr:      minerAddr,
 		MinerOwnerAddr: minerOwnerAddr,
-		MinerWorker:    minerWorker,
 		WorkerSigner:   node.Wallet,
 
 		GetStateTree: node.getStateTree,

--- a/node/node.go
+++ b/node/node.go
@@ -1090,7 +1090,11 @@ func initStorageMinerForNode(ctx context.Context, node *Node) (*storage.Miner, a
 	if err != nil {
 		return nil, address.Undef, errors.Wrap(err, "no mining owner available, skipping storage miner setup")
 	}
-	workerAddress := ownerAddress
+
+	workerAddress, err := node.PorcelainAPI.MinerGetWorkerAddress(ctx, minerAddr)
+	if err != nil {
+		return nil, address.Undef, errors.Wrap(err, "failed to fetch miner's worker address")
+	}
 
 	sectorSize, err := node.PorcelainAPI.MinerGetSectorSize(ctx, minerAddr)
 	if err != nil {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -142,7 +142,7 @@ func TestNodeStartMining(t *testing.T) {
 	mineraddr, ownerAddr := seed.GiveMiner(t, minerNode, 0)
 	// Start mining give error for fail to get miner actor from the heaviest tipset stateroot
 	assert.Contains(t, minerNode.StartMining(ctx).Error(), "failed to get miner actor")
-	_, err := storage.NewMiner(mineraddr, ownerAddr, ownerAddr, &storage.FakeProver{}, types.OneKiBSectorSize, minerNode, minerNode.Repo.DealsDatastore(), nil)
+	_, err := storage.NewMiner(mineraddr, ownerAddr, &storage.FakeProver{}, types.OneKiBSectorSize, minerNode, minerNode.Repo.DealsDatastore(), nil)
 	assert.NoError(t, err)
 
 	assert.NoError(t, minerNode.Start(ctx))

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -147,11 +147,6 @@ func (a *API) MinerGetLastCommittedSectorID(ctx context.Context, minerAddr addre
 	return MinerGetLastCommittedSectorID(ctx, a, minerAddr)
 }
 
-// MinerGetWorker queries for the public key of the given miner
-func (a *API) MinerGetWorker(ctx context.Context, minerAddr address.Address) (address.Address, error) {
-	return MinerGetWorker(ctx, a, minerAddr)
-}
-
 // MinerGetPeerID queries for the peer id of the given miner
 func (a *API) MinerGetPeerID(ctx context.Context, minerAddr address.Address) (peer.ID, error) {
 	return MinerGetPeerID(ctx, a, minerAddr)

--- a/porcelain/miner.go
+++ b/porcelain/miner.go
@@ -359,16 +359,6 @@ func MinerGetLastCommittedSectorID(ctx context.Context, plumbing minerQueryAndDe
 	return lastUsedSectorID, nil
 }
 
-// MinerGetWorker queries for the public key of the given miner
-func MinerGetWorker(ctx context.Context, plumbing minerQueryAndDeserialize, minerAddr address.Address) (address.Address, error) {
-	res, err := plumbing.MessageQuery(ctx, address.Undef, minerAddr, "getWorker")
-	if err != nil {
-		return address.Undef, err
-	}
-
-	return address.NewFromBytes(res[0])
-}
-
 // mgaAPI is the subset of the plumbing.API that MinerGetAsk uses.
 type mgaAPI interface {
 	MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error)

--- a/protocol/block/mining_api_test.go
+++ b/protocol/block/mining_api_test.go
@@ -141,7 +141,7 @@ func newAPI(t *testing.T) (bapi.MiningAPI, *node.Node) {
 	bt := nd.PorcelainAPI.BlockTime()
 	seed.GiveKey(t, nd, 0)
 	mAddr, ownerAddr := seed.GiveMiner(t, nd, 0)
-	_, err := storage.NewMiner(mAddr, ownerAddr, ownerAddr, &storage.FakeProver{}, types.OneKiBSectorSize, nd, nd.Repo.DealsDatastore(), nd.PorcelainAPI)
+	_, err := storage.NewMiner(mAddr, ownerAddr, &storage.FakeProver{}, types.OneKiBSectorSize, nd, nd.Repo.DealsDatastore(), nd.PorcelainAPI)
 	assert.NoError(t, err)
 	return bapi.New(
 		nd.MiningAddress,

--- a/protocol/storage/fault_slasher.go
+++ b/protocol/storage/fault_slasher.go
@@ -51,7 +51,7 @@ type FaultSlasher struct {
 	slashed map[string]struct{}
 }
 
-// NewFaultSlasher creates a new FaultSlasher with the provided plumbing, outbox and message sender.
+// NewFaultSlasher creates a new FaultSlasher with the provided plumbing and outbox
 // Message sender must be an account actor address.
 func NewFaultSlasher(plumbing monitorPlumbing, outbox slashingMsgOutbox, gasPrice types.AttoFIL, gasLimit types.GasUnits) *FaultSlasher {
 	return &FaultSlasher{

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -60,7 +60,6 @@ func TestReceiveStorageProposal(t *testing.T) {
 		miner := Miner{
 			porcelainAPI:      porcelainAPI,
 			ownerAddr:         porcelainAPI.targetAddress,
-			workerAddr:        porcelainAPI.workerAddress,
 			sectorSize:        types.OneKiBSectorSize,
 			proposalProcessor: func(ctx context.Context, m *Miner, cid cid.Cid) {},
 		}
@@ -638,6 +637,10 @@ func (mtp *minerTestPorcelain) MessageQuery(ctx context.Context, optFrom, to add
 	return mtp.messageQueryPaymentBrokerLs()
 }
 
+func (mtp *minerTestPorcelain) MinerGetWorkerAddress(ctx context.Context, minerAddr address.Address) (address.Address, error) {
+	return mtp.workerAddress, nil
+}
+
 func messageQueryGetProofsMode() ([][]byte, error) {
 	return [][]byte{{byte(types.TestProofsMode)}}, nil
 }
@@ -702,7 +705,6 @@ func newTestMiner(api *minerTestPorcelain) *Miner {
 	return &Miner{
 		porcelainAPI:      api,
 		ownerAddr:         api.targetAddress,
-		workerAddr:        api.workerAddress,
 		prover:            &FakeProver{},
 		sectorSize:        types.OneKiBSectorSize,
 		proposalProcessor: func(ctx context.Context, m *Miner, cid cid.Cid) {},

--- a/protocol/storage/prover.go
+++ b/protocol/storage/prover.go
@@ -31,6 +31,8 @@ type ProofReader interface {
 	MinerCalculateLateFee(ctx context.Context, addr address.Address, height *types.BlockHeight) (types.AttoFIL, error)
 	// WalletBalance returns the balance for an actor.
 	WalletBalance(ctx context.Context, addr address.Address) (types.AttoFIL, error)
+	// MinerGetWorkerAddress returns the current worker address for a miner
+	MinerGetWorkerAddress(ctx context.Context, minerAddr address.Address) (address.Address, error)
 }
 
 // ProofCalculator creates the proof-of-spacetime bytes.
@@ -42,11 +44,10 @@ type ProofCalculator interface {
 
 // Prover orchestrates the calculation and submission of a proof-of-spacetime.
 type Prover struct {
-	actorAddress  address.Address
-	workerAddress address.Address
-	sectorSize    *types.BytesAmount
-	chain         ProofReader
-	calculator    ProofCalculator
+	actorAddress address.Address
+	sectorSize   *types.BytesAmount
+	chain        ProofReader
+	calculator   ProofCalculator
 }
 
 // PoStInputs contains the sector id and related commitments used to generate a proof-of-spacetime.
@@ -68,11 +69,10 @@ type PoStSubmission struct {
 // NewProver constructs a new Prover.
 func NewProver(actor address.Address, worker address.Address, sectorSize *types.BytesAmount, reader ProofReader, calculator ProofCalculator) *Prover {
 	return &Prover{
-		actorAddress:  actor,
-		workerAddress: worker,
-		sectorSize:    sectorSize,
-		chain:         reader,
-		calculator:    calculator,
+		actorAddress: actor,
+		sectorSize:   sectorSize,
+		chain:        reader,
+		calculator:   calculator,
 	}
 }
 
@@ -98,9 +98,14 @@ func (p *Prover) CalculatePoSt(ctx context.Context, start, end *types.BlockHeigh
 	}
 
 	// Compute fees.
-	balance, err := p.chain.WalletBalance(ctx, p.workerAddress)
+	workerAddr, err := p.chain.MinerGetWorkerAddress(ctx, p.actorAddress)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to check wallet balance for %s", p.workerAddress)
+		return nil, errors.Wrapf(err, "failed to read miner worker address for miner %s", p.actorAddress)
+	}
+
+	balance, err := p.chain.WalletBalance(ctx, workerAddr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to check wallet balance for %s", workerAddr)
 	}
 
 	height, err := p.chain.ChainBlockHeight()
@@ -116,7 +121,7 @@ func (p *Prover) CalculatePoSt(ctx context.Context, start, end *types.BlockHeigh
 		return nil, err
 	}
 	if feeDue.GreaterThan(balance) {
-		log.Warningf("PoSt fee of %s exceeds available balance of %s for owner %s", feeDue, balance, p.workerAddress)
+		log.Warningf("PoSt fee of %s exceeds available balance of %s for owner %s", feeDue, balance, workerAddr)
 		// Submit anyway, in case the balance is topped up before the PoSt message is mined.
 	}
 

--- a/protocol/storage/prover.go
+++ b/protocol/storage/prover.go
@@ -67,7 +67,7 @@ type PoStSubmission struct {
 }
 
 // NewProver constructs a new Prover.
-func NewProver(actor address.Address, worker address.Address, sectorSize *types.BytesAmount, reader ProofReader, calculator ProofCalculator) *Prover {
+func NewProver(actor address.Address, sectorSize *types.BytesAmount, reader ProofReader, calculator ProofCalculator) *Prover {
 	return &Prover{
 		actorAddress: actor,
 		sectorSize:   sectorSize,

--- a/protocol/storage/prover_test.go
+++ b/protocol/storage/prover_test.go
@@ -150,3 +150,7 @@ func (f *fakeProverContext) WalletBalance(ctx context.Context, addr address.Addr
 func (f *fakeProverContext) CalculatePoSt(ctx context.Context, sortedCommRs go_sectorbuilder.SortedSectorInfo, seed types.PoStChallengeSeed) (types.PoStProof, error) {
 	return f.proof, nil
 }
+
+func (f *fakeProverContext) MinerGetWorkerAddress(ctx context.Context, minerAddr address.Address) (address.Address, error) {
+	return f.workerAddress, nil
+}

--- a/protocol/storage/prover_test.go
+++ b/protocol/storage/prover_test.go
@@ -46,7 +46,7 @@ func TestProver(t *testing.T) {
 
 	t.Run("produces on-time proof", func(t *testing.T) {
 		pc := makeProofContext()
-		prover := storage.NewProver(actorAddress, workerAddress, sectorSize, pc, pc)
+		prover := storage.NewProver(actorAddress, sectorSize, pc, pc)
 		submission, e := prover.CalculatePoSt(ctx, start, end, fakeInputs)
 		require.NoError(t, e)
 		assert.Equal(t, pc.proof, submission.Proof)
@@ -66,7 +66,7 @@ func TestProver(t *testing.T) {
 
 		for _, height := range heights {
 			pc.height = height
-			prover := storage.NewProver(actorAddress, workerAddress, sectorSize, pc, pc)
+			prover := storage.NewProver(actorAddress, sectorSize, pc, pc)
 			submission, e := prover.CalculatePoSt(ctx, start, end, fakeInputs)
 			require.NoError(t, e)
 			assert.Equal(t, pc.proof, submission.Proof)
@@ -78,7 +78,7 @@ func TestProver(t *testing.T) {
 		pc := makeProofContext()
 		pc.height = deadline // proof could only appear in block deadline+1
 
-		prover := storage.NewProver(actorAddress, workerAddress, sectorSize, pc, pc)
+		prover := storage.NewProver(actorAddress, sectorSize, pc, pc)
 		_, e := prover.CalculatePoSt(ctx, start, end, fakeInputs)
 		require.Error(t, e)
 	})
@@ -87,7 +87,7 @@ func TestProver(t *testing.T) {
 		pc := makeProofContext()
 		pc.height = start.Sub(types.NewBlockHeight(1))
 
-		prover := storage.NewProver(actorAddress, workerAddress, sectorSize, pc, pc)
+		prover := storage.NewProver(actorAddress, sectorSize, pc, pc)
 		_, e := prover.CalculatePoSt(ctx, start, end, fakeInputs)
 		require.Error(t, e)
 	})
@@ -96,7 +96,7 @@ func TestProver(t *testing.T) {
 		pc := makeProofContext()
 		pc.height = nil
 
-		prover := storage.NewProver(actorAddress, workerAddress, sectorSize, pc, pc)
+		prover := storage.NewProver(actorAddress, sectorSize, pc, pc)
 		_, e := prover.CalculatePoSt(ctx, start, end, fakeInputs)
 		require.Error(t, e)
 	})
@@ -105,7 +105,7 @@ func TestProver(t *testing.T) {
 		pc := makeProofContext()
 		pc.seed = nil
 
-		prover := storage.NewProver(actorAddress, workerAddress, sectorSize, pc, pc)
+		prover := storage.NewProver(actorAddress, sectorSize, pc, pc)
 		_, e := prover.CalculatePoSt(ctx, start, end, fakeInputs)
 		require.Error(t, e)
 	})

--- a/testhelpers/mining.go
+++ b/testhelpers/mining.go
@@ -1,9 +1,11 @@
 package testhelpers
 
 import (
+	"context"
 	"crypto/rand"
 	"time"
 
+	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -12,17 +14,23 @@ const BlockTimeTest = time.Second
 
 // TestWorkerPorcelainAPI implements the WorkerPorcelainAPI>
 type TestWorkerPorcelainAPI struct {
-	blockTime time.Duration
+	blockTime  time.Duration
+	workerAddr address.Address
 }
 
-// NewDefaultTestWorkerPorcelainAPI returns a TestWrokerPorcelainAPI.
-func NewDefaultTestWorkerPorcelainAPI() *TestWorkerPorcelainAPI {
-	return &TestWorkerPorcelainAPI{blockTime: BlockTimeTest}
+// NewDefaultTestWorkerPorcelainAPI returns a TestWorkerPorcelainAPI.
+func NewDefaultTestWorkerPorcelainAPI(signer address.Address) *TestWorkerPorcelainAPI {
+	return &TestWorkerPorcelainAPI{blockTime: BlockTimeTest, workerAddr: signer}
 }
 
-// BlockTime returns the blocktime TestWrokerPorcelainAPI si configured with.
+// BlockTime returns the blocktime TestWorkerPorcelainAPI is configured with.
 func (t *TestWorkerPorcelainAPI) BlockTime() time.Duration {
 	return t.blockTime
+}
+
+// MinerGetWorkerAddress returns the worker address set in TestWorkerPorcelainAPI
+func (t *TestWorkerPorcelainAPI) MinerGetWorkerAddress(ctx context.Context, minerAddr address.Address) (address.Address, error) {
+	return t.workerAddr, nil
 }
 
 // MakeCommitment creates a random commitment.


### PR DESCRIPTION
## Summary
Use the miner worker address from the miner's state in various places: ticket signing, PoSt proving, accepting proposals, etc.

Companion to PR #3261, resolves #2959 
