### PR TITLE
refactor: cleanup node initialization 

### DIFF
--- a/node/blockservice_submoodule.go
+++ b/node/blockservice_submoodule.go
@@ -1,0 +1,15 @@
+package node
+
+import (
+	bserv "github.com/ipfs/go-blockservice"
+)
+
+// BlockserviceSubmodule enhances the `Node` with networked key/value fetching capabilities.
+//
+// TODO: split chain data from piece data (issue: https://github.com/filecoin-project/go-filecoin/issues/3481)
+// Note: at present:
+// - `BlockService` is shared by chain/graphsync and piece/bitswap data
+type BlockserviceSubmodule struct {
+	// Blockservice is a higher level interface for fetching data
+	blockservice bserv.BlockService
+}

--- a/node/blockstore_submodule.go
+++ b/node/blockstore_submodule.go
@@ -1,25 +1,20 @@
 package node
 
 import (
-	bserv "github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-hamt-ipld"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
 )
 
-// BlockstoreSubmodule enhances the `Node` with key/value storing capabilities.
+// BlockstoreSubmodule enhances the `Node` with local key/value storing capabilities.
 //
 // TODO: split chain data from piece data (issue: https://github.com/filecoin-project/go-filecoin/issues/3481)
 // Note: at present:
-// - `BlockService` is shared by chain/graphsync and piece/bitswap data
 // - `Blockstore` is shared by chain/graphsync and piece/bitswap data
 // - `cborStore` is used for chain state and shared with piece data exchange for deals at the moment.
 type BlockstoreSubmodule struct {
-	// Blockservice is a higher level interface for fetching data
-	blockservice bserv.BlockService
-
 	// Blockstore is the un-networked blocks interface
 	Blockstore bstore.Blockstore
 
-	// cborStore is a temporary interface for interacting with IPLD objects.
+	// cborStore is a wrapper for a `hamt.CborIpldStore` that works on the local IPLD-Cbor objects stored in `Blockstore`.
 	cborStore *hamt.CborIpldStore
 }

--- a/node/builder.go
+++ b/node/builder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-bitswap"
 	bsnet "github.com/ipfs/go-bitswap/network"
 	bserv "github.com/ipfs/go-blockservice"
+	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/ipldbridge"
 	gsnet "github.com/ipfs/go-graphsync/network"
