### PR TITLE
refactor: cleanup node internals 

### DIFF
--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -10,12 +10,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/ipfs/go-ipfs-cmdkit"
-	"github.com/ipfs/go-ipfs-cmds"
+	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
+	cmds "github.com/ipfs/go-ipfs-cmds"
 	cmdhttp "github.com/ipfs/go-ipfs-cmds/http"
 	writer "github.com/ipfs/go-log/writer"
 	ma "github.com/multiformats/go-multiaddr"
-	"github.com/multiformats/go-multiaddr-net"
+	manet "github.com/multiformats/go-multiaddr-net"
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/clock"
@@ -153,12 +153,12 @@ func getRepo(req *cmds.Request) (repo.Repo, error) {
 // A message sent to or closure of the `terminate` channel signals the server to stop.
 func RunAPIAndWait(ctx context.Context, nd *node.Node, config *config.APIConfig, ready chan interface{}, terminate chan os.Signal) error {
 	servenv := &Env{
-		blockMiningAPI: nd.BlockMiningAPI,
+		blockMiningAPI: nd.BlockMining.BlockMiningAPI,
 		ctx:            ctx,
 		inspectorAPI:   NewInspectorAPI(nd.Repo),
 		porcelainAPI:   nd.PorcelainAPI,
-		retrievalAPI:   nd.RetrievalAPI,
-		storageAPI:     nd.StorageAPI,
+		retrievalAPI:   nd.RetrievalProtocol.RetrievalAPI,
+		storageAPI:     nd.StorageProtocol.StorageAPI,
 	}
 
 	cfg := cmdhttp.NewServerConfig()

--- a/commands/ping_daemon_test.go
+++ b/commands/ping_daemon_test.go
@@ -23,18 +23,18 @@ func TestPing2Nodes(t *testing.T) {
 	defer n2.Stop(ctx)
 
 	// The node are not initially connected, so ping should fail.
-	res0, err := n1.PorcelainAPI.NetworkPing(ctx, n2.PeerHost.ID())
+	res0, err := n1.PorcelainAPI.NetworkPing(ctx, n2.Network.PeerHost.ID())
 	assert.NoError(t, err)
 	assert.Error(t, (<-res0).Error) // No peers in table
 
 	// Connect nodes and check each can ping the other.
 	node.ConnectNodes(t, n1, n2)
 
-	res1, err := n1.PorcelainAPI.NetworkPing(ctx, n2.PeerHost.ID())
+	res1, err := n1.PorcelainAPI.NetworkPing(ctx, n2.Network.PeerHost.ID())
 	assert.NoError(t, err)
 	assert.NoError(t, (<-res1).Error)
 
-	res2, err := n2.PorcelainAPI.NetworkPing(ctx, n1.PeerHost.ID())
+	res2, err := n2.PorcelainAPI.NetworkPing(ctx, n1.Network.PeerHost.ID())
 	assert.NoError(t, err)
 	assert.NoError(t, (<-res2).Error)
 }

--- a/commands/protocol_cmd_test.go
+++ b/commands/protocol_cmd_test.go
@@ -23,7 +23,7 @@ func TestProtocol(t *testing.T) {
 			c.Mining.AutoSealIntervalSeconds = 120
 		}).
 		Build(ctx)
-	require.NoError(t, node.ChainReader.Load(ctx))
+	require.NoError(t, node.Chain.ChainReader.Load(ctx))
 
 	// Run the command API.
 	cmd, stop := test.RunNodeAPI(ctx, node, t)

--- a/node/block_mining_submodule.go
+++ b/node/block_mining_submodule.go
@@ -1,0 +1,26 @@
+package node
+
+import (
+	"context"
+	"sync"
+
+	"github.com/filecoin-project/go-filecoin/mining"
+	"github.com/filecoin-project/go-filecoin/protocol/block"
+)
+
+// BlockMiningSubmodule enhances the `Node` with block mining capabilities.
+type BlockMiningSubmodule struct {
+	BlockMiningAPI *block.MiningAPI
+
+	// Mining stuff.
+	AddNewlyMinedBlock newBlockFunc
+	// cancelMining cancels the context for block production and sector commitments.
+	cancelMining    context.CancelFunc
+	MiningWorker    mining.Worker
+	MiningScheduler mining.Scheduler
+	mining          struct {
+		sync.Mutex
+		isMining bool
+	}
+	miningDoneWg *sync.WaitGroup
+}

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -31,8 +31,8 @@ func connect(t *testing.T, nd1, nd2 *Node) {
 }
 
 func requireMineOnce(ctx context.Context, t *testing.T, minerNode *Node) *types.Block {
-	head := minerNode.ChainReader.GetHead()
-	headTipSet, err := minerNode.ChainReader.GetTipSet(head)
+	head := minerNode.Chain.ChainReader.GetHead()
+	headTipSet, err := minerNode.Chain.ChainReader.GetTipSet(head)
 	require.NoError(t, err)
 	baseTS := headTipSet
 	require.NotNil(t, baseTS)
@@ -85,7 +85,7 @@ func TestBlockPropsManyNodes(t *testing.T) {
 	equal := false
 	for i := 0; i < 30; i++ {
 		for j := 1; j < numNodes; j++ {
-			otherHead := nodes[j].ChainReader.GetHead()
+			otherHead := nodes[j].Chain.ChainReader.GetHead()
 			assert.NotNil(t, otherHead)
 			equal = otherHead.ToSlice()[0].Equals(nextBlk.Cid())
 			if equal {
@@ -118,7 +118,7 @@ func TestChainSync(t *testing.T) {
 	connect(t, nodes[0], nodes[1])
 	equal := false
 	for i := 0; i < 30; i++ {
-		otherHead := nodes[1].ChainReader.GetHead()
+		otherHead := nodes[1].Chain.ChainReader.GetHead()
 		assert.NotNil(t, otherHead)
 		equal = otherHead.ToSlice()[0].Equals(thirdBlock.Cid())
 		if equal {

--- a/node/blockstore_submodule.go
+++ b/node/blockstore_submodule.go
@@ -1,0 +1,25 @@
+package node
+
+import (
+	bserv "github.com/ipfs/go-blockservice"
+	"github.com/ipfs/go-hamt-ipld"
+	bstore "github.com/ipfs/go-ipfs-blockstore"
+)
+
+// BlockstoreSubmodule enhances the `Node` with key/value storing capabilities.
+//
+// TODO: split chain data from piece data (issue: https://github.com/filecoin-project/go-filecoin/issues/3481)
+// Note: at present:
+// - `BlockService` is shared by chain/graphsync and piece/bitswap data
+// - `Blockstore` is shared by chain/graphsync and piece/bitswap data
+// - `cborStore` is used for chain state and shared with piece data exchange for deals at the moment.
+type BlockstoreSubmodule struct {
+	// Blockservice is a higher level interface for fetching data
+	blockservice bserv.BlockService
+
+	// Blockstore is the un-networked blocks interface
+	Blockstore bstore.Blockstore
+
+	// cborStore is a temporary interface for interacting with IPLD objects.
+	cborStore *hamt.CborIpldStore
+}

--- a/node/builder.go
+++ b/node/builder.go
@@ -272,28 +272,40 @@ func (nc *Builder) build(ctx context.Context) (*Node, error) {
 	outbox := message.NewOutbox(fcWallet, consensus.NewOutboundMessageValidator(), msgQueue, msgPublisher, outboxPolicy, chainStore, chainState)
 
 	nd := &Node{
-		blockservice: bservice,
-		Blockstore:   bs,
-		cborStore:    &ipldCborStore,
-		Clock:        nc.Clock,
-		Consensus:    nodeConsensus,
-		ChainReader:  chainStore,
-		ChainSynced:  moresync.NewLatch(1),
-		MessageStore: messageStore,
-		Syncer:       chainSyncer,
-		PowerTable:   powerTable,
-		PeerTracker:  peerTracker,
-		Fetcher:      fetcher,
-		Exchange:     bswap,
-		host:         peerHost,
-		Inbox:        inbox,
-		OfflineMode:  nc.OfflineMode,
-		Outbox:       outbox,
-		NetworkName:  network,
-		PeerHost:     peerHost,
-		Repo:         nc.Repo,
-		Wallet:       fcWallet,
-		Router:       router,
+		Clock:       nc.Clock,
+		OfflineMode: nc.OfflineMode,
+		Repo:        nc.Repo,
+		Network: NetworkSubmodule{
+			host:        peerHost,
+			PeerHost:    peerHost,
+			NetworkName: network,
+			PeerTracker: peerTracker,
+			Router:      router,
+		},
+		Wallet: WalletSubmodule{
+			Wallet: fcWallet,
+		},
+		Messaging: MessagingSubmodule{
+			Inbox:  inbox,
+			Outbox: outbox,
+		},
+		Blockstore: BlockstoreSubmodule{
+			blockservice: bservice,
+			Blockstore:   bs,
+			cborStore:    &ipldCborStore,
+		},
+		StorageNetworking: StorageNetworkingSubmodule{
+			Exchange: bswap,
+		},
+		Chain: ChainSubmodule{
+			Fetcher:      fetcher,
+			Consensus:    nodeConsensus,
+			ChainReader:  chainStore,
+			ChainSynced:  moresync.NewLatch(1),
+			MessageStore: messageStore,
+			Syncer:       chainSyncer,
+			PowerTable:   powerTable,
+		},
 	}
 
 	nd.PorcelainAPI = porcelain.New(plumbing.New(&plumbing.APIDeps{
@@ -328,7 +340,7 @@ func (nc *Builder) build(ctx context.Context) (*Node, error) {
 		return nil, errors.Wrapf(err, "couldn't parse bootstrap addresses [%s]", ba)
 	}
 	minPeerThreshold := nd.Repo.Config().Bootstrap.MinPeerThreshold
-	nd.Bootstrapper = net.NewBootstrapper(bpi, nd.Host(), nd.Host().Network(), nd.Router, minPeerThreshold, period)
+	nd.Network.Bootstrapper = net.NewBootstrapper(bpi, nd.Host(), nd.Host().Network(), nd.Network.Router, minPeerThreshold, period)
 
 	return nd, nil
 }

--- a/node/chain_submodule.go
+++ b/node/chain_submodule.go
@@ -1,0 +1,32 @@
+package node
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/net"
+	"github.com/filecoin-project/go-filecoin/net/pubsub"
+	"github.com/filecoin-project/go-filecoin/util/moresync"
+)
+
+// ChainSubmodule enhances the `Node` with chain capabilities.
+type ChainSubmodule struct {
+	BlockSub     pubsub.Subscription
+	Consensus    consensus.Protocol
+	ChainReader  nodeChainReader
+	MessageStore *chain.MessageStore
+	Syncer       nodeChainSyncer
+	PowerTable   consensus.PowerTableView
+	// HeavyTipSetCh is a subscription to the heaviest tipset topic on the chain.
+	// https://github.com/filecoin-project/go-filecoin/issues/2309
+	HeaviestTipSetCh chan interface{}
+	// cancelChainSync cancels the context for chain sync subscriptions and handlers.
+	cancelChainSync context.CancelFunc
+	// ChainSynced is a latch that releases when a nodes chain reaches a caught-up state.
+	// It serves as a barrier to be released when the initial chain sync has completed.
+	// Services which depend on a more-or-less synced chain can wait for this before starting up.
+	ChainSynced *moresync.Latch
+	// Fetcher is the interface for fetching data from nodes.
+	Fetcher net.Fetcher
+}

--- a/node/fault_slasher_submodule.go
+++ b/node/fault_slasher_submodule.go
@@ -1,0 +1,6 @@
+package node
+
+// FaultSlasherSubmodule enhances the `Node` with storage slashing capabilities.
+type FaultSlasherSubmodule struct {
+	StorageFaultSlasher storageFaultSlasher
+}

--- a/node/hello_protocol_submodule.go
+++ b/node/hello_protocol_submodule.go
@@ -1,0 +1,8 @@
+package node
+
+import "github.com/filecoin-project/go-filecoin/protocol/hello"
+
+// HelloProtocolSubmodule enhances the `Node` with "Hello" protocol capabilities.
+type HelloProtocolSubmodule struct {
+	HelloSvc *hello.Handler
+}

--- a/node/helpers.go
+++ b/node/helpers.go
@@ -1,0 +1,57 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+
+	ps "github.com/cskr/pubsub"
+	"github.com/filecoin-project/go-filecoin/chain"
+	"github.com/filecoin-project/go-filecoin/net/pubsub"
+	"github.com/filecoin-project/go-filecoin/state"
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/pkg/errors"
+)
+
+type pubSubHandler func(ctx context.Context, msg pubsub.Message) error
+
+type nodeChainReader interface {
+	GenesisCid() cid.Cid
+	GetHead() types.TipSetKey
+	GetTipSet(types.TipSetKey) (types.TipSet, error)
+	GetTipSetState(ctx context.Context, tsKey types.TipSetKey) (state.Tree, error)
+	HeadEvents() *ps.PubSub
+	Load(context.Context) error
+	Stop()
+}
+
+type nodeChainSyncer interface {
+	HandleNewTipSet(ctx context.Context, ci *types.ChainInfo, trusted bool) error
+}
+
+// storageFaultSlasher is the interface for needed FaultSlasher functionality
+type storageFaultSlasher interface {
+	OnNewHeaviestTipSet(context.Context, types.TipSet) error
+}
+
+type blankValidator struct{}
+
+func (blankValidator) Validate(_ string, _ []byte) error        { return nil }
+func (blankValidator) Select(_ string, _ [][]byte) (int, error) { return 0, nil }
+
+// readGenesisCid is a helper function that queries the provided datastore for
+// an entry with the genesisKey cid, returning if found.
+func readGenesisCid(ds datastore.Datastore) (cid.Cid, error) {
+	bb, err := ds.Get(chain.GenesisKey)
+	if err != nil {
+		return cid.Undef, errors.Wrap(err, "failed to read genesisKey")
+	}
+
+	var c cid.Cid
+	err = json.Unmarshal(bb, &c)
+	if err != nil {
+		return cid.Undef, errors.Wrap(err, "failed to cast genesisCid")
+	}
+	return c, nil
+}

--- a/node/mesaging_submodule.go
+++ b/node/mesaging_submodule.go
@@ -1,0 +1,18 @@
+package node
+
+import (
+	"github.com/filecoin-project/go-filecoin/message"
+	"github.com/filecoin-project/go-filecoin/net/pubsub"
+)
+
+// MessagingSubmodule enhances the `Node` with internal messaging capabilities.
+type MessagingSubmodule struct {
+	// Incoming messages for block mining.
+	Inbox *message.Inbox
+
+	// Messages sent and not yet mined.
+	Outbox *message.Outbox
+
+	// Network Fields
+	MessageSub pubsub.Subscription
+}

--- a/node/message.go
+++ b/node/message.go
@@ -21,6 +21,6 @@ func (node *Node) processMessage(ctx context.Context, pubSubMsg pubsub.Message) 
 
 	log.Debugf("Received new message %s from peer %s", unmarshaled, pubSubMsg.GetFrom())
 
-	_, err = node.Inbox.Add(ctx, unmarshaled)
+	_, err = node.Messaging.Inbox.Add(ctx, unmarshaled)
 	return err
 }

--- a/node/message_propagate_test.go
+++ b/node/message_propagate_test.go
@@ -58,9 +58,9 @@ func TestMessagePropagation(t *testing.T) {
 	// Wait for network connection notifications to propagate
 	time.Sleep(time.Millisecond * 50)
 
-	require.Equal(t, 0, len(nodes[1].Inbox.Pool().Pending()))
-	require.Equal(t, 0, len(nodes[2].Inbox.Pool().Pending()))
-	require.Equal(t, 0, len(nodes[0].Inbox.Pool().Pending()))
+	require.Equal(t, 0, len(nodes[1].Messaging.Inbox.Pool().Pending()))
+	require.Equal(t, 0, len(nodes[2].Messaging.Inbox.Pool().Pending()))
+	require.Equal(t, 0, len(nodes[0].Messaging.Inbox.Pool().Pending()))
 
 	t.Run("message propagates", func(t *testing.T) {
 		_, err := sender.PorcelainAPI.MessageSend(
@@ -75,13 +75,13 @@ func TestMessagePropagation(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, th.WaitForIt(50, 100*time.Millisecond, func() (bool, error) {
-			return len(nodes[0].Inbox.Pool().Pending()) == 1 &&
-				len(nodes[1].Inbox.Pool().Pending()) == 1 &&
-				len(nodes[2].Inbox.Pool().Pending()) == 1, nil
+			return len(nodes[0].Messaging.Inbox.Pool().Pending()) == 1 &&
+				len(nodes[1].Messaging.Inbox.Pool().Pending()) == 1 &&
+				len(nodes[2].Messaging.Inbox.Pool().Pending()) == 1, nil
 		}), "failed to propagate messages")
 
-		assert.True(t, nodes[0].Inbox.Pool().Pending()[0].Message.Method == "foo")
-		assert.True(t, nodes[1].Inbox.Pool().Pending()[0].Message.Method == "foo")
-		assert.True(t, nodes[2].Inbox.Pool().Pending()[0].Message.Method == "foo")
+		assert.True(t, nodes[0].Messaging.Inbox.Pool().Pending()[0].Message.Method == "foo")
+		assert.True(t, nodes[1].Messaging.Inbox.Pool().Pending()[0].Message.Method == "foo")
+		assert.True(t, nodes[2].Messaging.Inbox.Pool().Pending()[0].Message.Method == "foo")
 	})
 }

--- a/node/network_submodule.go
+++ b/node/network_submodule.go
@@ -1,0 +1,25 @@
+package node
+
+import (
+	"github.com/filecoin-project/go-filecoin/net"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/routing"
+)
+
+// NetworkSubmodule enhances the `Node` with networking capabilities.
+type NetworkSubmodule struct {
+	NetworkName string
+
+	host host.Host
+
+	// TODO: do we need a second host? (see: https://github.com/filecoin-project/go-filecoin/issues/3477)
+	PeerHost host.Host
+
+	Bootstrapper *net.Bootstrapper
+
+	// PeerTracker maintains a list of peers good for fetching.
+	PeerTracker *net.PeerTracker
+
+	// Router is a router from IPFS
+	Router routing.Routing
+}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -94,8 +94,8 @@ func TestConnectsToBootstrapNodes(t *testing.T) {
 		require.NoError(t, err)
 		nd, err := node.New(ctx, opts...)
 		require.NoError(t, err)
-		nd.Bootstrapper.MinPeerThreshold = 2
-		nd.Bootstrapper.Period = 10 * time.Millisecond
+		nd.Network.Bootstrapper.MinPeerThreshold = 2
+		nd.Network.Bootstrapper.Period = 10 * time.Millisecond
 		assert.NoError(t, nd.Start(ctx))
 		defer nd.Stop(ctx)
 
@@ -126,7 +126,7 @@ func TestNodeInit(t *testing.T) {
 
 	assert.NoError(t, nd.Start(ctx))
 
-	assert.NotEqual(t, 0, nd.ChainReader.GetHead().Len())
+	assert.NotEqual(t, 0, nd.Chain.ChainReader.GetHead().Len())
 	nd.Stop(ctx)
 }
 
@@ -150,11 +150,11 @@ func TestNodeStartMining(t *testing.T) {
 	t.Run("Start/Stop/Start results in a MiningScheduler that is started", func(t *testing.T) {
 		assert.NoError(t, minerNode.StartMining(ctx))
 		defer minerNode.StopMining(ctx)
-		assert.True(t, minerNode.MiningScheduler.IsStarted())
+		assert.True(t, minerNode.BlockMining.MiningScheduler.IsStarted())
 		minerNode.StopMining(ctx)
-		assert.False(t, minerNode.MiningScheduler.IsStarted())
+		assert.False(t, minerNode.BlockMining.MiningScheduler.IsStarted())
 		assert.NoError(t, minerNode.StartMining(ctx))
-		assert.True(t, minerNode.MiningScheduler.IsStarted())
+		assert.True(t, minerNode.BlockMining.MiningScheduler.IsStarted())
 	})
 
 	t.Run("Start + Start gives an error message saying mining is already started", func(t *testing.T) {
@@ -167,7 +167,7 @@ func TestNodeStartMining(t *testing.T) {
 	t.Run("MiningStart sets storage fault slasher", func(t *testing.T) {
 		assert.NoError(t, minerNode.StartMining(ctx))
 		defer minerNode.StopMining(ctx)
-		assert.NotNil(t, minerNode.StorageFaultSlasher)
+		assert.NotNil(t, minerNode.FaultSlasher.StorageFaultSlasher)
 	})
 }
 

--- a/node/retrieval_protocol_submodule.go
+++ b/node/retrieval_protocol_submodule.go
@@ -1,0 +1,11 @@
+package node
+
+import "github.com/filecoin-project/go-filecoin/protocol/retrieval"
+
+// RetrievalProtocolSubmodule enhances the `Node` with "Retrieval" protocol capabilities.
+type RetrievalProtocolSubmodule struct {
+	RetrievalAPI *retrieval.API
+
+	// Retrieval Interfaces
+	RetrievalMiner *retrieval.Miner
+}

--- a/node/sector_builder_submodule.go
+++ b/node/sector_builder_submodule.go
@@ -1,0 +1,9 @@
+package node
+
+import "github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
+
+// SectorBuilderSubmodule enhances the `Node` with sector storage capabilities.
+type SectorBuilderSubmodule struct {
+	// SectorBuilder is used by the miner to fill and seal sectors.
+	sectorBuilder sectorbuilder.SectorBuilder
+}

--- a/node/storage_networking_submodule.go
+++ b/node/storage_networking_submodule.go
@@ -1,0 +1,9 @@
+package node
+
+import exchange "github.com/ipfs/go-ipfs-exchange-interface"
+
+// StorageNetworkingSubmodule enhances the `Node` with data transfer capabilities.
+type StorageNetworkingSubmodule struct {
+	// Exchange is the interface for fetching data from other nodes.
+	Exchange exchange.Interface
+}

--- a/node/storage_protocol_submodule.go
+++ b/node/storage_protocol_submodule.go
@@ -1,0 +1,11 @@
+package node
+
+import "github.com/filecoin-project/go-filecoin/protocol/storage"
+
+// StorageProtocolSubmodule enhances the `Node` with "Storage" protocol capabilities.
+type StorageProtocolSubmodule struct {
+	StorageAPI *storage.API
+
+	// Storage Market Interfaces
+	StorageMiner *storage.Miner
+}

--- a/node/testing.go
+++ b/node/testing.go
@@ -91,7 +91,7 @@ func (cs *ChainSeed) GenesisInitFunc(cst *hamt.CborIpldStore, bs blockstore.Bloc
 // GiveKey gives the given key to the given node
 func (cs *ChainSeed) GiveKey(t *testing.T, nd *Node, key int) address.Address {
 	t.Helper()
-	bcks := nd.Wallet.Backends(wallet.DSBackendType)
+	bcks := nd.Wallet.Wallet.Backends(wallet.DSBackendType)
 	require.Len(t, bcks, 1, "expected to get exactly one datastore backend")
 
 	dsb := bcks[0].(*wallet.DSBackend)

--- a/node/wallet_submodule.go
+++ b/node/wallet_submodule.go
@@ -1,0 +1,8 @@
+package node
+
+import "github.com/filecoin-project/go-filecoin/wallet"
+
+// WalletSubmodule enhances the `Node` with a "Wallet" and FIL transfer capabilities.
+type WalletSubmodule struct {
+	Wallet *wallet.Wallet
+}

--- a/protocol/block/mining_api_test.go
+++ b/protocol/block/mining_api_test.go
@@ -144,7 +144,7 @@ func newAPI(t *testing.T) (bapi.MiningAPI, *node.Node) {
 	return bapi.New(
 		nd.MiningAddress,
 		nd.AddNewBlock,
-		nd.ChainReader,
+		nd.Chain.ChainReader,
 		nd.IsMining,
 		bt,
 		nd.SetupMining,

--- a/protocol/retrieval/retrieval_protocol_test.go
+++ b/protocol/retrieval/retrieval_protocol_test.go
@@ -35,7 +35,7 @@ func TestRetrievalProtocolPieceNotFound(t *testing.T) {
 	minerPID, err := minerNode.PorcelainAPI.MinerGetPeerID(ctx, minerAddr)
 	require.NoError(t, err)
 
-	_, err = retrievePieceBytes(ctx, minerNode.RetrievalAPI, someRandomCid, minerPID, minerAddr)
+	_, err = retrievePieceBytes(ctx, minerNode.RetrievalProtocol.RetrievalAPI, someRandomCid, minerPID, minerAddr)
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
**Remaining work:**
- [x] ~I will proceed to group up the extracted pieces by submodules "block production, sector committing & proving, etc" to then rebuild the construction/cleanup based on the pieces.~
- [x] ~finish finding new homes for things in `ToSplitOrNotToSplitNode`~

**Following PRs:**
- cleanup initialization for each submodule.
- split start/stop code into pieces and move them to each submodule. 
- move submodules to their own package to force visibility issues 