### PR TITLE
add chain status command to fast chain actions

### DIFF
--- a/tools/fast/action_chain.go
+++ b/tools/fast/action_chain.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 
 	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/go-filecoin/chain"
 )
 
 // ChainHead runs the chain head command against the filecoin process.
@@ -20,4 +22,13 @@ func (f *Filecoin) ChainHead(ctx context.Context) ([]cid.Cid, error) {
 // ChainLs runs the chain ls command against the filecoin process.
 func (f *Filecoin) ChainLs(ctx context.Context) (*json.Decoder, error) {
 	return f.RunCmdLDJSONWithStdin(ctx, nil, "go-filecoin", "chain", "ls")
+}
+
+// ChainStatus runs the chain status command against the filecoin process.
+func (f *Filecoin) ChainStatus(ctx context.Context) (*chain.Status, error) {
+	var out *chain.Status
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "chain", "status"); err != nil {
+		return nil, err
+	}
+	return out, nil
 }


### PR DESCRIPTION
Missed this while adding the `chain status` command, here's a fix for it.