### PR TITLE
Fix TestDaemon to allow the OS to allocate a port for the command API when binding.

### DIFF
--- a/commands/daemon_daemon_test.go
+++ b/commands/daemon_daemon_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr-net"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,7 +48,7 @@ func TestDaemonCORS(t *testing.T) {
 		td := th.NewDaemon(t).Start()
 		defer td.ShutdownSuccess()
 
-		maddr, err := ma.NewMultiaddr(td.CmdAddr())
+		maddr, err := td.CmdAddr()
 		assert.NoError(t, err)
 
 		_, host, err := manet.DialArgs(maddr)
@@ -89,7 +88,7 @@ func TestDaemonCORS(t *testing.T) {
 		td := th.NewDaemon(t).Start()
 		defer td.ShutdownSuccess()
 
-		maddr, err := ma.NewMultiaddr(td.CmdAddr())
+		maddr, err := td.CmdAddr()
 		assert.NoError(t, err)
 
 		_, host, err := manet.DialArgs(maddr)
@@ -111,7 +110,7 @@ func TestDaemonOverHttp(t *testing.T) {
 	td := th.NewDaemon(t).Start()
 	defer td.ShutdownSuccess()
 
-	maddr, err := ma.NewMultiaddr(td.CmdAddr())
+	maddr, err := td.CmdAddr()
 	require.NoError(t, err)
 
 	_, host, err := manet.DialArgs(maddr)

--- a/commands/init_daemon_test.go
+++ b/commands/init_daemon_test.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"testing"
 
-	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr-net"
 	"github.com/stretchr/testify/require"
 
@@ -22,7 +21,7 @@ func TestInitOverHttp(t *testing.T) {
 	td := th.NewDaemon(t).Start()
 	defer td.ShutdownSuccess()
 
-	maddr, err := ma.NewMultiaddr(td.CmdAddr())
+	maddr, err := td.CmdAddr()
 	require.NoError(t, err)
 
 	_, host, err := manet.DialArgs(maddr)

--- a/commands/version_daemon_test.go
+++ b/commands/version_daemon_test.go
@@ -11,7 +11,6 @@ import (
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 
-	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multiaddr-net"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,7 +34,7 @@ func TestVersionOverHttp(t *testing.T) {
 	td := th.NewDaemon(t).Start()
 	defer td.ShutdownSuccess()
 
-	maddr, err := multiaddr.NewMultiaddr(td.CmdAddr())
+	maddr, err := td.CmdAddr()
 	require.NoError(t, err)
 
 	_, host, err := manet.DialArgs(maddr)


### PR DESCRIPTION
This prevents a race for the port causing flaky tests, #3145.