### PR TITLE
update megascript to use "show messages" command to look for commitSector and submitPoSt

### DIFF
--- a/functional-tests/lib/helpers.bash
+++ b/functional-tests/lib/helpers.bash
@@ -156,7 +156,9 @@ function wait_for_message_in_chain_by_method_and_sender {
         exit 1
     fi
 
-    __hodl=$(echo "$(chain_ls "$3")" | jq ".[] | select(.messages != null) | .messages[].meteredMessage.message | select(.method == \"$1\").from | select(. == \"$2\")" 2>/dev/null | head -n 1 || true)
+    __hodl=$(echo "$(chain_ls $3)" \
+        | jq -r '.[].messages["/"]' | while read -r cid; do ./go-filecoin show messages $cid --enc=json --repodir=$3; done | jq -s 'add' \
+        | jq ".[] | select(.meteredMessage != null) | .meteredMessage.message | select(.method == \"$1\").from | select(. == \"$2\")" 2>/dev/null | head -n 1 || true)
 
     __polls_remaining=$((__polls_remaining - 1))
     local seconds_remaining=$((__polls_remaining*10))

--- a/functional-tests/retrieval
+++ b/functional-tests/retrieval
@@ -8,6 +8,7 @@ source "$DIR/lib/helpers.bash"
 
 export GO_FILECOIN_LOG_LEVEL=3
 export FILECOIN_PROOFS_FAST_DELAY_SECONDS=1
+export RUST_LOG=info
 
 if [ -z "$1" ]; then
     FIXTURES_PATH="./fixtures/test"


### PR DESCRIPTION
## Why does this PR exist?

After messages were removed from the `chain ls` output, the megascript broke.

## What's in this PR?

This changeset modifies the megascript to instead use `show messages` to look for `commitSector` and `submitPoSt`.