### PR TITLE
Feat/3433 prep randomness sampling to current spec: ticket iterator

### DIFF
--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -957,7 +957,6 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, poStProof types.PoStProof, fault
 			for i, ssi := range sortedSectorInfo.Values() {
 				log.Infof("ssi %d: sector id %d -- commR %x", i, ssi.SectorID, ssi.CommR)
 			}
-			
 
 			req := verification.VerifyPoStRequest{
 				ChallengeSeed:    seed,

--- a/chain/get_ancestors_test.go
+++ b/chain/get_ancestors_test.go
@@ -69,7 +69,7 @@ func TestCollectTipSetsOfHeightAtLeastStartingEpochIsNull(t *testing.T) {
 
 	// Now add 10 null blocks and 1 tipset.
 	head = builder.BuildOneOn(head, func(b *chain.BlockBuilder) {
-		b.IncHeight(10)
+		b.PrependNull(10)
 	})
 
 	// Now add 19 more tipsets.
@@ -160,7 +160,7 @@ func TestCollectTipSetsPastHeightStartingEpochIsNull(t *testing.T) {
 
 	// Now add 10 null blocks and 1 tipset.
 	head = builder.BuildOneOn(head, func(b *chain.BlockBuilder) {
-		b.IncHeight(10)
+		b.PrependNull(10)
 	})
 
 	// Now add 19 more tipsets.
@@ -267,7 +267,7 @@ func TestGetRecentAncestorsStartingEpochIsNull(t *testing.T) {
 	head = builder.AppendManyOn(30, head)
 	// Add 10 null blocks and 1 tipset.
 	head = builder.BuildOneOn(head, func(b *chain.BlockBuilder) {
-		b.IncHeight(10)
+		b.PrependNull(10)
 	})
 	// Add 19 more tipsets, so there are 20 after the nulls.
 	len2 := 19
@@ -358,7 +358,7 @@ func TestFindCommonAncestorNullBlockFork(t *testing.T) {
 
 	// From the common ancestor, add a block following a null block.
 	headAfterNull := builder.BuildOneOn(commonHead, func(b *chain.BlockBuilder) {
-		b.IncHeight(1)
+		b.PrependNull(1)
 	})
 	afterNullItr := chain.IterAncestors(ctx, builder, headAfterNull)
 

--- a/chain/store_test.go
+++ b/chain/store_test.go
@@ -99,7 +99,7 @@ func TestGetByKey(t *testing.T) {
 	link1 := builder.AppendOn(genTS, 2)
 	link2 := builder.AppendOn(link1, 3)
 	link3 := builder.AppendOn(link2, 1)
-	link4 := builder.BuildOn(link3, 2, func(bb *chain.BlockBuilder, i int) { bb.IncHeight(2) })
+	link4 := builder.BuildOn(link3, 2, func(bb *chain.BlockBuilder, i int) { bb.PrependNull(2) })
 
 	// Put the test chain to the store
 	requirePutTestChain(ctx, t, cs, link4.Key(), builder, 5)
@@ -192,7 +192,7 @@ func TestGetByParent(t *testing.T) {
 	link1 := builder.AppendOn(genTS, 2)
 	link2 := builder.AppendOn(link1, 3)
 	link3 := builder.AppendOn(link2, 1)
-	link4 := builder.BuildOn(link3, 2, func(bb *chain.BlockBuilder, i int) { bb.IncHeight(2) })
+	link4 := builder.BuildOn(link3, 2, func(bb *chain.BlockBuilder, i int) { bb.PrependNull(2) })
 
 	// Put the test chain to the store
 	requirePutTestChain(ctx, t, cs, link4.Key(), builder, 5)
@@ -229,7 +229,7 @@ func TestGetMultipleByParent(t *testing.T) {
 	link1 := builder.AppendOn(genTS, 2)
 	link2 := builder.AppendOn(link1, 3)
 	link3 := builder.AppendOn(link2, 1)
-	link4 := builder.BuildOn(link3, 2, func(bb *chain.BlockBuilder, i int) { bb.IncHeight(2) })
+	link4 := builder.BuildOn(link3, 2, func(bb *chain.BlockBuilder, i int) { bb.PrependNull(2) })
 
 	// Put the test chain to the store
 	requirePutTestChain(ctx, t, cs, link4.Key(), builder, 5)
@@ -287,7 +287,7 @@ func TestHead(t *testing.T) {
 	link1 := builder.AppendOn(genTS, 2)
 	link2 := builder.AppendOn(link1, 3)
 	link3 := builder.AppendOn(link2, 1)
-	link4 := builder.BuildOn(link3, 2, func(bb *chain.BlockBuilder, i int) { bb.IncHeight(2) })
+	link4 := builder.BuildOn(link3, 2, func(bb *chain.BlockBuilder, i int) { bb.PrependNull(2) })
 
 	// Head starts as an empty cid set
 	assert.Equal(t, types.TipSetKey{}, cs.GetHead())
@@ -329,7 +329,7 @@ func TestHeadEvents(t *testing.T) {
 	link1 := builder.AppendOn(genTS, 2)
 	link2 := builder.AppendOn(link1, 3)
 	link3 := builder.AppendOn(link2, 1)
-	link4 := builder.BuildOn(link3, 2, func(bb *chain.BlockBuilder, i int) { bb.IncHeight(2) })
+	link4 := builder.BuildOn(link3, 2, func(bb *chain.BlockBuilder, i int) { bb.PrependNull(2) })
 	ps := chainStore.HeadEvents()
 	chA := ps.Sub(chain.NewHeadTopic)
 	chB := ps.Sub(chain.NewHeadTopic)
@@ -375,7 +375,7 @@ func TestLoadAndReboot(t *testing.T) {
 	link1 := builder.AppendOn(genTS, 2)
 	link2 := builder.AppendOn(link1, 3)
 	link3 := builder.AppendOn(link2, 1)
-	link4 := builder.BuildOn(link3, 2, func(bb *chain.BlockBuilder, i int) { bb.IncHeight(2) })
+	link4 := builder.BuildOn(link3, 2, func(bb *chain.BlockBuilder, i int) { bb.PrependNull(2) })
 
 	// Add blocks to blockstore
 	requirePutBlocksToCborStore(t, cst, genTS.ToSlice()...)

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -258,6 +258,7 @@ type BlockBuilder struct {
 
 // SetTickets sets the block's tickets.
 func (bb *BlockBuilder) SetTickets(rawVals [][]byte) {
+	bb.block.Tickets = []types.Ticket{}
 	for _, raw := range rawVals {
 		ticket := types.Ticket{
 			VRFProof:  types.VRFPi(raw),

--- a/chain/traversal.go
+++ b/chain/traversal.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"context"
+	"errors"
 
 	"github.com/ipfs/go-cid"
 
@@ -87,7 +88,7 @@ func (it *TicketIterator) Complete() bool {
 // https://github.com/filecoin-project/specs/blob/master/definitions.md#ticket-chain
 func (it *TicketIterator) Next() error {
 	if it.tips.Complete() {
-		return errors.NewError("calling next on complete ticket iterator")
+		return errors.New("calling next on complete ticket iterator")
 	}
 
 	// Advance internal tipset iterator
@@ -99,14 +100,13 @@ func (it *TicketIterator) Next() error {
 			it.value = types.UndefTicket
 			return nil
 		}
+		// Start with the last ticket in the new min-ticket block's array
 		it.idx = len(it.tips.Value().At(0).Tickets) - 1
-		it.value = it.tips.Value().At(0).Tickets[it.idx]
-		}
-		return nil 
+	} else {
+		// Advance internally along min-ticket block's ticket array
+		it.idx = it.idx - 1
 	}
-
-	// Advance internally along min-ticket block's ticket array
-	it.idx = it.idx - 1
+	
 	it.value = it.tips.Value().At(0).Tickets[it.idx]
 	return nil
 }

--- a/chain/traversal.go
+++ b/chain/traversal.go
@@ -106,7 +106,7 @@ func (it *TicketIterator) Next() error {
 		// Advance internally along min-ticket block's ticket array
 		it.idx = it.idx - 1
 	}
-	
+
 	it.value = it.tips.Value().At(0).Tickets[it.idx]
 	return nil
 }

--- a/chain/traversal_test.go
+++ b/chain/traversal_test.go
@@ -2,6 +2,7 @@ package chain_test
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"testing"
 
@@ -73,4 +74,99 @@ func TestIterAncestors(t *testing.T) {
 
 		assert.Error(t, it.Next())
 	})
+}
+
+func TestIterTickets(t *testing.T) {
+	tf.UnitTest(t)
+	miner, err := address.NewActorAddress([]byte(fmt.Sprintf("address")))
+	require.NoError(t, err)
+
+	t.Run("chain of single block single ticket tipsets", func(t *testing.T) {
+		ctx := context.Background()
+		builder := chain.NewBuilder(t, miner)
+		height := 5
+		gen := builder.NewGenesis()
+		head := builder.AppendManyOn(height, gen)
+		it := chain.IterTickets(ctx, builder, head)
+
+		expected := []uint64{5, 4, 3, 2, 1, 0}
+		iterExpect(t, it, expected)
+	})
+
+	t.Run("multi-block tipsets", func(t *testing.T) {
+		ctx := context.Background()
+		builder := chain.NewBuilder(t, miner)
+		height := 2
+		gen := builder.NewGenesis()             // ticket 0
+		h1 := builder.AppendManyOn(height, gen) // tickets 1, 2
+		h2 := builder.AppendOn(h1, 3)           // tickets 3, 4, 5
+		h3 := builder.AppendOn(h2, 2)           // tickets 6, 7
+		it := chain.IterTickets(ctx, builder, h3)
+
+		expected := []uint64{6, 3, 2, 1, 0}
+		iterExpect(t, it, expected)
+	})
+
+	t.Run("chain with null blocks", func(t *testing.T) {
+		ctx := context.Background()
+		builder := chain.NewBuilder(t, miner)
+		gen := builder.NewGenesis() // ticket 0
+		ticketsA := [][]byte{
+			uint64ToByte(6),
+			uint64ToByte(72),
+			uint64ToByte(10),
+		}
+		ticketsB := [][]byte{
+			uint64ToByte(5),
+			uint64ToByte(6),
+			uint64ToByte(34),
+		}
+		ticketsC := [][]byte{
+			uint64ToByte(4),
+			uint64ToByte(6),
+			uint64ToByte(35),
+		}
+		tipSetTickets := [][][]byte{ticketsA, ticketsB, ticketsC}
+
+		h1 := builder.BuildOn(gen, 3, func(bb *chain.BlockBuilder, i int) {
+			bb.SetTickets(tipSetTickets[i]) // 33, 72, 6
+		})
+
+		h2 := builder.BuildOn(h1, 1, func(bb *chain.BlockBuilder, i int) {
+			bb.SetTickets([][]byte{
+				uint64ToByte(1),
+				uint64ToByte(7),
+				uint64ToByte(9),
+			}) // 9, 7, 1
+		})
+
+		it := chain.IterTickets(ctx, builder, h2)
+		expected := []uint64{9, 7, 1, 10, 72, 6, 0}
+		iterExpect(t, it, expected)
+	})
+}
+
+// helpers
+
+func iterExpect(t *testing.T, it *chain.TicketIterator, expected []uint64) {
+	t.Helper()
+	for _, exp := range expected {
+		assert.False(t, it.Complete())
+		assert.Equal(t, exp, ticketToUint64(it.Value()))
+		assert.NoError(t, it.Next())
+	}
+	assert.True(t, it.Complete())
+	assert.Error(t, it.Next())
+
+}
+
+func ticketToUint64(ticket types.Ticket) uint64 {
+	fmt.Printf("ticket %x\n", ticket.VDFResult)
+	return binary.BigEndian.Uint64(ticket.VDFResult)
+}
+
+func uint64ToByte(i uint64) []byte {
+	out := make([]byte, binary.Size(i))
+	binary.BigEndian.PutUint64(out, i)
+	return out
 }

--- a/message/inbox_test.go
+++ b/message/inbox_test.go
@@ -341,7 +341,7 @@ func TestUpdateMessagePool(t *testing.T) {
 			// update pool with tipset that has no messages and four
 			// null blocks
 			next := chainProvider.BuildOneOn(head, func(bb *chain.BlockBuilder) {
-				bb.IncHeight(types.Uint64(4)) // 4 null blocks
+				bb.PrependNull(types.Uint64(4)) // 4 null blocks
 			})
 
 			assert.NoError(t, ib.HandleNewHead(ctx, nil, []types.TipSet{next}))

--- a/message/outbox_test.go
+++ b/message/outbox_test.go
@@ -45,7 +45,7 @@ func TestOutbox(t *testing.T) {
 		provider := message.NewFakeProvider(t)
 
 		head := provider.BuildOneOn(types.UndefTipSet, func(b *chain.BlockBuilder) {
-			b.IncHeight(1000)
+			b.PrependNull(1000)
 		})
 		actr, _ := account.NewActor(types.ZeroAttoFIL)
 		actr.Nonce = 42
@@ -86,7 +86,7 @@ func TestOutbox(t *testing.T) {
 		bcast := true
 
 		head := provider.BuildOneOn(types.UndefTipSet, func(b *chain.BlockBuilder) {
-			b.IncHeight(1000)
+			b.PrependNull(1000)
 		})
 		actr, _ := account.NewActor(types.ZeroAttoFIL)
 		actr.Nonce = 42

--- a/message/policy_test.go
+++ b/message/policy_test.go
@@ -89,7 +89,7 @@ func TestMessageQueuePolicy(t *testing.T) {
 		assert.Equal(t, qm(msgs[3], 100), q.List(bob)[0])
 
 		root := blocks.BuildOneOn(types.UndefTipSet, func(b *chain.BlockBuilder) {
-			b.IncHeight(103)
+			b.PrependNull(103)
 		})
 		b1 := blocks.BuildOneOn(root, func(b *chain.BlockBuilder) {
 			b.AddMessages(
@@ -151,12 +151,12 @@ func TestMessageQueuePolicy(t *testing.T) {
 		assert.Equal(t, qm(msgs[3], 200), q.List(bob)[0])
 
 		root := blocks.BuildOneOn(types.UndefTipSet, func(b *chain.BlockBuilder) {
-			b.IncHeight(100)
+			b.PrependNull(100)
 		})
 
 		// Skip 9 rounds since alice's first message enqueued, so b1 has height 110
 		b1 := blocks.BuildOneOn(root, func(b *chain.BlockBuilder) {
-			b.IncHeight(9)
+			b.PrependNull(9)
 		})
 
 		err := policy.HandleNewHead(ctx, q, nil, []types.TipSet{b1})
@@ -185,7 +185,7 @@ func TestMessageQueuePolicy(t *testing.T) {
 		}
 
 		root := blocks.BuildOneOn(types.UndefTipSet, func(b *chain.BlockBuilder) {
-			b.IncHeight(100)
+			b.PrependNull(100)
 		})
 
 		b1 := blocks.BuildOneOn(root, func(b *chain.BlockBuilder) {
@@ -211,7 +211,7 @@ func TestMessageQueuePolicy(t *testing.T) {
 		}
 
 		root := blocks.BuildOnBlock(nil, func(b *chain.BlockBuilder) {
-			b.IncHeight(100)
+			b.PrependNull(100)
 		})
 
 		// Construct two blocks at the same height, each with one message. The canonical
@@ -223,7 +223,7 @@ func TestMessageQueuePolicy(t *testing.T) {
 				[]*types.SignedMessage{msgs[0]},
 				types.EmptyReceipts(1),
 			)
-			b.SetTicket([]byte{1})
+			b.SetTickets([][]byte{{1}})
 			b.SetTimestamp(1)
 		})
 		b2 := blocks.BuildOnBlock(root, func(b *chain.BlockBuilder) {
@@ -231,8 +231,8 @@ func TestMessageQueuePolicy(t *testing.T) {
 				[]*types.SignedMessage{msgs[1]},
 				types.EmptyReceipts(1),
 			)
-			b.SetTicket([]byte{2})
-			b.SetTimestamp(2) // Tweak if necessary to force CID ordering opposite ticket ordering.
+			b.SetTickets([][]byte{{2}})
+			b.SetTimestamp(5) // Tweak if necessary to force CID ordering opposite ticket ordering.
 		})
 
 		assert.True(t, bytes.Compare(b1.Cid().Bytes(), b2.Cid().Bytes()) > 0)

--- a/message/policy_test.go
+++ b/message/policy_test.go
@@ -232,7 +232,7 @@ func TestMessageQueuePolicy(t *testing.T) {
 				types.EmptyReceipts(1),
 			)
 			b.SetTickets([][]byte{{2}})
-			b.SetTimestamp(5) // Tweak if necessary to force CID ordering opposite ticket ordering.
+			b.SetTimestamp(3) // Tweak if necessary to force CID ordering opposite ticket ordering.
 		})
 
 		assert.True(t, bytes.Compare(b1.Cid().Bytes(), b2.Cid().Bytes()) > 0)

--- a/sampling/chain_randomness_test.go
+++ b/sampling/chain_randomness_test.go
@@ -43,7 +43,7 @@ func TestSamplingChainRandomness(t *testing.T) {
 		// i.e.: 25 20 19 18 ... 0
 		headAfterNulls := builder.BuildOneOn(ch[0], func(b *chain.BlockBuilder) {
 			b.IncHeight(4)
-			b.SetTicket(types.Signature(strconv.Itoa(25)))
+			b.SetTickets([][]byte{types.Signature(strconv.Itoa(25))})
 		})
 		ch = append([]types.TipSet{headAfterNulls}, ch...)
 
@@ -90,7 +90,7 @@ func makeChain(t *testing.T, length int) (*chain.Builder, []types.TipSet) {
 	b := chain.NewBuilder(t, address.Undef)
 	height := 0
 	head := b.BuildManyOn(length, types.UndefTipSet, func(b *chain.BlockBuilder) {
-		b.SetTicket(types.Signature(strconv.Itoa(height)))
+		b.SetTickets([][]byte{types.Signature(strconv.Itoa(height))})
 		height++
 	})
 	return b, b.RequireTipSets(head.Key(), length)

--- a/types/ticket.go
+++ b/types/ticket.go
@@ -10,6 +10,9 @@ func init() {
 	cbor.RegisterCborType(Ticket{})
 }
 
+// UndefTicket is a singleton representing an undefined ticket
+var UndefTicket = Ticket{}
+
 // A Ticket is a marker of a tick of the blockchain's clock.  It is the source
 // of randomness for proofs of storage and leader election.  It is generated
 // by the miner of a block using a VRF and a VDF.


### PR DESCRIPTION
This PR updates randomness sampling to make use of all ticket array values per the spec.  Closes out #3433, don't review until #2223 is merged.

This is a protocol breaking change.  If we can get it in for 0.5.x awesome, if not we need to make an upgrade.