### PR TITLE
Export and Import chain to/from a .car file

### DIFF
--- a/chain/car.go
+++ b/chain/car.go
@@ -1,0 +1,102 @@
+package chain
+
+import (
+	"context"
+	"io"
+
+	blocks "github.com/ipfs/go-block-format"
+	car "github.com/ipfs/go-car"
+	carutil "github.com/ipfs/go-car/util"
+	cbor "github.com/ipfs/go-ipld-cbor"
+	logging "github.com/ipfs/go-log"
+
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+var logCar = logging.Logger("chain/car")
+
+type carChainReader interface {
+	GetTipSet(types.TipSetKey) (types.TipSet, error)
+}
+type carMessageReader interface {
+	MessageProvider
+}
+
+// Export will export a chain (all blocks and their messages) to the writer `out`.
+func Export(ctx context.Context, headTS types.TipSet, cr carChainReader, mr carMessageReader, out io.Writer) (types.TipSetKey, error) {
+	// fail if headTS isn't in the store.
+	if _, err := cr.GetTipSet(headTS.Key()); err != nil {
+		return types.UndefTipSet.Key(), err
+	}
+
+	// Write the car header
+	chb, err := cbor.DumpObject(car.CarHeader{
+		Roots:   headTS.Key().ToSlice(),
+		Version: 1,
+	})
+	if err != nil {
+		return types.UndefTipSet.Key(), err
+	}
+
+	logCar.Debugf("car file chain head: %s", headTS.Key())
+	if err := carutil.LdWrite(out, chb); err != nil {
+		return types.UndefTipSet.Key(), err
+	}
+
+	iter := IterAncestors(ctx, cr, headTS)
+	// accumulate TipSets in descending order.
+	for ; !iter.Complete(); err = iter.Next() {
+		if err != nil {
+			return types.UndefTipSet.Key(), err
+		}
+		tip := iter.Value()
+		// write blocks
+		for i := 0; i < tip.Len(); i++ {
+			hdr := tip.At(i)
+			logCar.Debugf("writing block: %s", hdr.Cid())
+			if err := carutil.LdWrite(out, hdr.Cid().Bytes(), hdr.ToNode().RawData()); err != nil {
+				return types.UndefTipSet.Key(), err
+			}
+
+			msgs, err := mr.LoadMessages(ctx, hdr.Messages)
+			if err != nil {
+				return types.UndefTipSet.Key(), err
+			}
+
+			if len(msgs) > 0 {
+				logCar.Debugf("writing message collection: %s", hdr.Messages)
+				if err := carutil.LdWrite(out, hdr.Messages.Bytes(), types.MessageCollection(msgs).ToNode().RawData()); err != nil {
+					return types.UndefTipSet.Key(), err
+				}
+			}
+
+			// TODO(#3473) we can remove MessageReceipts from the exported file once addressed.
+			rect, err := mr.LoadReceipts(ctx, hdr.MessageReceipts)
+			if err != nil {
+				return types.UndefTipSet.Key(), err
+			}
+
+			if len(rect) > 0 {
+				logCar.Debugf("writing message-receipt collection: %s", hdr.Messages)
+				if err := carutil.LdWrite(out, hdr.MessageReceipts.Bytes(), types.ReceiptCollection(rect).ToNode().RawData()); err != nil {
+					return types.UndefTipSet.Key(), err
+				}
+			}
+		}
+	}
+	return headTS.Key(), nil
+}
+
+type carStore interface {
+	Put(blocks.Block) error
+}
+
+// Import imports a chain from `in` to `bs`.
+func Import(ctx context.Context, cs carStore, in io.Reader) (types.TipSetKey, error) {
+	header, err := car.LoadCar(cs, in)
+	if err != nil {
+		return types.UndefTipSet.Key(), err
+	}
+	headKey := types.NewTipSetKey(header.Roots...)
+	return headKey, nil
+}

--- a/chain/car.go
+++ b/chain/car.go
@@ -66,17 +66,25 @@ func Export(ctx context.Context, headTS types.TipSet, cr carChainReader, mr carM
 				filter[hdr.Cid()] = true
 			}
 
-			msgs, err := mr.LoadMessages(ctx, hdr.Messages)
+			secpMsgs, blsMsgs, err := mr.LoadMessages(ctx, hdr.Messages)
 			if err != nil {
 				return err
 			}
 
-			if !filter[hdr.Messages] {
+			if !filter[hdr.Messages.SecpRoot] {
 				logCar.Debugf("writing message collection: %s", hdr.Messages)
-				if err := carutil.LdWrite(out, hdr.Messages.Bytes(), types.MessageCollection(msgs).ToNode().RawData()); err != nil {
+				if err := carutil.LdWrite(out, hdr.Messages.SecpRoot.Bytes(), types.MessageCollection(secpMsgs).ToNode().RawData()); err != nil {
 					return err
 				}
-				filter[hdr.Messages] = true
+				filter[hdr.Messages.SecpRoot] = true
+			}
+
+			if !filter[hdr.Messages.BLSRoot] {
+				logCar.Debugf("writing message collection: %s", hdr.Messages)
+				if err := carutil.LdWrite(out, hdr.Messages.BLSRoot.Bytes(), types.MessageCollection(blsMsgs).ToNode().RawData()); err != nil {
+					return err
+				}
+				filter[hdr.Messages.BLSRoot] = true
 			}
 
 			// TODO(#3473) we can remove MessageReceipts from the exported file once addressed.

--- a/chain/car_test.go
+++ b/chain/car_test.go
@@ -256,19 +256,15 @@ func validateBlockstoreImport(t *testing.T, start, stop types.TipSetKey, bstore 
 			blk, err := types.DecodeBlock(bsBlk.RawData())
 			assert.NoError(t, err)
 
-			if !blk.Messages.Equals(types.EmptyMessagesCID) {
-				bsMsgs, err := bstore.Get(blk.Messages)
-				assert.NoError(t, err)
-				_, err = types.DecodeMessages(bsMsgs.RawData())
-				assert.NoError(t, err)
-			}
+			bsMsgs, err := bstore.Get(blk.Messages)
+			assert.NoError(t, err)
+			_, err = types.DecodeMessages(bsMsgs.RawData())
+			assert.NoError(t, err)
 
-			if !blk.MessageReceipts.Equals(types.EmptyReceiptsCID) {
-				bsRcts, err := bstore.Get(blk.MessageReceipts)
-				assert.NoError(t, err)
-				_, err = types.DecodeReceipts(bsRcts.RawData())
-				assert.NoError(t, err)
-			}
+			bsRcts, err := bstore.Get(blk.MessageReceipts)
+			assert.NoError(t, err)
+			_, err = types.DecodeReceipts(bsRcts.RawData())
+			assert.NoError(t, err)
 
 			for _, p := range blk.Parents.ToSlice() {
 				parents = append(parents, p)

--- a/chain/car_test.go
+++ b/chain/car_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	cid "github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/stretchr/testify/assert"
@@ -17,39 +18,265 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
-func TestChainImportExportSimple(t *testing.T) {
+func TestChainImportExportGenesis(t *testing.T) {
 	tf.UnitTest(t)
-	ctx := context.Background()
 
-	cb := chain.NewBuilder(t, address.Undef)
+	ctx, gene, cb, carW, carR, bstore := setupDeps(t)
 
-	gene := cb.NewGenesis()
-	ts10 := cb.AppendManyOn(9, gene)
+	// export the car file to a carW
+	mustExportToBuffer(ctx, t, gene, cb, carW)
 
-	var buf bytes.Buffer
-	carW := bufio.NewWriter(&buf)
-
-	// export the car file to a buffer
-	exportedKey, err := chain.Export(ctx, ts10, cb, cb, carW)
-	assert.NoError(t, err)
-	assert.Equal(t, ts10.Key(), exportedKey)
-	require.NoError(t, carW.Flush())
-
-	mds := ds.NewMapDatastore()
-	bstore := blockstore.NewBlockstore(mds)
-
-	// import the car file from the buffer
-	carR := bufio.NewReader(&buf)
-	importedKey, err := chain.Import(ctx, bstore, carR)
-	assert.NoError(t, err)
-	assert.Equal(t, ts10.Key(), importedKey)
+	// import the car file from the carR
+	importedKey := mustImportFromBuffer(ctx, t, bstore, carR)
+	assert.Equal(t, gene.Key(), importedKey)
 
 	// walk the blockstore and assert it had all blocks imported
-	cur := ts10.At(0).Cid()
-	for !cur.Equals(gene.At(0).Cid()) {
-		bsBlk, err := bstore.Get(cur)
-		assert.NoError(t, err)
-		blk, err := types.DecodeBlock(bsBlk.RawData())
-		cur = blk.Parents.ToSlice()[0]
+	validateBlockstoreImport(t, gene.Key(), gene.Key(), bstore)
+}
+
+func TestChainImportExportSingleTip(t *testing.T) {
+	tf.UnitTest(t)
+	ctx, gene, cb, carW, carR, bstore := setupDeps(t)
+	// extend the head by one
+	headTS := cb.AppendOn(gene, 1)
+
+	// export the car file to carW
+	mustExportToBuffer(ctx, t, headTS, cb, carW)
+
+	// import the car file from carR
+	importedKey := mustImportFromBuffer(ctx, t, bstore, carR)
+	assert.Equal(t, headTS.Key(), importedKey)
+
+	// walk the blockstore and assert it had all blocks imported
+	validateBlockstoreImport(t, headTS.Key(), gene.Key(), bstore)
+}
+
+func TestChainImportExportWideTip(t *testing.T) {
+	tf.UnitTest(t)
+	ctx, gene, cb, carW, carR, bstore := setupDeps(t)
+	// extend the head by one, two wide
+	headTS := cb.AppendOn(gene, 2)
+
+	// export the car file to a carW
+	mustExportToBuffer(ctx, t, headTS, cb, carW)
+
+	// import the car file from carR
+	importedKey := mustImportFromBuffer(ctx, t, bstore, carR)
+	assert.Equal(t, headTS.Key(), importedKey)
+
+	// walk the blockstore and assert it had all blocks imported
+	validateBlockstoreImport(t, headTS.Key(), gene.Key(), bstore)
+}
+
+func TestChainImportExportMultiTip(t *testing.T) {
+	tf.UnitTest(t)
+	ctx, gene, cb, carW, carR, bstore := setupDeps(t)
+	// extend the head by one
+	headTS := cb.AppendOn(gene, 1)
+	headTS = cb.AppendOn(headTS, 1)
+
+	// export the car file to a buffer
+	mustExportToBuffer(ctx, t, headTS, cb, carW)
+
+	// import the car file from the buffer
+	importedKey := mustImportFromBuffer(ctx, t, bstore, carR)
+	assert.Equal(t, headTS.Key(), importedKey)
+
+	// walk the blockstore and assert it had all blocks imported
+	validateBlockstoreImport(t, headTS.Key(), gene.Key(), bstore)
+}
+
+func TestChainImportExportMultiWideTip(t *testing.T) {
+	tf.UnitTest(t)
+	ctx, gene, cb, carW, carR, bstore := setupDeps(t)
+	// extend the head by one
+	headTS := cb.AppendOn(gene, 1)
+	// extend by one, two wide.
+	headTS = cb.AppendOn(headTS, 2)
+
+	// export the car file to a buffer
+	mustExportToBuffer(ctx, t, headTS, cb, carW)
+
+	// import the car file from the buffer
+	importedKey := mustImportFromBuffer(ctx, t, bstore, carR)
+	assert.Equal(t, headTS.Key(), importedKey)
+
+	// walk the blockstore and assert it had all blocks imported
+	validateBlockstoreImport(t, headTS.Key(), gene.Key(), bstore)
+}
+
+func TestChainImportExportMultiWideBaseTip(t *testing.T) {
+	tf.UnitTest(t)
+	ctx, gene, cb, carW, carR, bstore := setupDeps(t)
+	// extend the head by one, two wide
+	headTS := cb.AppendOn(gene, 2)
+	// extend by one
+	headTS = cb.AppendOn(headTS, 1)
+
+	// export the car file to a buffer
+	mustExportToBuffer(ctx, t, headTS, cb, carW)
+
+	// import the car file from the buffer
+	importedKey := mustImportFromBuffer(ctx, t, bstore, carR)
+	assert.Equal(t, headTS.Key(), importedKey)
+
+	// walk the blockstore and assert it had all blocks imported
+	validateBlockstoreImport(t, headTS.Key(), gene.Key(), bstore)
+}
+
+func TestChainImportExportMultiWideTips(t *testing.T) {
+	tf.UnitTest(t)
+	ctx, gene, cb, carW, carR, bstore := setupDeps(t)
+	// extend the head by one, two wide
+	headTS := cb.AppendOn(gene, 2)
+	// extend by one, two wide
+	headTS = cb.AppendOn(headTS, 2)
+
+	// export the car file to a buffer
+	mustExportToBuffer(ctx, t, headTS, cb, carW)
+
+	// import the car file from the buffer
+	importedKey := mustImportFromBuffer(ctx, t, bstore, carR)
+	assert.Equal(t, headTS.Key(), importedKey)
+
+	// walk the blockstore and assert it had all blocks imported
+	validateBlockstoreImport(t, headTS.Key(), gene.Key(), bstore)
+}
+
+func TestChainImportExportMessages(t *testing.T) {
+	tf.UnitTest(t)
+
+	ctx, gene, cb, carW, carR, bstore := setupDeps(t)
+
+	keys := types.MustGenerateKeyInfo(1, 42)
+	mm := types.NewMessageMaker(t, keys)
+	alice := mm.Addresses()[0]
+
+	ts1 := cb.AppendManyOn(1, gene)
+	msgs := []*types.SignedMessage{
+		mm.NewSignedMessage(alice, 1),
+		mm.NewSignedMessage(alice, 2),
+		mm.NewSignedMessage(alice, 3),
+		mm.NewSignedMessage(alice, 4),
+		mm.NewSignedMessage(alice, 5),
+	}
+	rcts := types.EmptyReceipts(5)
+	ts2 := cb.BuildOneOn(ts1, func(b *chain.BlockBuilder) {
+		b.AddMessages(msgs, rcts)
+	})
+
+	// export the car file to a buffer
+	mustExportToBuffer(ctx, t, ts2, cb, carW)
+
+	// import the car file from the buffer
+	importedKey := mustImportFromBuffer(ctx, t, bstore, carR)
+	assert.Equal(t, ts2.Key(), importedKey)
+
+	// walk the blockstore and assert it had all blocks imported
+	validateBlockstoreImport(t, ts2.Key(), gene.Key(), bstore)
+}
+
+func TestChainImportExportMultiTipSetWithMessages(t *testing.T) {
+	tf.UnitTest(t)
+
+	ctx, gene, cb, carW, carR, bstore := setupDeps(t)
+
+	keys := types.MustGenerateKeyInfo(1, 42)
+	mm := types.NewMessageMaker(t, keys)
+	alice := mm.Addresses()[0]
+
+	ts1 := cb.AppendManyOn(1, gene)
+	msgs := []*types.SignedMessage{
+		mm.NewSignedMessage(alice, 1),
+		mm.NewSignedMessage(alice, 2),
+		mm.NewSignedMessage(alice, 3),
+		mm.NewSignedMessage(alice, 4),
+		mm.NewSignedMessage(alice, 5),
+	}
+	rcts := types.EmptyReceipts(5)
+	ts2 := cb.BuildOneOn(ts1, func(b *chain.BlockBuilder) {
+		b.AddMessages(
+			msgs,
+			rcts,
+		)
+	})
+
+	ts3 := cb.AppendOn(ts2, 3)
+
+	// export the car file to a buffer
+	mustExportToBuffer(ctx, t, ts3, cb, carW)
+
+	// import the car file from the buffer
+	importedKey := mustImportFromBuffer(ctx, t, bstore, carR)
+	assert.Equal(t, ts3.Key(), importedKey)
+
+	// walk the blockstore and assert it had all blocks imported
+	validateBlockstoreImport(t, ts3.Key(), gene.Key(), bstore)
+}
+
+func mustExportToBuffer(ctx context.Context, t *testing.T, head types.TipSet, cb *chain.Builder, carW *bufio.Writer) {
+	err := chain.Export(ctx, head, cb, cb, carW)
+	assert.NoError(t, err)
+	require.NoError(t, carW.Flush())
+}
+
+func mustImportFromBuffer(ctx context.Context, t *testing.T, bstore blockstore.Blockstore, carR *bufio.Reader) types.TipSetKey {
+	importedKey, err := chain.Import(ctx, bstore, carR)
+	assert.NoError(t, err)
+	return importedKey
+}
+
+func setupDeps(t *testing.T) (context.Context, types.TipSet, *chain.Builder, *bufio.Writer, *bufio.Reader, blockstore.Blockstore) {
+	// context for operations
+	ctx := context.Background()
+
+	// chain builder and its genesis
+	cb := chain.NewBuilder(t, address.Undef)
+	gene := cb.NewGenesis()
+	// buffers to read and write the car file from
+	var buf bytes.Buffer
+	carW := bufio.NewWriter(&buf)
+	carR := bufio.NewReader(&buf)
+
+	// a store to import the car file to and validate from.
+	mds := ds.NewMapDatastore()
+	bstore := blockstore.NewBlockstore(mds)
+	return ctx, gene, cb, carW, carR, bstore
+
+}
+
+func validateBlockstoreImport(t *testing.T, start, stop types.TipSetKey, bstore blockstore.Blockstore) {
+	// walk the blockstore and assert it had all blocks imported
+	cur := start
+	for {
+		var parents []cid.Cid
+		for _, c := range cur.ToSlice() {
+			bsBlk, err := bstore.Get(c)
+			assert.NoError(t, err)
+			blk, err := types.DecodeBlock(bsBlk.RawData())
+			assert.NoError(t, err)
+
+			if !blk.Messages.Equals(types.EmptyMessagesCID) {
+				bsMsgs, err := bstore.Get(blk.Messages)
+				assert.NoError(t, err)
+				_, err = types.DecodeMessages(bsMsgs.RawData())
+				assert.NoError(t, err)
+			}
+
+			if !blk.MessageReceipts.Equals(types.EmptyReceiptsCID) {
+				bsRcts, err := bstore.Get(blk.MessageReceipts)
+				assert.NoError(t, err)
+				_, err = types.DecodeReceipts(bsRcts.RawData())
+				assert.NoError(t, err)
+			}
+
+			for _, p := range blk.Parents.ToSlice() {
+				parents = append(parents, p)
+			}
+		}
+		if cur.Equals(stop) {
+			break
+		}
+		cur = types.NewTipSetKey(parents...)
 	}
 }

--- a/chain/car_test.go
+++ b/chain/car_test.go
@@ -1,0 +1,55 @@
+package chain_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"testing"
+
+	ds "github.com/ipfs/go-datastore"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/chain"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+func TestChainImportExportSimple(t *testing.T) {
+	tf.UnitTest(t)
+	ctx := context.Background()
+
+	cb := chain.NewBuilder(t, address.Undef)
+
+	gene := cb.NewGenesis()
+	ts10 := cb.AppendManyOn(9, gene)
+
+	var buf bytes.Buffer
+	carW := bufio.NewWriter(&buf)
+
+	// export the car file to a buffer
+	exportedKey, err := chain.Export(ctx, ts10, cb, cb, carW)
+	assert.NoError(t, err)
+	assert.Equal(t, ts10.Key(), exportedKey)
+	require.NoError(t, carW.Flush())
+
+	mds := ds.NewMapDatastore()
+	bstore := blockstore.NewBlockstore(mds)
+
+	// import the car file from the buffer
+	carR := bufio.NewReader(&buf)
+	importedKey, err := chain.Import(ctx, bstore, carR)
+	assert.NoError(t, err)
+	assert.Equal(t, ts10.Key(), importedKey)
+
+	// walk the blockstore and assert it had all blocks imported
+	cur := ts10.At(0).Cid()
+	for !cur.Equals(gene.At(0).Cid()) {
+		bsBlk, err := bstore.Get(cur)
+		assert.NoError(t, err)
+		blk, err := types.DecodeBlock(bsBlk.RawData())
+		cur = blk.Parents.ToSlice()[0]
+	}
+}

--- a/chain/car_test.go
+++ b/chain/car_test.go
@@ -256,9 +256,14 @@ func validateBlockstoreImport(t *testing.T, start, stop types.TipSetKey, bstore 
 			blk, err := types.DecodeBlock(bsBlk.RawData())
 			assert.NoError(t, err)
 
-			bsMsgs, err := bstore.Get(blk.Messages)
+			bsSecpMsgs, err := bstore.Get(blk.Messages.SecpRoot)
 			assert.NoError(t, err)
-			_, err = types.DecodeMessages(bsMsgs.RawData())
+			_, err = types.DecodeMessages(bsSecpMsgs.RawData())
+			assert.NoError(t, err)
+
+			bsBlsMsgs, err := bstore.Get(blk.Messages.BLSRoot)
+			assert.NoError(t, err)
+			_, err = types.DecodeMessages(bsBlsMsgs.RawData())
 			assert.NoError(t, err)
 
 			bsRcts, err := bstore.Get(blk.MessageReceipts)

--- a/commands/chain.go
+++ b/commands/chain.go
@@ -198,11 +198,10 @@ var storeExportCmd = &cmds.Command{
 		}
 		expKey := types.NewTipSetKey(expCids...)
 
-		headKey, err := GetPorcelainAPI(env).ChainExport(req.Context, expKey, f)
-		if err != nil {
+		if err := GetPorcelainAPI(env).ChainExport(req.Context, expKey, f); err != nil {
 			return err
 		}
-		return re.Emit(headKey)
+		return nil
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/ipfs/go-bitswap v0.1.5
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.0.2
-	github.com/ipfs/go-car v0.0.1
+	github.com/ipfs/go-car v0.0.2-0.20190926002512-a64e86334410
 	github.com/ipfs/go-cid v0.0.3
 	github.com/ipfs/go-datastore v0.0.5
 	github.com/ipfs/go-ds-badger v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,8 @@ github.com/ipfs/go-blockservice v0.0.2 h1:ZiKTWdZAPifdWhjjO7HjAF8grUVE86IPzcUtGC
 github.com/ipfs/go-blockservice v0.0.2/go.mod h1:2Ao89U7jV1KIqqNk5EdhSTBG/Pgc1vMFr0bhkx376j4=
 github.com/ipfs/go-car v0.0.1 h1:Nn3RjJbysnDud4wILAybzOAvzsaycrCoKM4BMIK0Y04=
 github.com/ipfs/go-car v0.0.1/go.mod h1:pUz3tUIpudsTch0ZQrEPOvNUBT1LufCXg8aZ4KOrEMM=
+github.com/ipfs/go-car v0.0.2-0.20190926002512-a64e86334410 h1:iT6RiMoKP9oR0LnPbjk8/J+qhy9SShtxbAdXYSa0EBs=
+github.com/ipfs/go-car v0.0.2-0.20190926002512-a64e86334410/go.mod h1:pUz3tUIpudsTch0ZQrEPOvNUBT1LufCXg8aZ4KOrEMM=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -194,12 +194,12 @@ func (api *API) ChainSyncHandleNewTipSet(ctx context.Context, ci *types.ChainInf
 	return api.syncer.HandleNewTipSet(ctx, ci, trusted)
 }
 
-// ChainExport exports the chain store to `out`.
-func (api *API) ChainExport(ctx context.Context, head types.TipSetKey, out io.Writer) (types.TipSetKey, error) {
+// ChainExport exports the chain from `head` up to and including the genesis block to `out`
+func (api *API) ChainExport(ctx context.Context, head types.TipSetKey, out io.Writer) error {
 	return api.chain.ChainExport(ctx, head, out)
 }
 
-// ChainImport imports the chain with the same genesis block from `in`.
+// ChainImport imports a chain from `in`.
 func (api *API) ChainImport(ctx context.Context, in io.Reader) (types.TipSetKey, error) {
 	return api.chain.ChainImport(ctx, in)
 }

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -194,6 +194,16 @@ func (api *API) ChainSyncHandleNewTipSet(ctx context.Context, ci *types.ChainInf
 	return api.syncer.HandleNewTipSet(ctx, ci, trusted)
 }
 
+// ChainExport exports the chain store to `out`.
+func (api *API) ChainExport(ctx context.Context, head types.TipSetKey, out io.Writer) (types.TipSetKey, error) {
+	return api.chain.ChainExport(ctx, head, out)
+}
+
+// ChainImport imports the chain with the same genesis block from `in`.
+func (api *API) ChainImport(ctx context.Context, in io.Reader) (types.TipSetKey, error) {
+	return api.chain.ChainImport(ctx, in)
+}
+
 // DealsIterator returns an iterator to access all deals
 func (api *API) DealsIterator() (*query.Results, error) {
 	return api.storagedeals.Iterator()


### PR DESCRIPTION
### Goals
Allow a go-filecoin node to export a chain to a [car file](https://github.com/ipfs/go-car) and import a chain from a car file.

### Non-Goals
Allow a go-filecoin node to initialize from a car file (filed #3554 to address this)

### Implementation
- A new file: `car.go`  was added to the chain/ package. This file contains all logic for importing and exporting a chain.
- Two new sub-commands were added to the `chain` command:
```
go-filecoin chain export <file> <TipSetKey...> - Export the chain store to a car file.
go-filecoin chain import <file> - Import the chain from a car file.
```
- Export is an operation on the chain store, it writes its internal store to a car file.
- Import is an operation on the chain store, it imports the contents of a car file into its blockstore.

### Follow-on issues:
#3554
#3555