### PR TITLE
Return a SignedResponse from the `client query-storage-deal` command

### DIFF
--- a/commands/client.go
+++ b/commands/client.go
@@ -190,9 +190,9 @@ format is specified with the --enc flag.
 
 		return re.Emit(resp)
 	},
-	Type: storagedeal.Response{},
+	Type: storagedeal.SignedResponse{},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, resp *storagedeal.Response) error {
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, resp *storagedeal.SignedResponse) error {
 			fmt.Fprintf(w, "Status: %s\n", resp.State.String()) // nolint: errcheck
 			fmt.Fprintf(w, "Message: %s\n", resp.Message)       // nolint: errcheck
 			return nil


### PR DESCRIPTION
## Summary
Returned a `storagedeal.SignedResponse` from `query-storage-deal`.

### Sample Output
```json
{
  "State": 7,
  "Message": "",
  "ProposalCid": {
    "/": "bafy2bzacebwfakwyxdnhwfhtapwkerpmps4up5hkte3pmopyteoqexm6foxz4"
  },
  "ProofInfo": {
    "SectorID": 1,
    "CommD": "dZ2edPVzA1nSK0PpmFfz4DiTanhYjpchghwN8d1oeg8=",
    "CommR": "OodhwUTX1buSWDjZqql0rf2DRJvRmraEbYGyHLakIGg=",
    "CommRStar": "aFZOviu+UJkAuMYGLQMzjNlealquZ7BqKI3tX/2YQF4=",
    "CommitmentMessage": {
      "/": "bafy2bzaceaa4wo5zktetxmm5llsuqhnytsek5wcenhpums6cilovqaady3txg"
    },
    "PieceInclusionProof": "EAAAAAAAAABEral84RHiyMCNHov3CfFrz7fyFnBV7SIim5V6oiSdaw=="
  },
  "Signature": "Fl40oZ5WOpRd4sOeWqy+dnt08jkO+yLWmmnqOse100Z1IihVmWp1vUfEEreV6p1eJ2UF9hysL3A3d3baGMNjLwE="
}
```