### PR TITLE
feat(net): request peer finder abstraction

### DIFF
--- a/chain/syncer_integration_test.go
+++ b/chain/syncer_integration_test.go
@@ -51,7 +51,7 @@ func TestLoadFork(t *testing.T) {
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but
 	// *not* as the store, to which the syncer must ensure to put blocks.
 	eval := &chain.FakeStateEvaluator{}
-	syncer := chain.NewSyncer(eval, store, builder, builder, chain.NewStatusReporter(), th.NewFakeSystemClock(time.Unix(1234567890, 0)))
+	syncer := chain.NewSyncer(eval, store, builder, builder, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 
 	base := builder.AppendManyOn(3, genesis)
 	left := builder.AppendManyOn(4, base)
@@ -79,7 +79,7 @@ func TestLoadFork(t *testing.T) {
 	newStore := chain.NewStore(repo.ChainDatastore(), &cborStore, &state.TreeStateLoader{}, chain.NewStatusReporter(), genesis.At(0).Cid())
 	require.NoError(t, newStore.Load(ctx))
 	fakeFetcher := th.NewTestFetcher()
-	offlineSyncer := chain.NewSyncer(eval, newStore, builder, fakeFetcher, chain.NewStatusReporter(), th.NewFakeSystemClock(time.Unix(1234567890, 0)))
+	offlineSyncer := chain.NewSyncer(eval, newStore, builder, fakeFetcher, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 
 	assert.True(t, newStore.HasTipSetAndState(ctx, left.Key()))
 	assert.False(t, newStore.HasTipSetAndState(ctx, right.Key()))
@@ -186,7 +186,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 
 	// Now sync the chainStore with consensus using a MarketView.
 	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &consensus.MarketView{}, calcGenBlk.Cid(), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
-	syncer := chain.NewSyncer(con, chainStore, messageStore, blockSource, chain.NewStatusReporter(), th.NewFakeSystemClock(time.Unix(1234567890, 0)))
+	syncer := chain.NewSyncer(con, chainStore, messageStore, blockSource, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 	baseTS := requireHeadTipset(t, chainStore) // this is the last block of the bootstrapping chain creating miners
 	require.Equal(t, 1, baseTS.Len())
 	bootstrapStateRoot := baseTS.ToSlice()[0].StateRoot

--- a/chain/syncer_test.go
+++ b/chain/syncer_test.go
@@ -194,7 +194,7 @@ func TestFarFutureTipsets(t *testing.T) {
 		genesis := builder.RequireTipSet(store.GetHead())
 		farHead := builder.AppendManyOn(chain.UntrustedChainHeightLimit+1, genesis)
 
-		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, builder, chain.NewStatusReporter(), th.NewFakeSystemClock(time.Unix(1234567890, 0)))
+		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, builder, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 		assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), true))
 	})
 
@@ -203,7 +203,7 @@ func TestFarFutureTipsets(t *testing.T) {
 		genesis := builder.RequireTipSet(store.GetHead())
 		farHead := builder.AppendManyOn(chain.UntrustedChainHeightLimit+1, genesis)
 
-		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, builder, chain.NewStatusReporter(), th.NewFakeSystemClock(time.Unix(1234567890, 0)))
+		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, builder, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 		err := syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), false)
 		assert.Error(t, err)
 	})
@@ -221,7 +221,7 @@ func TestNoUncessesaryFetch(t *testing.T) {
 	// A new syncer unable to fetch blocks from the network can handle a tipset that's already
 	// in the store and linked to genesis.
 	emptyFetcher := chain.NewBuilder(t, address.Undef)
-	newSyncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, emptyFetcher, chain.NewStatusReporter(), th.NewFakeSystemClock(time.Unix(1234567890, 0)))
+	newSyncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, emptyFetcher, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 	assert.NoError(t, newSyncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), head.Key(), heightFromTip(t, head)), true))
 }
 
@@ -471,7 +471,7 @@ func setup(ctx context.Context, t *testing.T) (*chain.Builder, *chain.Store, *ch
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but
 	// *not* as the store, to which the syncer must ensure to put blocks.
 	eval := &chain.FakeStateEvaluator{}
-	syncer := chain.NewSyncer(eval, store, builder, builder, sr, th.NewFakeSystemClock(time.Unix(1234567890, 0)))
+	syncer := chain.NewSyncer(eval, store, builder, builder, sr, th.NewFakeClock(time.Unix(1234567890, 0)))
 
 	return builder, store, syncer
 }

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -2,11 +2,18 @@ package clock
 
 import (
 	"github.com/jonboulle/clockwork"
+	"time"
 )
 
 // Clock provides an interface that packages can use instead of directly
 // using the time module, so that chronology-related behavior can be tested.
 type Clock interface {
+	clockwork.Clock
+	NewTimer(d time.Duration) Timer
+	AfterFunc(d time.Duration, f func()) Timer
+}
+
+type realClock struct {
 	clockwork.Clock
 }
 
