### PR TITLE
feat(clock): add timer functionality

### DIFF
--- a/chain/syncer_integration_test.go
+++ b/chain/syncer_integration_test.go
@@ -51,7 +51,7 @@ func TestLoadFork(t *testing.T) {
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but
 	// *not* as the store, to which the syncer must ensure to put blocks.
 	eval := &chain.FakeStateEvaluator{}
-	syncer := chain.NewSyncer(eval, store, builder, builder, chain.NewStatusReporter(), th.NewFakeSystemClock(time.Unix(1234567890, 0)))
+	syncer := chain.NewSyncer(eval, store, builder, builder, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 
 	base := builder.AppendManyOn(3, genesis)
 	left := builder.AppendManyOn(4, base)
@@ -79,7 +79,7 @@ func TestLoadFork(t *testing.T) {
 	newStore := chain.NewStore(repo.ChainDatastore(), &cborStore, &state.TreeStateLoader{}, chain.NewStatusReporter(), genesis.At(0).Cid())
 	require.NoError(t, newStore.Load(ctx))
 	fakeFetcher := th.NewTestFetcher()
-	offlineSyncer := chain.NewSyncer(eval, newStore, builder, fakeFetcher, chain.NewStatusReporter(), th.NewFakeSystemClock(time.Unix(1234567890, 0)))
+	offlineSyncer := chain.NewSyncer(eval, newStore, builder, fakeFetcher, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 
 	assert.True(t, newStore.HasTipSetAndState(ctx, left.Key()))
 	assert.False(t, newStore.HasTipSetAndState(ctx, right.Key()))
@@ -186,7 +186,7 @@ func TestTipSetWeightDeep(t *testing.T) {
 
 	// Now sync the chainStore with consensus using a MarketView.
 	con := consensus.NewExpected(cst, bs, th.NewTestProcessor(), th.NewFakeBlockValidator(), &consensus.MarketView{}, calcGenBlk.Cid(), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
-	syncer := chain.NewSyncer(con, chainStore, messageStore, blockSource, chain.NewStatusReporter(), th.NewFakeSystemClock(time.Unix(1234567890, 0)))
+	syncer := chain.NewSyncer(con, chainStore, messageStore, blockSource, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 	baseTS := requireHeadTipset(t, chainStore) // this is the last block of the bootstrapping chain creating miners
 	require.Equal(t, 1, baseTS.Len())
 	bootstrapStateRoot := baseTS.ToSlice()[0].StateRoot

--- a/chain/syncer_test.go
+++ b/chain/syncer_test.go
@@ -194,7 +194,7 @@ func TestFarFutureTipsets(t *testing.T) {
 		genesis := builder.RequireTipSet(store.GetHead())
 		farHead := builder.AppendManyOn(chain.UntrustedChainHeightLimit+1, genesis)
 
-		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, builder, chain.NewStatusReporter(), th.NewFakeSystemClock(time.Unix(1234567890, 0)))
+		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, builder, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 		assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), true))
 	})
 
@@ -203,7 +203,7 @@ func TestFarFutureTipsets(t *testing.T) {
 		genesis := builder.RequireTipSet(store.GetHead())
 		farHead := builder.AppendManyOn(chain.UntrustedChainHeightLimit+1, genesis)
 
-		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, builder, chain.NewStatusReporter(), th.NewFakeSystemClock(time.Unix(1234567890, 0)))
+		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, builder, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 		err := syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), false)
 		assert.Error(t, err)
 	})
@@ -221,7 +221,7 @@ func TestNoUncessesaryFetch(t *testing.T) {
 	// A new syncer unable to fetch blocks from the network can handle a tipset that's already
 	// in the store and linked to genesis.
 	emptyFetcher := chain.NewBuilder(t, address.Undef)
-	newSyncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, emptyFetcher, chain.NewStatusReporter(), th.NewFakeSystemClock(time.Unix(1234567890, 0)))
+	newSyncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, emptyFetcher, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 	assert.NoError(t, newSyncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), head.Key(), heightFromTip(t, head)), true))
 }
 
@@ -471,7 +471,7 @@ func setup(ctx context.Context, t *testing.T) (*chain.Builder, *chain.Store, *ch
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but
 	// *not* as the store, to which the syncer must ensure to put blocks.
 	eval := &chain.FakeStateEvaluator{}
-	syncer := chain.NewSyncer(eval, store, builder, builder, sr, th.NewFakeSystemClock(time.Unix(1234567890, 0)))
+	syncer := chain.NewSyncer(eval, store, builder, builder, sr, th.NewFakeClock(time.Unix(1234567890, 0)))
 
 	return builder, store, syncer
 }

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -2,11 +2,18 @@ package clock
 
 import (
 	"github.com/jonboulle/clockwork"
+	"time"
 )
 
 // Clock provides an interface that packages can use instead of directly
 // using the time module, so that chronology-related behavior can be tested.
 type Clock interface {
+	clockwork.Clock
+	NewTimer(d time.Duration) Timer
+	AfterFunc(d time.Duration, f func()) Timer
+}
+
+type realClock struct {
 	clockwork.Clock
 }
 
