### PR TITLE
Create Init Actor to store Network Name

### DIFF
--- a/actor/builtin/builtin.go
+++ b/actor/builtin/builtin.go
@@ -2,14 +2,14 @@
 package builtin
 
 import (
-	cid "github.com/ipfs/go-cid"
-
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/initactor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/storagemarket"
 	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/types"
+	cid "github.com/ipfs/go-cid"
 )
 
 // Actors is list of all actors that ship with Filecoin.
@@ -23,4 +23,5 @@ func init() {
 	Actors[types.PaymentBrokerActorCodeCid] = &paymentbroker.Actor{}
 	Actors[types.MinerActorCodeCid] = &miner.Actor{}
 	Actors[types.BootstrapMinerActorCodeCid] = &miner.Actor{Bootstrap: true}
+	Actors[types.InitActorCodeCid] = &initactor.Actor{}
 }

--- a/actor/builtin/initactor/init.go
+++ b/actor/builtin/initactor/init.go
@@ -40,7 +40,7 @@ func (a *Actor) Exports() exec.Exports {
 	return initExports
 }
 
-// NewActor returns a new storage market actor.
+// NewActor returns a init actor.
 func NewActor() *actor.Actor {
 	return actor.NewActor(types.InitActorCodeCid, types.ZeroAttoFIL)
 }

--- a/actor/builtin/initactor/init.go
+++ b/actor/builtin/initactor/init.go
@@ -1,6 +1,7 @@
 package initactor
 
 import (
+	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 
@@ -37,6 +38,11 @@ var initExports = exec.Exports{
 // Exports makes the available methods for this contract available.
 func (a *Actor) Exports() exec.Exports {
 	return initExports
+}
+
+// NewActor returns a new storage market actor.
+func NewActor() *actor.Actor {
+	return actor.NewActor(types.InitActorCodeCid, types.ZeroAttoFIL)
 }
 
 // InitializeState for init actor.

--- a/actor/builtin/initactor/init.go
+++ b/actor/builtin/initactor/init.go
@@ -1,0 +1,75 @@
+package initactor
+
+import (
+	"github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+
+	"github.com/filecoin-project/go-filecoin/abi"
+	"github.com/filecoin-project/go-filecoin/actor"
+	"github.com/filecoin-project/go-filecoin/exec"
+	"github.com/filecoin-project/go-filecoin/vm/errors"
+)
+
+func init() {
+	cbor.RegisterCborType(State{})
+}
+
+// Actor is the builtin actor responsible for network initialization.
+// More details on future responsibilities can be found at https://github.com/filecoin-project/specs/blob/master/actors.md#init-actor.
+type Actor struct{}
+
+// State is the init actor's storage.
+type State struct {
+	Network string
+}
+
+// Ensure InitActor is an ExecutableActor at compile time.
+var _ exec.ExecutableActor = (*Actor)(nil)
+
+// initExports are the publicly (externally callable) methods of the AccountActor.
+var initExports = exec.Exports{
+	"getNetwork": &exec.FunctionSignature{
+		Params: []abi.Type{},
+		Return: []abi.Type{abi.String},
+	},
+}
+
+// Exports makes the available methods for this contract available.
+func (a *Actor) Exports() exec.Exports {
+	return initExports
+}
+
+// InitializeState for init actor.
+func (ia *Actor) InitializeState(storage exec.Storage, networkInterface interface{}) error {
+	network := networkInterface.(string)
+
+	initStorage := &State{
+		Network: network,
+	}
+	stateBytes, err := cbor.DumpObject(initStorage)
+	if err != nil {
+		return err
+	}
+
+	id, err := storage.Put(stateBytes)
+	if err != nil {
+		return err
+	}
+
+	return storage.Commit(id, cid.Undef)
+}
+
+// GetNetwork returns the network name for this network
+func (sma *Actor) GetNetwork(vmctx exec.VMContext) (string, uint8, error) {
+	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
+		return "", exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
+	var state State
+	err := actor.ReadState(vmctx, &state)
+	if err != nil {
+		return "", errors.CodeError(err), err
+	}
+
+	return state.Network, 0, nil
+}

--- a/actor/builtin/initactor/init_test.go
+++ b/actor/builtin/initactor/init_test.go
@@ -1,0 +1,57 @@
+package initactor_test
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/go-filecoin/actor"
+	. "github.com/filecoin-project/go-filecoin/actor/builtin/initactor"
+	"github.com/filecoin-project/go-filecoin/address"
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/ipfs/go-ipld-cbor"
+	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitActorCreateInitActor(t *testing.T) {
+	tf.UnitTest(t)
+
+	initExecActor := &Actor{}
+
+	storageMap := th.VMStorage()
+	initActor := &actor.Actor{}
+	storage := storageMap.NewStorage(address.InitAddress, initActor)
+
+	// create state with a network name
+	initExecActor.InitializeState(storage, "foo")
+	storage.Flush()
+
+	// retrieve state directly and assert it's constructed correctly
+	state, err := storage.Get(initActor.Head)
+	require.NoError(t, err)
+
+	var initState State
+	err = cbornode.DecodeInto(state, &initState)
+	require.NoError(t, err)
+
+	assert.Equal(t, "foo", initState.Network)
+}
+
+func TestInitActorGetNetwork(t *testing.T) {
+	tf.UnitTest(t)
+
+	initExecActor := &Actor{}
+	state := &State{
+		Network: "bar",
+	}
+
+	msg := types.NewMessage(address.TestAddress, address.InitAddress, 0, types.ZeroAttoFIL, "getAddress", []byte{})
+	vmctx := th.NewFakeVMContext(msg, state)
+
+	network, code, err := initExecActor.GetNetwork(vmctx)
+	require.NoError(t, err)
+	require.Equal(t, uint8(0), code)
+
+	assert.Equal(t, "bar", network)
+}

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -1398,7 +1398,7 @@ func TestGetProofsMode(t *testing.T) {
 			Ancestors:   []types.TipSet{},
 		})
 
-		require.NoError(t, consensus.SetupDefaultActors(ctx, st, vms, types.TestProofsMode))
+		require.NoError(t, consensus.SetupDefaultActors(ctx, st, vms, types.TestProofsMode, "test"))
 
 		mode, err := GetProofsMode(vmCtx)
 		require.NoError(t, err)
@@ -1417,7 +1417,7 @@ func TestGetProofsMode(t *testing.T) {
 			Ancestors:   []types.TipSet{},
 		})
 
