### PR TITLE
change lookback parameter to 15

### DIFF
--- a/sampling/chain_randomness.go
+++ b/sampling/chain_randomness.go
@@ -9,7 +9,7 @@ import (
 // LookbackParameter defines how many non-empty tiptsets (not rounds) earlier than any sample
 // height (in rounds) from which to sample the chain for randomness.
 // This constant is a protocol (actor) parameter and should be defined in actor code.
-const LookbackParameter = 3
+const LookbackParameter = 15
 
 // SampleChainRandomness produces a slice of bytes (a ticket) sampled from the tipset `LookbackParameter`
 // tipsets (not rounds) prior to the highest tipset with height less than or equal to `sampleHeight`.


### PR DESCRIPTION
### Problem

Storage miners generate PoSt proofs at the very beginning of their proving window. The chain randomness they get had been 3 tip sets before this (defined by the `LookbackParameter`. It turns out 3 tipsets is too little because reorgs of 3 or more tipsets are fairly common.

### Solution

This is a short term solution to increase the lookback parameter to 15. The Rational PoSt spec does note define a LookbackInterval, so a better (but more time consuming) solution would be to remove the LookbackParameter altogether and define a safety interval (also 15) for the miner to wait after the proving window start to avoid reorgs.