### PR TITLE
Change HAMT bitwidth to 5 for both global state tree and actor state

### DIFF
--- a/actor/storage.go
+++ b/actor/storage.go
@@ -17,7 +17,7 @@ import (
 const (
 	// TreeBitWidth is the bit width of the HAMT used to by an actor to
 	// store its state
-	TreeBitWidth = 4
+	TreeBitWidth = 5
 )
 
 // MarshalStorage encodes the passed in data into bytes.

--- a/actor/storage.go
+++ b/actor/storage.go
@@ -14,6 +14,12 @@ import (
 	vmerrors "github.com/filecoin-project/go-filecoin/vm/errors"
 )
 
+const (
+	// TreeBitWidth is the bit width of the HAMT used to by an actor to
+	// store its state
+	TreeBitWidth = 4
+)
+
 // MarshalStorage encodes the passed in data into bytes.
 func MarshalStorage(in interface{}) ([]byte, error) {
 	return cbor.DumpObject(in)
@@ -130,9 +136,9 @@ func LoadLookup(ctx context.Context, storage exec.Storage, cid cid.Cid) (exec.Lo
 	var err error
 
 	if !cid.Defined() {
-		root = hamt.NewNode(cborStore)
+		root = hamt.NewNode(cborStore, hamt.UseTreeBitWidth(TreeBitWidth))
 	} else {
-		root, err = hamt.LoadNode(ctx, cborStore, cid)
+		root, err = hamt.LoadNode(ctx, cborStore, cid, hamt.UseTreeBitWidth(TreeBitWidth))
 		if err != nil {
 			return nil, err
 		}

--- a/state/tree.go
+++ b/state/tree.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// TreeBitWidth is the bit width of the HAMT used to store a state tree
-	TreeBitWidth = 4
+	TreeBitWidth = 5
 )
 
 // tree is a state tree that maps addresses to actors.

--- a/state/tree.go
+++ b/state/tree.go
@@ -14,6 +14,11 @@ import (
 	"github.com/filecoin-project/go-filecoin/exec"
 )
 
+const (
+	// TreeBitWidth is the bit width of the HAMT used to store a state tree
+	TreeBitWidth = 4
+)
+
 // tree is a state tree that maps addresses to actors.
 type tree struct {
 	// root is the root of the state merklehamt
@@ -68,7 +73,7 @@ func (stl *TreeStateLoader) LoadStateTree(ctx context.Context, store IpldStore, 
 // LoadStateTree loads the state tree referenced by the given cid.
 func LoadStateTree(ctx context.Context, store IpldStore, c cid.Cid, builtinActors map[cid.Cid]exec.ExecutableActor) (Tree, error) {
 	// TODO ideally this assertion can go away when #3078 lands in go-ipld-cbor
-	root, err := hamt.LoadNode(ctx, store.(*hamt.CborIpldStore), c)
+	root, err := hamt.LoadNode(ctx, store.(*hamt.CborIpldStore), c, hamt.UseTreeBitWidth(TreeBitWidth))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to load node for %s", c)
 	}
@@ -94,7 +99,7 @@ func NewEmptyStateTreeWithActors(store *hamt.CborIpldStore, builtinActors map[ci
 
 func newEmptyStateTree(store *hamt.CborIpldStore) *tree {
 	return &tree{
-		root:          hamt.NewNode(store),
+		root:          hamt.NewNode(store, hamt.UseTreeBitWidth(TreeBitWidth)),
 		store:         store,
 		builtinActors: map[cid.Cid]exec.ExecutableActor{},
 	}
@@ -201,7 +206,7 @@ func forEachActor(ctx context.Context, cst *hamt.CborIpldStore, nd *hamt.Node, w
 			}
 		}
 		if p.Link.Defined() {
-			n, err := hamt.LoadNode(context.Background(), cst, p.Link)
+			n, err := hamt.LoadNode(context.Background(), cst, p.Link, hamt.UseTreeBitWidth(TreeBitWidth))
 			if err != nil {
 				return err
 			}
@@ -230,7 +235,7 @@ func (t *tree) debugPointer(ps []*hamt.Pointer) {
 			fmt.Printf("%s: %X\n", kv.Key, kv.Value)
 		}
 		if p.Link.Defined() {
-			n, err := hamt.LoadNode(context.Background(), t.store, p.Link)
+			n, err := hamt.LoadNode(context.Background(), t.store, p.Link, hamt.UseTreeBitWidth(TreeBitWidth))
 			if err != nil {
 				fmt.Printf("unable to print link: %s: %s\n", p.Link.String(), err)
 				continue
@@ -283,7 +288,7 @@ func (t *tree) getActorsFromPointers(ctx context.Context, out chan<- GetAllActor
 			}
 		}
 		if p.Link.Defined() {
-			n, err := hamt.LoadNode(context.Background(), t.store, p.Link)
+			n, err := hamt.LoadNode(context.Background(), t.store, p.Link, hamt.UseTreeBitWidth(TreeBitWidth))
 			// Even if we hit an error and can't follow this link, we should
 			// keep traversing its siblings.
 			if err != nil {


### PR DESCRIPTION
# Goals

Lower the fanout on our HAMTs to increase performance of state transitions

# Implementation

- Simply use an alternate bitwidth for when creating and loading nodes in our HAMT.
- Based off testing of HAMT performance in https://github.com/ipfs/go-hamt-ipld/pull/33 - bitwidth 4 (fanout = 16) shows  very strong performance. Bitwidth 3 shows slightly stronger performance but approaches diminishing returns and my anxiety is lower than is commonly used in creating HAMTS
- Based of @acruikshank 's testing of Payment Channels however, bitwidth 5 shows the strongest performance in real world tests, so that is what we are using until we have better HAMT tests.

# For Discussion

This is a PROTOCOL BREAKING CHANGE because the difference in storage means there will be different state CIDs. We won't be able to change it again after 0.5 without breaking protocol, so it's not clear whether we want to do more extensive testing before we throw it in.