-		require.NoError(t, consensus.SetupDefaultActors(ctx, st, vms, types.LiveProofsMode))
+		require.NoError(t, consensus.SetupDefaultActors(ctx, st, vms, types.LiveProofsMode, "main"))
 
 		mode, err := GetProofsMode(vmCtx)
 		require.NoError(t, err)

--- a/address/constants.go
+++ b/address/constants.go
@@ -21,12 +21,12 @@ func init() {
 		panic(err)
 	}
 
-	NetworkAddress, err = NewIDAddress(1)
+	InitAddress, err = NewIDAddress(0)
 	if err != nil {
 		panic(err)
 	}
 
-	InitAddress, err = NewIDAddress(4)
+	NetworkAddress, err = NewIDAddress(1)
 	if err != nil {
 		panic(err)
 	}

--- a/address/constants.go
+++ b/address/constants.go
@@ -26,6 +26,11 @@ func init() {
 		panic(err)
 	}
 
+	InitAddress, err = NewIDAddress(4)
+	if err != nil {
+		panic(err)
+	}
+
 	StorageMarketAddress, err = NewIDAddress(2)
 	if err != nil {
 		panic(err)
@@ -48,6 +53,8 @@ var (
 	// TestAddress2 is an account with some initial funds in it.
 	TestAddress2 Address
 
+	// InitAddress is the filecoin network initializer.
+	InitAddress Address
 	// NetworkAddress is the filecoin network treasury.
 	NetworkAddress Address
 	// StorageMarketAddress is the hard-coded address of the filecoin storage market actor.

--- a/chain/power_table_view_test.go
+++ b/chain/power_table_view_test.go
@@ -67,6 +67,7 @@ func requireMinerWithNumCommittedSectors(ctx context.Context, t *testing.T, numC
 				SectorSize:          types.OneKiBSectorSize.Uint64(),
 			},
 		},
+		Network: "ptvtest",
 	}
 
 	info, err := gengen.GenGen(ctx, genCfg, cst, bs, 0)

--- a/chain/syncer_integration_test.go
+++ b/chain/syncer_integration_test.go
@@ -154,6 +154,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 				SectorSize:          types.OneKiBSectorSize.Uint64(),
 			},
 		},