@@ -14,5 +21,13 @@ type Clock interface {
 // SystemClock is a Clock which simply delegates calls to the actual time
 // package; it should be used by packages in production.
 func NewSystemClock() Clock {
-	return clockwork.NewRealClock()
+	return &realClock{Clock: clockwork.NewRealClock()}
+}
+
+func (rc *realClock) NewTimer(d time.Duration) Timer {
+	return &realTimer{time.NewTimer(d)}
+}
+
+func (rc *realClock) AfterFunc(d time.Duration, f func()) Timer {
+	return &realTimer{time.AfterFunc(d, f)}
 }

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -1,27 +1,44 @@
 package clock
 
 import (
-	"github.com/jonboulle/clockwork"
 	"time"
 )
 
 // Clock provides an interface that packages can use instead of directly
-// using the time module, so that chronology-related behavior can be tested.
+// using the time module, so that chronology-related behavior can be tested
+// Adapted from: https://github.com/jonboulle/clockwork
 type Clock interface {
-	clockwork.Clock
+	After(d time.Duration) <-chan time.Time
+	Sleep(d time.Duration)
+	Now() time.Time
+	Since(t time.Time) time.Duration
+
+	NewTicker(d time.Duration) Ticker
+
 	NewTimer(d time.Duration) Timer
 	AfterFunc(d time.Duration, f func()) Timer
 }
 
-type realClock struct {
-	clockwork.Clock
+type realClock struct{}
+
+func (rc *realClock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
 }
 
-// NewSystemClock returns a SystemClock that delegates calls to the jonboulee/clockwork package.
-// SystemClock is a Clock which simply delegates calls to the actual time
-// package; it should be used by packages in production.
-func NewSystemClock() Clock {
-	return &realClock{Clock: clockwork.NewRealClock()}
+func (rc *realClock) Sleep(d time.Duration) {
+	time.Sleep(d)
+}
+
+func (rc *realClock) Now() time.Time {
+	return time.Now()
+}
+
+func (rc *realClock) Since(t time.Time) time.Duration {
+	return rc.Now().Sub(t)
+}
+
+func (rc *realClock) NewTicker(d time.Duration) Ticker {
+	return &realTicker{time.NewTicker(d)}
 }
 
 func (rc *realClock) NewTimer(d time.Duration) Timer {
@@ -30,4 +47,11 @@ func (rc *realClock) NewTimer(d time.Duration) Timer {
 
 func (rc *realClock) AfterFunc(d time.Duration, f func()) Timer {
 	return &realTimer{time.AfterFunc(d, f)}
+}
+
+// NewSystemClock returns a SystemClock that delegates calls to the jonboulee/clockwork package.
+// SystemClock is a Clock which simply delegates calls to the actual time
+// package; it should be used by packages in production.
+func NewSystemClock() Clock {
+	return &realClock{}
 }

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -49,8 +49,7 @@ func (rc *realClock) AfterFunc(d time.Duration, f func()) Timer {
 	return &realTimer{time.AfterFunc(d, f)}
 }
 
-// NewSystemClock returns a SystemClock that delegates calls to the jonboulee/clockwork package.
-// SystemClock is a Clock which simply delegates calls to the actual time
+// NewSystemClock returns a Clock that delegates calls to the actual time
 // package; it should be used by packages in production.
 func NewSystemClock() Clock {
 	return &realClock{}

--- a/clock/ticker.go
+++ b/clock/ticker.go
@@ -1,0 +1,21 @@
+package clock
+
+import (
+	"time"
+)
+
+// Ticker provides an interface which can be used instead of directly
+// using the ticker within the time module. The real-time ticker t
+// provides ticks through t.C which becomes now t.Chan() to make
+// this channel requirement definable in this interface.
+// Adapted from: https://github.com/jonboulle/clockwork
+type Ticker interface {
+	Chan() <-chan time.Time
+	Stop()
+}
+
+type realTicker struct{ *time.Ticker }
+
+func (rt *realTicker) Chan() <-chan time.Time {
+	return rt.C
+}

--- a/clock/timer.go
+++ b/clock/timer.go
@@ -1,0 +1,21 @@
+package clock
+
+import (
+	"time"
+)
+
+// Timer provides an interface to a time.Timer which is testable.
+// See https://golang.org/pkg/time/#Timer for more details on how timers work.
+type Timer interface {
+	Chan() <-chan time.Time
+	Reset(d time.Duration) bool
+	Stop() bool
+}
+
+type realTimer struct {
+	*time.Timer
+}
+
+func (rt *realTimer) Chan() <-chan time.Time {
+	return rt.C
+}

--- a/consensus/block_validation_test.go
+++ b/consensus/block_validation_test.go
@@ -21,7 +21,7 @@ func TestBlockValidSemantic(t *testing.T) {
 
 	blockTime := consensus.DefaultBlockTime
 	ts := time.Unix(1234567890, 0)
-	mclock := th.NewFakeSystemClock(ts)
+	mclock := th.NewFakeClock(ts)
 	ctx := context.Background()
 
 	validator := consensus.NewDefaultBlockValidator(blockTime, mclock)
@@ -86,7 +86,7 @@ func TestBlockValidSyntax(t *testing.T) {
 
 	blockTime := consensus.DefaultBlockTime
 	ts := time.Unix(1234567890, 0)
-	mclock := th.NewFakeSystemClock(ts)
+	mclock := th.NewFakeClock(ts)
 
 	ctx := context.Background()
 

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -302,7 +302,7 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 		PowerTable:    &th.TestView{},
 		Blockstore:    bs,
 		MessageStore:  messages,
-		Clock:         th.NewFakeSystemClock(time.Unix(1234567890, 0)),
+		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	builder := chain.NewBuilder(t, address.Undef)
@@ -359,7 +359,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		PowerTable:    &th.TestView{},
 		Blockstore:    bs,
 		MessageStore:  messages,
-		Clock:         th.NewFakeSystemClock(time.Unix(1234567890, 0)),
+		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	// addr3 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
@@ -467,7 +467,7 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 		PowerTable:    &th.TestView{},
 		Blockstore:    bs,
 		MessageStore:  messages,
-		Clock:         th.NewFakeSystemClock(time.Unix(1234567890, 0)),
+		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	h := types.Uint64(100)
@@ -530,7 +530,7 @@ func TestGenerateWithoutMessages(t *testing.T) {
 		PowerTable:    &th.TestView{},
 		Blockstore:    bs,
 		MessageStore:  messages,
-		Clock:         th.NewFakeSystemClock(time.Unix(1234567890, 0)),
+		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	assert.Len(t, pool.Pending(), 0)
@@ -583,7 +583,7 @@ func TestGenerateError(t *testing.T) {
 		PowerTable:    &th.TestView{},
 		Blockstore:    bs,
 		MessageStore:  messages,
-		Clock:         th.NewFakeSystemClock(time.Unix(1234567890, 0)),
+		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	// This is actually okay and should result in a receipt

--- a/net/graphsync_fetcher.go
+++ b/net/graphsync_fetcher.go
@@ -24,10 +24,10 @@ import (
 var logGraphsyncFetcher = logging.Logger("net.graphsync_fetcher")
 
 const (
-	// Timeout for a single graphsync request (which may be for many blocks).
-	// We might prefer this timeout to scale with the number of blocks expected in the fetch,
-	// when that number is large.
-	requestTimeout = 60 * time.Second
+	// Timeout for a single graphsync request getting "stuck"
+	// -- if no more responses are received for a period greater than this,
+	// we will assume the request has hung-up and cancel it
+	unresponsiveTimeout = 10 * time.Second
 )
 
 // Fetcher defines an interface that may be used to fetch data from the network.
@@ -55,23 +55,41 @@ type graphsyncFallbackPeerTracker interface {
 // GraphSyncFetcher is used to fetch data over the network.  It is implemented
 // using a Graphsync exchange to fetch tipsets recursively
 type GraphSyncFetcher struct {
-	exchange    GraphExchange
-	validator   consensus.SyntaxValidator
-	store       bstore.Blockstore
-	ssb         selectorbuilder.SelectorSpecBuilder
-	peerTracker graphsyncFallbackPeerTracker
+	exchange            GraphExchange
+	validator           consensus.SyntaxValidator
+	store               bstore.Blockstore
+	ssb                 selectorbuilder.SelectorSpecBuilder
+	peerTracker         graphsyncFallbackPeerTracker
+	unresponsiveTimeout time.Duration
+}
+
+// GraphsyncFetcherOption is function that configures graphsync. It should not
+// be created directly but should instead generated through an option function like
+// UseFetcherTimeout
+type GraphsyncFetcherOption func(*GraphSyncFetcher)
+
+// UseUnresponsiveTimeout sets up the GraphsyncFetcher with a different
+// unresponsiveness timeout than the default
+func UseUnresponsiveTimeout(timeout time.Duration) GraphsyncFetcherOption {
+	return func(gsf *GraphSyncFetcher) {
+		gsf.unresponsiveTimeout = timeout
+	}
 }
 
 // NewGraphSyncFetcher returns a GraphsyncFetcher wired up to the input Graphsync exchange and
 // attached local blockservice for reloading blocks in memory once they are returned
 func NewGraphSyncFetcher(ctx context.Context, exchange GraphExchange, blockstore bstore.Blockstore,
-	bv consensus.SyntaxValidator, pt graphsyncFallbackPeerTracker) *GraphSyncFetcher {
+	bv consensus.SyntaxValidator, pt graphsyncFallbackPeerTracker, options ...GraphsyncFetcherOption) *GraphSyncFetcher {
 	gsf := &GraphSyncFetcher{
-		store:       blockstore,
-		validator:   bv,
-		exchange:    exchange,
-		ssb:         selectorbuilder.NewSelectorSpecBuilder(ipldfree.NodeBuilder()),
-		peerTracker: pt,
+		store:               blockstore,
+		validator:           bv,
+		exchange:            exchange,
+		ssb:                 selectorbuilder.NewSelectorSpecBuilder(ipldfree.NodeBuilder()),
+		peerTracker:         pt,
+		unresponsiveTimeout: unresponsiveTimeout,
+	}
+	for _, option := range options {
+		option(gsf)
 	}
 	return gsf
 }
@@ -224,18 +242,48 @@ func (gsf *GraphSyncFetcher) fetchBlocks(ctx context.Context, cids []cid.Cid, ta
 		efsb.Insert("messageReceipts", gsf.ssb.Matcher())
 	}).Node()
 	errChans := make([]<-chan error, 0, len(cids))
-	requestCtx, requestCancel := context.WithTimeout(ctx, requestTimeout)
-	defer requestCancel()
+	requestChans := make([]<-chan graphsync.ResponseProgress, 0, len(cids))
+	cancelFuncs := make([]func(), 0, len(cids))
 	for _, c := range cids {
-		_, errChan := gsf.exchange.Request(requestCtx, targetPeer, cidlink.Link{Cid: c}, selector)
+		requestCtx, requestCancel := context.WithCancel(ctx)
+		defer requestCancel()
+		requestChan, errChan := gsf.exchange.Request(requestCtx, targetPeer, cidlink.Link{Cid: c}, selector)
 		errChans = append(errChans, errChan)
+		requestChans = append(requestChans, requestChan)
+		cancelFuncs = append(cancelFuncs, requestCancel)
 	}
 	// Any of the multiple parallel requests might fail. Wait for all of them to complete, then
 	// return any error (in this case, the last one to be received).
 	var anyError error
-	for _, errChan := range errChans {
-		for err := range errChan {
+	for i, errChan := range errChans {
+		requestChan := requestChans[i]
+		cancelFunc := cancelFuncs[i]
+		err := gsf.consumeResponse(requestChan, errChan, cancelFunc)
+		if err != nil {
 			anyError = err
+		}
+	}
+	return anyError
+}
+
+func (gsf *GraphSyncFetcher) consumeResponse(requestChan <-chan graphsync.ResponseProgress, errChan <-chan error, cancelFunc func()) error {
+	timer := time.NewTimer(gsf.unresponsiveTimeout)
+	var anyError error
+	for errChan != nil || requestChan != nil {
+		select {
+		case err, ok := <-errChan:
+			if !ok {
+				errChan = nil
+			}
+			anyError = err
+			timer.Reset(gsf.unresponsiveTimeout)
+		case _, ok := <-requestChan:
+			if !ok {
+				requestChan = nil
+			}
+			timer.Reset(gsf.unresponsiveTimeout)
+		case <-timer.C:
+			cancelFunc()
 		}
 	}
 	return anyError
@@ -244,7 +292,7 @@ func (gsf *GraphSyncFetcher) fetchBlocks(ctx context.Context, cids []cid.Cid, ta
 // fetchBlocksRecursively gets the blocks from recursionDepth ancestor tipsets
 // starting from baseCid.
 func (gsf *GraphSyncFetcher) fetchBlocksRecursively(ctx context.Context, baseCid cid.Cid, targetPeer peer.ID, recursionDepth int) error {
-	requestCtx, requestCancel := context.WithTimeout(ctx, requestTimeout)
+	requestCtx, requestCancel := context.WithCancel(ctx)
 	defer requestCancel()
 
 	// recursive selector to fetch n sets of parent blocks
@@ -264,11 +312,8 @@ func (gsf *GraphSyncFetcher) fetchBlocksRecursively(ctx context.Context, baseCid
 		))
 	})).Node()
 
-	_, errChan := gsf.exchange.Request(requestCtx, targetPeer, cidlink.Link{Cid: baseCid}, selector)
-	for err := range errChan {
-		return err
-	}
-	return nil
+	requestChan, errChan := gsf.exchange.Request(requestCtx, targetPeer, cidlink.Link{Cid: baseCid}, selector)
+	return gsf.consumeResponse(requestChan, errChan, requestCancel)
 }
 
 // Loads the IPLD blocks for all blocks in a tipset, and checks for the presence of the

--- a/net/graphsync_fetcher_test.go
+++ b/net/graphsync_fetcher_test.go
@@ -43,7 +43,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 	tf.UnitTest(t)
 	ctx := context.Background()
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
-	bv := consensus.NewDefaultBlockValidator(5*time.Millisecond, th.NewFakeSystemClock(time.Now()))
+	bv := consensus.NewDefaultBlockValidator(5*time.Millisecond, th.NewFakeClock(time.Now()))
 	pid0 := th.RequireIntPeerID(t, 0)
 	builder := chain.NewBuilder(t, address.Undef)
 	keys := types.MustGenerateKeyInfo(1, 42)

--- a/net/graphsync_fetcher_test.go
+++ b/net/graphsync_fetcher_test.go
@@ -140,7 +140,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		mgs.stubResponseWithLoader(pid0, layer1Selector, loader, final.Key().ToSlice()...)
 		mgs.stubResponseWithLoader(pid0, recursiveSelector(1), loader, final.At(0).Cid())
 
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakePeerTracker(chain0))
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakeRequestPeerFinder(chain0))
 		done := doneAt(gen.Key())
 
 		ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
@@ -159,7 +159,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		chain0 := types.NewChainInfo(pid0, final.Key(), height)
 		chain1 := types.NewChainInfo(pid1, final.Key(), height)
 		chain2 := types.NewChainInfo(pid2, final.Key(), height)
-		pt := newFakePeerTracker(chain0, chain1, chain2)
+		pt := newFakeRequestPeerFinder(chain0, chain1, chain2)
 
 		mgs := newMockableGraphsync(ctx, bs, clock, t)
 		pid0Loader := errorOnCidsLoader(loader, final.At(1).Cid(), final.At(2).Cid())
@@ -189,7 +189,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		chain0 := types.NewChainInfo(pid0, final.Key(), height)
 		chain1 := types.NewChainInfo(pid1, final.Key(), height)
 		chain2 := types.NewChainInfo(pid2, final.Key(), height)
-		pt := newFakePeerTracker(chain0, chain1, chain2)
+		pt := newFakeRequestPeerFinder(chain0, chain1, chain2)
 		mgs := newMockableGraphsync(ctx, bs, clock, t)
 		errorLoader := errorOnCidsLoader(loader, final.At(1).Cid(), final.At(2).Cid())
 		mgs.expectRequestToRespondWithLoader(pid0, layer1Selector, errorLoader, final.Key().ToSlice()...)
@@ -217,7 +217,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		errorOnMessagesLoader := errorOnCidsLoader(loader, final.At(2).Messages)
 		mgs.expectRequestToRespondWithLoader(pid0, layer1Selector, errorOnMessagesLoader, final.Key().ToSlice()...)
 
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakePeerTracker(chain0))
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakeRequestPeerFinder(chain0))
 
 		done := doneAt(gen.Key())
 		ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
@@ -237,7 +237,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		errorOnMessagesReceiptsLoader := errorOnCidsLoader(loader, final.At(1).MessageReceipts)
 		mgs.expectRequestToRespondWithLoader(pid0, layer1Selector, errorOnMessagesReceiptsLoader, final.Key().ToSlice()...)
 
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakePeerTracker(chain0))
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakeRequestPeerFinder(chain0))
 
 		done := doneAt(gen.Key())
 		ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
@@ -264,7 +264,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		mgs.expectRequestToRespondWithLoader(pid2, layer1Selector, loader, final.At(1).Cid(), final.At(2).Cid())
 		mgs.expectRequestToRespondWithLoader(pid2, recursiveSelector(1), loader, final.At(0).Cid())
 
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakePeerTracker(chain0, chain1, chain2))
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakeRequestPeerFinder(chain0, chain1, chain2))
 		done := doneAt(gen.Key())
 
 		ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
@@ -284,7 +284,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		chain0 := types.NewChainInfo(pid0, final.Key(), height)
 		chain1 := types.NewChainInfo(pid1, final.Key(), height)
 		chain2 := types.NewChainInfo(pid2, final.Key(), height)
-		pt := newFakePeerTracker(chain0, chain1, chain2)
+		pt := newFakeRequestPeerFinder(chain0, chain1, chain2)
 
 		blocks := make([]*types.Block, 4) // in fetch order
 		prev := final.At(0)
@@ -342,7 +342,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		mgs.expectRequestToRespondWithLoader(pid0, recursiveSelector(1), errorInMultiBlockLoader, final.At(0).Cid())
 		mgs.expectRequestToRespondWithLoader(pid0, recursiveSelector(4), errorInMultiBlockLoader, penultimate.At(0).Cid())
 
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakePeerTracker(chain0))
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakeRequestPeerFinder(chain0))
 		done := doneAt(gen.Key())
 
 		ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
