### PR TITLE
[DONTMERGE] Reproduce proof verification failures from 0.5.0 staging devnet

### DIFF
--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -1,7 +1,10 @@
 package miner
 
 import (
+	"encoding/json"
+	"fmt"
 	"math/big"
+	"os"
 
 	"github.com/filecoin-project/go-sectorbuilder"
 	"github.com/ipfs/go-cid"
@@ -949,8 +952,19 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, poStProof types.PoStProof, fault
 				Proof:            poStProof,
 				SectorSize:       state.SectorSize,
 			}
+			// DONOTMERGE: dump request/response structures for reproduction.
+			//fmt.Println(req)
+			bytes, err := json.Marshal(req)
+			_, _ = os.Stdout.Write(bytes)
+			fmt.Println()
 
 			res, err := ctx.Verifier().VerifyPoSt(req)
+
+			//fmt.Println(res)
+			bytes, err = json.Marshal(res)
+			_, _ = os.Stdout.Write(bytes)
+			fmt.Println()
+
 			if err != nil {
 				return nil, errors.RevertErrorWrap(err, "failed to verify PoSt")
 			}

--- a/commands/chain.go
+++ b/commands/chain.go
@@ -11,17 +11,24 @@ import (
 	"github.com/ipfs/go-ipfs-cmdkit"
 	"github.com/ipfs/go-ipfs-cmds"
 
+	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/types"
 )
+
+type ExecutedMessage struct {
+	Message *types.SignedMessage
+	Receipt *types.MessageReceipt
+}
 
 var chainCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Inspect the filecoin blockchain",
 	},
 	Subcommands: map[string]*cmds.Command{
-		"head":   storeHeadCmd,
-		"ls":     storeLsCmd,
-		"status": storeStatusCmd,
+		"head":      storeHeadCmd,
+		"ls":        storeLsCmd,
+		"status":    storeStatusCmd,
+		"list-msgs": storeLsMsgsCmd,
 	},
 }
 
@@ -121,4 +128,57 @@ var storeStatusCmd = &cmds.Command{
 		}
 		return nil
 	},
+}
+
+var storeLsMsgsCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline:          "List messages in the blockchain",
+		ShortDescription: `Provides a list of messages in order from genesis to head`,
+	},
+	Options: []cmdkit.Option{
+		//cmdkit.BoolOption("long", "l", "List messages in long format (default: only CID)"),
+	},
+	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+		iter, err := GetPorcelainAPI(env).ChainLs(req.Context)
+		if err != nil {
+			return err
+		}
+		// Accumulate tipsets in descending order.
+		var tips []types.TipSet
+		for ; !iter.Complete(); err = iter.Next() {
+			if err != nil {
+				return err
+			}
+			tips = append(tips, iter.Value())
+		}
+		// Re-order into ascending order.
+		chain.Reverse(tips)
+
+		// BEWARE: the chain doesn't provide the true receipt status of messages since, in a
+		// multi-block tipset, the context for execution is not the tipset's parent state for blocks
+		// after the first in a tipset.
+		// A correct version would need to re-execute the messages.
+		for _, tip := range tips {
+			for i := 0; i < tip.Len(); i++ {
+				msgs, err := GetPorcelainAPI(env).ChainGetMessages(req.Context, tip.At(i).Messages)
+				if err != nil {
+					return err
+				}
+				rcps, err := GetPorcelainAPI(env).ChainGetReceipts(req.Context, tip.At(i).MessageReceipts)
+				if err != nil {
+					return err
+				}
+				for j := 0; j < len(msgs); j++ {
+					_ = re.Emit(&ExecutedMessage{
+						Message: msgs[j],
+						Receipt: rcps[j],
+					})
+				}
+			}
+		}
+
+		return nil
+	},
+	Type: ExecutedMessage{},
+	Encoders: cmds.EncoderMap{},
 }


### PR DESCRIPTION
Unit tests which reproduce PoSt verification failures on the staging-0.5.0 devnet, for further investigation.

Adds `chain list-msgs` command which dumps all message executions from a chain, in order (but is flawed b/c of multi-block tipset semantics).

Adds some debugging prints in the storage miner actor to export the proof verification requests, subsequently copied inline into a unit test. In order to reproduce the output, you'll need a small addition to `go-sectorbuilder/bindings.go` (which is in different repo):

```
func (s SortedSectorInfo) MarshalJSON() ([]byte, error) {
	return json.Marshal(s.f)
}

func (s *SortedSectorInfo) UnmarshalJSON(b []byte) error {
	return json.Unmarshal(b, &s.f)
}
```

@acruikshank @laser @dignifiedquire 