### PR TITLE
Remove lookback from chain sampling for PoSt challenge seed.

### DIFF
--- a/chain/syncer.go
+++ b/chain/syncer.go
@@ -14,7 +14,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/metrics"
 	"github.com/filecoin-project/go-filecoin/metrics/tracing"
 	"github.com/filecoin-project/go-filecoin/net"
-	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -152,9 +151,8 @@ func (syncer *Syncer) syncOne(ctx context.Context, parent, next types.TipSet) er
 	if err != nil {
 		return err
 	}
-	newBlockHeight := types.NewBlockHeight(h)
-	ancestorHeight := types.NewBlockHeight(consensus.AncestorRoundsNeeded)
-	ancestors, err := GetRecentAncestors(ctx, parent, syncer.chainStore, newBlockHeight, ancestorHeight, sampling.LookbackParameter)
+	ancestorHeight := types.NewBlockHeight(h).Sub(types.NewBlockHeight(consensus.AncestorRoundsNeeded))
+	ancestors, err := GetRecentAncestors(ctx, parent, syncer.chainStore, ancestorHeight)
 	if err != nil {
 		return err
 	}

--- a/consensus/expected.go
+++ b/consensus/expected.go
@@ -69,6 +69,7 @@ const ECPrM uint64 = 100
 // TODO: If the following PR is merged - and the network doesn't define a
 // largest sector size - this constant will need to be reconsidered.
 // https://github.com/filecoin-project/specs/pull/318
+// NOTE(anorth): This height is excessive, but safe, with the Rational PoSt construction.
 const AncestorRoundsNeeded = miner.LargestSectorSizeProvingPeriodBlocks + miner.PoStChallengeWindowBlocks
 
 // A Processor processes all the messages in a block or tip set.

--- a/node/node.go
+++ b/node/node.go
@@ -41,7 +41,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/protocol/retrieval"
 	"github.com/filecoin-project/go-filecoin/protocol/storage"
 	"github.com/filecoin-project/go-filecoin/repo"
