### PR TITLE
Miner addFaults method

### DIFF
--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -195,10 +195,11 @@ type testStorage struct {
 	state interface{}
 }
 
-var _ exec.Storage = testStorage{}
+var _ exec.Storage = &testStorage{}
 
-// Put satisfies the Storage interface but does nothing.
-func (ts testStorage) Put(v interface{}) (cid.Cid, error) {
+// Put satisfies the Storage interface
+func (ts *testStorage) Put(v interface{}) (cid.Cid, error) {
+	ts.state = v
 	return cid.Cid{}, nil
 }
 


### PR DESCRIPTION
## Summary
Add the Miner [`addFaults`](https://github.com/filecoin-project/specs/blob/069882c3e0c61ff19512879a6ceb0a422835a523/actors.md#addfaults) method, and use these faults in `submitPoSt`.

## Notes
The code is based on the spec and is not validating that the faulted sector ids are in the current sector commitments.  I've confirmed that the sector builder can handle bogus sector ids, but it's easy enough to add the validation if that seems prudent.

Also, [`submitPoSt`](https://github.com/filecoin-project/specs/blob/069882c3e0c61ff19512879a6ceb0a422835a523/actors.md#submitpost) no longer needs the `faults` parameter but we [still have it in the codebase](https://github.com/filecoin-project/go-filecoin/blob/2879caa02d9d9be6dbb36cae05de5b447e92ca68/actor/builtin/miner/miner.go#L273).

resolves #3425