### PR TITLE
Allow setting path to binary under test

### DIFF
--- a/testhelpers/testflags/flags.go
+++ b/testhelpers/testflags/flags.go
@@ -12,6 +12,18 @@ var unitTest = flag.Bool("unit", true, "Run the unit go tests")
 var functionalTest = flag.Bool("functional", false, "Run the functional go tests")
 var sectorBuilderTest = flag.Bool("sectorbuilder", false, "Run the sector builder tests")
 var deploymentTest = flag.String("deployment", "", "Run the deployment tests against a network")
+var binaryPath = flag.String("binary-path", "", "Run forked processes tests using provided binary")
+
+// BinaryPath will return the path to the user provided binary. The call is expected to check if
+// the return path points to an actual file. If the user did not provide a value an empty string
+// will be returned along with a false for the second return value.
+func BinaryPath() (string, bool) {
+	if len(*binaryPath) == 0 {
+		return "", false
+	}
+
+	return *binaryPath, true
+}
 
 // DeploymentTest will run the test its called from iff the `-deployment` flag
 // is passed when calling `go test`. Otherwise the test will be skipped. DeploymentTest

--- a/testhelpers/util.go
+++ b/testhelpers/util.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 )
 
 // GetFreePort gets a free port from the kernel
@@ -36,7 +38,10 @@ func MustGetFilecoinBinary() string {
 
 // GetFilecoinBinary returns the path where the filecoin binary will be if it has been built
 func GetFilecoinBinary() (string, error) {
-	bin := ProjectRoot("go-filecoin")
+	bin, provided := testflags.BinaryPath()
+	if !provided {
+		bin = ProjectRoot("go-filecoin")
+	}
 
 	_, err := os.Stat(bin)
 	if err != nil {


### PR DESCRIPTION
To enable running the network deployment tests during network setup we can build the tests as an executable binary using the `-c` flag of `go test`. Currently all of our tests are forced into using a binary located at the project root. This flags allows overriding the binary that will be used for tests which fork `go-filecoin`.