### PR TITLE
use localnet as a default so init without a network will work

### DIFF
--- a/consensus/genesis.go
+++ b/consensus/genesis.go
@@ -122,7 +122,7 @@ func NewEmptyConfig() *Config {
 		nonces:     make(map[address.Address]uint64),
 		actors:     make(map[address.Address]*actor.Actor),
 		miners:     make(map[address.Address]*minerActorConfig),
-		network:    "",
+		network:    "localnet",
 		proofsMode: types.TestProofsMode,
 	}
 }


### PR DESCRIPTION
closes #3398

### Problem

go-filecoin now requires a known network name to exist the genesis block so that we may choose the correct protocol version code to run. If a user initializes an ad hoc network using default configuration, the network will be the empty string which does not correspond to a know protocol schedule. This generates an error when this user attempts to initialize the network.

### Solution

Default the network name to "localnet" which is a known network.