### PR TITLE
do not close connection if hello not supported

### DIFF
--- a/protocol/hello/hello.go
+++ b/protocol/hello/hello.go
@@ -165,7 +165,6 @@ func (hn *helloNotify) Connected(n net.Network, c net.Conn) {
 		hello, err := hn.hello().ReceiveHello(ctx, from)
 		if err != nil {
 			log.Debugf("failed to receive hello handshake from peer %s: %s", from, err)
-			_ = c.Close()
 			return
 		}
 


### PR DESCRIPTION
This will allow filecoin nodes to continue to connect to the stats dashboard and other non-hello protocol speaking services.