### PR TITLE
Change user devnet name to be distinct from staging network. Change setup.json to use go-filecoin-test.

### DIFF
--- a/fixtures/setup.json
+++ b/fixtures/setup.json
@@ -11,5 +11,5 @@
     "owner": 0,
     "numCommittedSectors": 1
   }],
-  "network": "alpha1"
+  "network": "go-filecoin-test"
 }

--- a/version/protocol_versions.go
+++ b/version/protocol_versions.go
@@ -4,8 +4,8 @@ import (
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
-// ALPHA1 is the first alpha network
-const ALPHA1 = "alpha1"
+// USER is the user network
+const USER = "alpha2"
 
 // DEVNET4 is the network name of devnet
 const DEVNET4 = "devnet4"
@@ -20,9 +20,11 @@ const TEST = "go-filecoin-test"
 const Protocol0 = 0
 
 // ConfigureProtocolVersions configures all protocol upgrades for all known networks.
+// TODO: support arbitrary network names at "latest" protocol version so that only coordinated
+// network upgrades need to be represented here. See #3491.
 func ConfigureProtocolVersions(network string) (*ProtocolVersionTable, error) {
 	return NewProtocolVersionTableBuilder(network).
-		Add(ALPHA1, Protocol0, types.NewBlockHeight(0)).
+		Add(USER, Protocol0, types.NewBlockHeight(0)).
 		Add(DEVNET4, Protocol0, types.NewBlockHeight(0)).
 		Add(LOCALNET, Protocol0, types.NewBlockHeight(0)).
 		Add(TEST, Protocol0, types.NewBlockHeight(0)).


### PR DESCRIPTION
This will allow us to deploy the user devnet with a network name distinct from staging.

Future work will make this more flexible.

Context in #3491.