### PR TITLE
Re-queue messages from the losing chain segment in a re-org so that nonces are consistent with the pool.

### DIFF
--- a/core/outbox.go
+++ b/core/outbox.go
@@ -16,6 +16,11 @@ import (
 )
 
 // Outbox validates and marshals messages for sending and maintains the outbound message queue.
+// The code arrangement here is not quite right. We probably want to factor out the bits that
+// build and sign a message from those that add to the local queue/pool and broadcast it.
+// See discussion in
+// https://github.com/filecoin-project/go-filecoin/pull/3178#discussion_r311593312
+// and https://github.com/filecoin-project/go-filecoin/issues/3052#issuecomment-513643661
 type Outbox struct {
 	// Signs messages
 	signer types.Signer


### PR DESCRIPTION
Fixes #3052 (see discussion there for discussion of alternatives).