### PR TITLE
Set atomic coverage mode and configure CircleCI to wait for all builds before publishing coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ jobs:
   unit_test_linux:
     docker:
       - image: circleci/golang:1.12.1-stretch
-    parallelism: 3
+    parallelism: 2 # Check .codecov.yml "after_n_builds" if changing this
     working_directory: /go/src/github.com/filecoin-project/go-filecoin
     resource_class: large
     steps:
@@ -270,7 +270,7 @@ jobs:
   integration_test_linux:
     docker:
       - image: circleci/golang:1.12.1-stretch
-    parallelism: 3
+    parallelism: 2 # Check .codecov.yml "after_n_builds" if changing this
     working_directory: /go/src/github.com/filecoin-project/go-filecoin
     resource_class: xlarge
     steps:
@@ -784,7 +784,7 @@ commands:
             trap "go run github.com/jstemmer/go-junit-report < test-results/go-test-suite/go-test.out > test-results/go-test-suite/go-test-report.xml" EXIT
             export TEST_PACKAGES="$(go list ./... | circleci tests split)"
             # Parallelism and timeout set to support medium-class containers, for builds on forked repos.
-            go run ./build test -cover -coverprofile coverage.out -timeout=30m -parallel=4 -functional=<< parameters.functional >> -integration=<< parameters.integration >> -sectorbuilder=<< parameters.sector_builder_tests >> -unit=<< parameters.unit >> -v 2>&1 | tee test-results/go-test-suite/go-test.out
+            go run ./build test -cover -coverprofile coverage.out -covermode=atomic -timeout=30m -parallel=4 -functional=<< parameters.functional >> -integration=<< parameters.integration >> -sectorbuilder=<< parameters.sector_builder_tests >> -unit=<< parameters.unit >> -v 2>&1 | tee test-results/go-test-suite/go-test.out
             mkdir -p /tmp/artifacts
             mv coverage.out /tmp/artifacts/coverage.out
       - codecov/upload:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,20 +1,32 @@
+# "documentation": https://gist.github.com/stevepeak/53bee7b2c326b24a9b4a
 coverage:
   range: 50..100
   round: down
   precision: 0
 
   status:
-    project: off
-    patch: off
-    changes: off
+    project: false
+    patch: false
+    changes: false
 
-comment: off
-#  layout: "diff, flags, files"
-#  behavior: default
-#  require_changes: false  # if true: only post the comment if coverage changes
-#  require_base: yes       # [yes :: must have a base report to post]
-#  require_head: yes       # [yes :: must have a head report to post]
-#  branches: null          # branch names that can post comment
+# https://docs.codecov.io/docs/pull-request-comments
+comment:
+  layout: "diff"           # "diff, flags, files"
+  behavior: default
+  require_changes: false   # if true: only post the comment if coverage changes
+  require_base: true       # [yes :: must have a base report to post]
+  require_head: true       # [yes :: must have a head report to post]
+  branches: []             # branch names that can post comment
 
 ignore:
   - "*/testing.go"
+
+codecov:
+  notify:
+    # yes: will delay sending notifications until all ci is finished
+    # no: will send notifications without checking ci status and wait till "after_n_builds" are uploaded
+    require_ci_to_pass: false
+    # number of expected builds to receive before sending notifications
+    # we can set this to prevent notifications of partial results due to CI parallelism
+    # set this with respect to the unit- and integration-test parallelism in Circle CI configuration
+    after_n_builds: 4


### PR DESCRIPTION
I'm not 100% sure this solves all our problems, but we gotta try.

There remains a few lines of non-determinism which is reproducible locally.

Closes #2785