### PR TITLE
Remove sha check from Hello

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -19,7 +19,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/config"
 	"github.com/filecoin-project/go-filecoin/consensus"
-	"github.com/filecoin-project/go-filecoin/fixtures"
 	"github.com/filecoin-project/go-filecoin/node"
 	"github.com/filecoin-project/go-filecoin/paths"
 	"github.com/filecoin-project/go-filecoin/repo"
@@ -121,24 +120,6 @@ func getConfigFromOptions(options cmdkit.OptMap) (*config.Config, error) {
 	if devnetTest || devnetNightly || devnetUser {
 		newConfig.Bootstrap.MinPeerThreshold = 1
 		newConfig.Bootstrap.Period = "10s"
-	}
-
-	// Setup devnet staging specific config options.
-	if devnetTest {
-		newConfig.Bootstrap.Addresses = fixtures.DevnetStagingBootstrapAddrs
-		newConfig.Net = "devnet-staging"
-	}
-
-	// Setup devnet nightly specific config options.
-	if devnetNightly {
-		newConfig.Bootstrap.Addresses = fixtures.DevnetNightlyBootstrapAddrs
-		newConfig.Net = "devnet-nightly"
-	}
-
-	// Setup devnet user specific config options.
-	if devnetUser {
-		newConfig.Bootstrap.Addresses = fixtures.DevnetUserBootstrapAddrs
-		newConfig.Net = "devnet-user"
 	}
 
 	return newConfig, nil

--- a/commands/init.go
+++ b/commands/init.go
@@ -19,6 +19,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/config"
 	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/fixtures"
 	"github.com/filecoin-project/go-filecoin/node"
 	"github.com/filecoin-project/go-filecoin/paths"
 	"github.com/filecoin-project/go-filecoin/repo"
@@ -120,6 +121,21 @@ func getConfigFromOptions(options cmdkit.OptMap) (*config.Config, error) {
 	if devnetTest || devnetNightly || devnetUser {
 		newConfig.Bootstrap.MinPeerThreshold = 1
 		newConfig.Bootstrap.Period = "10s"
+	}
+
+	// Setup devnet staging specific config options.
+	if devnetTest {
+		newConfig.Bootstrap.Addresses = fixtures.DevnetStagingBootstrapAddrs
+	}
+
+	// Setup devnet nightly specific config options.
+	if devnetNightly {
+		newConfig.Bootstrap.Addresses = fixtures.DevnetNightlyBootstrapAddrs
+	}
+
+	// Setup devnet user specific config options.
+	if devnetUser {
+		newConfig.Bootstrap.Addresses = fixtures.DevnetUserBootstrapAddrs
 	}
 
 	return newConfig, nil

--- a/commands/inspector_daemon_test.go
+++ b/commands/inspector_daemon_test.go
@@ -42,6 +42,5 @@ func TestInspectConfig(t *testing.T) {
 	assert.Equal(t, rcfg.Mining, icfg.Mining)
 	assert.Equal(t, rcfg.Wallet, icfg.Wallet)
 	assert.Equal(t, rcfg.Heartbeat, icfg.Heartbeat)
-	assert.Equal(t, rcfg.Net, icfg.Net)
 	assert.Equal(t, rcfg.Mpool, icfg.Mpool)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,6 @@ type Config struct {
 	Heartbeat     *HeartbeatConfig     `json:"heartbeat"`
 	Mining        *MiningConfig        `json:"mining"`
 	Mpool         *MessagePoolConfig   `json:"mpool"`
-	Net           string               `json:"net"`
 	Observability *ObservabilityConfig `json:"observability"`
 	SectorBase    *SectorBaseConfig    `json:"sectorbase"`
 	Swarm         *SwarmConfig         `json:"swarm"`
@@ -241,7 +240,6 @@ func NewDefaultConfig() *Config {
 		Mining:        newDefaultMiningConfig(),
 		Wallet:        newDefaultWalletConfig(),
 		Heartbeat:     newDefaultHeartbeatConfig(),
-		Net:           "",
 		Mpool:         newDefaultMessagePoolConfig(),
 		SectorBase:    newDefaultSectorbaseConfig(),
 		Observability: newDefaultObservabilityConfig(),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -81,7 +81,6 @@ func TestWriteFile(t *testing.T) {
 		"maxPoolSize": 10000,
 		"maxNonceGap": "100"
 	},
-	"net": "",
 	"observability": {
 		"metrics": {
 			"prometheusEnabled": false,

--- a/node/builder.go
+++ b/node/builder.go
@@ -294,6 +294,7 @@ func (nc *Config) build(ctx context.Context) (*Node, error) {
 		Inbox:        inbox,
 		OfflineMode:  nc.OfflineMode,
 		Outbox:       outbox,
+		NetworkName:  network,
 		PeerHost:     peerHost,
 		Repo:         nc.Repo,
 		Wallet:       fcWallet,

--- a/node/node.go
+++ b/node/node.go
@@ -30,7 +30,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/config"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/core"
-	"github.com/filecoin-project/go-filecoin/flags"
 	"github.com/filecoin-project/go-filecoin/metrics"
 	"github.com/filecoin-project/go-filecoin/mining"
 	"github.com/filecoin-project/go-filecoin/net"
@@ -90,6 +89,7 @@ type Node struct {
 	MessageStore *chain.MessageStore
 	Syncer       nodeChainSyncer
 	PowerTable   consensus.PowerTableView
+	NetworkName  string
 	VersionTable version.ProtocolVersionTable
 
 	BlockMiningAPI *block.MiningAPI
@@ -270,7 +270,7 @@ func (node *Node) Start(ctx context.Context) error {
 			// See https://github.com/filecoin-project/go-filecoin/issues/1105
 			node.ChainSynced.Done()
 		}
-		node.HelloSvc = hello.New(node.Host(), node.ChainReader.GenesisCid(), helloCallback, node.PorcelainAPI.ChainHead, node.Repo.Config().Net, flags.Commit)
+		node.HelloSvc = hello.New(node.Host(), node.ChainReader.GenesisCid(), helloCallback, node.PorcelainAPI.ChainHead, node.NetworkName)
 
 		// register the update function on the peer tracker now that we have a hello service
 		node.PeerTracker.SetUpdateFn(func(ctx context.Context, p peer.ID) (*types.ChainInfo, error) {

--- a/protocol/hello/hello_test.go
+++ b/protocol/hello/hello_test.go
@@ -54,8 +54,8 @@ func TestHelloHandshake(t *testing.T) {
 	msc1, msc2 := new(mockHelloCallback), new(mockHelloCallback)
 	hg1, hg2 := &mockHeaviestGetter{heavy1}, &mockHeaviestGetter{heavy2}
 
-	New(a, genesisA.Cid(), msc1.HelloCallback, hg1.getHeaviestTipSet, "", "")
-	New(b, genesisA.Cid(), msc2.HelloCallback, hg2.getHeaviestTipSet, "", "")
+	New(a, genesisA.Cid(), msc1.HelloCallback, hg1.getHeaviestTipSet, "")
+	New(b, genesisA.Cid(), msc2.HelloCallback, hg2.getHeaviestTipSet, "")
 
 	msc1.On("HelloCallback", b.ID(), heavy2.Key(), uint64(3)).Return()
 	msc2.On("HelloCallback", a.ID(), heavy1.Key(), uint64(2)).Return()
@@ -110,76 +110,10 @@ func TestHelloBadGenesis(t *testing.T) {
 	msc1, msc2 := new(mockHelloCallback), new(mockHelloCallback)
 	hg1, hg2 := &mockHeaviestGetter{heavy1}, &mockHeaviestGetter{heavy2}
 
-	New(a, genesisA.Cid(), msc1.HelloCallback, hg1.getHeaviestTipSet, "", "")
-	New(b, genesisB.Cid(), msc2.HelloCallback, hg2.getHeaviestTipSet, "", "")
+	New(a, genesisA.Cid(), msc1.HelloCallback, hg1.getHeaviestTipSet, "")
+	New(b, genesisB.Cid(), msc2.HelloCallback, hg2.getHeaviestTipSet, "")
 
 	msc1.On("HelloCallback", mock.Anything, mock.Anything, mock.Anything).Return()
-	msc2.On("HelloCallback", mock.Anything, mock.Anything, mock.Anything).Return()
-
-	require.NoError(t, mn.LinkAll())
-	require.NoError(t, mn.ConnectAllButSelf())
-
-	time.Sleep(time.Millisecond * 50)
-
-	msc1.AssertNumberOfCalls(t, "HelloCallback", 0)
-	msc2.AssertNumberOfCalls(t, "HelloCallback", 0)
-}
-
-func TestHelloWrongVersion(t *testing.T) {
-	tf.UnitTest(t)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	mn, err := mocknet.WithNPeers(ctx, 2)
-	assert.NoError(t, err)
-
-	a, b := mn.Hosts()[0], mn.Hosts()[1]
-
-	genesisA := &types.Block{}
-
-	heavy := th.RequireNewTipSet(t, &types.Block{Height: 2, Tickets: []types.Ticket{{VRFProof: []byte{0}}}})
-
-	msc1, msc2 := new(mockHelloCallback), new(mockHelloCallback)
-	hg := &mockHeaviestGetter{heavy}
-
-	New(a, genesisA.Cid(), msc1.HelloCallback, hg.getHeaviestTipSet, "devnet-user", "sha1")
-	msc1.On("HelloCallback", mock.Anything, mock.Anything, mock.Anything).Return()
-
-	New(b, genesisA.Cid(), msc2.HelloCallback, hg.getHeaviestTipSet, "devnet-user", "sha2")
-	msc2.On("HelloCallback", mock.Anything, mock.Anything, mock.Anything).Return()
-
-	require.NoError(t, mn.LinkAll())
-	require.NoError(t, mn.ConnectAllButSelf())
-
-	time.Sleep(time.Millisecond * 50)
-
-	msc1.AssertNumberOfCalls(t, "HelloCallback", 0)
-	msc2.AssertNumberOfCalls(t, "HelloCallback", 0)
-}
-
-func TestHelloWrongVersionTestDevnet(t *testing.T) {
-	tf.UnitTest(t)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	mn, err := mocknet.WithNPeers(ctx, 2)
-	assert.NoError(t, err)
-
-	a, b := mn.Hosts()[0], mn.Hosts()[1]
-
-	genesisA := &types.Block{}
-
-	heavy := th.RequireNewTipSet(t, &types.Block{Height: 2, Tickets: []types.Ticket{{VRFProof: []byte{0}}}})
-
-	msc1, msc2 := new(mockHelloCallback), new(mockHelloCallback)
-	hg := &mockHeaviestGetter{heavy}
-
-	New(a, genesisA.Cid(), msc1.HelloCallback, hg.getHeaviestTipSet, "devnet-staging", "sha1")
-	msc1.On("HelloCallback", mock.Anything, mock.Anything, mock.Anything).Return()
-
-	New(b, genesisA.Cid(), msc2.HelloCallback, hg.getHeaviestTipSet, "devnet-staging", "sha2")
 	msc2.On("HelloCallback", mock.Anything, mock.Anything, mock.Anything).Return()
 
 	require.NoError(t, mn.LinkAll())
@@ -215,8 +149,8 @@ func TestHelloMultiBlock(t *testing.T) {
 	msc1, msc2 := new(mockHelloCallback), new(mockHelloCallback)
 	hg1, hg2 := &mockHeaviestGetter{heavy1}, &mockHeaviestGetter{heavy2}
 
-	New(a, genesisTipset.At(0).Cid(), msc1.HelloCallback, hg1.getHeaviestTipSet, "", "")
-	New(b, genesisTipset.At(0).Cid(), msc2.HelloCallback, hg2.getHeaviestTipSet, "", "")
+	New(a, genesisTipset.At(0).Cid(), msc1.HelloCallback, hg1.getHeaviestTipSet, "")
+	New(b, genesisTipset.At(0).Cid(), msc2.HelloCallback, hg2.getHeaviestTipSet, "")
 
 	msc1.On("HelloCallback", b.ID(), heavy2.Key(), uint64(3)).Return()
 	msc2.On("HelloCallback", a.ID(), heavy1.Key(), uint64(2)).Return()
@@ -253,8 +187,8 @@ func TestReceiveHello(t *testing.T) {
 	msc1, msc2 := new(mockHelloCallback), new(mockHelloCallback)
 	hg1, hg2 := &mockHeaviestGetter{heavy1}, &mockHeaviestGetter{heavy2}
 
-	h1 := New(a, genesisTipset.At(0).Cid(), msc1.HelloCallback, hg1.getHeaviestTipSet, "", "")
-	h2 := New(b, genesisTipset.At(0).Cid(), msc2.HelloCallback, hg2.getHeaviestTipSet, "", "")
+	h1 := New(a, genesisTipset.At(0).Cid(), msc1.HelloCallback, hg1.getHeaviestTipSet, "")
+	h2 := New(b, genesisTipset.At(0).Cid(), msc2.HelloCallback, hg2.getHeaviestTipSet, "")
 
 	msc1.On("HelloCallback", b.ID(), heavy2.Key(), uint64(3)).Return()
 	msc2.On("HelloCallback", a.ID(), heavy1.Key(), uint64(2)).Return()

--- a/repo/fsrepo_test.go
+++ b/repo/fsrepo_test.go
@@ -59,7 +59,6 @@ const (
 		"maxPoolSize": 10000,
 		"maxNonceGap": "100"
 	},
-	"net": "",
 	"observability": {
 		"metrics": {
 			"prometheusEnabled": false,


### PR DESCRIPTION
closes #2685

### Problem

Making protocol changes without an upgrade mechanism has forced us to reset the Devnet each release. Resetting the network causes problems when miners using the old code attempt to connect with nodes on the new network. As a short term fix, we added a code SHA check to the Hello protocol to ensure that miners on the network were using exactly the same version of the code. As we move to more durable networks, add protocol upgrades, and expect more customized solutions on the network, the SHA check is no longer necessary and is becomes a hindrance. We would, however, like to have some mechanism that ensures that we can reset the network without incompatible nodes attempting to communicate with each other.

### Solution

#3298 introduced network name into the genesis block, and #3354 introduces the concept of a protocol version. These lets us solve a couple of issues related to Hello protocol.

1. The Hello protocol already ensures that nodes share the same genesis Cid. Since the network name is now encoded in the genesis block, changing the network name in the genesis block is sufficient to ensure that nodes on different networks will not connect. 
2. Conversely, the protocol version table provides a mechanism to ensure that any node on the same network will be compatible. This allows us to remove the code SHA check.
3. The network specified in genesis removes the need for a `net` in config.
