### PR TITLE
expose set head and sync over cli

### DIFF
--- a/commands/utils.go
+++ b/commands/utils.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strconv"
 
+	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-ipfs-cmds"
 	"github.com/pkg/errors"
 
@@ -134,4 +135,16 @@ func fromAddrOrDefault(req *cmds.Request, env cmds.Environment) (address.Address
 		return GetPorcelainAPI(env).WalletDefaultAddress()
 	}
 	return addr, nil
+}
+
+func cidsFromSlice(args []string) ([]cid.Cid, error) {
+	out := make([]cid.Cid, len(args))
+	for i, arg := range args {
+		c, err := cid.Decode(arg)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = c
+	}
+	return out, nil
 }

--- a/node/builder.go
+++ b/node/builder.go
@@ -167,7 +167,7 @@ func (nc *Builder) build(ctx context.Context) (*Node, error) {
 	// set up chain and message stores
 	chainStore := chain.NewStore(nc.Repo.ChainDatastore(), &ipldCborStore, &state.TreeStateLoader{}, chainStatusReporter, genCid)
 	messageStore := chain.NewMessageStore(&ipldCborStore)
-	chainState := cst.NewChainStateProvider(chainStore, messageStore, &ipldCborStore)
+	chainState := cst.NewChainStateReadWriter(chainStore, messageStore, &ipldCborStore)
 	powerTable := &consensus.MarketView{}
 
 	// create protocol upgrade table

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -45,7 +45,7 @@ type API struct {
 	logger logging.EventLogger
 
 	bitswap       exchange.Interface
-	chain         *cst.ChainStateProvider
+	chain         *cst.ChainStateReadWriter
 	syncer        *cst.ChainSyncProvider
 	config        *cfg.Config
 	dag           *dag.DAG
@@ -64,7 +64,7 @@ type API struct {
 // APIDeps contains all the API's dependencies
 type APIDeps struct {
 	Bitswap       exchange.Interface
-	Chain         *cst.ChainStateProvider
+	Chain         *cst.ChainStateReadWriter
 	Sync          *cst.ChainSyncProvider
 	Config        *cfg.Config
 	DAG           *dag.DAG
@@ -159,6 +159,11 @@ func (api *API) ChainGetReceipts(ctx context.Context, id cid.Cid) ([]*types.Mess
 // ChainHeadKey returns the head tipset key
 func (api *API) ChainHeadKey() types.TipSetKey {
 	return api.chain.Head()
+}
+
+// ChainSetHead sets `key` as the new head of this chain iff it exists in the nodes chain store.
+func (api *API) ChainSetHead(ctx context.Context, key types.TipSetKey) error {
+	return api.chain.SetHead(ctx, key)
 }
 
 // ChainTipSet returns the tipset at the given key

--- a/plumbing/cst/chain_state.go
+++ b/plumbing/cst/chain_state.go
@@ -17,16 +17,18 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
-type chainReader interface {
+type chainReadWriter interface {
 	GetHead() types.TipSetKey
 	GetTipSet(types.TipSetKey) (types.TipSet, error)
 	GetTipSetState(context.Context, types.TipSetKey) (state.Tree, error)
+	SetHead(context.Context, types.TipSet) error
 }
 
-// ChainStateProvider composes a chain and a state store to provide access to
-// the state (including actors) derived from a chain.
-type ChainStateProvider struct {
-	reader          chainReader         // Provides chain tipsets and state roots.
+// ChainStateReadWriter composes a:
+// ChainReader providing read access to the chain and its associated state.
+// ChainWriter providing write access to the chain head.
+type ChainStateReadWriter struct {
+	readWriter      chainReadWriter
 	cst             *hamt.CborIpldStore // Provides chain blocks and state trees.
 	messageProvider chain.MessageProvider
 }
@@ -41,59 +43,59 @@ var (
 	ErrNoActorImpl = errors.New("no actor implementation")
 )
 
-// NewChainStateProvider returns a new ChainStateProvider.
-func NewChainStateProvider(chainReader chainReader, messages chain.MessageProvider, cst *hamt.CborIpldStore) *ChainStateProvider {
-	return &ChainStateProvider{
-		reader:          chainReader,
+// NewChainStateReadWriter returns a new ChainStateReadWriter.
+func NewChainStateReadWriter(crw chainReadWriter, messages chain.MessageProvider, cst *hamt.CborIpldStore) *ChainStateReadWriter {
+	return &ChainStateReadWriter{
+		readWriter:      crw,
 		cst:             cst,
 		messageProvider: messages,
 	}
 }
 
 // Head returns the head tipset
-func (chn *ChainStateProvider) Head() types.TipSetKey {
-	return chn.reader.GetHead()
+func (chn *ChainStateReadWriter) Head() types.TipSetKey {
+	return chn.readWriter.GetHead()
 }
 
 // GetTipSet returns the tipset at the given key
-func (chn *ChainStateProvider) GetTipSet(key types.TipSetKey) (types.TipSet, error) {
-	return chn.reader.GetTipSet(key)
+func (chn *ChainStateReadWriter) GetTipSet(key types.TipSetKey) (types.TipSet, error) {
+	return chn.readWriter.GetTipSet(key)
 }
 
 // Ls returns an iterator over tipsets from head to genesis.
-func (chn *ChainStateProvider) Ls(ctx context.Context) (*chain.TipsetIterator, error) {
-	ts, err := chn.reader.GetTipSet(chn.reader.GetHead())
+func (chn *ChainStateReadWriter) Ls(ctx context.Context) (*chain.TipsetIterator, error) {
+	ts, err := chn.readWriter.GetTipSet(chn.readWriter.GetHead())
 	if err != nil {
 		return nil, err
 	}
-	return chain.IterAncestors(ctx, chn.reader, ts), nil
+	return chain.IterAncestors(ctx, chn.readWriter, ts), nil
 }
 
 // GetBlock gets a block by CID
-func (chn *ChainStateProvider) GetBlock(ctx context.Context, id cid.Cid) (*types.Block, error) {
+func (chn *ChainStateReadWriter) GetBlock(ctx context.Context, id cid.Cid) (*types.Block, error) {
 	var out types.Block
 	err := chn.cst.Get(ctx, id, &out)
 	return &out, err
 }
 
 // GetMessages gets a message collection by CID.
-func (chn *ChainStateProvider) GetMessages(ctx context.Context, id cid.Cid) ([]*types.SignedMessage, error) {
+func (chn *ChainStateReadWriter) GetMessages(ctx context.Context, id cid.Cid) ([]*types.SignedMessage, error) {
 	return chn.messageProvider.LoadMessages(ctx, id)
 }
 
 // GetReceipts gets a receipt collection by CID.
-func (chn *ChainStateProvider) GetReceipts(ctx context.Context, id cid.Cid) ([]*types.MessageReceipt, error) {
+func (chn *ChainStateReadWriter) GetReceipts(ctx context.Context, id cid.Cid) ([]*types.MessageReceipt, error) {
 	return chn.messageProvider.LoadReceipts(ctx, id)
 }
 
 // SampleRandomness samples randomness from the chain at the given height.
-func (chn *ChainStateProvider) SampleRandomness(ctx context.Context, sampleHeight *types.BlockHeight) ([]byte, error) {
-	head := chn.reader.GetHead()
-	headTipSet, err := chn.reader.GetTipSet(head)
+func (chn *ChainStateReadWriter) SampleRandomness(ctx context.Context, sampleHeight *types.BlockHeight) ([]byte, error) {
+	head := chn.readWriter.GetHead()
+	headTipSet, err := chn.readWriter.GetTipSet(head)
 	if err != nil {
 		return nil, err
 	}
-	tipSetBuffer, err := chain.GetRecentAncestors(ctx, headTipSet, chn.reader, sampleHeight)
+	tipSetBuffer, err := chain.GetRecentAncestors(ctx, headTipSet, chn.readWriter, sampleHeight)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get recent ancestors")
 	}
@@ -102,13 +104,13 @@ func (chn *ChainStateProvider) SampleRandomness(ctx context.Context, sampleHeigh
 }
 
 // GetActor returns an actor from the latest state on the chain
-func (chn *ChainStateProvider) GetActor(ctx context.Context, addr address.Address) (*actor.Actor, error) {
-	return chn.GetActorAt(ctx, chn.reader.GetHead(), addr)
+func (chn *ChainStateReadWriter) GetActor(ctx context.Context, addr address.Address) (*actor.Actor, error) {
+	return chn.GetActorAt(ctx, chn.readWriter.GetHead(), addr)
 }
 
 // GetActorAt returns an actor at a specified tipset key.
-func (chn *ChainStateProvider) GetActorAt(ctx context.Context, tipKey types.TipSetKey, addr address.Address) (*actor.Actor, error) {
-	st, err := chn.reader.GetTipSetState(ctx, tipKey)
+func (chn *ChainStateReadWriter) GetActorAt(ctx context.Context, tipKey types.TipSetKey, addr address.Address) (*actor.Actor, error) {
+	st, err := chn.readWriter.GetTipSetState(ctx, tipKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load latest state")
 	}
@@ -121,8 +123,8 @@ func (chn *ChainStateProvider) GetActorAt(ctx context.Context, tipKey types.TipS
 }
 
 // LsActors returns a channel with actors from the latest state on the chain
-func (chn *ChainStateProvider) LsActors(ctx context.Context) (<-chan state.GetAllActorsResult, error) {
-	st, err := chn.reader.GetTipSetState(ctx, chn.reader.GetHead())
+func (chn *ChainStateReadWriter) LsActors(ctx context.Context) (<-chan state.GetAllActorsResult, error) {
+	st, err := chn.readWriter.GetTipSetState(ctx, chn.readWriter.GetHead())
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +134,7 @@ func (chn *ChainStateProvider) LsActors(ctx context.Context) (<-chan state.GetAl
 // GetActorSignature returns the signature of the given actor's given method.
 // The function signature is typically used to enable a caller to decode the
 // output of an actor method call (message).
-func (chn *ChainStateProvider) GetActorSignature(ctx context.Context, actorAddr address.Address, method string) (*exec.FunctionSignature, error) {
+func (chn *ChainStateReadWriter) GetActorSignature(ctx context.Context, actorAddr address.Address, method string) (*exec.FunctionSignature, error) {
 	if method == "" {
 		return nil, ErrNoMethod
 	}
@@ -144,7 +146,7 @@ func (chn *ChainStateProvider) GetActorSignature(ctx context.Context, actorAddr 
 		return nil, ErrNoActorImpl
 	}
 
-	st, err := chn.reader.GetTipSetState(ctx, chn.reader.GetHead())
+	st, err := chn.readWriter.GetTipSetState(ctx, chn.readWriter.GetHead())
 	if err != nil {
 		return nil, err
 	}
@@ -160,4 +162,13 @@ func (chn *ChainStateProvider) GetActorSignature(ctx context.Context, actorAddr 
 	}
 
 	return export, nil
+}
+
+// SetHead sets `key` as the new head of this chain iff it exists in the nodes chain store.
+func (chn *ChainStateReadWriter) SetHead(ctx context.Context, key types.TipSetKey) error {
+	headTs, err := chn.readWriter.GetTipSet(key)
+	if err != nil {
+		return err
+	}
+	return chn.readWriter.SetHead(ctx, headTs)
 }


### PR DESCRIPTION
This PR closes #3414
Of the options discussed here: https://github.com/filecoin-project/go-filecoin/issues/3442#issuecomment-532071672, we are going with C: bouncing the node after a call to SetHead to trigger chain reprocessing.