+		Network: "syncerIntegrationTest",
 	}
 
 	totalPower := types.NewBytesAmount(1000).Mul(types.OneKiBSectorSize)

--- a/commands/actor.go
+++ b/commands/actor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/initactor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/storagemarket"
@@ -69,6 +70,8 @@ var actorLsCmd = &cmds.Command{
 				output = makeActorView(result.Actor, result.Address, nil)
 			case result.Actor.Code.Equals(types.AccountActorCodeCid):
 				output = makeActorView(result.Actor, result.Address, &account.Actor{})
+			case result.Actor.Code.Equals(types.InitActorCodeCid):
+				output = makeActorView(result.Actor, result.Address, &initactor.Actor{})
 			case result.Actor.Code.Equals(types.StorageMarketActorCodeCid):
 				output = makeActorView(result.Actor, result.Address, &storagemarket.Actor{})
 			case result.Actor.Code.Equals(types.PaymentBrokerActorCodeCid):
@@ -150,6 +153,10 @@ func presentExports(e exec.Exports) readableExports {
 func getActorType(actType exec.ExecutableActor) string {
 	t := reflect.TypeOf(actType).Elem()
 	prefixes := strings.Split(t.PkgPath(), "/")
+	pkg := prefixes[len(prefixes)-1]
 
-	return strings.Title(prefixes[len(prefixes)-1]) + t.Name()
+	// strip actor suffix required if package would otherwise be a reserved word
+	pkg = strings.TrimSuffix(pkg, "actor")
+
+	return strings.Title(pkg) + t.Name()
 }

--- a/commands/actor_daemon_test.go
+++ b/commands/actor_daemon_test.go
@@ -39,7 +39,7 @@ func TestActorDaemon(t *testing.T) {
 		// The order of actors is consistent, but only within builds of genesis.car.
 		// We just want to make sure the views have something valid in them.
 		for _, av := range avs {
-			assert.Contains(t, []string{"StoragemarketActor", "AccountActor", "PaymentbrokerActor", "MinerActor", "BootstrapMinerActor"}, av.ActorType)
+			assert.Contains(t, []string{"StoragemarketActor", "AccountActor", "PaymentbrokerActor", "MinerActor", "BootstrapMinerActor", "InitActor"}, av.ActorType)
 			if av.ActorType == "AccountActor" {
 				assert.Zero(t, len(av.Exports))
 			} else {

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -414,4 +414,5 @@ var testConfig = &gengen.GenesisCfg{
 			SectorSize:          types.OneKiBSectorSize.Uint64(),
 		},
 	},
+	Network: "minerDaemonTest",
 }

--- a/commands/protocol.go
+++ b/commands/protocol.go
@@ -24,7 +24,12 @@ var protocolCmd = &cmds.Command{
 	Type: porcelain.ProtocolParams{},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, pp *porcelain.ProtocolParams) error {
-			_, err := fmt.Fprintf(w, "Auto-Seal Interval: %d seconds\nSector Sizes:\n", pp.AutoSealInterval)
+			_, err := fmt.Fprintf(w, "Network: %s\n", pp.Network)
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintf(w, "Auto-Seal Interval: %d seconds\nSector Sizes:\n", pp.AutoSealInterval)
 			if err != nil {
 				return err
 			}

--- a/commands/protocol_daemon_test.go
+++ b/commands/protocol_daemon_test.go
@@ -18,5 +18,6 @@ func TestProtocol(t *testing.T) {
 	protocol := d.RunSuccess("protocol")
 
 	protocolContent := protocol.ReadStdout()
+	assert.Contains(t, protocolContent, "Network: alpha1")
 	assert.Contains(t, protocolContent, "Auto-Seal Interval: 120 seconds")
 }

--- a/commands/schema/actor_ls.schema.json
+++ b/commands/schema/actor_ls.schema.json
@@ -14,6 +14,13 @@
       "type": "object",
       "additionalProperties": { "$ref": "#/definitions/Export" }
     },
+    "InitMemory": {
+      "type": "object",
+      "properties": {
+        "Network": { "type": "string" }
+      },
+      "required": ["Network"]
+    },
     "MinerMemory": {
       "type": "object",
       "properties": {
@@ -155,6 +162,17 @@
               ]
             },
             "memory": { "$ref": "#/definitions/StorageMarketMemory" }
+          }
+        },
+        {
+          "properties": {
+            "actorType": {
+              "type": "string",
+              "enum": [
+                "InitActor"
+              ]
+            },
+            "memory": { "$ref": "#/definitions/InitMemory" }
           }
         },
         {

--- a/fixtures/setup.json
+++ b/fixtures/setup.json
@@ -10,5 +10,6 @@
   "miners": [{
     "owner": 0,
     "numCommittedSectors": 1
-  }]
+  }],
+  "network": "alpha1"
 }

