### PR TITLE
Disable fetching of test groth parameters in favour of local generation

### DIFF
--- a/scripts/install-filecoin-parameters.sh
+++ b/scripts/install-filecoin-parameters.sh
@@ -10,5 +10,10 @@ generate_params() {
   RUST_LOG=info ./proofs/bin/paramcache --test-only
 }
 
-fetch_params
+# Fetching parameters, even small ones, has a long history of being slow and unreliable.
+# It's disabled now in favour of local generation of the small parameter files needed
+# for tests.
+# On a 2015 MacBook pro, generation takes about a minute, one-time.
+#fetch_params
+
 generate_params


### PR DESCRIPTION
On my MacBook, the one-time generation (whenever new parameters come in upstream) takes about a minute. It's my understanding they're usually cached on CI.

Please land this for me when it gets two ✅.