### PR TITLE
key protocol versions off network name prefix

### DIFF
--- a/cmd/go-filecoin/miner_daemon_test.go
+++ b/cmd/go-filecoin/miner_daemon_test.go
@@ -375,7 +375,7 @@ func minerDaemonTestConfig(t *testing.T) *gengen.GenesisCfg {
 				SectorSize:       constants.DevSectorSize,
 			},
 		},
-		Network: "go-filecoin-test",
+		Network: "gfctest",
 		Time:    123456789,
 	}
 }

--- a/cmd/go-filecoin/protocol_cmd_test.go
+++ b/cmd/go-filecoin/protocol_cmd_test.go
@@ -31,6 +31,6 @@ func TestProtocol(t *testing.T) {
 	defer stop()
 
 	out := cmd.RunSuccess(ctx, "protocol").ReadStdout()
-	assert.Contains(t, out, "Network: go-filecoin-test")
+	assert.Contains(t, out, "Network: gfctest")
 	assert.Contains(t, out, "Auto-Seal Interval: 120 seconds")
 }

--- a/fixtures/setup.json
+++ b/fixtures/setup.json
@@ -22,6 +22,6 @@
     }]
 
   }],
-  "network": "go-filecoin-test",
+  "network": "gfctest",
   "time": 123456789
 }