--- a/gengen/main.go
+++ b/gengen/main.go
@@ -52,7 +52,8 @@ $ cat setup.json
 			"owner": 1,
 			"power": 1000
 		}
-	]
+	],
+	Network: "test1",
 }
 $ cat setup.json | gengen > genesis.car
 

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -64,6 +64,9 @@ type GenesisCfg struct {
 	// Miners is a list of miners that should be set up at the start of the network
 	Miners []*CreateStorageMinerConfig
 
+	// Network is the name of the network
+	Network string
+
 	// ProofsMode affects sealing, sector packing, PoSt, etc. in the proofs library
 	ProofsMode types.ProofsMode
 }
@@ -107,7 +110,7 @@ func GenGen(ctx context.Context, cfg *GenesisCfg, cst *hamt.CborIpldStore, bs bl
 	st := state.NewEmptyStateTreeWithActors(cst, builtin.Actors)
 	storageMap := vm.NewStorageMap(bs)
 
-	if err := consensus.SetupDefaultActors(ctx, st, storageMap, cfg.ProofsMode); err != nil {
+	if err := consensus.SetupDefaultActors(ctx, st, storageMap, cfg.ProofsMode, cfg.Network); err != nil {
 		return nil, err
 	}
 
@@ -133,6 +136,9 @@ func GenGen(ctx context.Context, cfg *GenesisCfg, cst *hamt.CborIpldStore, bs bl
 		return nil, err
 	}
 	if err := cst.Blocks.AddBlock(types.PaymentBrokerActorCodeObj); err != nil {
+		return nil, err
+	}
+	if err := cst.Blocks.AddBlock(types.InitActorCodeObj); err != nil {
 		return nil, err
 	}
 

--- a/gengen/util/gengen_test.go
+++ b/gengen/util/gengen_test.go
@@ -35,6 +35,7 @@ var testConfig = &GenesisCfg{
 			SectorSize:          types.OneKiBSectorSize.Uint64(),
 		},
 	},
+	Network: "GenGenTest",
 }
 
 func TestGenGenLoading(t *testing.T) {
@@ -55,6 +56,7 @@ func TestGenGenLoading(t *testing.T) {
 	stdout := o.ReadStdout()
 	assert.Contains(t, stdout, `"MinerActor"`)
 	assert.Contains(t, stdout, `"StoragemarketActor"`)
+	assert.Contains(t, stdout, `"InitActor"`)
 }
 
 func TestGenGenDeterministicBetweenBuilds(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/libp2p/go-libp2p-swarm v0.1.1
 	github.com/libp2p/go-stream-muxer v0.0.1
 	github.com/libp2p/go-testutil v0.0.1 // indirect
-	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/magiconair/properties v1.8.1
 	github.com/miekg/dns v1.1.15 // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/minio/sha256-simd v0.1.0

--- a/node/testing.go
+++ b/node/testing.go
@@ -237,6 +237,7 @@ var TestGenCfg = &gengen.GenesisCfg{
 			SectorSize:          types.OneKiBSectorSize.Uint64(),
 		},
 	},
+	Network: "go-filecoin-test",
 	PreAlloc: []string{
 		"10000",
 		"10000",

--- a/porcelain/protocol_test.go
+++ b/porcelain/protocol_test.go
@@ -2,16 +2,17 @@ package porcelain_test
 
 import (
 	"context"
+	"testing"
 	"time"
 
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-sectorbuilder"
+	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 const protocolTestParamBlockTime = time.Second
@@ -27,7 +28,12 @@ func (tppp *testProtocolParamsPlumbing) ConfigGet(path string) (interface{}, err
 }
 
 func (tppp *testProtocolParamsPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, error) {
-	return [][]byte{{byte(types.TestProofsMode)}}, nil
+	if method == "getProofsMode" {
+		return [][]byte{{byte(types.TestProofsMode)}}, nil
+	} else if method == "getNetwork" {
+		return [][]byte{[]byte("protocolTest")}, nil
+	}
+	return [][]byte{}, errors.Errorf("call to unknown method %s", method)
 }
 
 func (tppp *testProtocolParamsPlumbing) BlockTime() time.Duration {
@@ -50,6 +56,7 @@ func TestProtocolParams(t *testing.T) {
 
 		expected := &porcelain.ProtocolParams{
 			AutoSealInterval: 120,
+			Network:          "protocolTest",
 			ProofsMode:       types.TestProofsMode,
 			SupportedSectors: []porcelain.SectorInfo{{sectorSize, maxUserBytes}},
 			BlockTime:        protocolTestParamBlockTime,

--- a/testhelpers/iptbtester/genesis.go
+++ b/testhelpers/iptbtester/genesis.go
@@ -42,6 +42,7 @@ func MustGenerateGenesis(t *testing.T, funds int64, dir string) *GenesisInfo {
 				SectorSize:          types.OneKiBSectorSize.Uint64(),
 			},
 		},
+		Network: "IPTBtest",
 	}
 
 	genfile, err := ioutil.TempFile(dir, "genesis.*.car")

--- a/tools/fast/environment/environment_memory_genesis.go
+++ b/tools/fast/environment/environment_memory_genesis.go
@@ -240,6 +240,7 @@ func (e *MemoryGenesis) buildGenesis(funds *big.Int) error {
 				NumCommittedSectors: 128,
 			},
 		},
+		Network:    "FASTtest",
 		ProofsMode: e.proofsMode,
 	}
 

--- a/types/constants.go
+++ b/types/constants.go
@@ -40,6 +40,12 @@ var BootstrapMinerActorCodeObj ipld.Node
 // BootstrapMinerActorCodeCid is the cid of the above object
 var BootstrapMinerActorCodeCid cid.Cid
 
+// InitActorCodeObj is the code representation of the builtin init actor.
+var InitActorCodeObj ipld.Node
+
+// InitActorCodeCid is the cid of the above object
+var InitActorCodeCid cid.Cid
+
 // ActorCodeCidTypeNames maps Actor codeCid's to the name of the associated Actor type.
 var ActorCodeCidTypeNames = make(map[cid.Cid]string)
 
@@ -54,6 +60,8 @@ func init() {
 	MinerActorCodeCid = MinerActorCodeObj.Cid()
 	BootstrapMinerActorCodeObj = dag.NewRawNode([]byte("bootstrapmineractor"))
 	BootstrapMinerActorCodeCid = BootstrapMinerActorCodeObj.Cid()
+	InitActorCodeObj = dag.NewRawNode([]byte("initactor"))
+	InitActorCodeCid = InitActorCodeObj.Cid()
 
 	// New Actors need to be added here.
 	// TODO: Make this work with reflection -- but note that nasty import cycles lie on that path.
@@ -63,6 +71,7 @@ func init() {
 	ActorCodeCidTypeNames[PaymentBrokerActorCodeCid] = "PaymentBrokerActor"
 	ActorCodeCidTypeNames[MinerActorCodeCid] = "MinerActor"
 	ActorCodeCidTypeNames[BootstrapMinerActorCodeCid] = "MinerActor"
+	ActorCodeCidTypeNames[InitActorCodeCid] = "InitActor"
 }
 
 // ActorCodeTypeName returns the (string) name of the Go type of the actor with cid, code.


### PR DESCRIPTION
closes #3301 

### Problem

We need a network name accessible internally go-filecoin code so a node can make decisions that depend on which network it's running on (e.g. devnet, testnet, mainnet, etc.). The primary and, perhaps, only decision nodes will need to make is when it should switch protocol versions.

For reasons described in detail here: https://github.com/filecoin-project/specs/pull/456, the network name should established at the time when the genesis block is created and stored in actor state.

### Solution

This PR introduces the `InitActor` to store the network name. In the future this actor will also provide a map of public key or named addresses to id addresses. There are really three parts to this PR that roughly correspond to the first 3 commits.

1. Create the InitActor with network name in state and a `GetNetwork` method.
2. Create a single instance of `InitActor` when creating the genesis block in gengen and elsewhere.
3. Add `Network` to the protocol parameters retrieved by the protocol command.