### PR TITLE
Update localnet to start mining after miner create

### DIFF
--- a/tools/fast/bin/localnet/main.go
+++ b/tools/fast/bin/localnet/main.go
@@ -287,6 +287,11 @@ func main() {
 			return
 		}
 
+		if err := miner.MiningStart(ctx); err != nil {
+			exitcode = handleError(err, "failed miner.MiningStart;")
+			return
+		}
+
 		var data bytes.Buffer
 		dataReader := io.LimitReader(rand.Reader, int64(sinfo.MaxPieceSize.Uint64()))
 		dataReader = io.TeeReader(dataReader, &data)

--- a/tools/fast/series/create_miner_with_ask.go
+++ b/tools/fast/series/create_miner_with_ask.go
@@ -10,7 +10,7 @@ import (
 )
 
 // CreateStorageMinerWithAsk setups a miner and sets an ask price. The created ask is
-// returned. The node will be mining as well.
+// returned.
 func CreateStorageMinerWithAsk(ctx context.Context, miner *fast.Filecoin, collateral *big.Int, price *big.Float, expiry *big.Int, sectorSize *types.BytesAmount) (porcelain.Ask, error) {
 	// Create miner
 	_, err := miner.MinerCreate(ctx, collateral, fast.AOSectorSize(sectorSize), fast.AOPrice(big.NewFloat(1.0)), fast.AOLimit(300))


### PR DESCRIPTION
Creating a miner with series.CreateMinerWithAsk no longer will start the mining scheduler with a call to `mining start`.