@@ -15,6 +16,7 @@ import (
 	bstore "github.com/ipfs/go-ipfs-blockstore"
 	offline "github.com/ipfs/go-ipfs-exchange-offline"
 	offroute "github.com/ipfs/go-ipfs-routing/offline"
+	cbornode "github.com/ipfs/go-ipld-cbor"
 	"github.com/ipfs/go-merkledag"
 	"github.com/libp2p/go-libp2p"
 	autonatsvc "github.com/libp2p/go-libp2p-autonat-svc"
@@ -30,9 +32,12 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 
+	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/clock"
+	"github.com/filecoin-project/go-filecoin/config"
 	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/message"
 	"github.com/filecoin-project/go-filecoin/net"
 	"github.com/filecoin-project/go-filecoin/net/pubsub"
@@ -46,6 +51,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/proofs/verification"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/state"
+	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/util/moresync"
 	"github.com/filecoin-project/go-filecoin/version"
 	"github.com/filecoin-project/go-filecoin/wallet"
@@ -61,6 +67,7 @@ type Builder struct {
 	Repo        repo.Repo
 	IsRelay     bool
 	Clock       clock.Clock
+	genCid      cid.Cid
 }
 
 // BuilderOpt is an option for building a filecoin node.
@@ -92,12 +99,12 @@ func BlockTime(blockTime time.Duration) BuilderOpt {
 
 // Libp2pOptions returns a node config option that sets up the libp2p node
 func Libp2pOptions(opts ...libp2p.Option) BuilderOpt {
-	return func(nc *Builder) error {
+	return func(b *Builder) error {
 		// Quietly having your options overridden leads to hair loss
-		if len(nc.Libp2pOpts) > 0 {
+		if len(b.Libp2pOpts) > 0 {
 			panic("Libp2pOptions can only be called once")
 		}
-		nc.Libp2pOpts = opts
+		b.Libp2pOpts = opts
 		return nil
 	}
 }
@@ -128,62 +135,177 @@ func ClockConfigOption(clk clock.Clock) BuilderOpt {
 
 // New creates a new node.
 func New(ctx context.Context, opts ...BuilderOpt) (*Node, error) {
-	n := &Builder{}
+	// initialize builder and set base values
+	n := &Builder{
+		OfflineMode: false,
+	}
+
+	// apply builder options
 	for _, o := range opts {
 		if err := o(n); err != nil {
 			return nil, err
 		}
 	}
 
+	// build the node
 	return n.build(ctx)
 }
 
-// Build instantiates a filecoin Node from the settings specified in the config.
-func (nc *Builder) build(ctx context.Context) (*Node, error) {
-	if nc.Repo == nil {
-		nc.Repo = repo.NewInMemoryRepo()
+func (b *Builder) build(ctx context.Context) (*Node, error) {
+	//
+	// Set default values on un-initialized fields
+	//
+
+	if b.Clock == nil {
+		b.Clock = clock.NewSystemClock()
 	}
-	if nc.Clock == nil {
-		nc.Clock = clock.NewSystemClock()
+
+	if b.Repo == nil {
+		b.Repo = repo.NewInMemoryRepo()
 	}
 
-	bs := bstore.NewBlockstore(nc.Repo.Datastore())
+	var err error
 
-	validator := blankValidator{}
+	// fetch genesis block id
+	b.genCid, err = readGenesisCid(b.Repo.Datastore())
+	if err != nil {
+		return nil, err
+	}
 
+	// create the node
+	nd := &Node{
+		OfflineMode: b.OfflineMode,
+		Clock:       b.Clock,
+		Repo:        b.Repo,
+	}
+
+	nd.Blockstore, err = b.buildBlockstore(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.Blockstore")
+	}
+
+	nd.Network, err = b.buildNetwork(ctx, nd.Repo.Config().Bootstrap, &nd.Blockstore)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.Network")
+	}
+
+	nd.Blockservice, err = b.buildBlockservice(ctx, &nd.Blockstore, &nd.Network)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.Blockservice")
+	}
+
+	nd.Chain, err = b.buildChain(ctx, &nd.Blockstore, &nd.Network)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.Chain")
+	}
+
+	nd.Wallet, err = b.buildWallet(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.Wallet")
+	}
+
+	nd.Messaging, err = b.buildMessaging(ctx, &nd.Network, &nd.Chain, &nd.Wallet)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.Messaging")
+	}
+
+	nd.StorageNetworking, err = b.buildStorgeNetworking(ctx, &nd.Network)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.StorageNetworking")
+	}
+
+	nd.BlockMining, err = b.buildBlockMining(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.BlockMining")
+	}
+
+	nd.SectorStorage, err = b.buildSectorStorage(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.SectorStorage")
+	}
+	nd.HelloProtocol, err = b.buildHelloProtocol(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.HelloProtocol")
+	}
+
+	nd.StorageProtocol, err = b.buildStorageProtocol(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.StorageProtocol")
+	}
+
+	nd.RetrievalProtocol, err = b.buildRetrievalProtocol(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.RetrievalProtocol")
+	}
+
+	nd.FaultSlasher, err = b.buildFaultSlasher(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.FaultSlasher")
+	}
+
+	// TODO: inject protocol upgrade table into code that requires it (#3360)
+	_, err = version.ConfigureProtocolVersions(nd.Network.NetworkName)
+	if err != nil {
+		return nil, err
+	}
+
+	nd.PorcelainAPI = porcelain.New(plumbing.New(&plumbing.APIDeps{
+		Bitswap:       nd.Network.bitswap,
+		Chain:         nd.Chain.State,
+		Sync:          cst.NewChainSyncProvider(nd.Chain.Syncer),
+		Config:        cfg.NewConfig(b.Repo),
+		DAG:           dag.NewDAG(merkledag.NewDAGService(nd.Blockservice.blockservice)),
+		Deals:         strgdls.New(b.Repo.DealsDatastore()),
+		Expected:      nd.Chain.Consensus,
+		MsgPool:       nd.Messaging.msgPool,
+		MsgPreviewer:  msg.NewPreviewer(nd.Chain.ChainReader, nd.Blockstore.cborStore, nd.Blockstore.Blockstore),
+		ActState:      nd.Chain.ActorState,
+		MsgWaiter:     msg.NewWaiter(nd.Chain.ChainReader, nd.Chain.MessageStore, nd.Blockstore.Blockstore, nd.Blockstore.cborStore),
+		Network:       nd.Network.Network,
+		Outbox:        nd.Messaging.Outbox,
+		SectorBuilder: nd.SectorBuilder,
+		Wallet:        nd.Wallet.Wallet,
+	}))
+
+	return nd, nil
+}
+
+func (b *Builder) buildNetwork(ctx context.Context, config *config.BootstrapConfig, blockstore *BlockstoreSubmodule) (NetworkSubmodule, error) {
+	bandwidthTracker := p2pmetrics.NewBandwidthCounter()
+	b.Libp2pOpts = append(b.Libp2pOpts, libp2p.BandwidthReporter(bandwidthTracker))
+
+	networkName, err := retrieveNetworkName(ctx, b.genCid, blockstore.Blockstore)
+	if err != nil {
+		return NetworkSubmodule{}, err
+	}
+
+	periodStr := config.Period
+	period, err := time.ParseDuration(periodStr)
+	if err != nil {
+		return NetworkSubmodule{}, errors.Wrapf(err, "couldn't parse bootstrap period %s", periodStr)
+	}
+
+	// bootstrapper maintains connections to some subset of addresses
+	ba := config.Addresses
+	bpi, err := net.PeerAddrsToAddrInfo(ba)
+	if err != nil {
+		return NetworkSubmodule{}, errors.Wrapf(err, "couldn't parse bootstrap addresses [%s]", ba)
+	}
+
+	minPeerThreshold := config.MinPeerThreshold
+
+	// set up host
 	var peerHost host.Host
 	var router routing.Routing
-
-	bandwidthTracker := p2pmetrics.NewBandwidthCounter()
-	nc.Libp2pOpts = append(nc.Libp2pOpts, libp2p.BandwidthReporter(bandwidthTracker))
-
-	ipldCborStore := hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
-	genCid, err := readGenesisCid(nc.Repo.Datastore())
-	if err != nil {
-		return nil, err
-	}
-
-	chainStatusReporter := chain.NewStatusReporter()
-	// set up chain and message stores
-	chainStore := chain.NewStore(nc.Repo.ChainDatastore(), &ipldCborStore, &state.TreeStateLoader{}, chainStatusReporter, genCid)
-	messageStore := chain.NewMessageStore(&ipldCborStore)
-	chainState := cst.NewChainStateReadWriter(chainStore, messageStore, &ipldCborStore)
-	actorState := consensus.NewActorStateStore(chainStore, &ipldCborStore, bs)
-
-	// create protocol upgrade table
-	network, err := networkNameFromGenesis(ctx, chainStore, actorState)
-	if err != nil {
-		return nil, err
-	}
-
-	if !nc.OfflineMode {
+	validator := blankValidator{}
+	if !b.OfflineMode {
 		makeDHT := func(h host.Host) (routing.Routing, error) {
 			r, err := dht.New(
 				ctx,
 				h,
-				dhtopts.Datastore(nc.Repo.Datastore()),
+				dhtopts.Datastore(b.Repo.Datastore()),
 				dhtopts.NamespacedValidator("v", validator),
-				dhtopts.Protocols(net.FilecoinDHT(network)),
+				dhtopts.Protocols(net.FilecoinDHT(networkName)),
 			)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to setup routing")
@@ -193,160 +315,250 @@ func (nc *Builder) build(ctx context.Context) (*Node, error) {
 		}
 
 		var err error
-		peerHost, err = nc.buildHost(ctx, makeDHT)
+		peerHost, err = b.buildHost(ctx, makeDHT)
 		if err != nil {
-			return nil, err
+			return NetworkSubmodule{}, err
 		}
 	} else {
-		router = offroute.NewOfflineRouter(nc.Repo.Datastore(), validator)
+		router = offroute.NewOfflineRouter(b.Repo.Datastore(), validator)
 		peerHost = rhost.Wrap(noopLibP2PHost{}, router)
 	}
 
-	// set up pinger
-	pingService := ping.NewPingService(peerHost)
-
-	// setup block validation
-	// TODO when #2961 is resolved do the needful here.
-	blkValid := consensus.NewDefaultBlockValidator(nc.BlockTime, nc.Clock)
+	// create a bootstrapper
+	bootstrapper := net.NewBootstrapper(bpi, peerHost, peerHost.Network(), router, minPeerThreshold, period)
 
 	// set up peer tracking
 	peerTracker := net.NewPeerTracker(peerHost.ID())
 
-	// set up bitswap
-	nwork := bsnet.NewFromIpfsHost(peerHost, router)
-	//nwork := bsnet.NewFromIpfsHost(innerHost, router)
-	bswap := bitswap.New(ctx, nwork, bs)
-	bservice := bserv.New(bs, bswap)
-
-	graphsyncNetwork := gsnet.NewFromLibp2pHost(peerHost)
-	bridge := ipldbridge.NewIPLDBridge()
-	loader := gsstoreutil.LoaderForBlockstore(bs)
-	storer := gsstoreutil.StorerForBlockstore(bs)
-	gsync := graphsync.New(ctx, graphsyncNetwork, bridge, loader, storer)
-	fetcher := net.NewGraphSyncFetcher(ctx, gsync, bs, blkValid, nc.Clock, peerTracker)
-
-	// TODO: inject protocol upgrade table into code that requires it (#3360)
-	_, err = version.ConfigureProtocolVersions(network)
-	if err != nil {
-		return nil, err
-	}
-
-	// set up processor
-	var processor consensus.Processor
-	if nc.Rewarder == nil {
-		processor = consensus.NewDefaultProcessor()
-	} else {
-		processor = consensus.NewConfiguredProcessor(consensus.NewDefaultMessageValidator(), nc.Rewarder)
-	}
-
-	// set up consensus
-	nodeConsensus := consensus.NewExpected(&ipldCborStore, bs, processor, blkValid, actorState, genCid, nc.BlockTime, consensus.ElectionMachine{}, consensus.TicketMachine{})
-
 	// Set up libp2p network
-	// TODO PubSub requires strict message signing, disabled for now
+	// TODO: PubSub requires strict message signing, disabled for now
 	// reference issue: #3124
 	fsub, err := libp2pps.NewFloodSub(ctx, peerHost, libp2pps.WithMessageSigning(false))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to set up network")
-	}
-	// register block validation on floodsub
-	btv := net.NewBlockTopicValidator(blkValid)
-	if err := fsub.RegisterTopicValidator(btv.Topic(network), btv.Validator(), btv.Opts()...); err != nil {
-		return nil, errors.Wrap(err, "failed to register block validator")
+		return NetworkSubmodule{}, errors.Wrap(err, "failed to set up network")
 	}
 
-	backend, err := wallet.NewDSBackend(nc.Repo.WalletDatastore())
+	// set up bitswap
+	nwork := bsnet.NewFromIpfsHost(peerHost, router)
+	//nwork := bsnet.NewFromIpfsHost(innerHost, router)
+	bswap := bitswap.New(ctx, nwork, blockstore.Blockstore)
+
+	// set up pinger
+	pingService := ping.NewPingService(peerHost)
+
+	// build network
+	network := net.New(peerHost, pubsub.NewPublisher(fsub), pubsub.NewSubscriber(fsub), net.NewRouter(router), bandwidthTracker, net.NewPinger(peerHost, pingService))
+
+	// build the network submdule
+	return NetworkSubmodule{
+		NetworkName:  networkName,
+		host:         peerHost,
+		PeerHost:     peerHost,
+		Bootstrapper: bootstrapper,
+		PeerTracker:  peerTracker,
+		Router:       router,
+		fsub:         fsub,
+		bitswap:      bswap,
+		Network:      network,
+	}, nil
+}
+
+func (b *Builder) buildMessaging(ctx context.Context, network *NetworkSubmodule, chain *ChainSubmodule, wallet *WalletSubmodule) (MessagingSubmodule, error) {
+	msgPool := message.NewPool(b.Repo.Config().Mpool, consensus.NewIngestionValidator(chain.State, b.Repo.Config().Mpool))
+	inbox := message.NewInbox(msgPool, message.InboxMaxAgeTipsets, chain.ChainReader, chain.MessageStore)
+
+	msgQueue := message.NewQueue()
+	outboxPolicy := message.NewMessageQueuePolicy(chain.MessageStore, message.OutboxMaxAgeRounds)
+	msgPublisher := message.NewDefaultPublisher(pubsub.NewPublisher(network.fsub), net.MessageTopic(network.NetworkName), msgPool)
+	outbox := message.NewOutbox(wallet.Wallet, consensus.NewOutboundMessageValidator(), msgQueue, msgPublisher, outboxPolicy, chain.ChainReader, chain.State)
+
+	return MessagingSubmodule{
+		Inbox:   inbox,
+		Outbox:  outbox,
+		msgPool: msgPool,
+	}, nil
+}
+
+func (b *Builder) buildBlockstore(ctx context.Context) (BlockstoreSubmodule, error) {
+	// set up block store
+	bs := bstore.NewBlockstore(b.Repo.Datastore())
+	// setup a ipldCbor on top of the local store
+	ipldCborStore := hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
+
+	return BlockstoreSubmodule{
+		Blockstore: bs,
+		cborStore:  &ipldCborStore,
+	}, nil
+}
+
+func (b *Builder) buildBlockservice(ctx context.Context, blockstore *BlockstoreSubmodule, network *NetworkSubmodule) (BlockserviceSubmodule, error) {
+	bservice := bserv.New(blockstore.Blockstore, network.bitswap)
+
+	return BlockserviceSubmodule{
+		blockservice: bservice,
+	}, nil
+}
+
+func (b *Builder) buildChain(ctx context.Context, blockstore *BlockstoreSubmodule, network *NetworkSubmodule) (ChainSubmodule, error) {
+	// initialize chain store
+	chainStatusReporter := chain.NewStatusReporter()
+	chainStore := chain.NewStore(b.Repo.ChainDatastore(), blockstore.cborStore, &state.TreeStateLoader{}, chainStatusReporter, b.genCid)
+
+	// set up processor
+	var processor consensus.Processor
+	if b.Rewarder == nil {
+		processor = consensus.NewDefaultProcessor()
+	} else {
+		processor = consensus.NewConfiguredProcessor(consensus.NewDefaultMessageValidator(), b.Rewarder)
+	}
+
+	// setup block validation
+	// TODO when #2961 is resolved do the needful here.
+	blkValid := consensus.NewDefaultBlockValidator(b.BlockTime, b.Clock)
+
+	// register block validation on floodsub
+	btv := net.NewBlockTopicValidator(blkValid)
+	if err := network.fsub.RegisterTopicValidator(btv.Topic(network.NetworkName), btv.Validator(), btv.Opts()...); err != nil {
+		return ChainSubmodule{}, errors.Wrap(err, "failed to register block validator")
+	}
+
+	// set up consensus
+	actorState := consensus.NewActorStateStore(chainStore, blockstore.cborStore, blockstore.Blockstore)
+	nodeConsensus := consensus.NewExpected(blockstore.cborStore, blockstore.Blockstore, processor, blkValid, actorState, b.genCid, b.BlockTime, consensus.ElectionMachine{}, consensus.TicketMachine{})
+
+	// setup fecher
+	graphsyncNetwork := gsnet.NewFromLibp2pHost(network.host)
+	bridge := ipldbridge.NewIPLDBridge()
+	loader := gsstoreutil.LoaderForBlockstore(blockstore.Blockstore)
+	storer := gsstoreutil.StorerForBlockstore(blockstore.Blockstore)
+	gsync := graphsync.New(ctx, graphsyncNetwork, bridge, loader, storer)
+	fetcher := net.NewGraphSyncFetcher(ctx, gsync, blockstore.Blockstore, blkValid, b.Clock, network.PeerTracker)
+
+	messageStore := chain.NewMessageStore(blockstore.cborStore)
+
+	// only the syncer gets the storage which is online connected
+	chainSyncer := chain.NewSyncer(nodeConsensus, chainStore, messageStore, fetcher, chainStatusReporter, b.Clock)
+
+	chainState := cst.NewChainStateReadWriter(chainStore, messageStore, blockstore.cborStore)
+
+	return ChainSubmodule{
+		// BlockSub: nil,
+		Consensus:    nodeConsensus,
+		ChainReader:  chainStore,
+		MessageStore: messageStore,
+		Syncer:       chainSyncer,
+		ActorState:   actorState,
+		// HeaviestTipSetCh: nil,
+		// cancelChainSync: nil,
+		ChainSynced: moresync.NewLatch(1),
+		Fetcher:     fetcher,
+		State:       chainState,
+		validator:   blkValid,
+	}, nil
+}
+
+func (b *Builder) buildBlockMining(ctx context.Context) (BlockMiningSubmodule, error) {
+	return BlockMiningSubmodule{
+		// BlockMiningAPI:     nil,
+		// AddNewlyMinedBlock: nil,
+		// cancelMining:       nil,
+		// MiningWorker:       nil,
+		// MiningScheduler:    nil,
+		// mining:       nil,
+		// miningDoneWg: nil,
+		// MessageSub:   nil,
+	}, nil
+}
+
+func (b *Builder) buildSectorStorage(ctx context.Context) (SectorBuilderSubmodule, error) {
+	return SectorBuilderSubmodule{
+		// sectorBuilder: nil,
+	}, nil
+}
+
+func (b *Builder) buildHelloProtocol(ctx context.Context) (HelloProtocolSubmodule, error) {
+	return HelloProtocolSubmodule{
+		// HelloSvc: nil,
+	}, nil
+}
+
+func (b *Builder) buildStorageProtocol(ctx context.Context) (StorageProtocolSubmodule, error) {
+	return StorageProtocolSubmodule{
+		// StorageAPI: nil,
+		// StorageMiner: nil,
+	}, nil
+}
+
+func (b *Builder) buildRetrievalProtocol(ctx context.Context) (RetrievalProtocolSubmodule, error) {
+	return RetrievalProtocolSubmodule{
+		// RetrievalAPI: nil,
+		// RetrievalMiner: nil,
+	}, nil
+}
+
+func (b *Builder) buildWallet(ctx context.Context) (WalletSubmodule, error) {
+	backend, err := wallet.NewDSBackend(b.Repo.WalletDatastore())
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to set up wallet backend")
+		return WalletSubmodule{}, errors.Wrap(err, "failed to set up wallet backend")
 	}
 	fcWallet := wallet.New(backend)
 
-	// only the syncer gets the storage which is online connected
-	chainSyncer := chain.NewSyncer(nodeConsensus, chainStore, messageStore, fetcher, chainStatusReporter, nc.Clock)
-	msgPool := message.NewPool(nc.Repo.Config().Mpool, consensus.NewIngestionValidator(chainState, nc.Repo.Config().Mpool))
-	inbox := message.NewInbox(msgPool, message.InboxMaxAgeTipsets, chainStore, messageStore)
+	return WalletSubmodule{
+		Wallet: fcWallet,
+	}, nil
+}
 
-	msgQueue := message.NewQueue()
-	outboxPolicy := message.NewMessageQueuePolicy(messageStore, message.OutboxMaxAgeRounds)
-	msgPublisher := message.NewDefaultPublisher(pubsub.NewPublisher(fsub), net.MessageTopic(network), msgPool)
-	outbox := message.NewOutbox(fcWallet, consensus.NewOutboundMessageValidator(), msgQueue, msgPublisher, outboxPolicy, chainStore, chainState)
+func (b *Builder) buildStorgeNetworking(ctx context.Context, network *NetworkSubmodule) (StorageNetworkingSubmodule, error) {
+	return StorageNetworkingSubmodule{
+		Exchange: network.bitswap,
+	}, nil
+}
 
-	nd := &Node{
-		Clock:       nc.Clock,
-		OfflineMode: nc.OfflineMode,
-		Repo:        nc.Repo,
-		Network: NetworkSubmodule{
-			host:        peerHost,
-			PeerHost:    peerHost,
-			NetworkName: network,
-			PeerTracker: peerTracker,
-			Router:      router,
-		},
-		Wallet: WalletSubmodule{
-			Wallet: fcWallet,
-		},
-		Messaging: MessagingSubmodule{
-			Inbox:  inbox,
-			Outbox: outbox,
-		},
-		Blockstore: BlockstoreSubmodule{
-			blockservice: bservice,
-			Blockstore:   bs,
-			cborStore:    &ipldCborStore,
-		},
-		StorageNetworking: StorageNetworkingSubmodule{
-			Exchange: bswap,
-		},
-		Chain: ChainSubmodule{
-			Fetcher:      fetcher,
-			Consensus:    nodeConsensus,
-			ChainReader:  chainStore,
-			ChainSynced:  moresync.NewLatch(1),
-			MessageStore: messageStore,
-			Syncer:       chainSyncer,
-		},
-	}
+func (b *Builder) buildFaultSlasher(ctx context.Context) (FaultSlasherSubmodule, error) {
+	return FaultSlasherSubmodule{
+		// StorageFaultSlasher: nil,
+	}, nil
+}
 
-	nd.PorcelainAPI = porcelain.New(plumbing.New(&plumbing.APIDeps{
-		Bitswap:       bswap,
-		Chain:         chainState,
-		Sync:          cst.NewChainSyncProvider(chainSyncer),
-		Config:        cfg.NewConfig(nc.Repo),
-		DAG:           dag.NewDAG(merkledag.NewDAGService(bservice)),
-		Deals:         strgdls.New(nc.Repo.DealsDatastore()),
-		Expected:      nodeConsensus,
-		MsgPool:       msgPool,
-		MsgPreviewer:  msg.NewPreviewer(chainStore, &ipldCborStore, bs),
-		ActState:      actorState,
-		MsgWaiter:     msg.NewWaiter(chainStore, messageStore, bs, &ipldCborStore),
-		Network:       net.New(peerHost, pubsub.NewPublisher(fsub), pubsub.NewSubscriber(fsub), net.NewRouter(router), bandwidthTracker, net.NewPinger(peerHost, pingService)),
-		Outbox:        outbox,
-		SectorBuilder: nd.SectorBuilder,
-		Wallet:        fcWallet,
-	}))
+func retrieveNetworkName(ctx context.Context, genCid cid.Cid, bs bstore.Blockstore) (string, error) {
+	cborStore := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
+	var genesis types.Block
 
-	// Bootstrapping network peers.
-	periodStr := nd.Repo.Config().Bootstrap.Period
-	period, err := time.ParseDuration(periodStr)
+	err := cborStore.Get(ctx, genCid, &genesis)
 	if err != nil {
-		return nil, errors.Wrapf(err, "couldn't parse bootstrap period %s", periodStr)
+		return "", errors.Wrapf(err, "failed to get block %s", genCid.String())
 	}
 
-	// Bootstrapper maintains connections to some subset of addresses
-	ba := nd.Repo.Config().Bootstrap.Addresses
-	bpi, err := net.PeerAddrsToAddrInfo(ba)
+	tree, err := state.LoadStateTree(ctx, cborStore, genesis.StateRoot, map[cid.Cid]exec.ExecutableActor{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "couldn't parse bootstrap addresses [%s]", ba)
+		return "", errors.Wrapf(err, "failed to load node for %s", genesis.StateRoot)
 	}
-	minPeerThreshold := nd.Repo.Config().Bootstrap.MinPeerThreshold
-	nd.Network.Bootstrapper = net.NewBootstrapper(bpi, nd.Host(), nd.Host().Network(), nd.Network.Router, minPeerThreshold, period)
+	initActor, err := tree.GetActor(ctx, address.InitAddress)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to load init actor at %s", address.InitAddress.String())
+	}
 
-	return nd, nil
+	block, err := bs.Get(initActor.Head)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to load init actor state at %s", initActor.Head)
+	}
+
+	node, err := cbornode.DecodeBlock(block)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to decode init actor state")
+	}
+
+	networkName, _, err := node.Resolve([]string{"network"})
+	if err != nil || networkName == nil {
+		return "", errors.Wrapf(err, "failed to retrieve network name")
+	}
+
+	return networkName.(string), nil
 }
 
 // buildHost determines if we are publically dialable.  If so use public
 // Address, if not configure node to announce relay address.
