### PR TITLE
Storage miner worker waits 15 rounds before beginning PoSt computation.

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -429,7 +429,7 @@ func (node *Node) handleNewChainHeads(ctx context.Context, prevHead types.TipSet
 			}
 
 			if node.StorageMiner != nil {
-				if err := node.StorageMiner.OnNewHeaviestTipSet(newHead); err != nil {
+				if _, err := node.StorageMiner.OnNewHeaviestTipSet(newHead); err != nil {
 					log.Error(err)
 				}
 			}


### PR DESCRIPTION
This 15 is hard-coded in the name of expediency, but should be pulled out
into a configuration value, along with other policy constants.

The latch returned from OnNewHeaviestTipSet reduces the miner_test latency
from some 8 seconds to 20ms.

This is a partial solution to #3429.