@@ -371,7 +371,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		mgs.expectRequestToRespondWithLoader(pid0, recursiveSelector(4), errorInMultiBlockLoader, penultimate.At(0).Cid())
 		mgs.expectRequestToRespondWithLoader(pid1, recursiveSelector(4), loader, withMultiParent.At(0).Cid())
 
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakePeerTracker(chain0, chain1, chain2))
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakeRequestPeerFinder(chain0, chain1, chain2))
 		done := doneAt(gen.Key())
 
 		ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
@@ -422,7 +422,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 				receivedRequestCount++
 			}
 
-			fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakePeerTracker(chain0))
+			fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakeRequestPeerFinder(chain0))
 			done := doneAt(tipset.Key())
 
 			ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
@@ -446,7 +446,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		chain0 := types.NewChainInfo(pid0, key, 0)
 		notDecodableLoader := simpleLoader([]format.Node{notDecodableBlock})
 		mgs.stubResponseWithLoader(pid0, layer1Selector, notDecodableLoader, notDecodableBlock.Cid())
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakePeerTracker(chain0))
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakeRequestPeerFinder(chain0))
 
 		done := doneAt(key)
 		ts, err := fetcher.FetchTipSets(ctx, key, pid0, done)
@@ -462,7 +462,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		chain0 := types.NewChainInfo(pid0, key, uint64(block.Height))
 		invalidSyntaxLoader := simpleLoader([]format.Node{block.ToNode()})
 		mgs.stubResponseWithLoader(pid0, layer1Selector, invalidSyntaxLoader, block.Cid())
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakePeerTracker(chain0))
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakeRequestPeerFinder(chain0))
 		done := doneAt(key)
 		ts, err := fetcher.FetchTipSets(ctx, key, pid0, done)
 		require.EqualError(t, err, fmt.Sprintf("invalid block %s: block %s has nil StateRoot", block.Cid().String(), block.Cid().String()))
@@ -477,7 +477,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		chain0 := types.NewChainInfo(pid0, key, uint64(block.Height))
 		notDecodableLoader := simpleLoader([]format.Node{block.ToNode(), notDecodableBlock, types.ReceiptCollection{}.ToNode()})
 		mgs.stubResponseWithLoader(pid0, layer1Selector, notDecodableLoader, block.Cid())
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakePeerTracker(chain0))
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakeRequestPeerFinder(chain0))
 
 		done := doneAt(key)
 		ts, err := fetcher.FetchTipSets(ctx, key, pid0, done)
@@ -493,7 +493,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		chain0 := types.NewChainInfo(pid0, key, uint64(block.Height))
 		notDecodableLoader := simpleLoader([]format.Node{block.ToNode(), notDecodableBlock, types.MessageCollection{}.ToNode()})
 		mgs.stubResponseWithLoader(pid0, layer1Selector, notDecodableLoader, block.Cid())
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakePeerTracker(chain0))
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakeRequestPeerFinder(chain0))
 
 		done := doneAt(key)
 		ts, err := fetcher.FetchTipSets(ctx, key, pid0, done)
@@ -513,7 +513,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		errorMv := mockSyntaxValidator{
 			validateMessagesError: fmt.Errorf("Everything Failed"),
 		}
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, errorMv, clock, newFakePeerTracker(chain0))
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, errorMv, clock, newFakeRequestPeerFinder(chain0))
 		done := doneAt(gen.Key())
 
 		ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
@@ -533,7 +533,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		errorMv := mockSyntaxValidator{
 			validateReceiptsError: fmt.Errorf("Everything Failed"),
 		}
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, errorMv, clock, newFakePeerTracker(chain0))
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, errorMv, clock, newFakeRequestPeerFinder(chain0))
 		done := doneAt(gen.Key())
 
 		ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
@@ -549,7 +549,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		chain0 := types.NewChainInfo(pid0, final.Key(), height)
 		chain1 := types.NewChainInfo(pid1, final.Key(), height)
 		chain2 := types.NewChainInfo(pid2, final.Key(), height)
-		pt := newFakePeerTracker(chain0, chain1, chain2)
+		pt := newFakeRequestPeerFinder(chain0, chain1, chain2)
 
 		mgs := newMockableGraphsync(ctx, bs, clock, t)
 		mgs.expectRequestToRespondWithLoader(pid0, layer1Selector, loader, final.At(0).Cid())
@@ -579,7 +579,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		chain0 := types.NewChainInfo(pid0, final.Key(), height)
 		chain1 := types.NewChainInfo(pid1, final.Key(), height)
 		chain2 := types.NewChainInfo(pid2, final.Key(), height)
-		pt := newFakePeerTracker(chain0, chain1, chain2)
+		pt := newFakeRequestPeerFinder(chain0, chain1, chain2)
 		mgs := newMockableGraphsync(ctx, bs, clock, t)
 		mgs.expectRequestToRespondWithLoader(pid0, layer1Selector, loader, final.At(0).Cid())
 		mgs.expectRequestToRespondWithHangupAfter(pid0, layer1Selector, loader, 0, final.At(1).Cid(), final.At(2).Cid())
@@ -604,7 +604,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		chain0 := types.NewChainInfo(pid0, final.Key(), height)
 		chain1 := types.NewChainInfo(pid1, final.Key(), height)
 		chain2 := types.NewChainInfo(pid2, final.Key(), height)
-		pt := newFakePeerTracker(chain0, chain1, chain2)
+		pt := newFakeRequestPeerFinder(chain0, chain1, chain2)
 
 		blocks := make([]*types.Block, 4) // in fetch order
 		prev := final.At(0)
@@ -661,7 +661,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		mgs.expectRequestToRespondWithLoader(pid0, recursiveSelector(1), loader, final.At(0).Cid())
 		mgs.expectRequestToRespondWithHangupAfter(pid0, recursiveSelector(4), loader, 2*visitsPerBlock, penultimate.At(0).Cid())
 
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakePeerTracker(chain0))
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakeRequestPeerFinder(chain0))
 		done := doneAt(gen.Key())
 
 		ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
@@ -690,7 +690,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		mgs.expectRequestToRespondWithHangupAfter(pid0, recursiveSelector(4), loader, 2*visitsPerBlock, penultimate.At(0).Cid())
 		mgs.expectRequestToRespondWithLoader(pid1, recursiveSelector(4), loader, withMultiParent.At(0).Cid())
 
-		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakePeerTracker(chain0, chain1, chain2))
+		fetcher := net.NewGraphSyncFetcher(ctx, mgs, bs, bv, clock, newFakeRequestPeerFinder(chain0, chain1, chain2))
 		done := doneAt(gen.Key())
 
 		ts, err := fetcher.FetchTipSets(ctx, final.Key(), pid0, done)
