### PR TITLE
Implement test.NodeBuilder and test.NodeAPI for in-process integration tests

### DIFF
--- a/commands/main.go
+++ b/commands/main.go
@@ -199,8 +199,8 @@ func init() {
 }
 
 // Run processes the arguments and stdin
-func Run(args []string, stdin, stdout, stderr *os.File) (int, error) {
-	err := cli.Run(context.Background(), rootCmd, args, stdin, stdout, stderr, buildEnv, makeExecutor)
+func Run(ctx context.Context, args []string, stdin, stdout, stderr *os.File) (int, error) {
+	err := cli.Run(ctx, rootCmd, args, stdin, stdout, stderr, buildEnv, makeExecutor)
 	if err == nil {
 		return 0, nil
 	}

--- a/consensus/genesis.go
+++ b/consensus/genesis.go
@@ -91,6 +91,14 @@ func AddActor(addr address.Address, actor *actor.Actor) GenOption {
 	}
 }
 
+// NetworkName returns a config option that sets the network name.
+func NetworkName(name string) GenOption {
+	return func(gc *Config) error {
+		gc.network = name
+		return nil
+	}
+}
+
 // ProofsMode sets the mode of operation for the proofs library.
 func ProofsMode(proofsMode types.ProofsMode) GenOption {
 	return func(gc *Config) error {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"strconv"
 
@@ -44,6 +45,6 @@ func main() {
 	// TODO implement help text like so:
 	// https://github.com/ipfs/go-ipfs/blob/master/core/commands/root.go#L91
 	// TODO don't panic if run without a command.
-	code, _ := commands.Run(os.Args, os.Stdin, os.Stdout, os.Stderr)
+	code, _ := commands.Run(context.Background(), os.Args, os.Stdin, os.Stdout, os.Stderr)
 	os.Exit(code)
 }

--- a/node/init.go
+++ b/node/init.go
@@ -19,7 +19,9 @@ import (
 
 var ErrLittleBits = errors.New("Bitsize less than 1024 is considered unsafe") // nolint: golint
 
-// InitCfg contains configuration for initializing a node
+// InitCfg contains configuration for initializing a node.
+// Note that the DefaultWalletAddress and AutoSealIntervalSeconds are just modifications to the
+// repo config and don't justify special treatment here (c.f others in commands/init.go).
 type InitCfg struct {
 	PeerKey                 ci.PrivKey
 	DefaultWalletAddress    address.Address

--- a/node/node.go
+++ b/node/node.go
@@ -201,6 +201,7 @@ type Node struct {
 }
 
 // Config is a helper to aid in the construction of a filecoin node.
+// This is poorly named and easily confused with config.Config. It's really a node factory pattern.
 type Config struct {
 	BlockTime   time.Duration
 	Libp2pOpts  []libp2p.Option

--- a/node/test/api.go
+++ b/node/test/api.go
@@ -1,0 +1,124 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/node"
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+
+	"github.com/filecoin-project/go-filecoin/commands"
+)
+
+// NodeAPI wraps an in-process Node to provide a command API server and client for testing.
+type NodeAPI struct {
+	node *node.Node
+	tb   testing.TB
+}
+
+// NewNodeAPI creates a wrangler for a node.
+func NewNodeAPI(node *node.Node, tb testing.TB) *NodeAPI {
+	return &NodeAPI{node, tb}
+}
+
+// RunNodeAPI creates a new API server and `Run()`s it.
+func RunNodeAPI(ctx context.Context, node *node.Node, tb testing.TB) (client *Client, stop func()) {
+	api := NewNodeAPI(node, tb)
+	return api.Run(ctx)
+}
+
+// Node returns the node backing the API.
+func (a *NodeAPI) Node() *node.Node {
+	return a.node
+}
+
+// Run start s a command API server for the node.
+// Returns a client proxy and a function to terminate the NodeAPI server.
+func (a *NodeAPI) Run(ctx context.Context) (client *Client, stop func()) {
+	ready := make(chan interface{})
+	terminate := make(chan os.Signal, 1)
+	go func() {
+		err := commands.RunAPIAndWait(ctx, a.node, a.node.Repo.Config().API, ready, terminate)
+		require.NoError(a.tb, err)
+	}()
+	<-ready
+
+	addr, err := a.node.Repo.APIAddr()
+	require.NoError(a.tb, err)
+	require.NotEmpty(a.tb, addr, "empty API address")
+
+	return &Client{addr, a.tb}, func() { close(terminate) }
+}
+
+// Client is an in-process client to a command API.
+type Client struct {
+	address string
+	tb      testing.TB
+}
+
+// Address returns the address string to which the client sends command RPCs.
+func (c *Client) Address() string {
+	return c.address
+}
+
+// Run runs a CLI command and returns its output.
+func (c *Client) Run(ctx context.Context, command ...string) *th.CmdOutput {
+	c.tb.Helper()
+	args := []string{
+		"go-filecoin", // A dummy first arg is required, simulating shell invocation.
+		fmt.Sprintf("--cmdapiaddr=%s", c.address),
+	}
+	args = append(args, command...)
+
+	// Create pipes for the client to write stdout and stderr.
+	readStdOut, writeStdOut, err := os.Pipe()
+	require.NoError(c.tb, err)
+	readStdErr, writeStdErr, err := os.Pipe()
+	require.NoError(c.tb, err)
+	var readStdin *os.File // no stdin needed
+
+	exitCode, err := commands.Run(ctx, args, readStdin, writeStdOut, writeStdErr)
+	// Close the output side of the pipes so that ReadAll() on the read ends can complete.
+	require.NoError(c.tb, writeStdOut.Close())
+	require.NoError(c.tb, writeStdErr.Close())
+
+	out := th.ReadOutput(c.tb, command, readStdOut, readStdErr)
+	if err != nil {
+		out.SetInvocationError(err)
+	} else {
+		out.SetStatus(exitCode)
+	}
+
+	require.NoError(c.tb, err, "client execution error")
+	assert.Equal(c.tb, 0, exitCode, "client returned non-zero status")
+
+	return out
+}
+
+// RunSuccess runs a command and asserts that it succeeds (status of zero and logs no errors).
+func (c *Client) RunSuccess(ctx context.Context, command ...string) *th.CmdOutput {
+	output := c.Run(ctx, command...)
+	output.AssertSuccess()
+	return output
+}
+
+// RunFail runs a command and asserts that it fails with a specified message on stderr.
+func (c *Client) RunFail(ctx context.Context, error string, command ...string) *th.CmdOutput {
+	output := c.Run(ctx, command...)
+	output.AssertFail(error)
+	return output
+}
+
+// RunJSON runs a command, asserts success, and parses the response as JSON.
+func (c *Client) RunJSON(ctx context.Context, command ...string) map[string]interface{} {
+	out := c.RunSuccess(ctx, command...)
+	var parsed map[string]interface{}
+	require.NoError(c.tb, json.Unmarshal([]byte(out.ReadStdout()), &parsed))
+	return parsed
+}

--- a/node/test/builder.go
+++ b/node/test/builder.go
@@ -1,0 +1,118 @@
+package test
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/config"
+	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/node"
+	"github.com/filecoin-project/go-filecoin/repo"
+)
+
+// NodeBuilder creates and configures Filecoin nodes for in-process testing.
+// This is intended to replace use of GenNode and the various other node construction entry points
+// that end up there.
+// Note that (August 2019) there are two things called "config": the configuration read in from
+// file to the config.Config structure, and node.Config which is really just some dependency
+// injection. This builder avoids exposing the latter directly.
+type NodeBuilder struct {
+	// Initialisation function for the genesis block (should be an InitOpt).
+	gif consensus.GenesisInitFunc
+	// Options to the repo/config initialisation.
+	initOpts []node.InitOpt
+	// Mutations to be applied to node config after initialisation.
+	configMutations []func(*config.Config)
+
+	// Whether to skip network connection when starting.
+	offline bool
+
+	tb testing.TB
+}
+
+// NewNodeBuilder creates a new node builder.
+func NewNodeBuilder(tb testing.TB) *NodeBuilder {
+	return &NodeBuilder{
+		gif:      consensus.MakeGenesisFunc(consensus.NetworkName("test")),
+		initOpts: []node.InitOpt{},
+		configMutations: []func(*config.Config){
+			// Default configurations that make sense for integration tests.
+			// The can be overridden by subsequent `withConfigChanges`.
+			func(c *config.Config) {
+				// Bind only locally, defer port selection until binding.
+				c.API.Address = "/ip4/127.0.0.1/tcp/0"
+				c.Swarm.Address = "/ip4/127.0.0.1/tcp/0"
+			},
+		},
+		offline: false,
+		tb:      tb,
+	}
+}
+
+// WithGenesisInit sets the built nodes' genesis function.
+func (b *NodeBuilder) WithGenesisInit(gif consensus.GenesisInitFunc) *NodeBuilder {
+	b.gif = gif
+	return b
+}
+
+// WithInitOpt adds one or more options to repo initialisation.
+func (b *NodeBuilder) WithInitOpt(opts ...node.InitOpt) *NodeBuilder {
+	b.initOpts = append(b.initOpts, opts...)
+	return b
+}
+
+// WithConfig adds a configuration mutation function to be invoked after repo initialisation.
+func (b *NodeBuilder) WithConfig(cm func(config *config.Config)) *NodeBuilder {
+	b.configMutations = append(b.configMutations, cm)
+	return b
+}
+
+// WithOffline set's the built nodes' offline configuration (default false).
+func (b *NodeBuilder) WithOffline(offline bool) *NodeBuilder {
+	b.offline = offline
+	return b
+}
+
+// Build creates a node as specified by this builder.
+// This many be invoked multiple times to create many nodes.
+func (b *NodeBuilder) Build(ctx context.Context) *node.Node {
+	repo := repo.NewInMemoryRepo()
+
+	// Initialise repo.
+	b.requireNoError(node.Init(ctx, repo, b.gif, b.initOpts...))
+
+	// Apply configuration changes, which must happen before node.OptionsFromRepo().
+	sectorDir, err := ioutil.TempDir("", "go-fil-test-sectors")
+	b.requireNoError(err)
+	repo.Config().SectorBase.RootDir = sectorDir
+	for _, m := range b.configMutations {
+		m(repo.Config())
+	}
+
+	// Initialize the node.
+	repoConfigOpts, err := node.OptionsFromRepo(repo)
+	b.requireNoError(err)
+	builderConfigOpts := []node.ConfigOpt{
+		node.OfflineMode(b.offline),
+	}
+
+	nd, err := node.New(ctx, append(repoConfigOpts, builderConfigOpts...)...)
+	b.requireNoError(err)
+	return nd
+}
+
+// BuildAndStart build a node and starts it.
+func (b *NodeBuilder) BuildAndStart(ctx context.Context) *node.Node {
+	n := b.Build(ctx)
+	err := n.Start(ctx)
+	b.requireNoError(err)
+	return n
+}
+
+func (b *NodeBuilder) requireNoError(err error) {
+	b.tb.Helper()
+	require.NoError(b.tb, err)
+}


### PR DESCRIPTION
This PR introduces and demonstrates a couple of things.

`test.NodeBuilder` creates nodes configured for in-memory use. There is existing code in `node/testing.go` to create nodes, primarily `GenNode` and other methods that call into it. My goal is to replace all uses of that with this builder and extensions to it.

`test.NodeAPI` runs a real command API around an in-process node, that listens on a TCP socket. It also provides an in-process client that sends commands to that socket over the cmdkit RPC. That is, it provides both the daemon and client processes, in-process. If using the TestDaemon (deprecated) or FAST, both of those would involve forking processes, and the daemon would use an on-disk repo. The resulting tests run in ⅓ or less of the time and provide direct access to the node under test for configuration and inspection (things with otherwise have to be plumbed through the CLI).

I've ported two very simple tests to demonstrate this. The protocol daemon test is a direct replacement, exercising the cmdkit commands, and is testing the complete code path but much faster. The ping daemon test I've added an alternative version that demonstrates testing directly against the porcelain API, skipping over the cmdkit API entirely. This shows a path to testing things without forcing us to write CLI commands for them (though I'm not saying we won't want to expose this plumbing/porcelain over an RPC one day anyway). This one is waaay faster, ~500ms down from 2.2s (and probably be faster still with libp2p mocknet, which is now possible to use).

On request, I could change this ping test to also exercise the cmdkit I/O, but I am inclined not to. I intend to delete the daemon test version before merging.

For #3180