### PR TITLE
SayHello returns hello message from peer

### DIFF
--- a/protocol/hello/hello_test.go
+++ b/protocol/hello/hello_test.go
@@ -230,7 +230,7 @@ func TestHelloMultiBlock(t *testing.T) {
 	msc2.AssertExpectations(t)
 }
 
-func TestSayHello(t *testing.T) {
+func TestReceiveHello(t *testing.T) {
 	tf.UnitTest(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -245,7 +245,6 @@ func TestSayHello(t *testing.T) {
 	builder := chain.NewBuilder(t, address.Undef)
 
 	genesisTipset := builder.NewGenesis()
-	assert.Equal(t, 1, genesisTipset.Len())
 
 	heavy1 := builder.AppendOn(genesisTipset, 3)
 	heavy1 = builder.AppendOn(heavy1, 3)
@@ -263,10 +262,10 @@ func TestSayHello(t *testing.T) {
 	assert.NoError(t, mn.LinkAll())
 	assert.NoError(t, mn.ConnectAllButSelf())
 
-	h2Msg, err := h1.SayHello(ctx, b.ID())
+	h2Msg, err := h1.ReceiveHello(ctx, b.ID())
 	assert.NoError(t, err)
 
-	h1Msg, err := h2.SayHello(ctx, a.ID())
+	h1Msg, err := h2.ReceiveHello(ctx, a.ID())
 	assert.NoError(t, err)
 
 	assert.Equal(t, heavy1.Key(), h1Msg.HeaviestTipSetCids)

--- a/protocol/hello/hello_test.go
+++ b/protocol/hello/hello_test.go
@@ -229,3 +229,47 @@ func TestHelloMultiBlock(t *testing.T) {
 	msc1.AssertExpectations(t)
 	msc2.AssertExpectations(t)
 }
+
+func TestSayHello(t *testing.T) {
+	tf.UnitTest(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mn, err := mocknet.FullMeshConnected(ctx, 2)
+	assert.NoError(t, err)
+
+	a := mn.Hosts()[0]
+	b := mn.Hosts()[1]
+
+	builder := chain.NewBuilder(t, address.Undef)
+
+	genesisTipset := builder.NewGenesis()
+	assert.Equal(t, 1, genesisTipset.Len())
+
+	heavy1 := builder.AppendOn(genesisTipset, 3)
+	heavy1 = builder.AppendOn(heavy1, 3)
+	heavy2 := builder.AppendOn(heavy1, 3)
+
+	msc1, msc2 := new(mockHelloCallback), new(mockHelloCallback)
+	hg1, hg2 := &mockHeaviestGetter{heavy1}, &mockHeaviestGetter{heavy2}
+
+	h1 := New(a, genesisTipset.At(0).Cid(), msc1.HelloCallback, hg1.getHeaviestTipSet, "", "")
+	h2 := New(b, genesisTipset.At(0).Cid(), msc2.HelloCallback, hg2.getHeaviestTipSet, "", "")
+
+	msc1.On("HelloCallback", b.ID(), heavy2.Key(), uint64(3)).Return()
+	msc2.On("HelloCallback", a.ID(), heavy1.Key(), uint64(2)).Return()
+
+	assert.NoError(t, mn.LinkAll())
+	assert.NoError(t, mn.ConnectAllButSelf())
+
+	h2Msg, err := h1.SayHello(ctx, b.ID())
+	assert.NoError(t, err)
+
+	h1Msg, err := h2.SayHello(ctx, a.ID())
+	assert.NoError(t, err)
+
+	assert.Equal(t, heavy1.Key(), h1Msg.HeaviestTipSetCids)
+	assert.Equal(t, heavy2.Key(), h2Msg.HeaviestTipSetCids)
+
+}


### PR DESCRIPTION
### What
This PR lays the foundation for completing #3319 and later #3268 by modifying the `SayHello` method to receive a response. The method has also been exported so that it may be called externally to receive an updated chain head from a peer.

This is not a permanent change to the hello protocol and will likely be reverted once https://github.com/filecoin-project/go-filecoin/issues/2674 is implemented.