### PR TITLE
PeerTracker has trusted set and SelectHead logic

### DIFF
--- a/net/address.go
+++ b/net/address.go
@@ -23,3 +23,12 @@ func PeerAddrsToAddrInfo(addrs []string) ([]peer.AddrInfo, error) {
 	}
 	return pis, nil
 }
+
+// AddrInfoToPeerIDs converts a slice of AddrInfo to a slice of peerID's.
+func AddrInfoToPeerIDs(ai []peer.AddrInfo) []peer.ID {
+	var pis []peer.ID
+	for _, a := range ai {
+		pis = append(pis, a.ID)
+	}
+	return pis
+}

--- a/net/peer_tracker.go
+++ b/net/peer_tracker.go
@@ -1,11 +1,15 @@
 package net
 
 import (
+	"context"
+	"sort"
 	"sync"
 
 	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/filecoin-project/go-filecoin/types"
 )
@@ -18,19 +22,51 @@ var logPeerTracker = logging.Logger("peer-tracker")
 type PeerTracker struct {
 	// mu protects peers
 	mu sync.RWMutex
-	// peers maps stringified peer.IDs to info about their chains
-	peers map[string]*types.ChainInfo
 
 	// self tracks the ID of the peer tracker's owner
 	self peer.ID
+
+	// peers maps peer.IDs to info about their chains
+	peers    map[peer.ID]*types.ChainInfo
+	trusted  map[peer.ID]struct{}
+	updateFn updatePeerFn
 }
 
+type updatePeerFn func(ctx context.Context, p peer.ID) (*types.ChainInfo, error)
+
 // NewPeerTracker creates a peer tracker.