-	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/util/moresync"
@@ -929,8 +928,8 @@ func (node *Node) getWeight(ctx context.Context, ts types.TipSet) (uint64, error
 
 // getAncestors is the default GetAncestors function for the mining worker.
 func (node *Node) getAncestors(ctx context.Context, ts types.TipSet, newBlockHeight *types.BlockHeight) ([]types.TipSet, error) {
-	ancestorHeight := types.NewBlockHeight(consensus.AncestorRoundsNeeded)
-	return chain.GetRecentAncestors(ctx, ts, node.ChainReader, newBlockHeight, ancestorHeight, sampling.LookbackParameter)
+	ancestorHeight := newBlockHeight.Sub(types.NewBlockHeight(consensus.AncestorRoundsNeeded))
+	return chain.GetRecentAncestors(ctx, ts, node.ChainReader, ancestorHeight)
 }
 
 // -- Accessors

--- a/plumbing/cst/chain_state.go
+++ b/plumbing/cst/chain_state.go
@@ -11,7 +11,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
-	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/state"
@@ -94,8 +93,7 @@ func (chn *ChainStateProvider) SampleRandomness(ctx context.Context, sampleHeigh
 	if err != nil {
 		return nil, err
 	}
-	ancestorHeight := types.NewBlockHeight(consensus.AncestorRoundsNeeded)
-	tipSetBuffer, err := chain.GetRecentAncestors(ctx, headTipSet, chn.reader, sampleHeight, ancestorHeight, sampling.LookbackParameter)
+	tipSetBuffer, err := chain.GetRecentAncestors(ctx, headTipSet, chn.reader, sampleHeight)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get recent ancestors")
 	}

--- a/plumbing/msg/waiter.go
+++ b/plumbing/msg/waiter.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/consensus"
-	"github.com/filecoin-project/go-filecoin/sampling"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
@@ -220,13 +219,12 @@ func (w *Waiter) receiptFromTipSet(ctx context.Context, msgCid cid.Cid, ts types
 	if err != nil {
 		return nil, err
 	}
-	tsBlockHeight := types.NewBlockHeight(tsHeight)
-	ancestorHeight := types.NewBlockHeight(consensus.AncestorRoundsNeeded)
+	ancestorHeight := types.NewBlockHeight(tsHeight).Sub(types.NewBlockHeight(consensus.AncestorRoundsNeeded))
 	parentTs, err := w.chainReader.GetTipSet(ids)
 	if err != nil {
 		return nil, err
 	}
-	ancestors, err := chain.GetRecentAncestors(ctx, parentTs, w.chainReader, tsBlockHeight, ancestorHeight, sampling.LookbackParameter)
+	ancestors, err := chain.GetRecentAncestors(ctx, parentTs, w.chainReader, ancestorHeight)
 	if err != nil {
 		return nil, err
 	}

--- a/sampling/chain_randomness.go
+++ b/sampling/chain_randomness.go
@@ -6,22 +6,23 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
-// LookbackParameter defines how many non-empty tiptsets (not rounds) earlier than any sample
-// height (in rounds) from which to sample the chain for randomness.
-// This constant is a protocol (actor) parameter and should be defined in actor code.
-const LookbackParameter = 3
-
-// SampleChainRandomness produces a slice of bytes (a ticket) sampled from the tipset `LookbackParameter`
-// tipsets (not rounds) prior to the highest tipset with height less than or equal to `sampleHeight`.
+// SampleChainRandomness produces a slice of bytes (a ticket) sampled from the highest tipset with
+// height less than or equal to `sampleHeight`.
 // The tipset slice must be sorted by descending block height.
 func SampleChainRandomness(sampleHeight *types.BlockHeight, tipSetsDescending []types.TipSet) ([]byte, error) {
+	if sampleHeight.LessThan(types.NewBlockHeight(0)) {
+		return nil, errors.Errorf("can't sample chain at negative height %s", sampleHeight)
+	}
+	if len(tipSetsDescending) == 0 {
+		return nil, errors.New("can't sample empty chain segment")
+	}
 	// Find the first (highest) tipset with height less than or equal to sampleHeight.
 	// This is more complex than necessary: https://github.com/filecoin-project/go-filecoin/issues/3025
 	sampleIndex := -1
 	for i, tip := range tipSetsDescending {
 		height, err := tip.Height()
 		if err != nil {
-			return nil, errors.Wrap(err, "error obtaining tip set height")
+			return nil, errors.Wrapf(err, "failed sampling chain segment")
 		}
 
 		if types.NewBlockHeight(height).LessEqual(sampleHeight) {
@@ -32,32 +33,18 @@ func SampleChainRandomness(sampleHeight *types.BlockHeight, tipSetsDescending []
 
 	// Produce an error if the slice does not include any tipsets at least as low as `sampleHeight`.
 	if sampleIndex == -1 {
-		return nil, errors.Errorf("sample height out of range: %s", sampleHeight)
-	}
-
-	// Now look LookbackParameter tipsets (not rounds) prior to the sample tipset.
-	lookbackIdx := sampleIndex + LookbackParameter
-	lastIdx := len(tipSetsDescending) - 1
-	if lookbackIdx > lastIdx {
-		// If this index farther than the lowest height (last) tipset in the slice, then
-		// - if the lowest is the genesis, use that, else
-		// - error (the tipset slice is insufficient)
-		//
-		// TODO: security, spec, bootstrap implications.
-		// See issue https://github.com/filecoin-project/go-filecoin/issues/1872
+		lastIdx := len(tipSetsDescending) - 1
 		lowestAvailableHeight, err := tipSetsDescending[lastIdx].Height()
 		if err != nil {
-			return nil, errors.Wrap(err, "error obtaining tip set height")
+			return nil, errors.Wrap(err, "failed to read chain segment height")
 		}
 
-		if lowestAvailableHeight == uint64(0) {
-			lookbackIdx = lastIdx
-		} else {
-			errMsg := "sample height out of range: lookbackIdx=%d, lastHeightInChain=%d"
-			return nil, errors.Errorf(errMsg, lookbackIdx, lowestAvailableHeight)
-		}
+		return nil, errors.Errorf("sample height %s out of range %d...", sampleHeight, lowestAvailableHeight)
 	}
 
-	ticket, err := tipSetsDescending[lookbackIdx].MinTicket()
-	return ticket.SortKey(), err
+	ticket, err := tipSetsDescending[sampleIndex].MinTicket()
+	if err != nil {
+		return nil, err
+	}
+	return ticket.SortKey(), nil
 }

--- a/sampling/chain_randomness_test.go
+++ b/sampling/chain_randomness_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
@@ -17,31 +16,28 @@ import (
 func TestSamplingChainRandomness(t *testing.T) {
 	tf.UnitTest(t)
 
-	// set a tripwire
-	require.Equal(t, sampling.LookbackParameter, 3, "these tests assume LookbackParameter=3")
-
 	t.Run("happy path", func(t *testing.T) {
 		_, ch := makeChain(t, 21)
 		r, err := sampling.SampleChainRandomness(types.NewBlockHeight(uint64(20)), ch)
 		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(17)), r)
+		assert.Equal(t, []byte(strconv.Itoa(20)), r)
 
 		r, err = sampling.SampleChainRandomness(types.NewBlockHeight(uint64(3)), ch)
 		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(0)), r)
+		assert.Equal(t, []byte(strconv.Itoa(3)), r)
 
-		r, err = sampling.SampleChainRandomness(types.NewBlockHeight(uint64(10)), ch)
+		r, err = sampling.SampleChainRandomness(types.NewBlockHeight(uint64(0)), ch)
 		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(7)), r)
+		assert.Equal(t, []byte(strconv.Itoa(0)), r)
 	})
 
 	t.Run("skips missing tipsets", func(t *testing.T) {
 		builder, ch := makeChain(t, 21)
 
-		// Sample height after the head falls back to the head, and then looks back from there
+		// Sample height after the head falls back to the head
 		r, err := sampling.SampleChainRandomness(types.NewBlockHeight(uint64(25)), ch)
 		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(17)), r)
+		assert.Equal(t, []byte(strconv.Itoa(20)), r)
 
 		// Add new head so as to produce null blocks between 20 and 25
 		// i.e.: 25 20 19 18 ... 0
@@ -54,12 +50,12 @@ func TestSamplingChainRandomness(t *testing.T) {
 		// Sampling in the nulls falls back to the last non-null
 		r, err = sampling.SampleChainRandomness(types.NewBlockHeight(uint64(24)), ch)
 		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(17)), r)
