### PR TITLE
add peer tracker to porcelain with Trust method

### DIFF
--- a/commands/chain.go
+++ b/commands/chain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-ipfs-cmdkit"
 	"github.com/ipfs/go-ipfs-cmds"
+	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/filecoin-project/go-filecoin/types"
 )
@@ -22,6 +23,7 @@ var chainCmd = &cmds.Command{
 		"head":   storeHeadCmd,
 		"ls":     storeLsCmd,
 		"status": storeStatusCmd,
+		"trust":  trustPeerCmd,
 	},
 }
 
@@ -119,6 +121,23 @@ var storeStatusCmd = &cmds.Command{
 		if err := re.Emit(syncStatus); err != nil {
 			return err
 		}
+		return nil
+	},
+}
+
+var trustPeerCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Trusts a peer for chain sync operations.",
+	},
+	Arguments: []cmdkit.Argument{
+		cmdkit.StringArg("peerid", true, false, "Base58-encoded libp2p peer ID that the peer tracker will trust"),
+	},
+	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+		trustedPeer, err := peer.IDB58Decode(req.Arguments[0])
+		if err != nil {
+			return err
+		}
+		GetPorcelainAPI(env).TrustPeer(trustedPeer)
 		return nil
 	},
 }

--- a/net/peer_tracker.go
+++ b/net/peer_tracker.go
@@ -69,6 +69,14 @@ func (tracker *PeerTracker) UpdateTrusted(ctx context.Context) error {
 	return tracker.updatePeers(ctx, tracker.trustedPeers()...)
 }
 
+// Trust adds `pid` to the peer trackers trusted node set.
+func (tracker *PeerTracker) Trust(pid peer.ID) {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	tracker.trusted[pid] = struct{}{}
+	logPeerTracker.Infof("Trusting peer=%s", pid.Pretty())
+}
+
 // Track adds information about a given peer.ID
 func (tracker *PeerTracker) Track(ci *types.ChainInfo) {
 	tracker.mu.Lock()

--- a/node/builder.go
+++ b/node/builder.go
@@ -314,6 +314,7 @@ func (nc *Builder) build(ctx context.Context) (*Node, error) {
 		MsgWaiter:     msg.NewWaiter(chainStore, messageStore, bs, &ipldCborStore),
 		Network:       net.New(peerHost, pubsub.NewPublisher(fsub), pubsub.NewSubscriber(fsub), net.NewRouter(router), bandwidthTracker, net.NewPinger(peerHost, pingService)),
 		Outbox:        outbox,
+		PeerTracker:   peerTracker,
 		SectorBuilder: nd.SectorBuilder,
 		Wallet:        fcWallet,
 	}))

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -56,6 +56,7 @@ type API struct {
 	msgWaiter     *msg.Waiter
 	network       *net.Network
 	outbox        *core.Outbox
+	peerTracker   *net.PeerTracker
 	sectorBuilder func() sectorbuilder.SectorBuilder
 	storagedeals  *strgdls.Store
 	wallet        *wallet.Wallet
@@ -76,6 +77,7 @@ type APIDeps struct {
 	MsgWaiter     *msg.Waiter
 	Network       *net.Network
 	Outbox        *core.Outbox
+	PeerTracker   *net.PeerTracker
 	SectorBuilder func() sectorbuilder.SectorBuilder
 	Wallet        *wallet.Wallet
 }
@@ -97,6 +99,7 @@ func New(deps *APIDeps) *API {
 		msgWaiter:     deps.MsgWaiter,
 		network:       deps.Network,
 		outbox:        deps.Outbox,
+		peerTracker:   deps.PeerTracker,
 		sectorBuilder: deps.SectorBuilder,
 		storagedeals:  deps.Deals,
 		wallet:        deps.Wallet,
@@ -317,6 +320,11 @@ func (api *API) NetworkPeers(ctx context.Context, verbose, latency, streams bool
 // SignBytes uses private key information associated with the given address to sign the given bytes.
 func (api *API) SignBytes(data []byte, addr address.Address) (types.Signature, error) {
 	return api.wallet.SignBytes(data, addr)
+}
+
+// TrustPeer adds `p` to the peer trackers trusted node set.
+func (api *API) TrustPeer(p peer.ID) {
+	api.peerTracker.Trust(p)
 }
 
 // WalletAddresses gets addresses from the wallet

--- a/plumbing/net/peer_tracker.go
+++ b/plumbing/net/peer_tracker.go
@@ -1,0 +1,26 @@
+package net
+
+import (
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+type peerTracker interface {
+	Trust(pid peer.ID)
+}
+
+// PeerTrackerProvider provides access to the peers currently being tracked.
+type PeerTrackerProvider struct {
+	pt peerTracker
+}
+
+// NewPeerTrackerProvider returns a new PeerTrackerProvider
+func NewPeerTrackerProvider(pt peerTracker) *PeerTrackerProvider {
+	return &PeerTrackerProvider{
+		pt: pt,
+	}
+}
+
+// TrustPeer adds `p` to the peer trackers trusted node set.
+func (pt *PeerTrackerProvider) TrustPeer(p peer.ID) {
+	pt.pt.Trust(p)
+}

--- a/tools/fast/action_chain.go
+++ b/tools/fast/action_chain.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/filecoin-project/go-filecoin/chain"
 )
@@ -31,4 +32,12 @@ func (f *Filecoin) ChainStatus(ctx context.Context) (*chain.Status, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// TrustPeer runs the peertrackers trust command against the filecoin process.
+func (f *Filecoin) TrustPeer(ctx context.Context, p peer.ID) error {
+	if _, err := f.RunCmdWithStdin(ctx, nil, "go-filecoin", "chain", "trust", p.Pretty()); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
### What
This adds the PeerTracker to porcelain. We need this for catch up syncing daemon tests as we must instruct daemons to trust each other in order for them to sync their chains initially. Without this daemons will be unable to move out of the catch up sync phase.