-func NewPeerTracker(self peer.ID) *PeerTracker {
-	return &PeerTracker{
-		peers: make(map[string]*types.ChainInfo),
-		self:  self,
+func NewPeerTracker(self peer.ID, trust ...peer.ID) *PeerTracker {
+	trustedSet := make(map[peer.ID]struct{}, len(trust))
+	for _, t := range trust {
+		trustedSet[t] = struct{}{}
 	}
+	return &PeerTracker{
+		peers:   make(map[peer.ID]*types.ChainInfo),
+		trusted: trustedSet,
+		self:    self,
+	}
+}
+
+// SetUpdateFn sets the update function `f` on the peer tracker. This function is a prerequisite
+// to the UpdateTrusted logic.
+func (tracker *PeerTracker) SetUpdateFn(f updatePeerFn) {
+	tracker.updateFn = f
+}
+
+// SelectHead returns the chain info from trusted peers with the greatest height.
+// An error is returned if no peers are in the tracker.
+func (tracker *PeerTracker) SelectHead() (*types.ChainInfo, error) {
+	heads := tracker.listTrusted()
+	if len(heads) == 0 {
+		return nil, errors.New("no peers tracked")
+	}
+	sort.Slice(heads, func(i, j int) bool { return heads[i].Height > heads[j].Height })
+	return heads[0], nil
+}
+
+// UpdateTrusted updates ChainInfo for all trusted peers.
+func (tracker *PeerTracker) UpdateTrusted(ctx context.Context) error {
+	return tracker.updatePeers(ctx, tracker.trustedPeers()...)
 }
 
 // Track adds information about a given peer.ID
@@ -38,10 +74,10 @@ func (tracker *PeerTracker) Track(ci *types.ChainInfo) {
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
 
-	pidKey := ci.Peer.Pretty()
-	_, tracking := tracker.peers[pidKey]
-	tracker.peers[pidKey] = ci
-	logPeerTracker.Infof("Tracking %s, new=%t, count=%d", ci, !tracking, len(tracker.peers))
+	_, tracking := tracker.peers[ci.Peer]
+	_, trusted := tracker.trusted[ci.Peer]
+	tracker.peers[ci.Peer] = ci
+	logPeerTracker.Infof("Tracking %s, new=%t, count=%d trusted=%t", ci, !tracking, len(tracker.peers), trusted)
 }
 
 // Self returns the peer tracker's owner ID
@@ -49,10 +85,10 @@ func (tracker *PeerTracker) Self() peer.ID {
 	return tracker.self
 }
 
-// List returns the chain info of the currently tracked peers.  The info
-// tracked by the tracker can change arbitrarily after this is called -- there
-// is no guarantee that the peers returned will be tracked when they are used
-// by the caller and no guarantee that the chain info is up to date.
+// List returns the chain info of the currently tracked peers (both trusted and untrusted).
+// The info tracked by the tracker can change arbitrarily after this is called -- there is no
+// guarantee that the peers returned will be tracked when they are used by the caller and no
+// guarantee that the chain info is up to date.
 func (tracker *PeerTracker) List() []*types.ChainInfo {
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
@@ -71,10 +107,14 @@ func (tracker *PeerTracker) Remove(pid peer.ID) {
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
 
-	pidKey := pid.Pretty()
-	if _, tracking := tracker.peers[pidKey]; tracking {
-		logPeerTracker.Infof("Dropping peer %s", pidKey)
-		delete(tracker.peers, pidKey)
+	_, trusted := tracker.trusted[pid]
+	if _, tracking := tracker.peers[pid]; tracking {
+		delete(tracker.peers, pid)
+		if trusted {
+			logPeerTracker.Warningf("Dropping peer=%s trusted=%t", pid.Pretty(), trusted)
+		} else {
+			logPeerTracker.Infof("Dropping peer=%s trusted=%t", pid.Pretty(), trusted)
+		}
 	}
 }
 
@@ -87,4 +127,70 @@ func TrackerRegisterDisconnect(ntwk network.Network, tracker *PeerTracker) {
 		tracker.Remove(pid)
 	}
 	ntwk.Notify(notifee)
+}
+
+// trustedPeers returns a slice of peers trusted by the PeerTracker. trustedPeers remain constant after
+// the PeerTracker has been initialized.
+func (tracker *PeerTracker) trustedPeers() []peer.ID {
+	var peers []peer.ID
+	for p := range tracker.trusted {
+		peers = append(peers, p)
+	}
+	return peers
+}
+
+// listTrusted returns the chain info of the trusted tracked peers. The info tracked by the tracker can
+// change arbitrarily after this is called -- there is no guarantee that the peers returned will be
+// tracked when they are used by the caller and no guarantee that the chain info is up to date.
+func (tracker *PeerTracker) listTrusted() []*types.ChainInfo {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	var tracked []*types.ChainInfo
+	for p, ci := range tracker.peers {
+		if _, trusted := tracker.trusted[p]; trusted {
+			tracked = append(tracked, ci)
+		}
+	}
+	out := make([]*types.ChainInfo, len(tracked))
+	copy(out, tracked)
+	return out
+}
+
+// updatePeers will run the trackers updateFn on each peer in `ps` in parallel, iff all updates fail
+// is an error is returned, a partial update is considered successful.
+func (tracker *PeerTracker) updatePeers(ctx context.Context, ps ...peer.ID) error {
+	if tracker.updateFn == nil {
+		return errors.New("canot call PeerTracker peer update logic without setting an update function")
+	}
+	if len(ps) == 0 {
+		logPeerTracker.Info("update peers aborting: no peers to update")
+		return nil
+	}
+	var updateErr []error
+	grp, ctx := errgroup.WithContext(ctx)
+	for _, p := range ps {
+		peer := p
+		grp.Go(func() error {
+			ci, err := tracker.updateFn(ctx, peer)
+			if err != nil {
+				err = errors.Wrapf(err, "failed to update peer=%s", peer.Pretty())
+				updateErr = append(updateErr, err)
+				return err
+			}
+			tracker.Track(ci)
+			return nil
+		})
+	}
+	// check if anyone failed to update
+	if err := grp.Wait(); err != nil {
+		// full failure return an error
+		if len(updateErr) == len(ps) {
+			logPeerTracker.Errorf("failed to update all %d peers:%v", len(ps), updateErr)
+			return errors.New("all peers failed to update")
+		}
+		// partial failure
+		logPeerTracker.Infof("failed to update %d of %d peers:%v", len(updateErr), len(ps), updateErr)
+	}
+	return nil
 }

--- a/net/peer_tracker_test.go
+++ b/net/peer_tracker_test.go
@@ -2,6 +2,7 @@ package net_test
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -40,6 +41,151 @@ func TestPeerTrackerTracks(t *testing.T) {
 	expected := []*types.ChainInfo{ci0, ci1, ci3, ci7}
 	sort.Sort(types.CISlice(expected))
 	assert.Equal(t, expected, tracked)
+
+}
+
+func TestPeerTrackerSelectHead(t *testing.T) {
+	tf.UnitTest(t)
+
+	pid0 := th.RequireIntPeerID(t, 0)
+	pid1 := th.RequireIntPeerID(t, 1)
+	pid2 := th.RequireIntPeerID(t, 2)
+	pid3 := th.RequireIntPeerID(t, 3)
+
+	ci0 := types.NewChainInfo(pid0, types.NewTipSetKey(types.CidFromString(t, "somecid0")), 6)
+	ci1 := types.NewChainInfo(pid1, types.NewTipSetKey(types.CidFromString(t, "somecid1")), 10)
+	ci2 := types.NewChainInfo(pid2, types.NewTipSetKey(types.CidFromString(t, "somecid2")), 7)
+	ci3 := types.NewChainInfo(pid3, types.NewTipSetKey(types.CidFromString(t, "somecid3")), 9)
+
+	// trusting pid2 and pid3
+	tracker := net.NewPeerTracker(pid2, pid3)
+	tracker.Track(ci0)
+	tracker.Track(ci1)
+	tracker.Track(ci2)
+	tracker.Track(ci3)
+
+	// select the highest head
+	head, err := tracker.SelectHead()
+	assert.NoError(t, err)
+	assert.Equal(t, head.Head, ci3.Head)
+}
+
+func TestPeerTrackerUpdateTrusted(t *testing.T) {
+	tf.UnitTest(t)
+
+	pid0 := th.RequireIntPeerID(t, 0)
+	pid1 := th.RequireIntPeerID(t, 1)
+	pid2 := th.RequireIntPeerID(t, 2)
+	pid3 := th.RequireIntPeerID(t, 3)
+
+	// trust pid2 and pid3
+	tracker := net.NewPeerTracker(pid3, pid2)
+
+	ci0 := types.NewChainInfo(pid0, types.NewTipSetKey(types.CidFromString(t, "somecid0")), 600)
+	ci1 := types.NewChainInfo(pid1, types.NewTipSetKey(types.CidFromString(t, "somecid1")), 10)
+	ci2 := types.NewChainInfo(pid2, types.NewTipSetKey(types.CidFromString(t, "somecid2")), 7)
+	ci3 := types.NewChainInfo(pid3, types.NewTipSetKey(types.CidFromString(t, "somecid3")), 9)
+
+	tracker.Track(ci0)
+	tracker.Track(ci1)
+	tracker.Track(ci2)
+	tracker.Track(ci3)
+
+	updatedHead := types.NewTipSetKey(types.CidFromString(t, "UPDATE"))
+	updatedHeight := uint64(100)
+	// update function that changes the tipset and sets height to 100
+	tracker.SetUpdateFn(func(ctx context.Context, p peer.ID) (*types.ChainInfo, error) {
+		return &types.ChainInfo{
+			Head:   updatedHead,
+			Height: updatedHeight,
+			Peer:   p,
+		}, nil
+	})
+
+	// update the trusted peers
+	assert.NoError(t, tracker.UpdateTrusted(context.Background()))
+
+	tracked := tracker.List()
+	assert.Equal(t, 4, len(tracked))
+	for i := range tracked {
+		if tracked[i].Peer == pid0 || tracked[i].Peer == pid1 {
+			assert.NotEqual(t, updatedHead, tracked[i].Head)
+			assert.NotEqual(t, updatedHeight, tracked[i].Height)
+			assert.False(t, tracked[i].Peer == pid3 || tracked[i].Peer == pid2)
+		}
+	}
+
+	// Selecting head returns the largest of trusted peers.
+	trustHead, err := tracker.SelectHead()
+	assert.NoError(t, err)
+	assert.Equal(t, updatedHead, trustHead.Head)
+	assert.Equal(t, updatedHeight, trustHead.Height)
+
+}
+
+func TestUpdateWithErrors(t *testing.T) {
+	tf.UnitTest(t)
+
+	pid0 := th.RequireIntPeerID(t, 0)
+	pid1 := th.RequireIntPeerID(t, 1)
+	pid2 := th.RequireIntPeerID(t, 2)
+	failPeer := th.RequireIntPeerID(t, 3)
+
+	self := peer.ID("")
+	trusted := []peer.ID{pid0, pid1, pid2, failPeer}
+
+	// trust them all
+	tracker := net.NewPeerTracker(self, trusted...)
+
+	ci0 := types.NewChainInfo(pid0, types.NewTipSetKey(types.CidFromString(t, "somecid0")), 600)
+	ci1 := types.NewChainInfo(pid1, types.NewTipSetKey(types.CidFromString(t, "somecid0")), 600)
+	ci2 := types.NewChainInfo(pid2, types.NewTipSetKey(types.CidFromString(t, "somecid0")), 600)
+	ci3 := types.NewChainInfo(failPeer, types.NewTipSetKey(types.CidFromString(t, "somecid0")), 600)
+
+	tracker.Track(ci0)
+	tracker.Track(ci1)
+	tracker.Track(ci2)
+	tracker.Track(ci3)
+
+	updatedHead := types.NewTipSetKey(types.CidFromString(t, "UPDATE"))
+	updatedHeight := uint64(100)
+
+	// fail everything
+	tracker.SetUpdateFn(func(ctx context.Context, p peer.ID) (*types.ChainInfo, error) {
+		return nil, fmt.Errorf("failed to update peer")
+	})
+
+	// if it all fails error.
+	err := tracker.UpdateTrusted(context.Background())
+	assert.Error(t, err, "all updates failed")
+
+	// fail to update `failPeer`
+	tracker.SetUpdateFn(func(ctx context.Context, p peer.ID) (*types.ChainInfo, error) {
+		if p == failPeer {
+			return nil, fmt.Errorf("failed to update peer")
+		}
+		return &types.ChainInfo{
+			Head:   updatedHead,
+			Height: updatedHeight,
+			Peer:   p,
+		}, nil
+	})
+
+	// call update on all peers, there should not be an error for partial failure
+	err = tracker.UpdateTrusted(context.Background())
+	assert.NoError(t, err, "partial update successful")
+
+	// the peers that didn't error should have an updated head
+	cis := tracker.List()
+	assert.Equal(t, 4, len(cis))
+	for _, ci := range cis {
+		if ci.Peer == failPeer {
+			assert.Equal(t, ci.Head, ci0.Head)
+		} else {
+			assert.Equal(t, ci.Head, updatedHead)
+		}
+	}
+
 }
 
 func TestPeerTrackerRemove(t *testing.T) {


### PR DESCRIPTION
### What
This PR extends the PeerTracker to have:
- A set of trusted peers that it my be initialized with
- An update function that may be applied to tracked peers, currently is is only exposed via `UpdateTrusted`.
- A method for setting an update function.
- A method for selecting the head with the greatest height from all tracked peers or just the trusted peers.
- Testing for the above
-  An initial set of trusted node which for now are the bootstrap nodes.

### Goal
This PR makes progress towards implementing chain catch-up logic. In a follow on the trusted peers and select head logic will be used to fully sync a chain before proceeding with caught up chain sync. 

### Status
This PR is a follow on to #3327 