+		assert.Equal(t, []byte(strconv.Itoa(20)), r)
 
 		// When sampling immediately after the nulls, the look-back skips the nulls (not counting them).
 		r, err = sampling.SampleChainRandomness(types.NewBlockHeight(uint64(25)), ch)
 		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(18)), r)
+		assert.Equal(t, []byte(strconv.Itoa(25)), r)
 	})
 
 	t.Run("fails when chain insufficient", func(t *testing.T) {
@@ -72,14 +68,8 @@ func TestSamplingChainRandomness(t *testing.T) {
 		_, err := sampling.SampleChainRandomness(types.NewBlockHeight(uint64(15)), ch)
 		assert.Error(t, err)
 
-		// Sample minus lookback is out of range
-		_, err = sampling.SampleChainRandomness(types.NewBlockHeight(uint64(16)), ch)
-		assert.Error(t, err)
-		_, err = sampling.SampleChainRandomness(types.NewBlockHeight(uint64(18)), ch)
-		assert.Error(t, err)
-
 		// Ok when the chain is just sufficiently long.
-		r, err := sampling.SampleChainRandomness(types.NewBlockHeight(uint64(19)), ch)
+		r, err := sampling.SampleChainRandomness(types.NewBlockHeight(uint64(16)), ch)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte(strconv.Itoa(16)), r)
 	})
@@ -87,13 +77,8 @@ func TestSamplingChainRandomness(t *testing.T) {
 	t.Run("falls back to genesis block", func(t *testing.T) {
 		_, ch := makeChain(t, 6)
 
-		// Three blocks back from "1"
-		r, err := sampling.SampleChainRandomness(types.NewBlockHeight(uint64(1)), ch)
-		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(0)), r)
-
 		// Sample height can be zero.
-		r, err = sampling.SampleChainRandomness(types.NewBlockHeight(uint64(0)), ch)
+		r, err := sampling.SampleChainRandomness(types.NewBlockHeight(uint64(0)), ch)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte(strconv.Itoa(0)), r)
 	})


### PR DESCRIPTION
Rational PoSt has no lookback, the chain is sampled at the opening of the proving window.
The spec is unclear about what to do if this is a null tipset, this PR takes the previous
non-empty tipset. This is intended to make sense along with #3450, which waits for the
chain to settle before beginning a PoSt.

This removes PoSt challenge generation from the scope of #1872.

The code that gets the blocks for sampling is all waaay more complicated than necessary now (#3025).