### PR TITLE
use network name to namespace dht

### DIFF
--- a/net/protocols.go
+++ b/net/protocols.go
@@ -1,8 +1,12 @@
 package net
 
 import (
+	"fmt"
+
 	"github.com/libp2p/go-libp2p-core/protocol"
 )
 
-// FilecoinDHT is the protocol of the filecoin DHT.
-const FilecoinDHT protocol.ID = "/fil/kad/devnet-4"
+// FilecoinDHT is creates a protocol for the filecoin DHT.
+func FilecoinDHT(network string) protocol.ID {
+	return protocol.ID(fmt.Sprintf("/fil/kad/%s", network))
+}


### PR DESCRIPTION
closes #2509

### Problem

We use a DHT to discover peers on the network. The DHT is self healing by design, so it will attempt to merge with any other DHT of the same protocol that it finds. Unfortunately, this means that the DHTs of Filecoin nodes on different networks could end up merging and the nodes will end up trying to connect to each other (unsuccessfully since they'll have different genesis nodes).

### Solution

Append the network name to the DHT protocol to prevent merging.