@@ -14,5 +21,13 @@ type Clock interface {
 // SystemClock is a Clock which simply delegates calls to the actual time
 // package; it should be used by packages in production.
 func NewSystemClock() Clock {
-	return clockwork.NewRealClock()
+	return &realClock{Clock: clockwork.NewRealClock()}
+}
+
+func (rc *realClock) NewTimer(d time.Duration) Timer {
+	return &realTimer{time.NewTimer(d)}
+}
+
+func (rc *realClock) AfterFunc(d time.Duration, f func()) Timer {
+	return &realTimer{time.AfterFunc(d, f)}
 }

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -1,27 +1,44 @@
 package clock
 
 import (
-	"github.com/jonboulle/clockwork"
 	"time"
 )
 
 // Clock provides an interface that packages can use instead of directly
-// using the time module, so that chronology-related behavior can be tested.
+// using the time module, so that chronology-related behavior can be tested
+// Adapted from: https://github.com/jonboulle/clockwork
 type Clock interface {
-	clockwork.Clock
+	After(d time.Duration) <-chan time.Time
+	Sleep(d time.Duration)
+	Now() time.Time
+	Since(t time.Time) time.Duration
+
+	NewTicker(d time.Duration) Ticker
+
 	NewTimer(d time.Duration) Timer
 	AfterFunc(d time.Duration, f func()) Timer
 }
 
-type realClock struct {
-	clockwork.Clock
+type realClock struct{}
+
+func (rc *realClock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
 }
 
-// NewSystemClock returns a SystemClock that delegates calls to the jonboulee/clockwork package.
-// SystemClock is a Clock which simply delegates calls to the actual time
-// package; it should be used by packages in production.
-func NewSystemClock() Clock {
-	return &realClock{Clock: clockwork.NewRealClock()}
+func (rc *realClock) Sleep(d time.Duration) {
+	time.Sleep(d)
+}
+
+func (rc *realClock) Now() time.Time {
+	return time.Now()
+}
+
+func (rc *realClock) Since(t time.Time) time.Duration {
+	return rc.Now().Sub(t)
+}
+
+func (rc *realClock) NewTicker(d time.Duration) Ticker {
+	return &realTicker{time.NewTicker(d)}
 }
 
 func (rc *realClock) NewTimer(d time.Duration) Timer {
@@ -30,4 +47,11 @@ func (rc *realClock) NewTimer(d time.Duration) Timer {
 
 func (rc *realClock) AfterFunc(d time.Duration, f func()) Timer {
 	return &realTimer{time.AfterFunc(d, f)}
+}
+
+// NewSystemClock returns a SystemClock that delegates calls to the jonboulee/clockwork package.
+// SystemClock is a Clock which simply delegates calls to the actual time
+// package; it should be used by packages in production.
+func NewSystemClock() Clock {
+	return &realClock{}
 }

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -49,8 +49,7 @@ func (rc *realClock) AfterFunc(d time.Duration, f func()) Timer {
 	return &realTimer{time.AfterFunc(d, f)}
 }
 
-// NewSystemClock returns a SystemClock that delegates calls to the jonboulee/clockwork package.
-// SystemClock is a Clock which simply delegates calls to the actual time
+// NewSystemClock returns a Clock that delegates calls to the actual time
 // package; it should be used by packages in production.
 func NewSystemClock() Clock {
 	return &realClock{}

--- a/clock/ticker.go
+++ b/clock/ticker.go
@@ -1,0 +1,21 @@
+package clock
+
+import (
+	"time"
+)
+
+// Ticker provides an interface which can be used instead of directly
+// using the ticker within the time module. The real-time ticker t
+// provides ticks through t.C which becomes now t.Chan() to make
+// this channel requirement definable in this interface.
+// Adapted from: https://github.com/jonboulle/clockwork
+type Ticker interface {
+	Chan() <-chan time.Time
+	Stop()
+}
+
+type realTicker struct{ *time.Ticker }
+
+func (rt *realTicker) Chan() <-chan time.Time {
+	return rt.C
+}

--- a/clock/timer.go
+++ b/clock/timer.go
@@ -1,0 +1,21 @@
+package clock
+
+import (
+	"time"
+)
+
+// Timer provides an interface to a time.Timer which is testable.
+// See https://golang.org/pkg/time/#Timer for more details on how timers work.
+type Timer interface {
+	Chan() <-chan time.Time
+	Reset(d time.Duration) bool
+	Stop() bool
+}
+
+type realTimer struct {
+	*time.Timer
+}
+
+func (rt *realTimer) Chan() <-chan time.Time {
+	return rt.C
+}

--- a/consensus/block_validation_test.go
+++ b/consensus/block_validation_test.go
@@ -21,7 +21,7 @@ func TestBlockValidSemantic(t *testing.T) {
 
 	blockTime := consensus.DefaultBlockTime
 	ts := time.Unix(1234567890, 0)
-	mclock := th.NewFakeSystemClock(ts)
+	mclock := th.NewFakeClock(ts)
 	ctx := context.Background()
 
 	validator := consensus.NewDefaultBlockValidator(blockTime, mclock)
@@ -86,7 +86,7 @@ func TestBlockValidSyntax(t *testing.T) {
 
 	blockTime := consensus.DefaultBlockTime
 	ts := time.Unix(1234567890, 0)
-	mclock := th.NewFakeSystemClock(ts)
+	mclock := th.NewFakeClock(ts)
 
 	ctx := context.Background()
 

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -302,7 +302,7 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 		PowerTable:    &th.TestView{},
 		Blockstore:    bs,
 		MessageStore:  messages,
-		Clock:         th.NewFakeSystemClock(time.Unix(1234567890, 0)),
+		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	builder := chain.NewBuilder(t, address.Undef)
@@ -359,7 +359,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		PowerTable:    &th.TestView{},
 		Blockstore:    bs,
 		MessageStore:  messages,
-		Clock:         th.NewFakeSystemClock(time.Unix(1234567890, 0)),
+		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	// addr3 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
@@ -467,7 +467,7 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 		PowerTable:    &th.TestView{},
 		Blockstore:    bs,
 		MessageStore:  messages,
-		Clock:         th.NewFakeSystemClock(time.Unix(1234567890, 0)),
+		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	h := types.Uint64(100)
@@ -530,7 +530,7 @@ func TestGenerateWithoutMessages(t *testing.T) {
 		PowerTable:    &th.TestView{},
 		Blockstore:    bs,
 		MessageStore:  messages,
-		Clock:         th.NewFakeSystemClock(time.Unix(1234567890, 0)),
+		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	assert.Len(t, pool.Pending(), 0)
@@ -583,7 +583,7 @@ func TestGenerateError(t *testing.T) {
 		PowerTable:    &th.TestView{},
 		Blockstore:    bs,
 		MessageStore:  messages,
-		Clock:         th.NewFakeSystemClock(time.Unix(1234567890, 0)),
+		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	// This is actually okay and should result in a receipt

--- a/net/graphsync_fetcher_test.go
+++ b/net/graphsync_fetcher_test.go
@@ -43,7 +43,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 	tf.UnitTest(t)
 	ctx := context.Background()
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
-	bv := consensus.NewDefaultBlockValidator(5*time.Millisecond, th.NewFakeSystemClock(time.Now()))
+	bv := consensus.NewDefaultBlockValidator(5*time.Millisecond, th.NewFakeClock(time.Now()))
 	pid0 := th.RequireIntPeerID(t, 0)
 	builder := chain.NewBuilder(t, address.Undef)
 	keys := types.MustGenerateKeyInfo(1, 42)

--- a/net/validators_test.go
+++ b/net/validators_test.go
@@ -57,7 +57,7 @@ func TestBlockPubSubValidation(t *testing.T) {
 
 	// create a fake clock to trigger block validation failures
 	now := time.Unix(1234567890, 0)
-	mclock := th.NewFakeSystemClock(now)
+	mclock := th.NewFakeClock(now)
 	// block time will be 1 second
 	blocktime := time.Second * 1
 

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -133,7 +133,7 @@ func TestChainSync(t *testing.T) {
 // makeNodes makes at least two nodes, a miner and a client; numNodes is the total wanted
 func makeNodesBlockPropTests(t *testing.T, numNodes int) (address.Address, []*Node) {
 	seed := MakeChainSeed(t, TestGenCfg)
-	builderOpts := []BuilderOpt{ClockConfigOption(th.NewFakeSystemClock(time.Unix(1234567890, 0)))}
+	builderOpts := []BuilderOpt{ClockConfigOption(th.NewFakeClock(time.Unix(1234567890, 0)))}
 	minerNode := MakeNodeWithChainSeed(t, seed, builderOpts,
 		PeerKeyOpt(PeerKeys[0]),
 	)

--- a/testhelpers/clock.go
+++ b/testhelpers/clock.go
@@ -1,9 +1,12 @@
 package testhelpers
 
 import (
+	"sync"
 	"time"
 
 	"github.com/jonboulle/clockwork"
+
+	"github.com/filecoin-project/go-filecoin/clock"
 )
 
 // FakeSystemClock wrapps the jonboulle/clockwork.FakeClock interface.
@@ -11,9 +14,124 @@ import (
 // manually advanced through time.
 type FakeSystemClock interface {
 	clockwork.FakeClock
+	NewTimer(d time.Duration) clock.Timer
+	AfterFunc(d time.Duration, f func()) clock.Timer
+}
+
+type fakeSystemClock struct {
+	clockwork.FakeClock
+	timersLk sync.RWMutex
+	timers   []*fakeTimer
 }
 
 // NewFakeSystemClock returns a FakeSystemClock initialised at the given time.Time.
 func NewFakeSystemClock(n time.Time) FakeSystemClock {
-	return clockwork.NewFakeClockAt(n)
+	return &fakeSystemClock{FakeClock: clockwork.NewFakeClockAt(n)}
+}
+
+func (fsc *fakeSystemClock) NewTimer(d time.Duration) clock.Timer {
+	out := make(chan time.Time, 1)
+	sendTime := func(c interface{}, now time.Time) {
+		c.(chan time.Time) <- now
+	}
+
+	ft := &fakeTimer{
+		clock:    fsc,
+		until:    fsc.Now().Add(d),
+		callback: sendTime,
+		arg:      out,
+		out:      out,
+	}
+	fsc.addTimer(ft)
+	return ft
+}
+
+func (fsc *fakeSystemClock) AfterFunc(d time.Duration, f func()) clock.Timer {
+	goFunc := func(fn interface{}, _ time.Time) {
+		go fn.(func())()
+	}
+
+	s := &fakeTimer{
+		clock:    fsc,
+		until:    fsc.Now().Add(d),
+		callback: goFunc,
+		arg:      f,
+		// zero-valued c, the same as it is in the `time` pkg
+	}
+	fsc.addTimer(s)
+	return s
+}
+
+func (fsc *fakeSystemClock) addTimer(ft *fakeTimer) {
+
+	now := fsc.Now()
+	if now.Sub(ft.until) >= 0 {
+		ft.awaken(now)
+	} else {
+		fsc.timersLk.Lock()
+		fsc.timers = append(fsc.timers, ft)
+		fsc.timersLk.Unlock()
+	}
+}
+
+func (fsc *fakeSystemClock) Advance(d time.Duration) {
+	fsc.FakeClock.Advance(d)
+	now := fsc.Now()
+	fsc.timersLk.Lock()
+	var newTimers []*fakeTimer
+	for _, ft := range fsc.timers {
+		if now.Sub(ft.until) >= 0 {
+			ft.awaken(now)
+		} else {
+			newTimers = append(newTimers, ft)
+		}
+	}
+	fsc.timers = newTimers
+	fsc.timersLk.Unlock()
+}
+
+type fakeTimer struct {
+	clock    *fakeSystemClock
+	until    time.Time
+	callback func(interface{}, time.Time)
+	arg      interface{}
+	doneLk   sync.RWMutex
+	done     bool
+	out      chan time.Time
+}
+
+func (ft *fakeTimer) awaken(now time.Time) {
+	ft.doneLk.Lock()
+	if !ft.done {
+		ft.done = true
+		ft.callback(ft.arg, now)
+	}
+	ft.doneLk.Unlock()
+}
+
+func (ft *fakeTimer) Chan() <-chan time.Time {
+	return ft.out
+}
+
+func (ft *fakeTimer) Reset(d time.Duration) bool {
+	active := ft.Stop()
+	ft.until = ft.clock.Now().Add(d)
+	ft.doneLk.Lock()
+	ft.done = false
+	ft.doneLk.Unlock()
+	ft.clock.addTimer(ft)
+	return active
+}
+
+func (ft *fakeTimer) Stop() bool {
+	ft.doneLk.Lock()
+	wasActive := !ft.done
+	ft.done = true
+	ft.doneLk.Unlock()
+
+	if wasActive {
+		ft.until = ft.clock.Now()
+		ft.clock.Advance(0)
+	}
+	return wasActive
 }

--- a/testhelpers/clock.go
+++ b/testhelpers/clock.go
@@ -4,134 +4,274 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jonboulle/clockwork"
-
 	"github.com/filecoin-project/go-filecoin/clock"
 )
 
-// FakeSystemClock wrapps the jonboulle/clockwork.FakeClock interface.
 // FakeSystemClock provides an interface for a clock which can be
-// manually advanced through time.
+// manually advanced through time
+// Adapted from: https://github.com/jonboulle/clockwork
 type FakeSystemClock interface {
-	clockwork.FakeClock
-	NewTimer(d time.Duration) clock.Timer
-	AfterFunc(d time.Duration, f func()) clock.Timer
-}
-
-type fakeSystemClock struct {
-	clockwork.FakeClock
-	timersLk sync.RWMutex
-	timers   []*fakeTimer
+	clock.Clock
+	// Advance advances the FakeClock to a new point in time, ensuring any existing
+	// sleepers are notified appropriately before returning
+	Advance(d time.Duration)
+	// BlockUntil will block until the FakeClock has the given number of
+	// sleepers (callers of Sleep or After)
+	BlockUntil(n int)
 }
 
 // NewFakeSystemClock returns a FakeSystemClock initialised at the given time.Time.
 func NewFakeSystemClock(n time.Time) FakeSystemClock {
-	return &fakeSystemClock{FakeClock: clockwork.NewFakeClockAt(n)}
+	return &fakeClock{
+		time: n,
+	}
 }
 
-func (fsc *fakeSystemClock) NewTimer(d time.Duration) clock.Timer {
-	out := make(chan time.Time, 1)
+type fakeClock struct {
+	timers   []*timer
+	blockers []*blocker
+	time     time.Time
+
+	l sync.RWMutex
+}
+
+// timer represents a waiting timer from NewTimer, Sleep, After, etc.
+type timer struct {
+	until    time.Time
+	callback func(interface{}, time.Time)
+	arg      interface{}
+
+	c      chan time.Time
+	doneLk sync.RWMutex
+	done   bool
+	clock  *fakeClock // needed for Reset()
+}
+
+// blocker represents a caller of BlockUntil
+type blocker struct {
+	count int
+	ch    chan struct{}
+}
+
+func (s *timer) awaken(now time.Time) {
+	s.doneLk.Lock()
+	defer s.doneLk.Unlock()
+	if !s.done {
+		s.done = true
+		s.callback(s.arg, now)
+	}
+}
+
+func (s *timer) Chan() <-chan time.Time { return s.c }
+
+func (s *timer) Reset(d time.Duration) bool {
+	wasActive := s.Stop()
+	s.until = s.clock.Now().Add(d)
+	s.doneLk.Lock()
+	s.done = false
+	s.doneLk.Unlock()
+	s.clock.addTimer(s)
+	return wasActive
+}
+
+func (s *timer) Stop() bool {
+	s.doneLk.Lock()
+	if s.done {
+		s.doneLk.Unlock()
+		return false
+	}
+	s.done = true
+	s.doneLk.Unlock()
+	// Expire the timer and notify blockers
+	s.until = s.clock.Now()
+	s.clock.Advance(0)
+	return true
+}
+
+func (fc *fakeClock) addTimer(s *timer) {
+	fc.l.Lock()
+	defer fc.l.Unlock()
+
+	now := fc.time
+	if now.Sub(s.until) >= 0 {
+		// special case - trigger immediately
+		s.awaken(now)
+	} else {
+		// otherwise, add to the set of sleepers
+		fc.timers = append(fc.timers, s)
+		// and notify any blockers
+		fc.blockers = notifyBlockers(fc.blockers, len(fc.timers))
+	}
+}
+
+// After mimics time.After; it waits for the given duration to elapse on the
+// fakeClock, then sends the current time on the returned channel.
+func (fc *fakeClock) After(d time.Duration) <-chan time.Time {
+	return fc.NewTimer(d).Chan()
+}
+
+// notifyBlockers notifies all the blockers waiting until the
+// given number of sleepers are waiting on the fakeClock. It
+// returns an updated slice of blockers (i.e. those still waiting)
+func notifyBlockers(blockers []*blocker, count int) (newBlockers []*blocker) {
+	for _, b := range blockers {
+		if b.count == count {
+			close(b.ch)
+		} else {
+			newBlockers = append(newBlockers, b)
+		}
+	}
+	return
+}
+
+// Sleep blocks until the given duration has passed on the fakeClock
+func (fc *fakeClock) Sleep(d time.Duration) {
+	<-fc.After(d)
+}
+
+// Time returns the current time of the fakeClock
+func (fc *fakeClock) Now() time.Time {
+	fc.l.RLock()
+	t := fc.time
+	fc.l.RUnlock()
+	return t
+}
+
+// Since returns the duration that has passed since the given time on the fakeClock
+func (fc *fakeClock) Since(t time.Time) time.Duration {
+	return fc.Now().Sub(t)
+}
+
+func (fc *fakeClock) NewTicker(d time.Duration) clock.Ticker {
+	ft := &fakeTicker{
+		c:      make(chan time.Time, 1),
+		stop:   make(chan bool, 1),
+		clock:  fc,
+		period: d,
+	}
+	go ft.tick()
+	return ft
+}
+
+// NewTimer creates a new Timer that will send the current time on its channel
+// after the given duration elapses on the fake clock.
+func (fc *fakeClock) NewTimer(d time.Duration) clock.Timer {
+	done := make(chan time.Time, 1)
 	sendTime := func(c interface{}, now time.Time) {
 		c.(chan time.Time) <- now
 	}
 
-	ft := &fakeTimer{
-		clock:    fsc,
-		until:    fsc.Now().Add(d),
+	s := &timer{
+		clock:    fc,
+		until:    fc.time.Add(d),
 		callback: sendTime,
-		arg:      out,
-		out:      out,
+		arg:      done,
+		c:        done,
 	}
-	fsc.addTimer(ft)
-	return ft
+	fc.addTimer(s)
+	return s
 }
 
-func (fsc *fakeSystemClock) AfterFunc(d time.Duration, f func()) clock.Timer {
+// AfterFunc waits for the duration to elapse on the fake clock and then calls f
+// in its own goroutine.
+// It returns a Timer that can be used to cancel the call using its Stop method.
+func (fc *fakeClock) AfterFunc(d time.Duration, f func()) clock.Timer {
 	goFunc := func(fn interface{}, _ time.Time) {
 		go fn.(func())()
 	}
 
-	s := &fakeTimer{
-		clock:    fsc,
-		until:    fsc.Now().Add(d),
+	s := &timer{
+		clock:    fc,
+		until:    fc.time.Add(d),
 		callback: goFunc,
 		arg:      f,
 		// zero-valued c, the same as it is in the `time` pkg
 	}
-	fsc.addTimer(s)
+	fc.addTimer(s)
 	return s
 }
 
-func (fsc *fakeSystemClock) addTimer(ft *fakeTimer) {
+// Advance advances fakeClock to a new point in time, ensuring channels from any
+// previous invocations of After are notified appropriately before returning
+func (fc *fakeClock) Advance(d time.Duration) {
+	fc.l.Lock()
+	defer fc.l.Unlock()
 
-	now := fsc.Now()
-	if now.Sub(ft.until) >= 0 {
-		ft.awaken(now)
-	} else {
-		fsc.timersLk.Lock()
-		fsc.timers = append(fsc.timers, ft)
-		fsc.timersLk.Unlock()
-	}
-}
-
-func (fsc *fakeSystemClock) Advance(d time.Duration) {
-	fsc.FakeClock.Advance(d)
-	now := fsc.Now()
-	fsc.timersLk.Lock()
-	var newTimers []*fakeTimer
-	for _, ft := range fsc.timers {
-		if now.Sub(ft.until) >= 0 {
-			ft.awaken(now)
+	end := fc.time.Add(d)
+	var newSleepers []*timer
+	for _, s := range fc.timers {
+		if end.Sub(s.until) >= 0 {
+			s.awaken(end)
 		} else {
-			newTimers = append(newTimers, ft)
+			newSleepers = append(newSleepers, s)
 		}
 	}
-	fsc.timers = newTimers
-	fsc.timersLk.Unlock()
+	fc.timers = newSleepers
+	fc.blockers = notifyBlockers(fc.blockers, len(fc.timers))
+	fc.time = end
 }
 
-type fakeTimer struct {
-	clock    *fakeSystemClock
-	until    time.Time
-	callback func(interface{}, time.Time)
-	arg      interface{}
-	doneLk   sync.RWMutex
-	done     bool
-	out      chan time.Time
-}
-
-func (ft *fakeTimer) awaken(now time.Time) {
-	ft.doneLk.Lock()
-	if !ft.done {
-		ft.done = true
-		ft.callback(ft.arg, now)
+// BlockUntil will block until the fakeClock has the given number of sleepers
+// (callers of Sleep or After)
+func (fc *fakeClock) BlockUntil(n int) {
+	fc.l.Lock()
+	// Fast path: current number of sleepers is what we're looking for
+	if len(fc.timers) == n {
+		fc.l.Unlock()
+		return
 	}
-	ft.doneLk.Unlock()
-}
-
-func (ft *fakeTimer) Chan() <-chan time.Time {
-	return ft.out
-}
-
-func (ft *fakeTimer) Reset(d time.Duration) bool {
-	active := ft.Stop()
-	ft.until = ft.clock.Now().Add(d)
-	ft.doneLk.Lock()
-	ft.done = false
-	ft.doneLk.Unlock()
-	ft.clock.addTimer(ft)
-	return active
-}
-
-func (ft *fakeTimer) Stop() bool {
-	ft.doneLk.Lock()
-	wasActive := !ft.done
-	ft.done = true
-	ft.doneLk.Unlock()
-
-	if wasActive {
-		ft.until = ft.clock.Now()
-		ft.clock.Advance(0)
+	// Otherwise, set up a new blocker
+	b := &blocker{
+		count: n,
+		ch:    make(chan struct{}),
 	}
-	return wasActive
+	fc.blockers = append(fc.blockers, b)
+	fc.l.Unlock()
+	<-b.ch
+}
+
+type fakeTicker struct {
+	c      chan time.Time
+	stop   chan bool
+	clock  FakeSystemClock
+	period time.Duration
+}
+
+func (ft *fakeTicker) Chan() <-chan time.Time {
+	return ft.c
+}
+
+func (ft *fakeTicker) Stop() {
+	ft.stop <- true
+}
+
+// tick sends the tick time to the ticker channel after every period.
+// Tick events are discarded if the underlying ticker channel does
+// not have enough capacity.
+func (ft *fakeTicker) tick() {
+	tick := ft.clock.Now()
+	for {
+		tick = tick.Add(ft.period)
+		remaining := tick.Sub(ft.clock.Now())
+		if remaining <= 0 {
+			// The tick should have already happened. This can happen when
+			// Advance() is called on the fake clock with a duration larger
+			// than this ticker's period.
+			select {
+			case ft.c <- tick:
+			default:
+			}
+			continue
+		}
+
+		select {
+		case <-ft.stop:
+			return
+		case <-ft.clock.After(remaining):
+			select {
+			case ft.c <- tick:
+			default:
+			}
+		}
+	}
 }

--- a/testhelpers/clock_test.go
+++ b/testhelpers/clock_test.go
@@ -1,0 +1,73 @@
+package testhelpers_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	th "github.com/filecoin-project/go-filecoin/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+)
+
+func TestFakeClockTimers(t *testing.T) {
+	tf.UnitTest(t)
+	fc := th.NewFakeSystemClock(time.Now())
+
+	zero := fc.NewTimer(0)
+
+	assert.False(t, zero.Stop(), "zero timer could be stopped")
+	select {
+	case <-zero.Chan():
+	default:
+		t.Errorf("zero timer didn't emit time")
+	}
+
+	one := fc.NewTimer(1)
+
+	select {
+	case <-one.Chan():
+		t.Errorf("non-zero timer did emit time")
+	default:
+	}
+
+	assert.True(t, one.Stop(), "non-zero timer couldn't be stopped")
+
+	fc.Advance(5)
+
+	select {
+	case <-one.Chan():
+		t.Errorf("stopped timer did emit time")
+	default:
+	}
+
+	assert.False(t, one.Reset(1), "resetting stopped timer didn't return false")
+	assert.True(t, one.Reset(1), "resetting active timer didn't return true")
+
+	fc.Advance(1)
+
+	assert.False(t, one.Stop(), "triggered timer could be stopped")
+
+	select {
+	case <-one.Chan():
+	default:
+		t.Errorf("triggered timer didn't emit time")
+	}
+
+	fc.Advance(1)
+
+	select {
+	case <-one.Chan():
+		t.Errorf("triggered timer emitted time more than once")
+	default:
+	}
+
+	one.Reset(0)
+
+	assert.False(t, one.Stop(), "reset to zero timer could be stopped")
+	select {
+	case <-one.Chan():
+	default:
+		t.Errorf("reset to zero timer didn't emit time")
+	}
+}

--- a/testhelpers/clock_test.go
+++ b/testhelpers/clock_test.go
@@ -10,6 +10,92 @@ import (
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 )
 
+func TestFakeClockAfter(t *testing.T) {
+	tf.UnitTest(t)
+	fc := th.NewFakeSystemClock(time.Now())
+
+	zero := fc.After(0)
+	select {
+	case <-zero:
+	default:
+		t.Errorf("zero did not return!")
+	}
+	one := fc.After(1)
+	two := fc.After(2)
+	six := fc.After(6)
+	ten := fc.After(10)
+	fc.Advance(1)
+	select {
+	case <-one:
+	default:
+		t.Errorf("one did not return!")
+	}
+	select {
+	case <-two:
+		t.Errorf("two returned prematurely!")
+	case <-six:
+		t.Errorf("six returned prematurely!")
+	case <-ten:
+		t.Errorf("ten returned prematurely!")
+	default:
+	}
+	fc.Advance(1)
+	select {
+	case <-two:
+	default:
+		t.Errorf("two did not return!")
+	}
+	select {
+	case <-six:
+		t.Errorf("six returned prematurely!")
+	case <-ten:
+		t.Errorf("ten returned prematurely!")
+	default:
+	}
+	fc.Advance(1)
+	select {
+	case <-six:
+		t.Errorf("six returned prematurely!")
+	case <-ten:
+		t.Errorf("ten returned prematurely!")
+	default:
+	}
+	fc.Advance(3)
+	select {
+	case <-six:
+	default:
+		t.Errorf("six did not return!")
+	}
+	select {
+	case <-ten:
+		t.Errorf("ten returned prematurely!")
+	default:
+	}
+	fc.Advance(100)
+	select {
+	case <-ten:
+	default:
+		t.Errorf("ten did not return!")
+	}
+}
+
+func TestNewFakeClockAt(t *testing.T) {
+	tf.UnitTest(t)
+	t1 := time.Date(1999, time.February, 3, 4, 5, 6, 7, time.UTC)
+	fc := th.NewFakeSystemClock(t1)
+	now := fc.Now()
+	assert.Equalf(t, now, t1, "fakeClock.Now() returned unexpected non-initialised value: want=%#v, got %#v", t1, now)
+}
+
+func TestFakeClockSince(t *testing.T) {
+	tf.UnitTest(t)
+	fc := th.NewFakeSystemClock(time.Now())
+	now := fc.Now()
+	elapsedTime := time.Second
+	fc.Advance(elapsedTime)
+	assert.Truef(t, fc.Since(now) == elapsedTime, "fakeClock.Since() returned unexpected duration, got: %d, want: %d", fc.Since(now), elapsedTime)
+}
+
 func TestFakeClockTimers(t *testing.T) {
 	tf.UnitTest(t)
 	fc := th.NewFakeSystemClock(time.Now())
@@ -70,4 +156,164 @@ func TestFakeClockTimers(t *testing.T) {
 	default:
 		t.Errorf("reset to zero timer didn't emit time")
 	}
+}
+
+type syncFunc func(didAdvance func(), shouldAdvance func(string), shouldBlock func(string))
+
+func inSync(t *testing.T, func1 syncFunc, func2 syncFunc) {
+	stepChan1 := make(chan struct{}, 16)
+	stepChan2 := make(chan struct{}, 16)
+	go func() {
+		func1(func() { stepChan1 <- struct{}{} }, func(point string) {
+			select {
+			case <-stepChan2:
+			case <-time.After(time.Second):
+				t.Errorf("Did not advance, should have %s", point)
+			}
+		},
+			func(point string) {
+				select {
+				case <-stepChan2:
+					t.Errorf("Was able to advance, should not have %s", point)
+				case <-time.After(10 * time.Millisecond):
+				}
+			},
+		)
+	}()
+	func2(func() { stepChan2 <- struct{}{} }, func(point string) {
+		select {
+		case <-stepChan1:
+		case <-time.After(time.Second):
+			t.Errorf("Did not advance, should have %s", point)
+		}
+	},
+		func(point string) {
+			select {
+			case <-stepChan1:
+				t.Errorf("Was able to advance, should not have %s", point)
+			case <-time.After(10 * time.Millisecond):
+			}
+		})
+}
+
+func TestBlockingOnTimers(t *testing.T) {
+	tf.UnitTest(t)
+	fc := th.NewFakeSystemClock(time.Now())
+
+	inSync(t, func(didAdvance func(), shouldAdvance func(string), _ func(string)) {
+		fc.BlockUntil(0)
+		didAdvance()
+		fc.BlockUntil(1)
+		didAdvance()
+		shouldAdvance("timers stopped")
+		fc.BlockUntil(0)
+		didAdvance()
+		fc.BlockUntil(1)
+		didAdvance()
+		fc.BlockUntil(2)
+		didAdvance()
+		fc.BlockUntil(3)
+		didAdvance()
+		shouldAdvance("timers stopped")
+		fc.BlockUntil(2)
+		didAdvance()
+		shouldAdvance("time advanced")
+		fc.BlockUntil(0)
+		didAdvance()
+	}, func(didAdvance func(), shouldAdvance func(string), shouldBlock func(string)) {
+		shouldAdvance("when only blocking for 0 timers")
+		shouldBlock("when waiting for 1 timer")
+		fc.NewTimer(0)
+		shouldBlock("when immediately expired timer added")
+		one := fc.NewTimer(1)
+		shouldAdvance("once a timer exists")
+		one.Stop()
+		didAdvance()
+		shouldAdvance("when only blocking for 0 timers")
+		shouldBlock("when all timers are stopped and waiting for a timer")
+		one.Reset(1)
+		shouldAdvance("once timer is restarted")
+		shouldBlock("when waiting for 2 timers with one active")
+		_ = fc.NewTimer(2)
+		shouldAdvance("when second timer added")
+		shouldBlock("when waiting for 3 timers with 2 active")
+		_ = fc.NewTimer(3)
+		shouldAdvance("when third timer added")
+		one.Stop()
+		didAdvance()
+		shouldAdvance("when blocking for 2 timers if a third is stopped")
+		fc.Advance(3)
+		didAdvance()
+		shouldAdvance("waiting for no timers")
+	})
+}
+
+func TestAdvancePastAfter(t *testing.T) {
+	tf.UnitTest(t)
+
+	fc := th.NewFakeSystemClock(time.Now())
+
+	start := fc.Now()
+	one := fc.After(1)
+	two := fc.After(2)
+	six := fc.After(6)
+
+	fc.Advance(1)
+	assert.False(t, start.Add(1).Sub(<-one) > 0, "timestamp is too early")
+
+	fc.Advance(5)
+	assert.False(t, start.Add(2).Sub(<-two) > 0, "timestamp is too early")
+	assert.False(t, start.Add(6).Sub(<-six) > 0, "timestamp is too early")
+}
+
+func TestFakeTickerStop(t *testing.T) {
+	tf.UnitTest(t)
+	fc := th.NewFakeSystemClock(time.Now())
+
+	ft := fc.NewTicker(1)
+	ft.Stop()
+	fc.Advance(1)
+	select {
+	case <-ft.Chan():
+		t.Errorf("received unexpected tick!")
+	default:
+	}
+}
+
+func TestFakeTickerTick(t *testing.T) {
+	tf.UnitTest(t)
+	fc := th.NewFakeSystemClock(time.Now())
+	now := fc.Now()
+
+	// The tick at now.Add(2) should not get through since we advance time by
+	// two units below and the channel can hold at most one tick until it's
+	// consumed.
+	first := now.Add(1)
+	second := now.Add(3)
+
+	// We wrap the Advance() calls with blockers to make sure that the ticker
+	// can go to sleep and produce ticks without time passing in parallel.
+	ft := fc.NewTicker(1)
+	fc.BlockUntil(1)
+	fc.Advance(2)
+	fc.BlockUntil(1)
+
+	select {
+	case tick := <-ft.Chan():
+		assert.Truef(t, tick == first, "wrong tick time, got: %v, want: %v", tick, first)
+	default:
+		t.Errorf("expected tick!")
+	}
+
+	// Advance by one more unit, we should get another tick now.
+	fc.Advance(1)
+	fc.BlockUntil(1)
+
+	select {
+	case tick := <-ft.Chan():
+		assert.Truef(t, tick == second, "wrong tick time, got: %v, want: %v", tick, second)
+	default:
+		t.Errorf("expected tick!")
+	}
+	ft.Stop()
 }

--- a/testhelpers/clock_test.go
+++ b/testhelpers/clock_test.go
@@ -10,9 +10,11 @@ import (
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 )
 
+var startTime = time.Unix(123456789, 0)
+
 func TestFakeClockAfter(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(time.Now())
+	fc := th.NewFakeSystemClock(startTime)
 
 	zero := fc.After(0)
 	select {
@@ -89,7 +91,7 @@ func TestNewFakeClockAt(t *testing.T) {
 
 func TestFakeClockSince(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(time.Now())
+	fc := th.NewFakeSystemClock(startTime)
 	now := fc.Now()
 	elapsedTime := time.Second
 	fc.Advance(elapsedTime)
@@ -98,7 +100,7 @@ func TestFakeClockSince(t *testing.T) {
 
 func TestFakeClockTimers(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(time.Now())
+	fc := th.NewFakeSystemClock(startTime)
 
 	zero := fc.NewTimer(0)
 
@@ -198,7 +200,7 @@ func inSync(t *testing.T, func1 syncFunc, func2 syncFunc) {
 
 func TestBlockingOnTimers(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(time.Now())
+	fc := th.NewFakeSystemClock(startTime)
 
 	inSync(t, func(didAdvance func(), shouldAdvance func(string), _ func(string)) {
 		fc.BlockUntil(0)
@@ -251,7 +253,7 @@ func TestBlockingOnTimers(t *testing.T) {
 func TestAdvancePastAfter(t *testing.T) {
 	tf.UnitTest(t)
 
-	fc := th.NewFakeSystemClock(time.Now())
+	fc := th.NewFakeSystemClock(startTime)
 
 	start := fc.Now()
 	one := fc.After(1)
@@ -268,7 +270,7 @@ func TestAdvancePastAfter(t *testing.T) {
 
 func TestFakeTickerStop(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(time.Now())
+	fc := th.NewFakeSystemClock(startTime)
 
 	ft := fc.NewTicker(1)
 	ft.Stop()
@@ -282,7 +284,7 @@ func TestFakeTickerStop(t *testing.T) {
 
 func TestFakeTickerTick(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(time.Now())
+	fc := th.NewFakeSystemClock(startTime)
 	now := fc.Now()
 
 	// The tick at now.Add(2) should not get through since we advance time by

--- a/testhelpers/clock_test.go
+++ b/testhelpers/clock_test.go
@@ -14,7 +14,7 @@ var startTime = time.Unix(123456789, 0)
 
 func TestFakeClockAfter(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(startTime)
+	fc := th.NewFakeClock(startTime)
 
 	zero := fc.After(0)
 	select {
@@ -84,14 +84,14 @@ func TestFakeClockAfter(t *testing.T) {
 func TestNewFakeClockAt(t *testing.T) {
 	tf.UnitTest(t)
 	t1 := time.Date(1999, time.February, 3, 4, 5, 6, 7, time.UTC)
-	fc := th.NewFakeSystemClock(t1)
+	fc := th.NewFakeClock(t1)
 	now := fc.Now()
 	assert.Equalf(t, now, t1, "fakeClock.Now() returned unexpected non-initialised value: want=%#v, got %#v", t1, now)
 }
 
 func TestFakeClockSince(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(startTime)
+	fc := th.NewFakeClock(startTime)
 	now := fc.Now()
 	elapsedTime := time.Second
 	fc.Advance(elapsedTime)
@@ -100,7 +100,7 @@ func TestFakeClockSince(t *testing.T) {
 
 func TestFakeClockTimers(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(startTime)
+	fc := th.NewFakeClock(startTime)
 
 	zero := fc.NewTimer(0)
 
@@ -200,7 +200,7 @@ func inSync(t *testing.T, func1 syncFunc, func2 syncFunc) {
 
 func TestBlockingOnTimers(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(startTime)
+	fc := th.NewFakeClock(startTime)
 
 	inSync(t, func(didAdvance func(), shouldAdvance func(string), _ func(string)) {
 		fc.BlockUntil(0)
@@ -253,7 +253,7 @@ func TestBlockingOnTimers(t *testing.T) {
 func TestAdvancePastAfter(t *testing.T) {
 	tf.UnitTest(t)
 
-	fc := th.NewFakeSystemClock(startTime)
+	fc := th.NewFakeClock(startTime)
 
 	start := fc.Now()
 	one := fc.After(1)
@@ -270,7 +270,7 @@ func TestAdvancePastAfter(t *testing.T) {
 
 func TestFakeTickerStop(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(startTime)
+	fc := th.NewFakeClock(startTime)
 
 	ft := fc.NewTicker(1)
 	ft.Stop()
@@ -284,7 +284,7 @@ func TestFakeTickerStop(t *testing.T) {
 
 func TestFakeTickerTick(t *testing.T) {
 	tf.UnitTest(t)
-	fc := th.NewFakeSystemClock(startTime)
+	fc := th.NewFakeClock(startTime)
 	now := fc.Now()
 
 	// The tick at now.Add(2) should not get through since we advance time by


### PR DESCRIPTION
# Goals

Adds timer functionality to clock and fake clock, so we can use timers but still test them easily

# Implementation

Based off https://github.com/jonboulle/clockwork/pull/22 -- merges code in from base library and PR, so that we are not dependent on https://github.com/jonboulle/clockwork which seems to be somewhat dead.

# For Discussion

This is a bunch of code but the vast majority of it has moved over with only minor modifications from the source library.
 
Here are the deltas from the source library:
- everything related to the fake clock is moved over to testhelpers
- I used the existing factory method names we were using in our code
- the tests have been updated to use testify
- I renamed "sleeper" to "timer" cause it make more sense to me
- I removed one test of a private function because we intentionally keep our tests in a different module than the code
- I rewrote one of the tests so that it tested more accurately the behavior of BlockUntil (it's still not perfect, but should be closer to capturing actual behavior)

Will be integrated into: https://github.com/filecoin-project/go-filecoin/pull/3460 once merged