### PR TITLE
disable paramfetch until optimizations are made

### DIFF
--- a/scripts/install-filecoin-parameters.sh
+++ b/scripts/install-filecoin-parameters.sh
@@ -10,5 +10,11 @@ generate_params() {
   RUST_LOG=info ./proofs/bin/paramcache --test-only
 }
 
-fetch_params
+# Disabling paramfetch until optimizations can be completed
+# Fetching parameters, even small ones, has a long history of being slow and unreliable.
+# It's disabled now in favour of local generation of the small parameter files needed
+# for tests.
+# On a 2015 MacBook pro, generation takes about a minute, one-time.
+#
+# fetch_params
 generate_params


### PR DESCRIPTION
paramfetch can sometimes timeout, causing builds to fail and blocking general development pipeline.
problems are especially prevelant for outside committers during CircleCI builds, as they are unable to use the CircleCI cache storing the parameters.