-func (nc *Builder) buildHost(ctx context.Context, makeDHT func(host host.Host) (routing.Routing, error)) (host.Host, error) {
+func (b *Builder) buildHost(ctx context.Context, makeDHT func(host host.Host) (routing.Routing, error)) (host.Host, error) {
 	// Node must build a host acting as a libp2p relay.  Additionally it
 	// runs the autoNAT service which allows other nodes to check for their
 	// own dialability by having this node attempt to dial them.
@@ -354,8 +566,8 @@ func (nc *Builder) buildHost(ctx context.Context, makeDHT func(host host.Host) (
 		return makeDHT(h)
 	}
 
-	if nc.IsRelay {
-		cfg := nc.Repo.Config()
+	if b.IsRelay {
+		cfg := b.Repo.Config()
 		publicAddr, err := ma.NewMultiaddr(cfg.Swarm.PublicRelayAddress)
 		if err != nil {
 			return nil, err
@@ -375,7 +587,7 @@ func (nc *Builder) buildHost(ctx context.Context, makeDHT func(host host.Host) (
 			libp2p.EnableAutoRelay(),
 			libp2p.Routing(makeDHTRightType),
 			publicAddrFactory,
-			libp2p.ChainOptions(nc.Libp2pOpts...),
+			libp2p.ChainOptions(b.Libp2pOpts...),
 		)
 		if err != nil {
 			return nil, err
@@ -391,6 +603,6 @@ func (nc *Builder) buildHost(ctx context.Context, makeDHT func(host host.Host) (
 		ctx,
 		libp2p.EnableAutoRelay(),
 		libp2p.Routing(makeDHTRightType),
-		libp2p.ChainOptions(nc.Libp2pOpts...),
+		libp2p.ChainOptions(b.Libp2pOpts...),
 	)
 }

--- a/node/chain_submodule.go
+++ b/node/chain_submodule.go
@@ -7,6 +7,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/net"
 	"github.com/filecoin-project/go-filecoin/net/pubsub"
+	"github.com/filecoin-project/go-filecoin/plumbing/cst"
 	"github.com/filecoin-project/go-filecoin/util/moresync"
 )
 
@@ -17,7 +18,7 @@ type ChainSubmodule struct {
 	ChainReader  nodeChainReader
 	MessageStore *chain.MessageStore
 	Syncer       nodeChainSyncer
-	PowerTable   consensus.PowerTableView
+	ActorState   *consensus.ActorStateStore
 	// HeavyTipSetCh is a subscription to the heaviest tipset topic on the chain.
 	// https://github.com/filecoin-project/go-filecoin/issues/2309
 	HeaviestTipSetCh chan interface{}
@@ -29,4 +30,7 @@ type ChainSubmodule struct {
 	ChainSynced *moresync.Latch
 	// Fetcher is the interface for fetching data from nodes.
 	Fetcher net.Fetcher
+	State   *cst.ChainStateReadWriter
+
+	validator consensus.BlockValidator
 }

--- a/node/helpers.go
+++ b/node/helpers.go
@@ -28,6 +28,7 @@ type nodeChainReader interface {
 
 type nodeChainSyncer interface {
 	HandleNewTipSet(ctx context.Context, ci *types.ChainInfo, trusted bool) error
+	Status() chain.Status
 }
 
 // storageFaultSlasher is the interface for needed FaultSlasher functionality

--- a/node/messaging_submodule.go
+++ b/node/messaging_submodule.go
@@ -15,4 +15,6 @@ type MessagingSubmodule struct {
 
 	// Network Fields
 	MessageSub pubsub.Subscription
+
+	msgPool *message.Pool
 }

--- a/node/network_submodule.go
+++ b/node/network_submodule.go
@@ -2,8 +2,10 @@ package node
 
 import (
 	"github.com/filecoin-project/go-filecoin/net"
+	exchange "github.com/ipfs/go-ipfs-exchange-interface"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/routing"
+	libp2pps "github.com/libp2p/go-libp2p-pubsub"
 )
 
 // NetworkSubmodule enhances the `Node` with networking capabilities.
@@ -22,4 +24,11 @@ type NetworkSubmodule struct {
 
 	// Router is a router from IPFS
 	Router routing.Routing
+
+	fsub *libp2pps.PubSub
+
+	// TODO: split chain bitswap from storage bitswap (issue: ???)
+	bitswap exchange.Interface
+
+	Network *net.Network
 }

--- a/node/node.go
+++ b/node/node.go
@@ -54,38 +54,51 @@ type Node struct {
 	// Clock is a clock used by the node for time.
 	Clock clock.Clock
 
-	VersionTable version.ProtocolVersionTable
-
-	PorcelainAPI *porcelain.API
-
 	// Repo is the repo this node was created with.
 	//
 	// It contains all persistent artifacts of the filecoin node.
 	Repo repo.Repo
 
-	Blockstore BlockstoreSubmodule
+	PorcelainAPI *porcelain.API
 
-	Network NetworkSubmodule
+	//
+	// Core services
+	//
 
-	Messaging MessagingSubmodule
+	Blockstore   BlockstoreSubmodule
+	Network      NetworkSubmodule
+	Blockservice BlockserviceSubmodule
 
-	Chain ChainSubmodule
+	//
+	// Subsystems
+	//
 
-	BlockMining BlockMiningSubmodule
-
-	StorageProtocol StorageProtocolSubmodule
-
-	RetrievalProtocol RetrievalProtocolSubmodule
-
+	Chain         ChainSubmodule
+	BlockMining   BlockMiningSubmodule
 	SectorStorage SectorBuilderSubmodule
 
-	FaultSlasher FaultSlasherSubmodule
+	//
+	// Supporting services
+	//
 
-	HelloProtocol HelloProtocolSubmodule
-
+	Wallet            WalletSubmodule
+	Messaging         MessagingSubmodule
 	StorageNetworking StorageNetworkingSubmodule
 
-	Wallet WalletSubmodule
+	//
+	// Protocols
+	//
+
+	VersionTable      version.ProtocolVersionTable
+	HelloProtocol     HelloProtocolSubmodule
+	StorageProtocol   StorageProtocolSubmodule
+	RetrievalProtocol RetrievalProtocolSubmodule
+
+	//
+	// Additional services
+	//
+
+	FaultSlasher FaultSlasherSubmodule
 }
 
 // Start boots up the node.
@@ -105,7 +118,7 @@ func (node *Node) Start(ctx context.Context) error {
 
 	// Only set these up if there is a miner configured.
 	if _, err := node.MiningAddress(); err == nil {
-		if err := node.setupMining(ctx); err != nil {
+		if err := node.setupSectorBuilder(ctx); err != nil {
 			log.Errorf("setup mining failed: %v", err)
 			return err
 		}
@@ -251,7 +264,7 @@ func (node *Node) setupHeartbeatServices(ctx context.Context) error {
 	return nil
 }
 
-func (node *Node) setupMining(ctx context.Context) error {
+func (node *Node) setupSectorBuilder(ctx context.Context) error {
 	// initialize a sector builder
 	sectorBuilder, err := initSectorBuilderForNode(ctx, node)
 	if err != nil {
@@ -422,7 +435,7 @@ func (node *Node) SetupMining(ctx context.Context) error {
 
 	// ensure we have a sector builder
 	if node.SectorBuilder() == nil {
-		if err := node.setupMining(ctx); err != nil {
+		if err := node.setupSectorBuilder(ctx); err != nil {
 			return err
 		}
 	}
@@ -571,25 +584,6 @@ func (node *Node) StartMining(ctx context.Context) error {
 	return nil
 }
 
-// NetworkNameFromGenesis retrieves the name of the current network from the genesis block.
-// The network name can not change while this node is running. Since the network name determines
-// the protocol version, we must retrieve it at genesis where the protocol is known.
-func networkNameFromGenesis(ctx context.Context, chainStore *chain.Store, as *consensus.ActorStateStore) (string, error) {
-	st, err := chainStore.GetGenesisState(ctx)
-	if err != nil {
-		return "", errors.Wrap(err, "could not get genesis state")
-	}
-
-	snapshot := as.StateTreeSnapshot(st, types.NewBlockHeight(0))
-
-	res, err := snapshot.Query(ctx, address.Undef, address.InitAddress, "getNetwork")
-	if err != nil {
-		return "", errors.Wrap(err, "error querying for network name")
-	}
-
-	return string(res[0]), nil
-}
-
 func initSectorBuilderForNode(ctx context.Context, node *Node) (sectorbuilder.SectorBuilder, error) {
 	minerAddr, err := node.MiningAddress()
 	if err != nil {
@@ -629,7 +623,7 @@ func initSectorBuilderForNode(ctx context.Context, node *Node) (sectorbuilder.Se
 		return nil, err
 	}
 	cfg := sectorbuilder.RustSectorBuilderConfig{
-		BlockService:     node.Blockstore.blockservice,
+		BlockService:     node.Blockservice.blockservice,
 		LastUsedSectorID: lastUsedSectorID,
 		MetadataDir:      stagingDir,
 		MinerAddr:        minerAddr,
@@ -836,7 +830,7 @@ func (node *Node) SectorBuilder() sectorbuilder.SectorBuilder {
 
 // BlockService returns the nodes blockservice.
 func (node *Node) BlockService() bserv.BlockService {
-	return node.Blockstore.blockservice
+	return node.Blockservice.blockservice
 }
 
 // CborStore returns the nodes cborStore.


### PR DESCRIPTION
One of many PRs addressing https://github.com/filecoin-project/go-filecoin/issues/3140.

This PR attempts to cleanup the `build()` method and separate it into pieces that build each of the subsystems instead. 

### Pending:
- [x] breaking apart the builder 
- [x] move `pingService` somewhere 
- [x] move `PorcelainAPI.Network` somewhere 

### Next PR: 
- [ ] cleaning up some building happening in start
