### PR TITLE
replace clock impl with wrapper around clockwork

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -1,31 +1,25 @@
 package clock
 
 import (
-	"time"
+	"github.com/jonboulle/clockwork"
 )
 
-// Clock defines an interface for fetching time that may be used instead of the
-// time module.
+// Clock provides an interface that packages can use instead of directly
+// using the time module, so that chronology-related behavior can be tested.
 type Clock interface {
-	Now() time.Time
-	Sleep(d time.Duration)
+	clockwork.Clock
 }
 
-// SystemClock delegates calls to the time package.
-type SystemClock struct{}
+// SystemClock is a wrapper around the jonboulle/clockwork.Clock interface
+// Clock provides an interface that packages can use instead of directly
+// using the time module, so that chronology-related behavior can be tested.
+type SystemClock struct {
+	clockwork.Clock
+}
 
-// NewSystemClock returns a SystemClock that delegates calls to the time package.
+// NewSystemClock returns a SystemClock that delegates calls to the jonboulee/clockwork package.
 func NewSystemClock() *SystemClock {
-	return &SystemClock{}
-}
-
-// Now returns the current local time.
-func (sc *SystemClock) Now() time.Time {
-	return time.Now()
-}
-
-// Sleep pauses the current goroutine for at least the duration d.
-// A negative or zero duration causes Sleep to return immediately.
-func (sc *SystemClock) Sleep(d time.Duration) {
-	time.Sleep(d)
+	return &SystemClock{
+		Clock: clockwork.NewRealClock(),
+	}
 }

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -10,16 +10,9 @@ type Clock interface {
 	clockwork.Clock
 }
 
-// SystemClock is a wrapper around the jonboulle/clockwork.Clock interface
-// Clock provides an interface that packages can use instead of directly
-// using the time module, so that chronology-related behavior can be tested.
-type SystemClock struct {
-	clockwork.Clock
-}
-
 // NewSystemClock returns a SystemClock that delegates calls to the jonboulee/clockwork package.
-func NewSystemClock() *SystemClock {
-	return &SystemClock{
-		Clock: clockwork.NewRealClock(),
-	}
+// SystemClock is a Clock which simply delegates calls to the actual time
+// package; it should be used by packages in production.
+func NewSystemClock() Clock {
+	return clockwork.NewRealClock()
 }

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jbenet/goprocess v0.1.3
 	github.com/jessevdk/go-flags v1.4.0 // indirect
+	github.com/jonboulle/clockwork v0.1.1-0.20190114141812-62fb9bc030d1
 	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
 	github.com/kisielk/errcheck v1.2.0 // indirect
 	github.com/kkdai/bstream v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -465,6 +465,8 @@ github.com/jbenet/goprocess v0.1.3/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZl
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jonboulle/clockwork v0.1.1-0.20190114141812-62fb9bc030d1 h1:qBCV/RLV02TSfQa7tFmxTihnG+u+7JXByOkhlkR5rmQ=
+github.com/jonboulle/clockwork v0.1.1-0.20190114141812-62fb9bc030d1/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/testhelpers/clock.go
+++ b/testhelpers/clock.go
@@ -1,34 +1,20 @@
 package testhelpers
 
 import (
+	"github.com/jonboulle/clockwork"
 	"time"
 )
 
-// FakeSystemClock returns a mocked clock implementation that may be manually
-// set for testing things related to time.
+// FakeSystemClock wrapps the jonboulle/clockwork.FakeClock interface.
+// FakeSystemClock provides an interface for a clock which can be
+// manually advanced through time.
 type FakeSystemClock struct {
-	now time.Time
+	clockwork.FakeClock
 }
 
-// NewFakeSystemClock returns a mocked clock implementation that may be manually
-// set for testing things related to time.
+// NewFakeSystemClock returns a FakeSystemClock initialised at the given time.Time.
 func NewFakeSystemClock(n time.Time) *FakeSystemClock {
 	return &FakeSystemClock{
-		now: n,
+		FakeClock: clockwork.NewFakeClockAt(n),
 	}
-}
-
-// Now returns the current value of the FakeSystemClock.
-func (fc *FakeSystemClock) Now() time.Time {
-	return fc.now
-}
-
-// Sleep returns immediately.
-func (fc *FakeSystemClock) Sleep(d time.Duration) {
-	return
-}
-
-// Set sets the current time value of the FakeSystemClock.
-func (fc *FakeSystemClock) Set(t time.Time) {
-	fc.now = t
 }

--- a/testhelpers/clock.go
+++ b/testhelpers/clock.go
@@ -1,20 +1,19 @@
 package testhelpers
 
 import (
-	"github.com/jonboulle/clockwork"
 	"time"
+
+	"github.com/jonboulle/clockwork"
 )
 
 // FakeSystemClock wrapps the jonboulle/clockwork.FakeClock interface.
 // FakeSystemClock provides an interface for a clock which can be
 // manually advanced through time.
-type FakeSystemClock struct {
+type FakeSystemClock interface {
 	clockwork.FakeClock
 }
 
 // NewFakeSystemClock returns a FakeSystemClock initialised at the given time.Time.
-func NewFakeSystemClock(n time.Time) *FakeSystemClock {
-	return &FakeSystemClock{
-		FakeClock: clockwork.NewFakeClockAt(n),
-	}
+func NewFakeSystemClock(n time.Time) FakeSystemClock {
+	return clockwork.NewFakeClockAt(n)
 }


### PR DESCRIPTION
### What
As a follow on to #3339, this PR replaces the existing clock implementation with a wrapper around [github.com/jonboulle/clockwork](https://github.com/jonboulle/clockwork). The package clockwork was chosen based on the interface's it provides and its frequent usage in the go ecosystem, a full list of importers can be seen [here](https://godoc.org/github.com/jonboulle/clockwork?importers). I wrapped this implementation instead of using it directly to make code changes easier if we decided to use something different, or write our own.

Clock interface:
```go
type Clock interface {
	After(d time.Duration) <-chan time.Time
	Sleep(d time.Duration)
	Now() time.Time
	Since(t time.Time) time.Duration
	NewTicker(d time.Duration) Ticker
}
```
FakeClock interface:
```go
type FakeClock interface {
	Clock
	// Advance advances the FakeClock to a new point in time, ensuring any existing
	// sleepers are notified appropriately before returning
	Advance(d time.Duration)
	// BlockUntil will block until the FakeClock has the given number of
	// sleepers (callers of Sleep or After)
	BlockUntil(n int)
}
```