### PR TITLE
Add Has to Peertracker, filter pubsub blocks

### DIFF
--- a/net/peer_tracker.go
+++ b/net/peer_tracker.go
@@ -40,6 +40,16 @@ func (tracker *PeerTracker) Track(ci *types.ChainInfo) {
 	logPeerTracker.Infof("Tracking %s, new=%t, count=%d", ci, !tracking, len(tracker.peers))
 }
 
+// Has returns true if this peerID is tracked
+func (tracker *PeerTracker) Has(pid peer.ID) bool {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	pidKey := pid.Pretty()
+	_, ok := tracker.peers[pidKey]
+	return ok
+}
+
 // List returns the chain info of the currently tracked peers.  The info
 // tracked by the tracker can change arbitrarily after this is called -- there
 // is no guarantee that the peers returned will be tracked when they are used

--- a/node/block.go
+++ b/node/block.go
@@ -52,6 +52,13 @@ func (node *Node) processBlock(ctx context.Context, pubSubMsg pubsub.Message) (e
 	if err != nil {
 		return errors.Wrap(err, "got bad block data")
 	}
+
+	// ignore messages from peers not yet tracked
+	if !node.PeerTracker.Has(from) {
+		log.Debugf("ignoring new block cid: %s from unconnected peer: %s", blk.Cid().String(), from.Pretty())
+		return nil
+	}
+
 	span.AddAttributes(trace.StringAttribute("block", blk.Cid().String()))
 
 	log.Infof("Received new block from network cid: %s", blk.Cid().String())


### PR DESCRIPTION
This is a simpler version of a change that has improved devnet forking situation.  It prevents syncing of pubsub messages that come from peers that a node does not have a connection with.

If these messages are valid heads coming in from a new peer then the parallel hello protocol will serve this head to the syncer anyway.  If that hello protocol fails then this change ensures that we don't end up blocking for a 60 second timeout on a peer that we can't connect to.