### PR TITLE
Remove @phritz from maintainer list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,7 +259,7 @@ A **Maintainer** is someone:
 3. **who is actively engaged in project progress and stewardship** by enabling others through project-wide planning, code reviews, design feedback, etc.; and
 4. **who is a model of trustworthiness, technical judgement, civility, and helpfulness**.
 
-Currently, `go-filecoin` maintainers are (alphabetically): @acruikshank, @anorth, @phritz, @whyrusleeping. They can be mentioned in issues and PRs by tagging `@filecoin-project/go-filecoin-maintainers`.
+Currently, `go-filecoin` maintainers are (alphabetically): @acruikshank, @anorth, and @whyrusleeping. They can be mentioned in issues and PRs by tagging `@filecoin-project/go-filecoin-maintainers`.
 
 Responsibilities:
 


### PR DESCRIPTION
@phritz departed the project 5 months ago and dropped maintainer status, but this doc wasn't updated and may mislead people.

While we'd welcome a return, I think regaining that status would require re-nomination.

FYI @whyrusleeping 