### PR TITLE
Feat/validate block sig

### DIFF
--- a/consensus/block_validation.go
+++ b/consensus/block_validation.go
@@ -108,7 +108,6 @@ func (dv *DefaultBlockValidator) ValidateSyntax(ctx context.Context, blk *types.
 			return fmt.Errorf("block %s has nil ticket", blk.Cid().String())
 		}
 	}
-	// TODO validate block signature #1054
 	return nil
 }
 

--- a/consensus/election_test.go
+++ b/consensus/election_test.go
@@ -69,8 +69,9 @@ func TestIsElectionWinner(t *testing.T) {
 	var st state.Tree
 
 	t.Run("IsElectionWinner performs as expected on cases", func(t *testing.T) {
+		minerToWorker := map[address.Address]address.Address{minerAddress: minerAddress}
 		for _, c := range cases {
-			ptv := th.NewTestPowerTableView(types.NewBytesAmount(c.myPower), types.NewBytesAmount(c.totalPower))
+			ptv := th.NewTestPowerTableView(types.NewBytesAmount(c.myPower), types.NewBytesAmount(c.totalPower), minerToWorker)
 			r, err := consensus.ElectionMachine{}.IsElectionWinner(ctx, bs, ptv, st, types.Ticket{VDFResult: c.ticket[:]}, c.electionProof, minerAddress, minerAddress)
 			assert.NoError(t, err)
 			assert.Equal(t, c.wins, r, "%+v", c)

--- a/consensus/expected_test.go
+++ b/consensus/expected_test.go
@@ -5,6 +5,16 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ipfs/go-blockservice"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-hamt-ipld"
+	"github.com/ipfs/go-ipfs-blockstore"
+	"github.com/ipfs/go-ipfs-exchange-offline"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/consensus"
@@ -13,15 +23,6 @@ import (
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
-
-	"github.com/ipfs/go-blockservice"
-	"github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-hamt-ipld"
-	"github.com/ipfs/go-ipfs-blockstore"
-	"github.com/ipfs/go-ipfs-exchange-offline"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewExpected(t *testing.T) {
@@ -29,22 +30,29 @@ func TestNewExpected(t *testing.T) {
 
 	t.Run("a new Expected can be created", func(t *testing.T) {
 		cst, bstore := setupCborBlockstore()
-		ptv := th.NewTestPowerTableView(types.NewBytesAmount(1), types.NewBytesAmount(5))
+		ptv := th.NewTestPowerTableView(types.NewBytesAmount(1), types.NewBytesAmount(5), make(map[address.Address]address.Address))
 		exp := consensus.NewExpected(cst, bstore, consensus.NewDefaultProcessor(), th.NewFakeBlockValidator(), ptv, types.CidFromString(t, "somecid"), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
 		assert.NotNil(t, exp)
 	})
 }
 
+func requireNewValidTestBlock(t *testing.T, baseTipSet types.TipSet, stateRootCid cid.Cid, height uint64, minerAddr address.Address, minerWorker address.Address, signer types.Signer) *types.Block {
+	b, err := th.NewValidTestBlockFromTipSet(baseTipSet, stateRootCid, height, minerAddr, minerWorker, signer)
+	require.NoError(t, err)
+	return b
+}
+
 // requireMakeBlocks sets up 3 blocks with 3 owner actors and 3 miner actors and puts them in the state tree.
-// the owner actors have associated mockSigners for signing blocks (not implemented yet) and tickets.
-func requireMakeBlocks(ctx context.Context, t *testing.T, pTipSet types.TipSet, tree state.Tree, vms vm.StorageMap) []*types.Block {
-	// make  a set of owner keypairs so they can sign blocks
+// the owner actors have associated mockSigners for signing blocks and tickets.
+func requireMakeBlocks(ctx context.Context, t *testing.T, pTipSet types.TipSet, tree state.Tree, vms vm.StorageMap) ([]*types.Block, map[address.Address]address.Address) {
+	// make a set of owner keypairs so they can sign blocks
 	mockSigner, kis := types.NewMockSignersAndKeyInfo(3)
 
 	// iterate over the keypairs and set up owner actors and miner actors with their own addresses
 	// and add them to the state tree
 	minerWorkers := make([]address.Address, 3)
 	minerAddrs := make([]address.Address, 3)
+	minerToWorker := make(map[address.Address]address.Address)
 	for i, name := range kis {
 		addr, err := kis[i].Address()
 		require.NoError(t, err)
@@ -57,6 +65,9 @@ func requireMakeBlocks(ctx context.Context, t *testing.T, pTipSet types.TipSet, 
 
 		minerAddrs[i], err = address.NewActorAddress([]byte(fmt.Sprintf("%s%s", name, "Miner")))
 		require.NoError(t, err)
+
+		minerToWorker[minerAddrs[i]] = minerWorkers[i]
+
 		minerActor := th.RequireNewMinerActor(t, vms, minerAddrs[i], addr,
 			10000, th.RequireRandomPeerID(t), types.ZeroAttoFIL)
 		require.NoError(t, tree.SetActor(ctx, minerAddrs[i], minerActor))
@@ -65,11 +76,11 @@ func requireMakeBlocks(ctx context.Context, t *testing.T, pTipSet types.TipSet, 
 	require.NoError(t, err)
 
 	blocks := []*types.Block{
-		th.NewValidTestBlockFromTipSet(pTipSet, stateRoot, 1, minerAddrs[0], minerWorkers[0], mockSigner),
-		th.NewValidTestBlockFromTipSet(pTipSet, stateRoot, 1, minerAddrs[1], minerWorkers[1], mockSigner),
-		th.NewValidTestBlockFromTipSet(pTipSet, stateRoot, 1, minerAddrs[2], minerWorkers[2], mockSigner),
+		requireNewValidTestBlock(t, pTipSet, stateRoot, 1, minerAddrs[0], minerWorkers[0], mockSigner),
+		requireNewValidTestBlock(t, pTipSet, stateRoot, 1, minerAddrs[1], minerWorkers[1], mockSigner),
+		requireNewValidTestBlock(t, pTipSet, stateRoot, 1, minerAddrs[2], minerWorkers[2], mockSigner),
 	}
-	return blocks
+	return blocks, minerToWorker
 }
 
 // TestExpected_RunStateTransition_validateMining is concerned only with validateMining behavior.
@@ -88,19 +99,18 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 	totalPower := types.NewBytesAmount(1)
 
 	t.Run("passes the validateMining section when given valid mining blocks", func(t *testing.T) {
-
-		ptv := th.NewTestPowerTableView(minerPower, totalPower)
-		exp := consensus.NewExpected(cistore, bstore, th.NewTestProcessor(), th.NewFakeBlockValidator(), ptv, genesisBlock.Cid(), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
-
 		pTipSet := types.RequireNewTipSet(t, genesisBlock)
-
 		stateTree, err := state.LoadStateTree(ctx, cistore, genesisBlock.StateRoot, builtin.Actors)
 		require.NoError(t, err)
 		vms := vm.NewStorageMap(bstore)
 
-		blocks := requireMakeBlocks(ctx, t, pTipSet, stateTree, vms)
+		blocks, minerToWorker := requireMakeBlocks(ctx, t, pTipSet, stateTree, vms)
 
 		tipSet := types.RequireNewTipSet(t, blocks...)
+		// Add the miner worker mapping into the test power table view
+		ptv := th.NewTestPowerTableView(minerPower, totalPower, minerToWorker)
+
+		exp := consensus.NewExpected(cistore, bstore, th.NewTestProcessor(), th.NewFakeBlockValidator(), ptv, genesisBlock.Cid(), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
 
 		var emptyMessages [][]*types.SignedMessage
 		var emptyReceipts [][]*types.MessageReceipt
@@ -114,9 +124,6 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 	})
 
 	t.Run("returns nil + mining error when election proof validation fails", func(t *testing.T) {
-		ptv := th.NewTestPowerTableView(minerPower, totalPower)
-		exp := consensus.NewExpected(cistore, bstore, consensus.NewDefaultProcessor(), th.NewFakeBlockValidator(), ptv, types.CidFromString(t, "somecid"), th.BlockTimeTest, &consensus.FailingElectionValidator{}, &consensus.FakeTicketMachine{})
-
 		pTipSet := types.RequireNewTipSet(t, genesisBlock)
 
 		stateTree, err := state.LoadStateTree(ctx, cistore, genesisBlock.StateRoot, builtin.Actors)
@@ -124,7 +131,10 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		vms := vm.NewStorageMap(bstore)
 
-		blocks := requireMakeBlocks(ctx, t, pTipSet, stateTree, vms)
+		blocks, minerToWorker := requireMakeBlocks(ctx, t, pTipSet, stateTree, vms)
+
+		ptv := th.NewTestPowerTableView(minerPower, totalPower, minerToWorker)
+		exp := consensus.NewExpected(cistore, bstore, consensus.NewDefaultProcessor(), th.NewFakeBlockValidator(), ptv, types.CidFromString(t, "somecid"), th.BlockTimeTest, &consensus.FailingElectionValidator{}, &consensus.FakeTicketMachine{})
 
 		tipSet := types.RequireNewTipSet(t, blocks...)
 
@@ -140,8 +150,6 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 	})
 
 	t.Run("returns nil + mining error when ticket validation fails", func(t *testing.T) {
-		ptv := th.NewTestPowerTableView(minerPower, totalPower)
-		exp := consensus.NewExpected(cistore, bstore, consensus.NewDefaultProcessor(), th.NewFakeBlockValidator(), ptv, types.CidFromString(t, "somecid"), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FailingTicketValidator{})
 
 		pTipSet := types.RequireNewTipSet(t, genesisBlock)
 
@@ -150,7 +158,10 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		vms := vm.NewStorageMap(bstore)
 
-		blocks := requireMakeBlocks(ctx, t, pTipSet, stateTree, vms)
+		blocks, minerToWorker := requireMakeBlocks(ctx, t, pTipSet, stateTree, vms)
+
+		ptv := th.NewTestPowerTableView(minerPower, totalPower, minerToWorker)
+		exp := consensus.NewExpected(cistore, bstore, consensus.NewDefaultProcessor(), th.NewFakeBlockValidator(), ptv, types.CidFromString(t, "somecid"), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FailingTicketValidator{})
 
 		tipSet := types.RequireNewTipSet(t, blocks...)
 
@@ -163,6 +174,33 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		_, err = exp.RunStateTransition(ctx, tipSet, emptyMessages, emptyReceipts, []types.TipSet{pTipSet}, genesisBlock.StateRoot)
 		assert.EqualError(t, err, "invalid ticket extension")
+	})
+
+	t.Run("returns nil + mining error when signature is invalid", func(t *testing.T) {
+		pTipSet := types.RequireNewTipSet(t, genesisBlock)
+		stateTree, err := state.LoadStateTree(ctx, cistore, genesisBlock.StateRoot, builtin.Actors)
+		require.NoError(t, err)
+		vms := vm.NewStorageMap(bstore)
+
+		blocks, minerToWorker := requireMakeBlocks(ctx, t, pTipSet, stateTree, vms)
+		// Give block 0 an invalid signature
+		blocks[0].BlockSig = blocks[1].BlockSig
+
+		tipSet := types.RequireNewTipSet(t, blocks...)
+		// Add the miner worker mapping into the test power table view
+		ptv := th.NewTestPowerTableView(minerPower, totalPower, minerToWorker)
+
+		exp := consensus.NewExpected(cistore, bstore, th.NewTestProcessor(), th.NewFakeBlockValidator(), ptv, genesisBlock.Cid(), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
+
+		var emptyMessages [][]*types.SignedMessage
+		var emptyReceipts [][]*types.MessageReceipt
+		for i := 0; i < len(blocks); i++ {
+			emptyMessages = append(emptyMessages, []*types.SignedMessage{})
+			emptyReceipts = append(emptyReceipts, []*types.MessageReceipt{})
+		}
+
+		_, err = exp.RunStateTransition(ctx, tipSet, emptyMessages, emptyReceipts, []types.TipSet{pTipSet}, blocks[0].StateRoot)
+		assert.EqualError(t, err, "block signature invalid")
 	})
 }
 

--- a/mining/block_generate.go
+++ b/mining/block_generate.go
@@ -105,6 +105,14 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 		Tickets:         []types.Ticket{ticket},
 		Timestamp:       types.Uint64(w.clock.Now().Unix()),
 	}
+	workerAddr, err := w.api.MinerGetWorkerAddress(ctx, w.minerAddr, baseTipSet.Key())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read workerAddr during block generation")
+	}
+	next.BlockSig, err = w.workerSigner.SignBytes(next.SignatureData(), workerAddr)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to sign block")
+	}
 
 	for i, msg := range res.PermanentFailures {
 		// We will not be able to apply this message in the future because the error was permanent.

--- a/testhelpers/chain.go
+++ b/testhelpers/chain.go
@@ -101,7 +101,10 @@ func MkFakeChildCore(parent types.TipSet,
 
 	pIDs := parent.Key()
 
-	newBlock := NewValidTestBlockFromTipSet(parent, stateRoot, height, minerAddr, minerWorker, signer)
+	newBlock, err := NewValidTestBlockFromTipSet(parent, stateRoot, height, minerAddr, minerWorker, signer)
+	if err != nil {
+		return nil, err
+	}
 
 	// Override fake values with our values
 	newBlock.Parents = pIDs

--- a/types/block.go
+++ b/types/block.go
@@ -142,3 +142,23 @@ func (b *Block) Score() uint64 {
 func (b *Block) Equals(other *Block) bool {
 	return b.Cid().Equals(other.Cid())
 }
+
+// SignatureData returns the block's bytes without the blocksig for signature
+// creating and verification
+func (b *Block) SignatureData() []byte {
+	tmp := &Block{
+		Miner:           b.Miner,
+		Tickets:         b.Tickets, // deep copy needed??
+		Parents:         b.Parents, // deep copy needed??
+		ParentWeight:    b.ParentWeight,
+		Height:          b.Height,
+		Messages:        b.Messages,
+		StateRoot:       b.StateRoot,
+		MessageReceipts: b.MessageReceipts,
+		ElectionProof:   b.ElectionProof,
+		Timestamp:       b.Timestamp,
+		// BlockSig omitted
+	}
+
+	return tmp.ToNode().RawData()
+}

--- a/types/signature.go
+++ b/types/signature.go
@@ -26,6 +26,5 @@ func IsValidSignature(data []byte, addr address.Address, sig Signature) bool {
 		log.Infof("error in recovered address: %s", err)
 		return false
 	}
-
 	return maybeAddr == addr
 }


### PR DESCRIPTION
Miners sign blocks and validation includes signature verification.

This Closes out various issues.

https://github.com/filecoin-project/go-filecoin/issues/3293
https://github.com/filecoin-project/go-filecoin/issues/1609
https://github.com/filecoin-project/go-filecoin/issues/1010

Note that previous issues describing this work + inline TODOs dictated performing the signature validation check as part of syntactic block validation but this PR puts the validation within the `validateMining` call of the expected consensus module.  This is necessary in our current validation architecture because the miner worker address is tracked in the state machine and header (syntactic) validation happens at header receive time which comes before there is any guarantee of being able to read the parent state.

There are tons of directions we could (and in some cases we should) go with our validation architecture to validate data more aggressively.  For example we could opportunistically check if we have the parent state and if so filter blocks by (1) miner's membership in the power table (2) valid signature.