--- a/internal/app/go-filecoin/node/test/builder.go
+++ b/internal/app/go-filecoin/node/test/builder.go
@@ -35,7 +35,7 @@ type NodeBuilder struct {
 // NewNodeBuilder creates a new node builder.
 func NewNodeBuilder(tb testing.TB) *NodeBuilder {
 	return &NodeBuilder{
-		gif:      consensus.MakeGenesisFunc(consensus.NetworkName("go-filecoin-test")),
+		gif:      consensus.MakeGenesisFunc(consensus.NetworkName("gfctest")),
 		initOpts: []node.InitOpt{},
 		configMutations: []node.ConfigOpt{
 			// Default configurations that make sense for integration tests.

--- a/internal/app/go-filecoin/node/testing.go
+++ b/internal/app/go-filecoin/node/testing.go
@@ -217,7 +217,7 @@ func MakeTestGenCfg(t *testing.T, numSectors int) *gengen.GenesisCfg {
 				SectorSize:       constants.DevSectorSize,
 			},
 		},
-		Network: "go-filecoin-test",
+		Network: "gfctest",
 		PreAlloc: []string{
 			"10000",
 			"10000",

--- a/internal/pkg/net/validators_test.go
+++ b/internal/pkg/net/validators_test.go
@@ -44,7 +44,7 @@ func TestBlockTopicValidator(t *testing.T) {
 
 	validator := tv.Validator()
 
-	network := "go-filecoin-test"
+	network := "gfctest"
 	assert.Equal(t, net.BlockTopic(network), tv.Topic(network))
 	assert.True(t, validator(ctx, pid1, blkToPubSub(goodBlk)))
 	assert.False(t, validator(ctx, pid1, blkToPubSub(badBlk)))
@@ -72,7 +72,7 @@ func TestBlockPubSubValidation(t *testing.T) {
 	btv := net.NewBlockTopicValidator(bv)
 
 	// setup a floodsub instance on the host and register the topic validator
-	network := "go-filecoin-test"
+	network := "gfctest"
 	fsub1, err := pubsub.NewFloodSub(ctx, host1, pubsub.WithMessageSigning(false))
 	require.NoError(t, err)
 	err = fsub1.RegisterTopicValidator(btv.Topic(network), btv.Validator(), btv.Opts()...)

--- a/internal/pkg/testhelpers/iptbtester/genesis.go
+++ b/internal/pkg/testhelpers/iptbtester/genesis.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/filecoin-project/go-filecoin/cmd/go-filecoin"
+	commands "github.com/filecoin-project/go-filecoin/cmd/go-filecoin"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/constants"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/tools/gengen/util"
+	gengen "github.com/filecoin-project/go-filecoin/tools/gengen/util"
 )
 
 // GenesisInfo chains require information to start a single node with funds
@@ -49,7 +49,7 @@ func RequireGenerateGenesis(t *testing.T, funds int64, dir string, genesisTime t
 				SectorSize:       constants.DevSectorSize,
 			},
 		},
-		Network: "go-filecoin-test",
+		Network: "gfctest",
 		Time:    uint64(genesisTime.Unix()),
 	}
 

--- a/internal/pkg/version/protocol_version_table.go
+++ b/internal/pkg/version/protocol_version_table.go
@@ -49,6 +49,7 @@ type ProtocolVersionTableBuilder struct {
 
 // NewProtocolVersionTableBuilder creates a new ProtocolVersionTable that only tracks versions for the given network
 func NewProtocolVersionTableBuilder(network string) *ProtocolVersionTableBuilder {
+	// ignore anything following a dot (including the dot)
 	networkPrefix := strings.Split(network, ".")[0]
 
 	return &ProtocolVersionTableBuilder{

--- a/internal/pkg/version/protocol_version_table.go
+++ b/internal/pkg/version/protocol_version_table.go
@@ -49,8 +49,8 @@ type ProtocolVersionTableBuilder struct {
 
 // NewProtocolVersionTableBuilder creates a new ProtocolVersionTable that only tracks versions for the given network
 func NewProtocolVersionTableBuilder(network string) *ProtocolVersionTableBuilder {
-	// ignore anything following a dot (including the dot)
-	networkPrefix := strings.Split(network, ".")[0]
+	// ignore anything following a dash (including the dash)
+	networkPrefix := strings.Split(network, "-")[0]
 
 	return &ProtocolVersionTableBuilder{
 		network:  networkPrefix,

--- a/internal/pkg/version/protocol_version_table.go
+++ b/internal/pkg/version/protocol_version_table.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/pkg/errors"
@@ -48,8 +49,10 @@ type ProtocolVersionTableBuilder struct {
 
 // NewProtocolVersionTableBuilder creates a new ProtocolVersionTable that only tracks versions for the given network
 func NewProtocolVersionTableBuilder(network string) *ProtocolVersionTableBuilder {
+	networkPrefix := strings.Split(network, ".")[0]
+
 	return &ProtocolVersionTableBuilder{
-		network:  network,
+		network:  networkPrefix,
 		versions: []protocolVersion{},
 	}
 }

--- a/internal/pkg/version/protocol_version_table_test.go
+++ b/internal/pkg/version/protocol_version_table_test.go
@@ -52,18 +52,6 @@ func TestUpgradeTable(t *testing.T) {
 		}
 	})
 
-	t.Run("finds correct version when suffix is applied", func(t *testing.T) {
-		// add out of order and expect table to sort
-		put, err := NewProtocolVersionTableBuilder("testnetwork.foo").
-			Add(network, 5, types.NewBlockHeight(0)).
-			Build()
-		require.NoError(t, err)
-
-		version, err := put.VersionAt(types.NewBlockHeight(0))
-		require.NoError(t, err)
-		assert.Equal(t, uint64(5), version)
-	})
-
 	t.Run("constructing a table with no versions is an error", func(t *testing.T) {
 		_, err := NewProtocolVersionTableBuilder(network).Build()
 		require.Error(t, err)
@@ -97,6 +85,28 @@ func TestUpgradeTable(t *testing.T) {
 			expectedVersion := uint64(0)
 			if i >= 30 {
 				expectedVersion = 3
+			}
+			assert.Equal(t, expectedVersion, version)
+		}
+	})
+
+	t.Run("version table name can be a prefix of network name", func(t *testing.T) {
+		network := "localnet-270a8688-1b23-4508-b675-444cb1e6f05d"
+		versionName := "localnet"
+
+		put, err := NewProtocolVersionTableBuilder(network).
+			Add(versionName, 0, abi.ChainEpoch(0)).
+			Add(versionName, 1, abi.ChainEpoch(10)).
+			Build()
+		require.NoError(t, err)
+
+		for i := uint64(0); i < 20; i++ {
+			version, err := put.VersionAt(abi.ChainEpoch(i))
+			require.NoError(t, err)
+
+			expectedVersion := uint64(0)
+			if i >= 10 {
+				expectedVersion = 1
 			}
 			assert.Equal(t, expectedVersion, version)
 		}

--- a/internal/pkg/version/protocol_version_table_test.go
+++ b/internal/pkg/version/protocol_version_table_test.go
@@ -52,6 +52,18 @@ func TestUpgradeTable(t *testing.T) {
 		}
 	})
 
+	t.Run("finds correct version when suffix is applied", func(t *testing.T) {
+		// add out of order and expect table to sort
+		put, err := NewProtocolVersionTableBuilder("testnetwork.foo").
+			Add(network, 5, types.NewBlockHeight(0)).
+			Build()
+		require.NoError(t, err)
+
+		version, err := put.VersionAt(types.NewBlockHeight(0))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(5), version)
+	})
+
 	t.Run("constructing a table with no versions is an error", func(t *testing.T) {
 		_, err := NewProtocolVersionTableBuilder(network).Build()
 		require.Error(t, err)

--- a/internal/pkg/version/protocol_versions.go
+++ b/internal/pkg/version/protocol_versions.go
@@ -13,6 +13,9 @@ const DEVNET4 = "devnet4"
 // LOCALNET is the network name of localnet
 const LOCALNET = "localnet"
 
+// NIGHTLY is the network for nightly builds
+const NIGHTLY = "nightly"
+
 // TEST is the network name for internal tests
 const TEST = "go-filecoin-test"
 

--- a/internal/pkg/version/protocol_versions.go
+++ b/internal/pkg/version/protocol_versions.go
@@ -14,7 +14,7 @@ const DEVNET4 = "devnet4"
 const LOCALNET = "localnet"
 
 // TEST is the network name for internal tests
-const TEST = "go-filecoin-test"
+const TEST = "gfctest"
 
 // Protocol0 is the first protocol version
 const Protocol0 = 0

--- a/internal/pkg/version/protocol_versions.go
+++ b/internal/pkg/version/protocol_versions.go
@@ -13,9 +13,6 @@ const DEVNET4 = "devnet4"
 // LOCALNET is the network name of localnet
 const LOCALNET = "localnet"
 
-// NIGHTLY is the network for nightly builds
-const NIGHTLY = "nightly"
-
 // TEST is the network name for internal tests
 const TEST = "go-filecoin-test"
 

--- a/tools/fast/environment/environment_memory_genesis.go
+++ b/tools/fast/environment/environment_memory_genesis.go
@@ -244,7 +244,7 @@ func (e *MemoryGenesis) buildGenesis(funds *big.Int) error {
 				CommittedSectors: commCfgs,
 			},
 		},
-		Network:    "go-filecoin-test",
+		Network:    "gfctest",
 		ProofsMode: e.proofsMode,
 	}
 

--- a/tools/gengen/util/gengen_test.go
+++ b/tools/gengen/util/gengen_test.go
@@ -41,7 +41,7 @@ func testConfig(t *testing.T) *GenesisCfg {
 				SectorSize:       constants.DevSectorSize,
 			},
 		},
-		Network: "go-filecoin-test",
+		Network: "gfctest",
 		Seed:    defaultSeed,
 		Time:    defaultTime,
 	}


### PR DESCRIPTION
fixes #3496

### Why this PR?

We need to spin up networks on a nightly basis for validation. We do not want these networks to communicate with each other. We also do not want to require new protocol versions on a nightly basis for each network.

### What's in this PR?

This PR introduces the ability to specified a dot delimited network (e.g. "nightly.2019-10-8") in the genesis block. For the purposes of determining the protocol version, only the part before the dot "nightly" will be considered. So "nightly.2019-10-8" and "nightly.2019-10-9" will get the same protocol table (so long as the nightly protocol table hasn't changed in code).

The full name in genesis ensures nodes on different networks won't be able to sync with each other. It also ensures that nodes on different networks won't be able to communicate on the same protocols.