@@ -766,7 +766,7 @@ func TestRealWorldGraphsyncFetchAcrossNetwork(t *testing.T) {
 
 	localGraphsync := graphsync.New(ctx, gsnet1, bridge1, localLoader, localStorer)
 
-	fetcher := net.NewGraphSyncFetcher(ctx, localGraphsync, bs, bv, clock, pt)
+	fetcher := net.NewGraphSyncFetcher(ctx, localGraphsync, bs, bv, clock, net.MakeDefaultRequestPeerFinderFactory(pt))
 
 	remoteLoader := func(lnk ipld.Link, lnkCtx ipld.LinkContext) (io.Reader, error) {
 		cid := lnk.(cidlink.Link).Cid
@@ -1126,22 +1126,9 @@ func (mgs *mockableGraphsync) Request(ctx context.Context, p peer.ID, root ipld.
 	return mgs.processResponse(ctx, fakeResponse{nil, []error{fmt.Errorf("unexpected request")}, nil, noHangup})
 }
 
-type fakePeerTracker struct {
-	peers []*types.ChainInfo
-}
-
-func newFakePeerTracker(cis ...*types.ChainInfo) *fakePeerTracker {
-	return &fakePeerTracker{
-		peers: cis,
-	}
-}
-
-func (fpt *fakePeerTracker) List() []*types.ChainInfo {
-	return fpt.peers
-}
-
-func (fpt *fakePeerTracker) Self() peer.ID {
-	return peer.ID("")
+func newFakeRequestPeerFinder(cis ...*types.ChainInfo) net.RequestPeerFinderFactory {
+	fpt := th.NewFakePeerTracker(peer.ID(""), cis...)
+	return net.MakeDefaultRequestPeerFinderFactory(fpt)
 }
 
 func requireBlockStorePut(t *testing.T, bs bstore.Blockstore, data format.Node) {

--- a/net/request_peer_finder.go
+++ b/net/request_peer_finder.go
@@ -1,0 +1,81 @@
+package net
+
+import (
+	"fmt"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// RequestPeerFinder is an interface that returns peers to make fetch requests
+// to, and can be told to find a new set of peers when the current peers fail
+type RequestPeerFinder interface {
+	FindNextPeers() error
+	CurrentPeers() []peer.ID
+}
+
+// RequestPeerFinderFactory is any function that will return a new peer finder for
+// a request with the given originating peer
+type RequestPeerFinderFactory func(originatingPeer peer.ID) (RequestPeerFinder, error)
+
+// RequestPeerTracker is an interface that returns information about connected peers
+// and their chains (an interface version of PeerTracker)
+type RequestPeerTracker interface {
+	List() []*types.ChainInfo
+	Self() peer.ID
+}
+
+// MakeDefaultRequestPeerFinderFactory makes a RequestPeerFinderFactory that
+// returns DefaultRequestPeerFinders connected to the given peer tracker
+func MakeDefaultRequestPeerFinderFactory(peerTracker RequestPeerTracker) RequestPeerFinderFactory {
+	return func(originatingPeer peer.ID) (RequestPeerFinder, error) {
+		fetchFromSelf := originatingPeer == peerTracker.Self()
+		pri := &DefaultRequestPeerFinder{
+			peerTracker: peerTracker,
+			triedPeers:  make(map[peer.ID]struct{}),
+		}
+
+		// If the new cid triggering this request came from ourselves then
+		// the first peer to request from should be ourselves.
+		if fetchFromSelf {
+			pri.triedPeers[peerTracker.Self()] = struct{}{}
+			pri.currentPeer = peerTracker.Self()
+			return pri, nil
+		}
+
+		// Get a peer ID from the peer tracker
+		err := pri.FindNextPeers()
+		if err != nil {
+			return nil, err
+		}
+		return pri, nil
+	}
+}
+
+// DefaultRequestPeerFinder is the default implementation of a request peer finder
+// It simply iterates through peers in the peer tracker, one at a time
+type DefaultRequestPeerFinder struct {
+	peerTracker RequestPeerTracker
+	currentPeer peer.ID
+	triedPeers  map[peer.ID]struct{}
+}
+
+// CurrentPeers returns one or more peers to make the next requests to
+func (pri *DefaultRequestPeerFinder) CurrentPeers() []peer.ID {
+	return []peer.ID{pri.currentPeer}
+}
+
+// FindNextPeers tells the peer finder that the current peers did not successfully
+// complete a request and it should look for more
+func (pri *DefaultRequestPeerFinder) FindNextPeers() error {
+	chains := pri.peerTracker.List()
+	for _, chain := range chains {
+		if _, tried := pri.triedPeers[chain.Peer]; !tried {
+			pri.triedPeers[chain.Peer] = struct{}{}
+			pri.currentPeer = chain.Peer
+			return nil
+		}
+	}
+	return fmt.Errorf("Unable to find any untried peers")
+}

--- a/net/request_peer_finder.go
+++ b/net/request_peer_finder.go
@@ -1,23 +1,37 @@
 package net
 
 import (
+	"context"
 	"fmt"
+	"sync"
 
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-graphsync"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/pkg/errors"
 
+	"github.com/filecoin-project/go-filecoin/clock"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
-// RequestPeerFinder is an interface that returns peers to make fetch requests
-// to, and can be told to find a new set of peers when the current peers fail
-type RequestPeerFinder interface {
-	FindNextPeers() error
-	CurrentPeers() []peer.ID
+// GraphExchange is an interface wrapper to Graphsync so it can be stubbed in
+// unit testing
+type GraphExchange interface {
+	Request(ctx context.Context, p peer.ID, root ipld.Link, selector ipld.Node) (<-chan graphsync.ResponseProgress, <-chan error)
 }
 
-// RequestPeerFinderFactory is any function that will return a new peer finder for
-// a request with the given originating peer
-type RequestPeerFinderFactory func(originatingPeer peer.ID) (RequestPeerFinder, error)
+// GraphsyncSession is an interface for graphsync queries
+type GraphsyncSession interface {
+	Request(ctx context.Context, roots []cid.Cid, selector ipld.Node, tryAllPeers bool) error
+}
+
+// GraphsyncSessionExchange is an interface which supports
+// making sessions for graphsync queuries.
+type GraphsyncSessionExchange interface {
+	NewSession(ctx context.Context, originatingPeer peer.ID) (GraphsyncSession, error)
+}
 
 // RequestPeerTracker is an interface that returns information about connected peers
 // and their chains (an interface version of PeerTracker)
@@ -26,56 +40,192 @@ type RequestPeerTracker interface {
 	Self() peer.ID
 }
 
-// MakeDefaultRequestPeerFinderFactory makes a RequestPeerFinderFactory that
-// returns DefaultRequestPeerFinders connected to the given peer tracker
-func MakeDefaultRequestPeerFinderFactory(peerTracker RequestPeerTracker) RequestPeerFinderFactory {
-	return func(originatingPeer peer.ID) (RequestPeerFinder, error) {
-		fetchFromSelf := originatingPeer == peerTracker.Self()
-		pri := &DefaultRequestPeerFinder{
-			peerTracker: peerTracker,
-			triedPeers:  make(map[peer.ID]struct{}),
-		}
+type DefaultGraphsyncSessionExchange struct {
+	exchange    GraphExchange
+	systemClock clock.Clock
+	peerTracker RequestPeerTracker
+}
 
-		// If the new cid triggering this request came from ourselves then
-		// the first peer to request from should be ourselves.
-		if fetchFromSelf {
-			pri.triedPeers[peerTracker.Self()] = struct{}{}
-			pri.currentPeer = peerTracker.Self()
-			return pri, nil
-		}
-
-		// Get a peer ID from the peer tracker
-		err := pri.FindNextPeers()
-		if err != nil {
-			return nil, err
-		}
-		return pri, nil
+// MakeDefaultGraphsyncSessionExchange makes a GraphsyncSessionExchange that
+// returns DefaultGraphsyncSessions connected to the given peer tracker
+func MakeDefaultGraphsyncSessionExchange(exchange GraphExchange, systemClock clock.Clock, peerTracker RequestPeerTracker) *DefaultGraphsyncSessionExchange {
+	return &DefaultGraphsyncSessionExchange{
+		exchange:    exchange,
+		systemClock: systemClock,
+		peerTracker: peerTracker,
 	}
 }
 
-// DefaultRequestPeerFinder is the default implementation of a request peer finder
+func (gse *DefaultGraphsyncSessionExchange) NewSession(ctx context.Context, originatingPeer peer.ID) (GraphsyncSession, error) {
+	fetchFromSelf := originatingPeer == gse.peerTracker.Self()
+	gss := &DefaultGraphsyncSession{
+		exchange:    gse.exchange,
+		systemClock: gse.systemClock,
+		peerTracker: gse.peerTracker,
+		triedPeers:  make(map[peer.ID]struct{}),
+	}
+
+	// If the new cid triggering this request came from ourselves then
+	// the first peer to request from should be ourselves.
+	if fetchFromSelf {
+		gss.triedPeers[gse.peerTracker.Self()] = struct{}{}
+		gss.currentPeer = gse.peerTracker.Self()
+		return gss, nil
+	}
+
+	// Get a peer ID from the peer tracker
+	err := gss.FindNextPeers()
+	if err != nil {
+		return nil, err
+	}
+	return gss, nil
+}
+
+// DefaultGraphsyncSession is the default implementation of a graphsync session
 // It simply iterates through peers in the peer tracker, one at a time
-type DefaultRequestPeerFinder struct {
+// and handles timeouts and retries
+type DefaultGraphsyncSession struct {
+	exchange    GraphExchange
+	systemClock clock.Clock
 	peerTracker RequestPeerTracker
 	currentPeer peer.ID
 	triedPeers  map[peer.ID]struct{}
 }
 
 // CurrentPeers returns one or more peers to make the next requests to
-func (pri *DefaultRequestPeerFinder) CurrentPeers() []peer.ID {
-	return []peer.ID{pri.currentPeer}
+func (gss *DefaultGraphsyncSession) CurrentPeers() []peer.ID {
+	return []peer.ID{gss.currentPeer}
 }
 
 // FindNextPeers tells the peer finder that the current peers did not successfully
 // complete a request and it should look for more
-func (pri *DefaultRequestPeerFinder) FindNextPeers() error {
-	chains := pri.peerTracker.List()
+func (gss *DefaultGraphsyncSession) FindNextPeers() error {
+	chains := gss.peerTracker.List()
 	for _, chain := range chains {
-		if _, tried := pri.triedPeers[chain.Peer]; !tried {
-			pri.triedPeers[chain.Peer] = struct{}{}
-			pri.currentPeer = chain.Peer
+		if _, tried := gss.triedPeers[chain.Peer]; !tried {
+			gss.triedPeers[chain.Peer] = struct{}{}
+			gss.currentPeer = chain.Peer
 			return nil
 		}
 	}
 	return fmt.Errorf("Unable to find any untried peers")
+}
+
+func (gss *DefaultGraphsyncSession) Request(ctx context.Context, roots []cid.Cid, selector ipld.Node, tryAllPeers bool) error {
+	remainingRoots := roots
+	for {
+		peers := gss.CurrentPeers()
+		remainingRoots = gss.fetchInParallel(ctx, remainingRoots, selector, peers)
+		if len(remainingRoots) == 0 {
+			return nil
+		}
+		err := gss.FindNextPeers()
+		if err != nil {
+			return errors.Wrapf(err, "makingquery for cids: %s", roots)
+		}
+		if !tryAllPeers {
+			return nil
+		}
+	}
+}
+
+// fetchInParallel performs the given fetch operation specified by the given roots and selector to
+// multiple peers at once
+func (gss *DefaultGraphsyncSession) fetchInParallel(ctx context.Context, roots []cid.Cid, selector ipld.Node, targetPeers []peer.ID) []cid.Cid {
+	var wg sync.WaitGroup
+	parallelCtx, parallelCancel := context.WithCancel(ctx)
+	var resultLk sync.RWMutex
+	globalIncomplete := make([]cid.Cid, 0, len(roots))
+	for _, c := range roots {
+		globalIncomplete = append(globalIncomplete, c)
+	}
+	defer parallelCancel()
+	for _, p := range targetPeers {
+		wg.Add(1)
+		go func(p peer.ID) {
+			defer wg.Done()
+			incomplete, err := gss.fetchBlocks(parallelCtx, roots, selector, p)
+			fmt.Println(incomplete)
+			fmt.Println(err)
+			select {
+			case <-parallelCtx.Done():
+			default:
+			}
+			resultLk.Lock()
+			newGlobalIncomplete := make([]cid.Cid, 0, len(globalIncomplete))
+			for _, c1 := range globalIncomplete {
+				for _, c2 := range incomplete {
+					if c1.Equals(c2) {
+						newGlobalIncomplete = append(newGlobalIncomplete, c1)
+						break
+					}
+				}
+			}
+			globalIncomplete = newGlobalIncomplete
+			done := len(globalIncomplete) == 0
+			resultLk.Unlock()
+			if done {
+				parallelCancel()
+			}
+			if err != nil {
+				// A likely case is the peer doesn't have the tipset. When graphsync provides
+				// this status we should quiet this log.
+				logGraphsyncFetcher.Infof("request failed: %s", err)
+			}
+		}(p)
+	}
+	wg.Wait()
+	return globalIncomplete
+}
+
+// fetchBlocks requests a single set of cids as individual blocks, fetching
+// non-recursively
+func (gss *DefaultGraphsyncSession) fetchBlocks(ctx context.Context, cids []cid.Cid, selector ipld.Node, targetPeer peer.ID) ([]cid.Cid, error) {
+	var wg sync.WaitGroup
+	// Any of the multiple parallel requests might fail. Wait for all of them to complete, then
+	// return any error (in this case, the first one to be received).
+	var resultLk sync.RWMutex
+	var anyError error
+	var incomplete []cid.Cid
+	for _, c := range cids {
+		requestCtx, requestCancel := context.WithCancel(ctx)
+		defer requestCancel()
+		requestChan, errChan := gss.exchange.Request(requestCtx, targetPeer, cidlink.Link{Cid: c}, selector)
+		wg.Add(1)
+		go func(requestChan <-chan graphsync.ResponseProgress, errChan <-chan error, cancelFunc func(), c cid.Cid) {
+			defer wg.Done()
+			err := gss.consumeResponse(requestChan, errChan, cancelFunc)
+			if err != nil {
+				resultLk.Lock()
+				incomplete = append(incomplete, c)
+				anyError = err
+				resultLk.Unlock()
+			}
+		}(requestChan, errChan, requestCancel, c)
+	}
+	wg.Wait()
+	return incomplete, anyError
+}
+
+func (gss *DefaultGraphsyncSession) consumeResponse(requestChan <-chan graphsync.ResponseProgress, errChan <-chan error, cancelFunc func()) error {
+	timer := gss.systemClock.NewTimer(progressTimeout)
+	var anyError error
+	for errChan != nil || requestChan != nil {
+		select {
+		case err, ok := <-errChan:
+			if !ok {
+				errChan = nil
+			}
+			anyError = err
+			timer.Reset(progressTimeout)
+		case _, ok := <-requestChan:
+			if !ok {
+				requestChan = nil
+			}
+			timer.Reset(progressTimeout)
+		case <-timer.Chan():
+			cancelFunc()
+		}
+	}
+	return anyError
 }

--- a/net/request_peer_finder_test.go
+++ b/net/request_peer_finder_test.go
@@ -1,0 +1,81 @@
+package net_test
+
+import (
+	"testing"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/net"
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+func TestDefaultRequestPeerFinder(t *testing.T) {
+	tf.UnitTest(t)
+	pid0 := th.RequireIntPeerID(t, 0)
+	pid1 := th.RequireIntPeerID(t, 1)
+	pid2 := th.RequireIntPeerID(t, 2)
+	chain0 := types.NewChainInfo(pid0, types.UndefTipSet.Key(), 0)
+	chain1 := types.NewChainInfo(pid1, types.UndefTipSet.Key(), 0)
+	chain2 := types.NewChainInfo(pid2, types.UndefTipSet.Key(), 0)
+
+	t.Run("when originating peer is self", func(t *testing.T) {
+		fpt := th.NewFakePeerTracker(pid1, chain0, chain1, chain2)
+		rpff := net.MakeDefaultRequestPeerFinderFactory(fpt)
+		rpf, err := rpff(pid1)
+		require.NoError(t, err)
+		require.Equal(t, rpf.CurrentPeers(), []peer.ID{pid1})
+		err = rpf.FindNextPeers()
+		require.NoError(t, err)
+		require.Contains(t, []peer.ID{pid0, pid2}, rpf.CurrentPeers()[0])
+		err = rpf.FindNextPeers()
+		require.NoError(t, err)
+		require.Contains(t, []peer.ID{pid0, pid2}, rpf.CurrentPeers()[0])
+		err = rpf.FindNextPeers()
+		require.EqualError(t, err, "Unable to find any untried peers")
+	})
+
+	t.Run("when originating peer is not self", func(t *testing.T) {
+		fpt := th.NewFakePeerTracker(pid1, chain0, chain1, chain2)
+		rpff := net.MakeDefaultRequestPeerFinderFactory(fpt)
+		rpf, err := rpff(pid2)
+		require.NoError(t, err)
+		require.Contains(t, []peer.ID{pid0, pid1, pid2}, rpf.CurrentPeers()[0])
+		err = rpf.FindNextPeers()
+		require.NoError(t, err)
+		require.Contains(t, []peer.ID{pid0, pid1, pid2}, rpf.CurrentPeers()[0])
+		err = rpf.FindNextPeers()
+		require.NoError(t, err)
+		require.Contains(t, []peer.ID{pid0, pid1, pid2}, rpf.CurrentPeers()[0])
+		err = rpf.FindNextPeers()
+		require.EqualError(t, err, "Unable to find any untried peers")
+	})
+
+	t.Run("when more peers are added to peer tracker", func(t *testing.T) {
+		fpt := th.NewFakePeerTracker(pid1, chain0)
+		rpff := net.MakeDefaultRequestPeerFinderFactory(fpt)
+		rpf, err := rpff(pid2)
+		require.NoError(t, err)
+		require.Equal(t, []peer.ID{pid0}, rpf.CurrentPeers())
+		fpt.SetList(chain1)
+		err = rpf.FindNextPeers()
+		require.NoError(t, err)
+		require.Equal(t, []peer.ID{pid1}, rpf.CurrentPeers())
+		fpt.SetList(chain2)
+		err = rpf.FindNextPeers()
+		require.NoError(t, err)
+		require.Equal(t, []peer.ID{pid2}, rpf.CurrentPeers())
+		err = rpf.FindNextPeers()
+		require.EqualError(t, err, "Unable to find any untried peers")
+	})
+
+	t.Run("when no peers are available", func(t *testing.T) {
+		fpt := th.NewFakePeerTracker(pid1)
+		rpff := net.MakeDefaultRequestPeerFinderFactory(fpt)
+		rpf, err := rpff(pid2)
+		require.Nil(t, rpf)
+		require.EqualError(t, err, "Unable to find any untried peers")
+	})
+}

--- a/net/request_peer_finder_test.go
+++ b/net/request_peer_finder_test.go
@@ -1,8 +1,13 @@
 package net_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/ipfs/go-datastore"
+	dss "github.com/ipfs/go-datastore/sync"
+	bstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
 
@@ -14,6 +19,10 @@ import (
 
 func TestDefaultRequestPeerFinder(t *testing.T) {
 	tf.UnitTest(t)
+	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
+	clock := th.NewFakeClock(time.Now())
+	ctx := context.Background()
+	mgs := newMockableGraphsync(ctx, bs, clock, t)
 	pid0 := th.RequireIntPeerID(t, 0)
 	pid1 := th.RequireIntPeerID(t, 1)
 	pid2 := th.RequireIntPeerID(t, 2)
@@ -22,9 +31,11 @@ func TestDefaultRequestPeerFinder(t *testing.T) {
 	chain2 := types.NewChainInfo(pid2, types.UndefTipSet.Key(), 0)
 
 	t.Run("when originating peer is self", func(t *testing.T) {
+
 		fpt := th.NewFakePeerTracker(pid1, chain0, chain1, chain2)
-		rpff := net.MakeDefaultRequestPeerFinderFactory(fpt)
-		rpf, err := rpff(pid1)
+		gse := net.MakeDefaultGraphsyncSessionExchange(mgs, clock, fpt)
+		gss, err := gse.NewSession(ctx, pid1)
+		rpf := gss.(*net.DefaultGraphsyncSession)
 		require.NoError(t, err)
 		require.Equal(t, rpf.CurrentPeers(), []peer.ID{pid1})
 		err = rpf.FindNextPeers()
@@ -39,8 +50,9 @@ func TestDefaultRequestPeerFinder(t *testing.T) {
 
 	t.Run("when originating peer is not self", func(t *testing.T) {
 		fpt := th.NewFakePeerTracker(pid1, chain0, chain1, chain2)
-		rpff := net.MakeDefaultRequestPeerFinderFactory(fpt)
-		rpf, err := rpff(pid2)
+		gse := net.MakeDefaultGraphsyncSessionExchange(mgs, clock, fpt)
+		gss, err := gse.NewSession(ctx, pid1)
+		rpf := gss.(*net.DefaultGraphsyncSession)
 		require.NoError(t, err)
 		require.Contains(t, []peer.ID{pid0, pid1, pid2}, rpf.CurrentPeers()[0])
 		err = rpf.FindNextPeers()
@@ -55,8 +67,9 @@ func TestDefaultRequestPeerFinder(t *testing.T) {
 
 	t.Run("when more peers are added to peer tracker", func(t *testing.T) {
 		fpt := th.NewFakePeerTracker(pid1, chain0)
-		rpff := net.MakeDefaultRequestPeerFinderFactory(fpt)
-		rpf, err := rpff(pid2)
+		gse := net.MakeDefaultGraphsyncSessionExchange(mgs, clock, fpt)
+		gss, err := gse.NewSession(ctx, pid2)
+		rpf := gss.(*net.DefaultGraphsyncSession)
 		require.NoError(t, err)
 		require.Equal(t, []peer.ID{pid0}, rpf.CurrentPeers())
 		fpt.SetList(chain1)
@@ -73,9 +86,9 @@ func TestDefaultRequestPeerFinder(t *testing.T) {
 
 	t.Run("when no peers are available", func(t *testing.T) {
 		fpt := th.NewFakePeerTracker(pid1)
-		rpff := net.MakeDefaultRequestPeerFinderFactory(fpt)
-		rpf, err := rpff(pid2)
-		require.Nil(t, rpf)
+		gse := net.MakeDefaultGraphsyncSessionExchange(mgs, clock, fpt)
+		gss, err := gse.NewSession(ctx, pid2)
+		require.Nil(t, gss)
 		require.EqualError(t, err, "Unable to find any untried peers")
 	})
 }

--- a/net/validators_test.go
+++ b/net/validators_test.go
@@ -57,7 +57,7 @@ func TestBlockPubSubValidation(t *testing.T) {
 
 	// create a fake clock to trigger block validation failures
 	now := time.Unix(1234567890, 0)
-	mclock := th.NewFakeSystemClock(now)
+	mclock := th.NewFakeClock(now)
 	// block time will be 1 second
 	blocktime := time.Second * 1
 

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -133,7 +133,7 @@ func TestChainSync(t *testing.T) {
 // makeNodes makes at least two nodes, a miner and a client; numNodes is the total wanted
 func makeNodesBlockPropTests(t *testing.T, numNodes int) (address.Address, []*Node) {
 	seed := MakeChainSeed(t, TestGenCfg)
-	builderOpts := []BuilderOpt{ClockConfigOption(th.NewFakeSystemClock(time.Unix(1234567890, 0)))}
+	builderOpts := []BuilderOpt{ClockConfigOption(th.NewFakeClock(time.Unix(1234567890, 0)))}
 	minerNode := MakeNodeWithChainSeed(t, seed, builderOpts,
 		PeerKeyOpt(PeerKeys[0]),
 	)

--- a/node/builder.go
+++ b/node/builder.go
@@ -223,7 +223,7 @@ func (nc *Builder) build(ctx context.Context) (*Node, error) {
 	loader := gsstoreutil.LoaderForBlockstore(bs)
 	storer := gsstoreutil.StorerForBlockstore(bs)
 	gsync := graphsync.New(ctx, graphsyncNetwork, bridge, loader, storer)
-	fetcher := net.NewGraphSyncFetcher(ctx, gsync, bs, blkValid, peerTracker)
+	fetcher := net.NewGraphSyncFetcher(ctx, gsync, bs, blkValid, nc.Clock, peerTracker)
 
 	// TODO: inject protocol upgrade table into code that requires it (#3360)
 	_, err = version.ConfigureProtocolVersions(network)

--- a/node/builder.go
+++ b/node/builder.go
@@ -223,7 +223,8 @@ func (nc *Builder) build(ctx context.Context) (*Node, error) {
 	loader := gsstoreutil.LoaderForBlockstore(bs)
 	storer := gsstoreutil.StorerForBlockstore(bs)
 	gsync := graphsync.New(ctx, graphsyncNetwork, bridge, loader, storer)
-	fetcher := net.NewGraphSyncFetcher(ctx, gsync, bs, blkValid, nc.Clock, peerTracker)
+	rpff := net.MakeDefaultRequestPeerFinderFactory(peerTracker)
+	fetcher := net.NewGraphSyncFetcher(ctx, gsync, bs, blkValid, nc.Clock, rpff)
 
 	// TODO: inject protocol upgrade table into code that requires it (#3360)
 	_, err = version.ConfigureProtocolVersions(network)

--- a/testhelpers/clock.go
+++ b/testhelpers/clock.go
@@ -1,9 +1,12 @@
 package testhelpers
 
 import (
+	"sync"
 	"time"
 
 	"github.com/jonboulle/clockwork"
+
+	"github.com/filecoin-project/go-filecoin/clock"
 )
 
 // FakeSystemClock wrapps the jonboulle/clockwork.FakeClock interface.
@@ -11,9 +14,124 @@ import (
 // manually advanced through time.
 type FakeSystemClock interface {
 	clockwork.FakeClock
+	NewTimer(d time.Duration) clock.Timer
+	AfterFunc(d time.Duration, f func()) clock.Timer
+}
+
+type fakeSystemClock struct {
+	clockwork.FakeClock
+	timersLk sync.RWMutex
+	timers   []*fakeTimer
 }
 
 // NewFakeSystemClock returns a FakeSystemClock initialised at the given time.Time.
 func NewFakeSystemClock(n time.Time) FakeSystemClock {
-	return clockwork.NewFakeClockAt(n)
+	return &fakeSystemClock{FakeClock: clockwork.NewFakeClockAt(n)}
+}
+
+func (fsc *fakeSystemClock) NewTimer(d time.Duration) clock.Timer {
+	out := make(chan time.Time, 1)
+	sendTime := func(c interface{}, now time.Time) {
+		c.(chan time.Time) <- now
+	}
+
+	ft := &fakeTimer{
+		clock:    fsc,
+		until:    fsc.Now().Add(d),
+		callback: sendTime,
+		arg:      out,
+		out:      out,
+	}
+	fsc.addTimer(ft)
+	return ft
+}
+
+func (fsc *fakeSystemClock) AfterFunc(d time.Duration, f func()) clock.Timer {
+	goFunc := func(fn interface{}, _ time.Time) {
+		go fn.(func())()
+	}
+
+	s := &fakeTimer{
+		clock:    fsc,
+		until:    fsc.Now().Add(d),
+		callback: goFunc,
+		arg:      f,
+		// zero-valued c, the same as it is in the `time` pkg
+	}
+	fsc.addTimer(s)
+	return s
+}
+
+func (fsc *fakeSystemClock) addTimer(ft *fakeTimer) {
+
+	now := fsc.Now()
+	if now.Sub(ft.until) >= 0 {
+		ft.awaken(now)
+	} else {
+		fsc.timersLk.Lock()
+		fsc.timers = append(fsc.timers, ft)
+		fsc.timersLk.Unlock()
+	}
+}
+
+func (fsc *fakeSystemClock) Advance(d time.Duration) {
+	fsc.FakeClock.Advance(d)
+	now := fsc.Now()
+	fsc.timersLk.Lock()
+	var newTimers []*fakeTimer
+	for _, ft := range fsc.timers {
+		if now.Sub(ft.until) >= 0 {
+			ft.awaken(now)
+		} else {
+			newTimers = append(newTimers, ft)
+		}
+	}
+	fsc.timers = newTimers
+	fsc.timersLk.Unlock()
+}
+
+type fakeTimer struct {
+	clock    *fakeSystemClock
+	until    time.Time
+	callback func(interface{}, time.Time)
+	arg      interface{}
+	doneLk   sync.RWMutex
+	done     bool
+	out      chan time.Time
+}
+
+func (ft *fakeTimer) awaken(now time.Time) {
+	ft.doneLk.Lock()
+	if !ft.done {
+		ft.done = true
+		ft.callback(ft.arg, now)
+	}
+	ft.doneLk.Unlock()
+}
+
+func (ft *fakeTimer) Chan() <-chan time.Time {
+	return ft.out
+}
+
+func (ft *fakeTimer) Reset(d time.Duration) bool {
+	active := ft.Stop()
+	ft.until = ft.clock.Now().Add(d)
+	ft.doneLk.Lock()
+	ft.done = false
+	ft.doneLk.Unlock()
+	ft.clock.addTimer(ft)
+	return active
+}
+
+func (ft *fakeTimer) Stop() bool {
+	ft.doneLk.Lock()
+	wasActive := !ft.done
+	ft.done = true
+	ft.doneLk.Unlock()
+
+	if wasActive {
+		ft.until = ft.clock.Now()
+		ft.clock.Advance(0)
+	}
+	return wasActive
 }

--- a/testhelpers/clock.go
+++ b/testhelpers/clock.go
@@ -4,134 +4,274 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jonboulle/clockwork"
-
 	"github.com/filecoin-project/go-filecoin/clock"
 )
 
-// FakeSystemClock wrapps the jonboulle/clockwork.FakeClock interface.
 // FakeSystemClock provides an interface for a clock which can be
-// manually advanced through time.
+// manually advanced through time
+// Adapted from: https://github.com/jonboulle/clockwork
 type FakeSystemClock interface {
-	clockwork.FakeClock
-	NewTimer(d time.Duration) clock.Timer
-	AfterFunc(d time.Duration, f func()) clock.Timer
-}
-
-type fakeSystemClock struct {
-	clockwork.FakeClock
-	timersLk sync.RWMutex
-	timers   []*fakeTimer
+	clock.Clock
+	// Advance advances the FakeClock to a new point in time, ensuring any existing
+	// sleepers are notified appropriately before returning
+	Advance(d time.Duration)
+	// BlockUntil will block until the FakeClock has the given number of
+	// sleepers (callers of Sleep or After)
+	BlockUntil(n int)
 }
 
 // NewFakeSystemClock returns a FakeSystemClock initialised at the given time.Time.
 func NewFakeSystemClock(n time.Time) FakeSystemClock {
-	return &fakeSystemClock{FakeClock: clockwork.NewFakeClockAt(n)}
+	return &fakeClock{
+		time: n,
+	}
 }
 
-func (fsc *fakeSystemClock) NewTimer(d time.Duration) clock.Timer {
-	out := make(chan time.Time, 1)
+type fakeClock struct {
+	timers   []*timer
+	blockers []*blocker
+	time     time.Time
+
+	l sync.RWMutex
+}
+
+// timer represents a waiting timer from NewTimer, Sleep, After, etc.
+type timer struct {
+	until    time.Time
+	callback func(interface{}, time.Time)
+	arg      interface{}
+
+	c      chan time.Time
+	doneLk sync.RWMutex
+	done   bool
+	clock  *fakeClock // needed for Reset()
+}
+
+// blocker represents a caller of BlockUntil
+type blocker struct {
+	count int
+	ch    chan struct{}
+}
+
+func (s *timer) awaken(now time.Time) {
+	s.doneLk.Lock()
+	defer s.doneLk.Unlock()
+	if !s.done {
+		s.done = true
+		s.callback(s.arg, now)
+	}
+}
+
+func (s *timer) Chan() <-chan time.Time { return s.c }
+
+func (s *timer) Reset(d time.Duration) bool {
+	wasActive := s.Stop()
+	s.until = s.clock.Now().Add(d)
+	s.doneLk.Lock()
+	s.done = false
+	s.doneLk.Unlock()
+	s.clock.addTimer(s)
+	return wasActive
+}
+
+func (s *timer) Stop() bool {
+	s.doneLk.Lock()
+	if s.done {
+		s.doneLk.Unlock()
+		return false
+	}
+	s.done = true
+	s.doneLk.Unlock()
+	// Expire the timer and notify blockers
+	s.until = s.clock.Now()
+	s.clock.Advance(0)
+	return true
+}
+
+func (fc *fakeClock) addTimer(s *timer) {
+	fc.l.Lock()
+	defer fc.l.Unlock()
+
+	now := fc.time
+	if now.Sub(s.until) >= 0 {
+		// special case - trigger immediately
+		s.awaken(now)
+	} else {
+		// otherwise, add to the set of sleepers
+		fc.timers = append(fc.timers, s)
+		// and notify any blockers
+		fc.blockers = notifyBlockers(fc.blockers, len(fc.timers))
+	}
+}
+
+// After mimics time.After; it waits for the given duration to elapse on the
+// fakeClock, then sends the current time on the returned channel.
+func (fc *fakeClock) After(d time.Duration) <-chan time.Time {
+	return fc.NewTimer(d).Chan()
+}
+
+// notifyBlockers notifies all the blockers waiting until the
+// given number of sleepers are waiting on the fakeClock. It
+// returns an updated slice of blockers (i.e. those still waiting)
+func notifyBlockers(blockers []*blocker, count int) (newBlockers []*blocker) {
+	for _, b := range blockers {
+		if b.count == count {
+			close(b.ch)
+		} else {
+			newBlockers = append(newBlockers, b)
+		}
+	}
+	return
+}
+
+// Sleep blocks until the given duration has passed on the fakeClock
+func (fc *fakeClock) Sleep(d time.Duration) {
+	<-fc.After(d)
+}
+
+// Time returns the current time of the fakeClock
+func (fc *fakeClock) Now() time.Time {
+	fc.l.RLock()
+	t := fc.time
+	fc.l.RUnlock()
+	return t
+}
+
+// Since returns the duration that has passed since the given time on the fakeClock
+func (fc *fakeClock) Since(t time.Time) time.Duration {
+	return fc.Now().Sub(t)
+}
+
+func (fc *fakeClock) NewTicker(d time.Duration) clock.Ticker {
+	ft := &fakeTicker{
+		c:      make(chan time.Time, 1),
+		stop:   make(chan bool, 1),
+		clock:  fc,
+		period: d,
+	}
+	go ft.tick()
+	return ft
+}
+
+// NewTimer creates a new Timer that will send the current time on its channel
+// after the given duration elapses on the fake clock.
+func (fc *fakeClock) NewTimer(d time.Duration) clock.Timer {
+	done := make(chan time.Time, 1)
 	sendTime := func(c interface{}, now time.Time) {
 		c.(chan time.Time) <- now
 	}
 
-	ft := &fakeTimer{
-		clock:    fsc,
-		until:    fsc.Now().Add(d),
+	s := &timer{
+		clock:    fc,
+		until:    fc.time.Add(d),
 		callback: sendTime,
-		arg:      out,
-		out:      out,
+		arg:      done,
+		c:        done,
 	}
-	fsc.addTimer(ft)
-	return ft
+	fc.addTimer(s)
+	return s
 }
 
-func (fsc *fakeSystemClock) AfterFunc(d time.Duration, f func()) clock.Timer {
+// AfterFunc waits for the duration to elapse on the fake clock and then calls f
+// in its own goroutine.
+// It returns a Timer that can be used to cancel the call using its Stop method.
+func (fc *fakeClock) AfterFunc(d time.Duration, f func()) clock.Timer {
 	goFunc := func(fn interface{}, _ time.Time) {
 		go fn.(func())()
 	}
 
-	s := &fakeTimer{
-		clock:    fsc,
-		until:    fsc.Now().Add(d),
+	s := &timer{
+		clock:    fc,
+		until:    fc.time.Add(d),
 		callback: goFunc,
 		arg:      f,
 		// zero-valued c, the same as it is in the `time` pkg
 	}
-	fsc.addTimer(s)
+	fc.addTimer(s)
 	return s
 }
 
-func (fsc *fakeSystemClock) addTimer(ft *fakeTimer) {
+// Advance advances fakeClock to a new point in time, ensuring channels from any
+// previous invocations of After are notified appropriately before returning
+func (fc *fakeClock) Advance(d time.Duration) {
+	fc.l.Lock()
+	defer fc.l.Unlock()
 
-	now := fsc.Now()
-	if now.Sub(ft.until) >= 0 {
-		ft.awaken(now)
-	} else {
-		fsc.timersLk.Lock()
-		fsc.timers = append(fsc.timers, ft)
-		fsc.timersLk.Unlock()
-	}
-}
-
-func (fsc *fakeSystemClock) Advance(d time.Duration) {
-	fsc.FakeClock.Advance(d)
-	now := fsc.Now()
-	fsc.timersLk.Lock()
-	var newTimers []*fakeTimer
-	for _, ft := range fsc.timers {
-		if now.Sub(ft.until) >= 0 {
-			ft.awaken(now)
+	end := fc.time.Add(d)
+	var newSleepers []*timer
+	for _, s := range fc.timers {
+		if end.Sub(s.until) >= 0 {
+			s.awaken(end)
 		} else {
-			newTimers = append(newTimers, ft)
+			newSleepers = append(newSleepers, s)
 		}
 	}
-	fsc.timers = newTimers
-	fsc.timersLk.Unlock()
+	fc.timers = newSleepers
+	fc.blockers = notifyBlockers(fc.blockers, len(fc.timers))
+	fc.time = end
 }
 
-type fakeTimer struct {
-	clock    *fakeSystemClock
-	until    time.Time
-	callback func(interface{}, time.Time)
-	arg      interface{}
-	doneLk   sync.RWMutex
-	done     bool
-	out      chan time.Time
-}
-
-func (ft *fakeTimer) awaken(now time.Time) {
-	ft.doneLk.Lock()
-	if !ft.done {
-		ft.done = true
-		ft.callback(ft.arg, now)
+// BlockUntil will block until the fakeClock has the given number of sleepers
+// (callers of Sleep or After)
+func (fc *fakeClock) BlockUntil(n int) {
+	fc.l.Lock()
+	// Fast path: current number of sleepers is what we're looking for
+	if len(fc.timers) == n {
+		fc.l.Unlock()
+		return
 	}
-	ft.doneLk.Unlock()
-}
-
-func (ft *fakeTimer) Chan() <-chan time.Time {
-	return ft.out
-}
-
-func (ft *fakeTimer) Reset(d time.Duration) bool {
-	active := ft.Stop()
-	ft.until = ft.clock.Now().Add(d)
-	ft.doneLk.Lock()
-	ft.done = false
-	ft.doneLk.Unlock()
-	ft.clock.addTimer(ft)
-	return active
-}
-
-func (ft *fakeTimer) Stop() bool {
-	ft.doneLk.Lock()
-	wasActive := !ft.done
-	ft.done = true
-	ft.doneLk.Unlock()
-
-	if wasActive {
-		ft.until = ft.clock.Now()
-		ft.clock.Advance(0)
+	// Otherwise, set up a new blocker
+	b := &blocker{
+		count: n,
+		ch:    make(chan struct{}),
 	}
-	return wasActive
+	fc.blockers = append(fc.blockers, b)
+	fc.l.Unlock()
+	<-b.ch
+}
+
+type fakeTicker struct {
+	c      chan time.Time
+	stop   chan bool
+	clock  FakeSystemClock
+	period time.Duration
+}
+
+func (ft *fakeTicker) Chan() <-chan time.Time {
+	return ft.c
+}
+
+func (ft *fakeTicker) Stop() {
+	ft.stop <- true
+}
+
+// tick sends the tick time to the ticker channel after every period.
+// Tick events are discarded if the underlying ticker channel does
+// not have enough capacity.
+func (ft *fakeTicker) tick() {
+	tick := ft.clock.Now()
+	for {
+		tick = tick.Add(ft.period)
+		remaining := tick.Sub(ft.clock.Now())
+		if remaining <= 0 {
+			// The tick should have already happened. This can happen when
+			// Advance() is called on the fake clock with a duration larger
+			// than this ticker's period.
+			select {
+			case ft.c <- tick:
+			default:
+			}
+			continue
+		}
+
+		select {
+		case <-ft.stop:
+			return
+		case <-ft.clock.After(remaining):
+			select {
+			case ft.c <- tick:
+			default:
+			}
+		}
+	}
 }

--- a/testhelpers/clock_test.go
+++ b/testhelpers/clock_test.go
@@ -1,0 +1,73 @@
+package testhelpers_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+)
+
+func TestFakeClockTimers(t *testing.T) {
+	tf.UnitTest(t)
+	fc := th.NewFakeSystemClock(time.Now())
+
+	zero := fc.NewTimer(0)
+
+	assert.False(t, zero.Stop(), "zero timer could be stopped")
+	select {
+	case <-zero.Chan():
+	default:
+		t.Errorf("zero timer didn't emit time")
+	}
+
+	one := fc.NewTimer(1)
+
+	select {
+	case <-one.Chan():
+		t.Errorf("non-zero timer did emit time")
+	default:
+	}
+
+	assert.True(t, one.Stop(), "non-zero timer couldn't be stopped")
+
+	fc.Advance(5)
+
+	select {
+	case <-one.Chan():
+		t.Errorf("stopped timer did emit time")
+	default:
+	}
+
+	assert.False(t, one.Reset(1), "resetting stopped timer didn't return false")
+	assert.True(t, one.Reset(1), "resetting active timer didn't return true")
+
+	fc.Advance(1)
+
+	assert.False(t, one.Stop(), "triggered timer could be stopped")
+
+	select {
+	case <-one.Chan():
+	default:
+		t.Errorf("triggered timer didn't emit time")
+	}
+
+	fc.Advance(1)
+
+	select {
+	case <-one.Chan():
+		t.Errorf("triggered timer emitted time more than once")
+	default:
+	}
+
+	one.Reset(0)
+
+	assert.False(t, one.Stop(), "reset to zero timer could be stopped")
+	select {
+	case <-one.Chan():
+	default:
+		t.Errorf("reset to zero timer didn't emit time")
+	}
+}

--- a/testhelpers/clock_test.go
+++ b/testhelpers/clock_test.go
@@ -10,6 +10,92 @@ import (
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 )
 
+func TestFakeClockAfter(t *testing.T) {
+	tf.UnitTest(t)
+	fc := th.NewFakeSystemClock(time.Now())
+
+	zero := fc.After(0)
+	select {
+	case <-zero:
+	default:
+		t.Errorf("zero did not return!")
+	}
+	one := fc.After(1)
+	two := fc.After(2)
+	six := fc.After(6)
+	ten := fc.After(10)
+	fc.Advance(1)
+	select {
+	case <-one:
+	default:
+		t.Errorf("one did not return!")
+	}
+	select {
+	case <-two:
+		t.Errorf("two returned prematurely!")
+	case <-six:
+		t.Errorf("six returned prematurely!")
+	case <-ten:
+		t.Errorf("ten returned prematurely!")
+	default:
+	}
+	fc.Advance(1)
+	select {
+	case <-two:
+	default:
+		t.Errorf("two did not return!")
+	}
+	select {
+	case <-six:
+		t.Errorf("six returned prematurely!")
+	case <-ten:
+		t.Errorf("ten returned prematurely!")
+	default:
+	}
+	fc.Advance(1)
+	select {
+	case <-six:
+		t.Errorf("six returned prematurely!")
+	case <-ten:
+		t.Errorf("ten returned prematurely!")
+	default:
+	}
+	fc.Advance(3)
+	select {
+	case <-six:
+	default:
+		t.Errorf("six did not return!")
+	}
+	select {
+	case <-ten:
+		t.Errorf("ten returned prematurely!")
+	default:
+	}
+	fc.Advance(100)
+	select {
+	case <-ten:
+	default:
+		t.Errorf("ten did not return!")
+	}
+}
+
+func TestNewFakeClockAt(t *testing.T) {
+	tf.UnitTest(t)
+	t1 := time.Date(1999, time.February, 3, 4, 5, 6, 7, time.UTC)
+	fc := th.NewFakeSystemClock(t1)
+	now := fc.Now()
+	assert.Equalf(t, now, t1, "fakeClock.Now() returned unexpected non-initialised value: want=%#v, got %#v", t1, now)
+}
+
+func TestFakeClockSince(t *testing.T) {
+	tf.UnitTest(t)
+	fc := th.NewFakeSystemClock(time.Now())
+	now := fc.Now()
+	elapsedTime := time.Second
+	fc.Advance(elapsedTime)
+	assert.Truef(t, fc.Since(now) == elapsedTime, "fakeClock.Since() returned unexpected duration, got: %d, want: %d", fc.Since(now), elapsedTime)
+}
+
 func TestFakeClockTimers(t *testing.T) {
 	tf.UnitTest(t)
 	fc := th.NewFakeSystemClock(time.Now())
@@ -70,4 +156,164 @@ func TestFakeClockTimers(t *testing.T) {
 	default:
 		t.Errorf("reset to zero timer didn't emit time")
 	}
+}
+
+type syncFunc func(didAdvance func(), shouldAdvance func(string), shouldBlock func(string))
+
+func inSync(t *testing.T, func1 syncFunc, func2 syncFunc) {
+	stepChan1 := make(chan struct{}, 16)
+	stepChan2 := make(chan struct{}, 16)
+	go func() {
+		func1(func() { stepChan1 <- struct{}{} }, func(point string) {
+			select {
+			case <-stepChan2:
+			case <-time.After(time.Second):
+				t.Errorf("Did not advance, should have %s", point)
+			}
+		},
+			func(point string) {
+				select {
+				case <-stepChan2:
+					t.Errorf("Was able to advance, should not have %s", point)
+				case <-time.After(10 * time.Millisecond):
+				}
+			},
+		)
+	}()
+	func2(func() { stepChan2 <- struct{}{} }, func(point string) {
+		select {
+		case <-stepChan1:
+		case <-time.After(time.Second):
+			t.Errorf("Did not advance, should have %s", point)
+		}
+	},
+		func(point string) {
+			select {
+			case <-stepChan1:
+				t.Errorf("Was able to advance, should not have %s", point)
+			case <-time.After(10 * time.Millisecond):
+			}
+		})
+}
+
+func TestBlockingOnTimers(t *testing.T) {
+	tf.UnitTest(t)
+	fc := th.NewFakeSystemClock(time.Now())
+
+	inSync(t, func(didAdvance func(), shouldAdvance func(string), _ func(string)) {
+		fc.BlockUntil(0)
+		didAdvance()
+		fc.BlockUntil(1)
+		didAdvance()
+		shouldAdvance("timers stopped")
+		fc.BlockUntil(0)
+		didAdvance()
+		fc.BlockUntil(1)
+		didAdvance()
+		fc.BlockUntil(2)
+		didAdvance()
+		fc.BlockUntil(3)
+		didAdvance()
+		shouldAdvance("timers stopped")
+		fc.BlockUntil(2)
+		didAdvance()
+		shouldAdvance("time advanced")
+		fc.BlockUntil(0)
+		didAdvance()
+	}, func(didAdvance func(), shouldAdvance func(string), shouldBlock func(string)) {
+		shouldAdvance("when only blocking for 0 timers")
+		shouldBlock("when waiting for 1 timer")
+		fc.NewTimer(0)
+		shouldBlock("when immediately expired timer added")
+		one := fc.NewTimer(1)
+		shouldAdvance("once a timer exists")
+		one.Stop()
+		didAdvance()
+		shouldAdvance("when only blocking for 0 timers")
+		shouldBlock("when all timers are stopped and waiting for a timer")
+		one.Reset(1)
+		shouldAdvance("once timer is restarted")
+		shouldBlock("when waiting for 2 timers with one active")
+		_ = fc.NewTimer(2)
+		shouldAdvance("when second timer added")
+		shouldBlock("when waiting for 3 timers with 2 active")
+		_ = fc.NewTimer(3)
+		shouldAdvance("when third timer added")
+		one.Stop()
+		didAdvance()
+		shouldAdvance("when blocking for 2 timers if a third is stopped")
+		fc.Advance(3)
+		didAdvance()
+		shouldAdvance("waiting for no timers")
+	})
+}
+
+func TestAdvancePastAfter(t *testing.T) {
+	tf.UnitTest(t)
+
+	fc := th.NewFakeSystemClock(time.Now())
+
+	start := fc.Now()
+	one := fc.After(1)
+	two := fc.After(2)
+	six := fc.After(6)
+
+	fc.Advance(1)
+	assert.False(t, start.Add(1).Sub(<-one) > 0, "timestamp is too early")
+
+	fc.Advance(5)
+	assert.False(t, start.Add(2).Sub(<-two) > 0, "timestamp is too early")
+	assert.False(t, start.Add(6).Sub(<-six) > 0, "timestamp is too early")
+}
+
+func TestFakeTickerStop(t *testing.T) {
+	tf.UnitTest(t)
+	fc := th.NewFakeSystemClock(time.Now())
+
+	ft := fc.NewTicker(1)
+	ft.Stop()
+	fc.Advance(1)
+	select {
+	case <-ft.Chan():
+		t.Errorf("received unexpected tick!")
+	default:
+	}
+}
+
+func TestFakeTickerTick(t *testing.T) {
+	tf.UnitTest(t)
+	fc := th.NewFakeSystemClock(time.Now())
+	now := fc.Now()
+
+	// The tick at now.Add(2) should not get through since we advance time by
+	// two units below and the channel can hold at most one tick until it's
+	// consumed.
+	first := now.Add(1)
+	second := now.Add(3)
+
+	// We wrap the Advance() calls with blockers to make sure that the ticker
+	// can go to sleep and produce ticks without time passing in parallel.
+	ft := fc.NewTicker(1)
+	fc.BlockUntil(1)
+	fc.Advance(2)
+	fc.BlockUntil(1)
+
+	select {
+	case tick := <-ft.Chan():
+		assert.Truef(t, tick == first, "wrong tick time, got: %v, want: %v", tick, first)
+	default:
+		t.Errorf("expected tick!")
+	}
+
+	// Advance by one more unit, we should get another tick now.
+	fc.Advance(1)
+	fc.BlockUntil(1)
+
+	select {
+	case tick := <-ft.Chan():
+		assert.Truef(t, tick == second, "wrong tick time, got: %v, want: %v", tick, second)
+	default:
+		t.Errorf("expected tick!")
+	}
+	ft.Stop()
 }

--- a/testhelpers/clock_test.go
+++ b/testhelpers/clock_test.go
@@ -10,9 +10,11 @@ import (
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 )
 
+var startTime = time.Unix(123456789, 0)
+
 func TestFakeClockAfter(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(time.Now())
+	fc := th.NewFakeSystemClock(startTime)
 
 	zero := fc.After(0)
 	select {
@@ -89,7 +91,7 @@ func TestNewFakeClockAt(t *testing.T) {
 
 func TestFakeClockSince(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(time.Now())
+	fc := th.NewFakeSystemClock(startTime)
 	now := fc.Now()
 	elapsedTime := time.Second
 	fc.Advance(elapsedTime)
@@ -98,7 +100,7 @@ func TestFakeClockSince(t *testing.T) {
 
 func TestFakeClockTimers(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(time.Now())
+	fc := th.NewFakeSystemClock(startTime)
 
 	zero := fc.NewTimer(0)
 
@@ -198,7 +200,7 @@ func inSync(t *testing.T, func1 syncFunc, func2 syncFunc) {
 
 func TestBlockingOnTimers(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(time.Now())
+	fc := th.NewFakeSystemClock(startTime)
 
 	inSync(t, func(didAdvance func(), shouldAdvance func(string), _ func(string)) {
 		fc.BlockUntil(0)
@@ -251,7 +253,7 @@ func TestBlockingOnTimers(t *testing.T) {
 func TestAdvancePastAfter(t *testing.T) {
 	tf.UnitTest(t)
 
-	fc := th.NewFakeSystemClock(time.Now())
+	fc := th.NewFakeSystemClock(startTime)
 
 	start := fc.Now()
 	one := fc.After(1)
@@ -268,7 +270,7 @@ func TestAdvancePastAfter(t *testing.T) {
 
 func TestFakeTickerStop(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(time.Now())
+	fc := th.NewFakeSystemClock(startTime)
 
 	ft := fc.NewTicker(1)
 	ft.Stop()
@@ -282,7 +284,7 @@ func TestFakeTickerStop(t *testing.T) {
 
 func TestFakeTickerTick(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(time.Now())
+	fc := th.NewFakeSystemClock(startTime)
 	now := fc.Now()
 
 	// The tick at now.Add(2) should not get through since we advance time by

--- a/testhelpers/clock_test.go
+++ b/testhelpers/clock_test.go
@@ -14,7 +14,7 @@ var startTime = time.Unix(123456789, 0)
 
 func TestFakeClockAfter(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(startTime)
+	fc := th.NewFakeClock(startTime)
 
 	zero := fc.After(0)
 	select {
@@ -84,14 +84,14 @@ func TestFakeClockAfter(t *testing.T) {
 func TestNewFakeClockAt(t *testing.T) {
 	tf.UnitTest(t)
 	t1 := time.Date(1999, time.February, 3, 4, 5, 6, 7, time.UTC)
-	fc := th.NewFakeSystemClock(t1)
+	fc := th.NewFakeClock(t1)
 	now := fc.Now()
 	assert.Equalf(t, now, t1, "fakeClock.Now() returned unexpected non-initialised value: want=%#v, got %#v", t1, now)
 }
 
 func TestFakeClockSince(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(startTime)
+	fc := th.NewFakeClock(startTime)
 	now := fc.Now()
 	elapsedTime := time.Second
 	fc.Advance(elapsedTime)
@@ -100,7 +100,7 @@ func TestFakeClockSince(t *testing.T) {
 
 func TestFakeClockTimers(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(startTime)
+	fc := th.NewFakeClock(startTime)
 
 	zero := fc.NewTimer(0)
 
@@ -200,7 +200,7 @@ func inSync(t *testing.T, func1 syncFunc, func2 syncFunc) {
 
 func TestBlockingOnTimers(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(startTime)
+	fc := th.NewFakeClock(startTime)
 
 	inSync(t, func(didAdvance func(), shouldAdvance func(string), _ func(string)) {
 		fc.BlockUntil(0)
@@ -253,7 +253,7 @@ func TestBlockingOnTimers(t *testing.T) {
 func TestAdvancePastAfter(t *testing.T) {
 	tf.UnitTest(t)
 
-	fc := th.NewFakeSystemClock(startTime)
+	fc := th.NewFakeClock(startTime)
 
 	start := fc.Now()
 	one := fc.After(1)
@@ -270,7 +270,7 @@ func TestAdvancePastAfter(t *testing.T) {
 
 func TestFakeTickerStop(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(startTime)
+	fc := th.NewFakeClock(startTime)
 
 	ft := fc.NewTicker(1)
 	ft.Stop()
@@ -284,7 +284,7 @@ func TestFakeTickerStop(t *testing.T) {
 
 func TestFakeTickerTick(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(startTime)
+	fc := th.NewFakeClock(startTime)
 	now := fc.Now()
 
 	// The tick at now.Add(2) should not get through since we advance time by

--- a/testhelpers/net.go
+++ b/testhelpers/net.go
@@ -203,3 +203,31 @@ func (f *TestFetcher) GetBlocks(ctx context.Context, cids []cid.Cid) ([]*types.B
 	}
 	return ret, nil
 }
+
+// FakePeerTracker implements the RequestPeerTracker interface with
+// stubbed values
+type FakePeerTracker struct {
+	peers []*types.ChainInfo
+	self  peer.ID
+}
+
+// NewFakePeerTracker returns a new fake peer tracker with the given self and chain infos
+func NewFakePeerTracker(self peer.ID, cis ...*types.ChainInfo) *FakePeerTracker {
+	return &FakePeerTracker{cis, self}
+}
+
+// List returns a list of ChainInfos about tracked peers
+func (fpt *FakePeerTracker) List() []*types.ChainInfo {
+	return fpt.peers
+}
+
+// SetList overwrites the existing ChainInfos so that List returns
+// a different value
+func (fpt *FakePeerTracker) SetList(cis ...*types.ChainInfo) {
+	fpt.peers = cis
+}
+
+// Self returns the peer tracker's owner ID
+func (fpt *FakePeerTracker) Self() peer.ID {
+	return fpt.self
+}


### PR DESCRIPTION
# Goals

This is a follow-on to the timeout PR that lays the ground work for requesting from multiple peers at once when making graphsync requests

# Implementation

- Move the request peer finder OUT of graphsync_fetcher itself, and have a factory function passed as a dependency to GraphSync instead of the peer tracker
- Change the request peer finder to return a slice of peers for CurrentPeers rather than a single peer for CurrentPeer
- Setup the graphsync fetcher to make multiple requests in parallel when CurrentPeers returns more than one peer
- However, don't actually change the implementation for RequestPeerFinder for now
- Also, move the fakePeerTracker to a helper in TestHelpers so its shared
- Though shortly, this could probably be moved out of the graphsync fetcher unit tests, and instead of using a FakePeerTracker, use a fake RequestPeerFinder

# For Discussion

There are a couple extra layers of indirection here -- theres a function to make a factory function... MakeDefaultRequestPeerFinderFactory which binds to the peer tracker... should we make it simpler? The nice thing is the peertracker is removed from the GraphsyncFetcher entirely and shortly we can remove any reference to it from the GraphsyncFetcher unit tests and simplify them.

Next steps are:
- implement a RequestPeerFinder that just returns two peers at once to start
- implement a fakeRequestPeerFinder in graphsync_fetcher_tests to simplify them.