### PR TITLE
Defer swarm listen port allocation until binding.

### DIFF
--- a/commands/id_daemon_test.go
+++ b/commands/id_daemon_test.go
@@ -20,7 +20,7 @@ func TestId(t *testing.T) {
 	id := d.RunSuccess("id")
 
 	idContent := id.ReadStdout()
-	assert.Containsf(t, idContent, d.SwarmAddr(), "default addr")
+	assert.Containsf(t, idContent, "/ip4/127.0.0.1/tcp/", "default addr")
 	assert.Contains(t, idContent, "ID")
 
 }
@@ -37,7 +37,7 @@ func TestIdFormat(t *testing.T) {
 
 	assert.Contains(t, idContent, "\t")
 	assert.Contains(t, idContent, "\n")
-	assert.Containsf(t, idContent, d.SwarmAddr(), "default addr")
+	assert.Containsf(t, idContent, "/ip4/127.0.0.1/tcp/", "default addr")
 	assert.NotContains(t, idContent, "ID")
 }
 

--- a/commands/ping_daemon_test.go
+++ b/commands/ping_daemon_test.go
@@ -12,9 +12,9 @@ import (
 func TestPing2Nodes(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	d1 := th.NewDaemon(t, th.SwarmAddr("/ip4/127.0.0.1/tcp/6000")).Start()
+	d1 := th.NewDaemon(t).Start()
 	defer d1.ShutdownSuccess()
-	d2 := th.NewDaemon(t, th.SwarmAddr("/ip4/127.0.0.1/tcp/6001")).Start()
+	d2 := th.NewDaemon(t).Start()
 	defer d2.ShutdownSuccess()
 
 	t.Log("[failure] not connected")

--- a/commands/swarm_daemon_test.go
+++ b/commands/swarm_daemon_test.go
@@ -10,10 +10,10 @@ import (
 func TestSwarmConnectPeersValid(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	d1 := th.NewDaemon(t, th.SwarmAddr("/ip4/0.0.0.0/tcp/6000")).Start()
+	d1 := th.NewDaemon(t).Start()
 	defer d1.ShutdownSuccess()
 
-	d2 := th.NewDaemon(t, th.SwarmAddr("/ip4/0.0.0.0/tcp/6001")).Start()
+	d2 := th.NewDaemon(t).Start()
 	defer d2.ShutdownSuccess()
 
 	d1.ConnectSuccess(d2)
@@ -22,7 +22,7 @@ func TestSwarmConnectPeersValid(t *testing.T) {
 func TestSwarmConnectPeersInvalid(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	d1 := th.NewDaemon(t, th.SwarmAddr("/ip4/0.0.0.0/tcp/6000")).Start()
+	d1 := th.NewDaemon(t).Start()
 	defer d1.ShutdownSuccess()
 
 	d1.RunFail("failed to parse ip4 addr",


### PR DESCRIPTION
Along with #3291, fixes #3145.