### PR TITLE
thread builtin actors through processor

### DIFF
--- a/actor/actor_test.go
+++ b/actor/actor_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/abi"
 	. "github.com/filecoin-project/go-filecoin/actor"
+	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/types"
@@ -114,6 +115,7 @@ func makeCtx(method string) exec.VMContext {
 		Message:     types.NewMessage(addrGetter(), addrGetter(), 0, types.ZeroAttoFIL, method, nil),
 		GasTracker:  vm.NewGasTracker(),
 		BlockHeight: types.NewBlockHeight(0),
+		Actors:      builtin.DefaultActors,
 	}
 
 	return vm.NewVMContext(vmCtxParams)

--- a/actor/builtin/builtin.go
+++ b/actor/builtin/builtin.go
@@ -27,11 +27,11 @@ type Actors struct {
 // GetActorCode returns executable code for an actor by code cid at a specific protocol version
 func (ba Actors) GetActorCode(code cid.Cid, version uint64) (exec.ExecutableActor, error) {
 	if !code.Defined() {
-		return nil, fmt.Errorf("missing code")
+		return nil, fmt.Errorf("undefined code cid")
 	}
 	actor, ok := ba.actors[codeVersion{code: code, protocolVersion: version}]
 	if !ok {
-		return nil, fmt.Errorf("unknown code: %s", code.String())
+		return nil, fmt.Errorf("unknown code: %s, version: %d", code.String(), version)
 	}
 	return actor, nil
 }
@@ -40,7 +40,8 @@ type BuiltinActorsBuilder struct {
 	actors map[codeVersion]exec.ExecutableActor
 }
 
-func NewActorsBuilder() *BuiltinActorsBuilder {
+// NewBuilder creates a builder to generate a builtin.Actor data structure
+func NewBuilder() *BuiltinActorsBuilder {
 	return &BuiltinActorsBuilder{actors: map[codeVersion]exec.ExecutableActor{}}
 }
 
@@ -62,7 +63,7 @@ func (bab *BuiltinActorsBuilder) Build() Actors {
 
 // DefaultActors is list of all actors that ship with Filecoin.
 // They are indexed by their CID.
-var DefaultActors = NewActorsBuilder().
+var DefaultActors = NewBuilder().
 	Add(types.AccountActorCodeCid, 0, &account.Actor{}).
 	Add(types.StorageMarketActorCodeCid, 0, &storagemarket.Actor{}).
 	Add(types.PaymentBrokerActorCodeCid, 0, &paymentbroker.Actor{}).

--- a/actor/builtin/builtin.go
+++ b/actor/builtin/builtin.go
@@ -24,7 +24,8 @@ type Actors struct {
 	actors map[codeVersion]exec.ExecutableActor
 }
 
-func (ba Actors) GetBuiltinActorCode(code cid.Cid, version uint64) (exec.ExecutableActor, error) {
+// GetActorCode returns executable code for an actor by code cid at a specific protocol version
+func (ba Actors) GetActorCode(code cid.Cid, version uint64) (exec.ExecutableActor, error) {
 	if !code.Defined() {
 		return nil, fmt.Errorf("missing code")
 	}
@@ -39,16 +40,15 @@ type BuiltinActorsBuilder struct {
 	actors map[codeVersion]exec.ExecutableActor
 }
 
-func NewBuiltinActorsBuilder() *BuiltinActorsBuilder {
+func NewActorsBuilder() *BuiltinActorsBuilder {
 	return &BuiltinActorsBuilder{actors: map[codeVersion]exec.ExecutableActor{}}
 }
 
-func BuiltinActorsExtender(actors Actors) *BuiltinActorsBuilder {
-	newActors := make(map[codeVersion]exec.ExecutableActor, len(actors.actors))
-	for k, v := range actors.actors {
-		newActors[k] = v
+func (bab *BuiltinActorsBuilder) AddAll(actors Actors) *BuiltinActorsBuilder {
+	for cv, a := range actors.actors {
+		bab.Add(cv.code, cv.protocolVersion, a)
 	}
-	return &BuiltinActorsBuilder{actors: newActors}
+	return bab
 }
 
 func (bab *BuiltinActorsBuilder) Add(c cid.Cid, version uint64, actor exec.ExecutableActor) *BuiltinActorsBuilder {
@@ -62,7 +62,7 @@ func (bab *BuiltinActorsBuilder) Build() Actors {
 
 // DefaultActors is list of all actors that ship with Filecoin.
 // They are indexed by their CID.
-var DefaultActors = NewBuiltinActorsBuilder().
+var DefaultActors = NewActorsBuilder().
 	Add(types.AccountActorCodeCid, 0, &account.Actor{}).
 	Add(types.StorageMarketActorCodeCid, 0, &storagemarket.Actor{}).
 	Add(types.PaymentBrokerActorCodeCid, 0, &paymentbroker.Actor{}).

--- a/actor/builtin/builtin.go
+++ b/actor/builtin/builtin.go
@@ -14,9 +14,10 @@ import (
 	cid "github.com/ipfs/go-cid"
 )
 
+// codeVersion identifies an ExecutableActor by its code and protocol version
 type codeVersion struct {
-	code    cid.Cid
-	version uint64
+	code            cid.Cid
+	protocolVersion uint64
 }
 
 type Actors struct {
@@ -27,7 +28,7 @@ func (ba Actors) GetBuiltinActorCode(code cid.Cid, version uint64) (exec.Executa
 	if !code.Defined() {
 		return nil, fmt.Errorf("missing code")
 	}
-	actor, ok := ba.actors[codeVersion{code: code, version: version}]
+	actor, ok := ba.actors[codeVersion{code: code, protocolVersion: version}]
 	if !ok {
 		return nil, fmt.Errorf("unknown code: %s", code.String())
 	}
@@ -51,7 +52,7 @@ func BuiltinActorsExtender(actors Actors) *BuiltinActorsBuilder {
 }
 
 func (bab *BuiltinActorsBuilder) Add(c cid.Cid, version uint64, actor exec.ExecutableActor) *BuiltinActorsBuilder {
-	bab.actors[codeVersion{code: c, version: version}] = actor
+	bab.actors[codeVersion{code: c, protocolVersion: version}] = actor
 	return bab
 }
 

--- a/actor/builtin/builtin.go
+++ b/actor/builtin/builtin.go
@@ -2,6 +2,8 @@
 package builtin
 
 import (
+	"fmt"
+
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/initactor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
@@ -12,16 +14,58 @@ import (
 	cid "github.com/ipfs/go-cid"
 )
 
-// Actors is list of all actors that ship with Filecoin.
-// They are indexed by their CID.
-var Actors = map[cid.Cid]exec.ExecutableActor{}
-
-func init() {
-	// Instance Actors
-	Actors[types.AccountActorCodeCid] = &account.Actor{}
-	Actors[types.StorageMarketActorCodeCid] = &storagemarket.Actor{}
-	Actors[types.PaymentBrokerActorCodeCid] = &paymentbroker.Actor{}
-	Actors[types.MinerActorCodeCid] = &miner.Actor{}
-	Actors[types.BootstrapMinerActorCodeCid] = &miner.Actor{Bootstrap: true}
-	Actors[types.InitActorCodeCid] = &initactor.Actor{}
+type codeVersion struct {
+	code    cid.Cid
+	version uint64
 }
+
+type Actors struct {
+	actors map[codeVersion]exec.ExecutableActor
+}
+
+func (ba Actors) GetBuiltinActorCode(code cid.Cid, version uint64) (exec.ExecutableActor, error) {
+	if !code.Defined() {
+		return nil, fmt.Errorf("missing code")
+	}
+	actor, ok := ba.actors[codeVersion{code: code, version: version}]
+	if !ok {
+		return nil, fmt.Errorf("unknown code: %s", code.String())
+	}
+	return actor, nil
+}
+
+type BuiltinActorsBuilder struct {
+	actors map[codeVersion]exec.ExecutableActor
+}
+
+func NewBuiltinActorsBuilder() *BuiltinActorsBuilder {
+	return &BuiltinActorsBuilder{actors: map[codeVersion]exec.ExecutableActor{}}
+}
+
+func BuiltinActorsExtender(actors Actors) *BuiltinActorsBuilder {
+	newActors := make(map[codeVersion]exec.ExecutableActor, len(actors.actors))
+	for k, v := range actors.actors {
+		newActors[k] = v
+	}
+	return &BuiltinActorsBuilder{actors: newActors}
+}
+
+func (bab *BuiltinActorsBuilder) Add(c cid.Cid, version uint64, actor exec.ExecutableActor) *BuiltinActorsBuilder {
+	bab.actors[codeVersion{code: c, version: version}] = actor
+	return bab
+}
+
+func (bab *BuiltinActorsBuilder) Build() Actors {
+	return Actors{actors: bab.actors}
+}
+
+// DefaultActors is list of all actors that ship with Filecoin.
+// They are indexed by their CID.
+var DefaultActors = NewBuiltinActorsBuilder().
+	Add(types.AccountActorCodeCid, 0, &account.Actor{}).
+	Add(types.StorageMarketActorCodeCid, 0, &storagemarket.Actor{}).
+	Add(types.PaymentBrokerActorCodeCid, 0, &paymentbroker.Actor{}).
+	Add(types.MinerActorCodeCid, 0, &miner.Actor{}).
+	Add(types.BootstrapMinerActorCodeCid, 0, &miner.Actor{Bootstrap: true}).
+	Add(types.InitActorCodeCid, 0, &initactor.Actor{}).
+	Build()

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -163,7 +163,7 @@ func TestChangeWorker(t *testing.T) {
 
 		gasPrice, _ := types.NewAttoFILFromFILString(".00001")
 		gasLimit := types.NewGasUnits(10)
-		result, err := th.ApplyTestMessageWithGas(st, vms, msg, types.NewBlockHeight(1), &mockSigner, gasPrice, gasLimit, mockSigner.Addresses[0])
+		result, err := th.ApplyTestMessageWithGas(builtin.DefaultActors, st, vms, msg, types.NewBlockHeight(1), &mockSigner, gasPrice, gasLimit, mockSigner.Addresses[0])
 		assert.NoError(t, err)
 
 		require.Error(t, result.ExecutionError)
@@ -438,7 +438,7 @@ func callQueryMethodSuccess(method string,
 	vms vm.StorageMap,
 	fromAddr address.Address,
 	minerAddr address.Address) [][]byte {
-	res, code, err := consensus.CallQueryMethod(ctx, st, vms, minerAddr, method, []byte{}, fromAddr, nil)
+	res, code, err := consensus.NewDefaultProcessor().CallQueryMethod(ctx, st, vms, minerAddr, method, []byte{}, fromAddr, nil)
 	require.NoError(t, err)
 	require.Equal(t, uint8(0), code)
 	return res
@@ -1292,7 +1292,7 @@ func TestActorSlashStorageFault(t *testing.T) {
 
 		gasPrice, _ := types.NewAttoFILFromFILString(".00001")
 		gasLimit := types.NewGasUnits(10)
-		result, err := th.ApplyTestMessageWithGas(st, vms, msg, types.NewBlockHeight(1), &mockSigner, gasPrice, gasLimit, mockSigner.Addresses[0])
+		result, err := th.ApplyTestMessageWithGas(builtin.DefaultActors, st, vms, msg, types.NewBlockHeight(1), &mockSigner, gasPrice, gasLimit, mockSigner.Addresses[0])
 		require.NoError(t, err)
 
 		require.Error(t, result.ExecutionError)
@@ -1543,6 +1543,7 @@ func TestGetProofsMode(t *testing.T) {
 			GasTracker:  gasTracker,
 			BlockHeight: types.NewBlockHeight(0),
 			Ancestors:   []types.TipSet{},
+			Actors:      builtin.DefaultActors,
 		})
 
 		require.NoError(t, consensus.SetupDefaultActors(ctx, st, vms, types.TestProofsMode, "test"))
@@ -1562,6 +1563,7 @@ func TestGetProofsMode(t *testing.T) {
 			GasTracker:  gasTracker,
 			BlockHeight: types.NewBlockHeight(0),
 			Ancestors:   []types.TipSet{},
+			Actors:      builtin.DefaultActors,
 		})
 
 		require.NoError(t, consensus.SetupDefaultActors(ctx, st, vms, types.LiveProofsMode, "main"))

--- a/actor/builtin/miner_redeem_test.go
+++ b/actor/builtin/miner_redeem_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/filecoin-project/go-filecoin/abi"
-	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
@@ -209,7 +208,7 @@ func requireGenesis(ctx context.Context, t *testing.T, targetAddresses ...addres
 	blk, err := th.DefaultGenesis(cst, bs)
 	require.NoError(err)
 
-	st, err := state.LoadStateTree(ctx, cst, blk.StateRoot, builtin.Actors)
+	st, err := state.LoadStateTree(ctx, cst, blk.StateRoot)
 	require.NoError(err)
 
 	for _, addr := range targetAddresses {

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -1137,7 +1137,7 @@ func requireGenesis(ctx context.Context, t *testing.T, targetAddresses ...addres
 }
 
 func builtinsWithTestActor() builtin.Actors {
-	return builtin.NewActorsBuilder().
+	return builtin.NewBuilder().
 		AddAll(builtin.DefaultActors).
 		Add(pbTestActorCid, 0, &PBTestActor{}).
 		Build()

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -1137,7 +1137,8 @@ func requireGenesis(ctx context.Context, t *testing.T, targetAddresses ...addres
 }
 
 func builtinsWithTestActor() builtin.Actors {
-	return builtin.BuiltinActorsExtender(builtin.DefaultActors).
+	return builtin.NewActorsBuilder().
+		AddAll(builtin.DefaultActors).
 		Add(pbTestActorCid, 0, &PBTestActor{}).
 		Build()
 }

--- a/chain/store.go
+++ b/chain/store.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/metrics/tracing"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/state"
@@ -247,7 +246,7 @@ func (store *Store) GetTipSetState(ctx context.Context, key types.TipSetKey) (st
 	if err != nil {
 		return nil, err
 	}
-	return store.stateTreeLoader.LoadStateTree(ctx, store.stateAndBlockSource.cborStore, stateCid, builtin.Actors)
+	return store.stateTreeLoader.LoadStateTree(ctx, store.stateAndBlockSource.cborStore, stateCid)
 }
 
 // GetGenesisState returns the state tree at genesis to retrieve initialization parameters.
@@ -259,7 +258,7 @@ func (store *Store) GetGenesisState(ctx context.Context) (state.Tree, error) {
 	}
 
 	// create state tree
-	return store.stateTreeLoader.LoadStateTree(ctx, store.stateAndBlockSource.cborStore, genesis.StateRoot, builtin.Actors)
+	return store.stateTreeLoader.LoadStateTree(ctx, store.stateAndBlockSource.cborStore, genesis.StateRoot)
 }
 
 // GetTipSetStateRoot returns the aggregate state root CID of the tipset identified by `key`.

--- a/chain/syncer_integration_test.go
+++ b/chain/syncer_integration_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ipfs/go-ipfs-exchange-offline"
 	"github.com/libp2p/go-libp2p-core/peer"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/consensus"
@@ -185,13 +184,14 @@ func TestTipSetWeightDeep(t *testing.T) {
 	blockSource := th.NewTestFetcher()
 
 	// Now sync the chainStore with consensus using a PowerTableView.
-	as := consensus.NewActorStateStore(chainStore, cst, bs)
+	processor := consensus.NewDefaultProcessor()
+	as := consensus.NewActorStateStore(chainStore, cst, bs, processor)
 	con := consensus.NewExpected(cst, bs, th.NewFakeProcessor(), th.NewFakeBlockValidator(), as, calcGenBlk.Cid(), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
 	syncer := chain.NewSyncer(con, chainStore, messageStore, blockSource, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 	baseTS := requireHeadTipset(t, chainStore) // this is the last block of the bootstrapping chain creating miners
 	require.Equal(t, 1, baseTS.Len())
 	bootstrapStateRoot := baseTS.ToSlice()[0].StateRoot
-	pSt, err := state.LoadStateTree(ctx, cst, baseTS.ToSlice()[0].StateRoot, builtin.Actors)
+	pSt, err := state.LoadStateTree(ctx, cst, baseTS.ToSlice()[0].StateRoot)
 	require.NoError(t, err)
 	/* Test chain diagram and weight calcs */
 	// (Note f1b1 = fork 1 block 1)

--- a/consensus/actor_state.go
+++ b/consensus/actor_state.go
@@ -29,11 +29,13 @@ type ActorStateStore struct {
 	cst *hamt.CborIpldStore
 	// For vm storage.
 	bs bstore.Blockstore
+	// executable actors
+	processor Processor
 }
 
 // NewActorStateStore constructs a ActorStateStore.
-func NewActorStateStore(chainReader chainStateChainReader, cst *hamt.CborIpldStore, bs bstore.Blockstore) *ActorStateStore {
-	return &ActorStateStore{chainReader, cst, bs}
+func NewActorStateStore(chainReader chainStateChainReader, cst *hamt.CborIpldStore, bs bstore.Blockstore, processor Processor) *ActorStateStore {
+	return &ActorStateStore{chainReader, cst, bs, processor}
 }
 
 // ActorStateSnapshot permits queries to chain state at a particular tip set.
@@ -61,22 +63,24 @@ func (cs ActorStateStore) Snapshot(ctx context.Context, baseKey types.TipSetKey)
 
 // StateTreeSnapshot returns a snapshot representation of a state tree at an optional block height
 func (cs ActorStateStore) StateTreeSnapshot(st state.Tree, bh *types.BlockHeight) ActorStateSnapshot {
-	return newProcessorQueryer(st, vm.NewStorageMap(cs.bs), bh)
+	return newProcessorQueryer(st, vm.NewStorageMap(cs.bs), bh, cs.processor)
 }
 
 // processorSnapshot queries the chain at a particular tipset
 type processorSnapshot struct {
-	st     state.Tree
-	vms    vm.StorageMap
-	height *types.BlockHeight
+	st        state.Tree
+	vms       vm.StorageMap
+	height    *types.BlockHeight
+	processor Processor
 }
 
 // newProcessorQueryer creates an ActorStateSnapshot
-func newProcessorQueryer(st state.Tree, vms vm.StorageMap, height *types.BlockHeight) ActorStateSnapshot {
+func newProcessorQueryer(st state.Tree, vms vm.StorageMap, height *types.BlockHeight, processor Processor) ActorStateSnapshot {
 	return &processorSnapshot{
-		st:     st,
-		vms:    vms,
-		height: height,
+		st:        st,
+		vms:       vms,
+		height:    height,
+		processor: processor,
 	}
 }
 
@@ -87,7 +91,7 @@ func (q *processorSnapshot) Query(ctx context.Context, optFrom, to address.Addre
 		return nil, errors.Wrap(err, "failed to encode message params")
 	}
 
-	r, ec, err := CallQueryMethod(ctx, q.st, q.vms, to, method, encodedParams, optFrom, q.height)
+	r, ec, err := q.processor.CallQueryMethod(ctx, q.st, q.vms, to, method, encodedParams, optFrom, q.height)
 	if err != nil {
 		return nil, errors.Wrap(err, "query method returned an error")
 	} else if ec != 0 {

--- a/consensus/actor_state_test.go
+++ b/consensus/actor_state_test.go
@@ -43,7 +43,7 @@ func TestQuery(t *testing.T) {
 		// actor implementation, so we do that here. Might be nice to handle this
 		// setup/teardown through geneisus helpers.
 
-		actors := builtin.NewActorsBuilder().AddAll(builtin.DefaultActors).Add(fakeActorCodeCid, 0, &actor.FakeActor{}).Build()
+		actors := builtin.NewBuilder().AddAll(builtin.DefaultActors).Add(fakeActorCodeCid, 0, &actor.FakeActor{}).Build()
 		processor := NewConfiguredProcessor(NewDefaultMessageValidator(), NewDefaultBlockRewarder(), actors)
 		testGen := MakeGenesisFunc(
 			// Actor we will send the query to.
@@ -83,7 +83,7 @@ func TestQuery(t *testing.T) {
 		// the given address but doesn't set up the mapping from its code cid to
 		// actor implementation, so we do that here. Might be nice to handle this
 		// setup/teardown through geneisus helpers.
-		actors := builtin.NewActorsBuilder().
+		actors := builtin.NewBuilder().
 			AddAll(builtin.DefaultActors).
 			Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 			Build()

--- a/consensus/actor_state_test.go
+++ b/consensus/actor_state_test.go
@@ -42,10 +42,8 @@ func TestQuery(t *testing.T) {
 		// the given address but doesn't set up the mapping from its code cid to
 		// actor implementation, so we do that here. Might be nice to handle this
 		// setup/teardown through geneisus helpers.
-		builtin.Actors[fakeActorCodeCid] = &actor.FakeActor{}
-		defer func() {
-			delete(builtin.Actors, fakeActorCodeCid)
-		}()
+		actors := builtin.BuiltinActorsExtender(builtin.DefaultActors).Add(fakeActorCodeCid, 0, &actor.FakeActor{}).Build()
+		processor := NewConfiguredProcessor(NewDefaultMessageValidator(), NewDefaultBlockRewarder(), actors)
 		testGen := MakeGenesisFunc(
 			// Actor we will send the query to.
 			AddActor(fakeActorAddr, fakeActor),
@@ -56,7 +54,7 @@ func TestQuery(t *testing.T) {
 		chainStore, err := chain.Init(context.Background(), r, bs, cst, testGen)
 		require.NoError(t, err)
 
-		chainState := NewActorStateStore(chainStore, cst, bs)
+		chainState := NewActorStateStore(chainStore, cst, bs, processor)
 		snapshot, err := chainState.Snapshot(ctx, chainStore.GetHead())
 		require.NoError(t, err)
 
@@ -84,10 +82,10 @@ func TestQuery(t *testing.T) {
 		// the given address but doesn't set up the mapping from its code cid to
 		// actor implementation, so we do that here. Might be nice to handle this
 		// setup/teardown through geneisus helpers.
-		builtin.Actors[fakeActorCodeCid] = &actor.FakeActor{}
-		defer func() {
-			delete(builtin.Actors, fakeActorCodeCid)
-		}()
+		actors := builtin.BuiltinActorsExtender(builtin.DefaultActors).
+			Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
+			Build()
+		processor := NewConfiguredProcessor(NewDefaultMessageValidator(), NewDefaultBlockRewarder(), actors)
 		testGen := MakeGenesisFunc(
 			// Actor we will send the query to.
 			AddActor(fakeActorAddr, fakeActor),
@@ -98,7 +96,7 @@ func TestQuery(t *testing.T) {
 		chainStore, err := chain.Init(context.Background(), r, bs, cst, testGen)
 		require.NoError(t, err)
 
-		chainState := NewActorStateStore(chainStore, cst, bs)
+		chainState := NewActorStateStore(chainStore, cst, bs, processor)
 		snapshot, err := chainState.Snapshot(ctx, chainStore.GetHead())
 		require.NoError(t, err)
 

--- a/consensus/actor_state_test.go
+++ b/consensus/actor_state_test.go
@@ -42,7 +42,8 @@ func TestQuery(t *testing.T) {
 		// the given address but doesn't set up the mapping from its code cid to
 		// actor implementation, so we do that here. Might be nice to handle this
 		// setup/teardown through geneisus helpers.
-		actors := builtin.BuiltinActorsExtender(builtin.DefaultActors).Add(fakeActorCodeCid, 0, &actor.FakeActor{}).Build()
+
+		actors := builtin.NewActorsBuilder().AddAll(builtin.DefaultActors).Add(fakeActorCodeCid, 0, &actor.FakeActor{}).Build()
 		processor := NewConfiguredProcessor(NewDefaultMessageValidator(), NewDefaultBlockRewarder(), actors)
 		testGen := MakeGenesisFunc(
 			// Actor we will send the query to.
@@ -82,7 +83,8 @@ func TestQuery(t *testing.T) {
 		// the given address but doesn't set up the mapping from its code cid to
 		// actor implementation, so we do that here. Might be nice to handle this
 		// setup/teardown through geneisus helpers.
-		actors := builtin.BuiltinActorsExtender(builtin.DefaultActors).
+		actors := builtin.NewActorsBuilder().
+			AddAll(builtin.DefaultActors).
 			Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 			Build()
 		processor := NewConfiguredProcessor(NewDefaultMessageValidator(), NewDefaultBlockRewarder(), actors)

--- a/consensus/expected.go
+++ b/consensus/expected.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/metrics/tracing"
@@ -79,6 +78,12 @@ type Processor interface {
 
 	// ProcessTipSet processes all messages in a tip set.
 	ProcessTipSet(context.Context, state.Tree, vm.StorageMap, types.TipSet, [][]*types.SignedMessage, []types.TipSet) (*ProcessTipSetResponse, error)
+
+	// CallQueryMethod calls a method on an actor in the given state tree.
+	CallQueryMethod(ctx context.Context, st state.Tree, vms vm.StorageMap, to address.Address, method string, params []byte, from address.Address, optBh *types.BlockHeight) ([][]byte, uint8, error)
+
+	// PreviewQueryMethod estimates the amount of gas that will be used by a method
+	PreviewQueryMethod(ctx context.Context, st state.Tree, vms vm.StorageMap, to address.Address, method string, params []byte, from address.Address, optBh *types.BlockHeight) (types.GasUnits, error)
 }
 
 // TicketValidator validates that an input ticket is valid.
@@ -416,5 +421,5 @@ func (c *Expected) createPowerTableView(st state.Tree) PowerTableView {
 }
 
 func (c *Expected) loadStateTree(ctx context.Context, id cid.Cid) (state.Tree, error) {
-	return state.LoadStateTree(ctx, c.cstore, id, builtin.Actors)
+	return state.LoadStateTree(ctx, c.cstore, id)
 }

--- a/consensus/expected.go
+++ b/consensus/expected.go
@@ -78,12 +78,6 @@ type Processor interface {
 
 	// ProcessTipSet processes all messages in a tip set.
 	ProcessTipSet(context.Context, state.Tree, vm.StorageMap, types.TipSet, [][]*types.SignedMessage, []types.TipSet) (*ProcessTipSetResponse, error)
-
-	// CallQueryMethod calls a method on an actor in the given state tree.
-	CallQueryMethod(ctx context.Context, st state.Tree, vms vm.StorageMap, to address.Address, method string, params []byte, from address.Address, optBh *types.BlockHeight) ([][]byte, uint8, error)
-
-	// PreviewQueryMethod estimates the amount of gas that will be used by a method
-	PreviewQueryMethod(ctx context.Context, st state.Tree, vms vm.StorageMap, to address.Address, method string, params []byte, from address.Address, optBh *types.BlockHeight) (types.GasUnits, error)
 }
 
 // TicketValidator validates that an input ticket is valid.

--- a/consensus/expected_test.go
+++ b/consensus/expected_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/state"
@@ -99,7 +98,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 	t.Run("passes the validateMining section when given valid mining blocks", func(t *testing.T) {
 		pTipSet := types.RequireNewTipSet(t, genesisBlock)
-		stateTree, err := state.LoadStateTree(ctx, cistore, genesisBlock.StateRoot, builtin.Actors)
+		stateTree, err := state.LoadStateTree(ctx, cistore, genesisBlock.StateRoot)
 		require.NoError(t, err)
 		vms := vm.NewStorageMap(bstore)
 
@@ -125,7 +124,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 	t.Run("returns nil + mining error when election proof validation fails", func(t *testing.T) {
 		pTipSet := types.RequireNewTipSet(t, genesisBlock)
 
-		stateTree, err := state.LoadStateTree(ctx, cistore, genesisBlock.StateRoot, builtin.Actors)
+		stateTree, err := state.LoadStateTree(ctx, cistore, genesisBlock.StateRoot)
 		require.NoError(t, err)
 
 		vms := vm.NewStorageMap(bstore)
@@ -152,7 +151,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		pTipSet := types.RequireNewTipSet(t, genesisBlock)
 
-		stateTree, err := state.LoadStateTree(ctx, cistore, genesisBlock.StateRoot, builtin.Actors)
+		stateTree, err := state.LoadStateTree(ctx, cistore, genesisBlock.StateRoot)
 		require.NoError(t, err)
 
 		vms := vm.NewStorageMap(bstore)
@@ -180,7 +179,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 	t.Run("fails when ticket array length inconsistent with block height", func(t *testing.T) {
 		pTipSet := types.RequireNewTipSet(t, genesisBlock)
 
-		stateTree, err := state.LoadStateTree(ctx, cistore, genesisBlock.StateRoot, builtin.Actors)
+		stateTree, err := state.LoadStateTree(ctx, cistore, genesisBlock.StateRoot)
 		require.NoError(t, err)
 		vms := vm.NewStorageMap(bstore)
 
@@ -203,7 +202,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 	t.Run("returns nil + mining error when signature is invalid", func(t *testing.T) {
 		pTipSet := types.RequireNewTipSet(t, genesisBlock)
-		stateTree, err := state.LoadStateTree(ctx, cistore, genesisBlock.StateRoot, builtin.Actors)
+		stateTree, err := state.LoadStateTree(ctx, cistore, genesisBlock.StateRoot)
 		require.NoError(t, err)
 		vms := vm.NewStorageMap(bstore)
 

--- a/consensus/genesis.go
+++ b/consensus/genesis.go
@@ -8,7 +8,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/filecoin-project/go-filecoin/actor"
-	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/initactor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
@@ -131,7 +130,7 @@ func NewEmptyConfig() *Config {
 func MakeGenesisFunc(opts ...GenOption) GenesisInitFunc {
 	return func(cst *hamt.CborIpldStore, bs blockstore.Blockstore) (*types.Block, error) {
 		ctx := context.Background()
-		st := state.NewEmptyStateTreeWithActors(cst, builtin.Actors)
+		st := state.NewEmptyStateTree(cst)
 		storageMap := vm.NewStorageMap(bs)
 
 		genCfg := NewEmptyConfig()

--- a/consensus/power_table_view_test.go
+++ b/consensus/power_table_view_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ipfs/go-hamt-ipld"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/gengen/util"
@@ -27,7 +26,7 @@ func TestTotal(t *testing.T) {
 	numCommittedSectors := uint64(19)
 	cst, bs, _, st := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors)
 
-	as := consensus.NewActorStateStore(nil, cst, bs)
+	as := consensus.NewActorStateStore(nil, cst, bs, consensus.NewDefaultProcessor())
 	snapshot := as.StateTreeSnapshot(st, types.NewBlockHeight(0))
 
 	actual, err := consensus.NewPowerTableView(snapshot).Total(ctx)
@@ -46,7 +45,7 @@ func TestMiner(t *testing.T) {
 	numCommittedSectors := uint64(12)
 	cst, bs, addr, st := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors)
 
-	as := consensus.NewActorStateStore(nil, cst, bs)
+	as := consensus.NewActorStateStore(nil, cst, bs, consensus.NewDefaultProcessor())
 	snapshot := as.StateTreeSnapshot(st, types.NewBlockHeight(0))
 
 	actual, err := consensus.NewPowerTableView(snapshot).Miner(ctx, addr)
@@ -81,7 +80,7 @@ func requireMinerWithNumCommittedSectors(ctx context.Context, t *testing.T, numC
 	var calcGenBlk types.Block
 	require.NoError(t, cst.Get(ctx, info.GenesisCid, &calcGenBlk))
 
-	stateTree, err := state.LoadStateTree(ctx, cst, calcGenBlk.StateRoot, builtin.Actors)
+	stateTree, err := state.LoadStateTree(ctx, cst, calcGenBlk.StateRoot)
 	require.NoError(t, err)
 
 	return cst, bs, info.Miners[0].Address, stateTree

--- a/consensus/processor.go
+++ b/consensus/processor.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"math/big"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/ipfs/go-cid"
 	"go.opencensus.io/tag"
 	"go.opencensus.io/trace"
 
 	"github.com/filecoin-project/go-filecoin/actor"
+	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/metrics"

--- a/consensus/processor_test.go
+++ b/consensus/processor_test.go
@@ -335,7 +335,8 @@ func TestProcessBlockVMErrors(t *testing.T) {
 
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.NewCidForTestGetter()()
-	actors := builtin.BuiltinActorsExtender(builtin.DefaultActors).
+	actors := builtin.NewActorsBuilder().
+		AddAll(builtin.DefaultActors).
 		Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 		Build()
 	mockSigner, _ := types.NewMockSignersAndKeyInfo(2)
@@ -612,7 +613,8 @@ func TestNestedSendBalance(t *testing.T) {
 
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.NewCidForTestGetter()()
-	actors := builtin.BuiltinActorsExtender(builtin.DefaultActors).
+	actors := builtin.NewActorsBuilder().
+		AddAll(builtin.DefaultActors).
 		Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 		Build()
 
@@ -661,7 +663,8 @@ func TestReentrantTransferDoesntAllowMultiSpending(t *testing.T) {
 
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.NewCidForTestGetter()()
-	actors := builtin.BuiltinActorsExtender(builtin.DefaultActors).
+	actors := builtin.NewActorsBuilder().
+		AddAll(builtin.DefaultActors).
 		Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 		Build()
 
@@ -748,7 +751,8 @@ func TestApplyQueryMessageWillNotAlterState(t *testing.T) {
 
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.NewCidForTestGetter()()
-	actors := builtin.BuiltinActorsExtender(builtin.DefaultActors).
+	actors := builtin.NewActorsBuilder().
+		AddAll(builtin.DefaultActors).
 		Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 		Build()
 
@@ -790,7 +794,8 @@ func TestApplyMessageChargesGas(t *testing.T) {
 
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.NewCidForTestGetter()()
-	actors := builtin.BuiltinActorsExtender(builtin.DefaultActors).
+	actors := builtin.NewActorsBuilder().
+		AddAll(builtin.DefaultActors).
 		Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 		Build()
 
@@ -944,7 +949,8 @@ func TestBlockGasLimitBehavior(t *testing.T) {
 	tf.BadUnitTestWithSideEffects(t)
 
 	fakeActorCodeCid := types.NewCidForTestGetter()()
-	builtinActors := builtin.BuiltinActorsExtender(builtin.DefaultActors).
+	builtinActors := builtin.NewActorsBuilder().
+		AddAll(builtin.DefaultActors).
 		Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 		Build()
 

--- a/consensus/processor_test.go
+++ b/consensus/processor_test.go
@@ -335,7 +335,7 @@ func TestProcessBlockVMErrors(t *testing.T) {
 
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.NewCidForTestGetter()()
-	actors := builtin.NewActorsBuilder().
+	actors := builtin.NewBuilder().
 		AddAll(builtin.DefaultActors).
 		Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 		Build()
@@ -613,7 +613,7 @@ func TestNestedSendBalance(t *testing.T) {
 
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.NewCidForTestGetter()()
-	actors := builtin.NewActorsBuilder().
+	actors := builtin.NewBuilder().
 		AddAll(builtin.DefaultActors).
 		Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 		Build()
@@ -663,7 +663,7 @@ func TestReentrantTransferDoesntAllowMultiSpending(t *testing.T) {
 
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.NewCidForTestGetter()()
-	actors := builtin.NewActorsBuilder().
+	actors := builtin.NewBuilder().
 		AddAll(builtin.DefaultActors).
 		Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 		Build()
@@ -751,7 +751,7 @@ func TestApplyQueryMessageWillNotAlterState(t *testing.T) {
 
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.NewCidForTestGetter()()
-	actors := builtin.NewActorsBuilder().
+	actors := builtin.NewBuilder().
 		AddAll(builtin.DefaultActors).
 		Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 		Build()
@@ -794,7 +794,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 
 	// Install the fake actor so we can execute it.
 	fakeActorCodeCid := types.NewCidForTestGetter()()
-	actors := builtin.NewActorsBuilder().
+	actors := builtin.NewBuilder().
 		AddAll(builtin.DefaultActors).
 		Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 		Build()
@@ -949,7 +949,7 @@ func TestBlockGasLimitBehavior(t *testing.T) {
 	tf.BadUnitTestWithSideEffects(t)
 
 	fakeActorCodeCid := types.NewCidForTestGetter()()
-	builtinActors := builtin.NewActorsBuilder().
+	builtinActors := builtin.NewBuilder().
 		AddAll(builtin.DefaultActors).
 		Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 		Build()

--- a/consensus/testing.go
+++ b/consensus/testing.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/actor"
@@ -112,10 +113,11 @@ func (tbr *FakeBlockRewarder) GasReward(ctx context.Context, st state.Tree, mine
 }
 
 // NewFakeProcessor creates a processor with a test validator and test rewarder
-func NewFakeProcessor() *DefaultProcessor {
+func NewFakeProcessor(actors builtin.Actors) *DefaultProcessor {
 	return &DefaultProcessor{
 		signedMessageValidator: &FakeSignedMessageValidator{},
 		blockRewarder:          &FakeBlockRewarder{},
+		actors:                 actors,
 	}
 }
 

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -180,7 +180,7 @@ func NewMockIngestionValidatorAPI() *FakeIngestionValidatorAPI {
 	return &FakeIngestionValidatorAPI{Actor: &actor.Actor{}}
 }
 
-// GetActor
+// GetActorCode
 func (api *FakeIngestionValidatorAPI) GetActor(ctx context.Context, a address.Address) (*actor.Actor, error) {
 	if a == api.ActorAddr {
 		return api.Actor, nil

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -107,7 +107,7 @@ func GenGen(ctx context.Context, cfg *GenesisCfg, cst *hamt.CborIpldStore, bs bl
 		return nil, err
 	}
 
-	st := state.NewEmptyStateTreeWithActors(cst, builtin.Actors)
+	st := state.NewEmptyStateTree(cst)
 	storageMap := vm.NewStorageMap(bs)
 
 	if err := consensus.SetupDefaultActors(ctx, st, storageMap, cfg.ProofsMode, cfg.Network); err != nil {
@@ -367,7 +367,7 @@ func applyMessageDirect(ctx context.Context, st state.Tree, vms vm.StorageMap, f
 	}
 
 	// create new processor that doesn't reward and doesn't validate
-	applier := consensus.NewConfiguredProcessor(&messageValidator{}, &blockRewarder{})
+	applier := consensus.NewConfiguredProcessor(&messageValidator{}, &blockRewarder{}, builtin.DefaultActors)
 
 	res, err := applier.ApplyMessagesAndPayRewards(ctx, st, vms, []*types.SignedMessage{smsg}, address.Undef, types.NewBlockHeight(0), nil)
 	if err != nil {

--- a/node/chain_submodule.go
+++ b/node/chain_submodule.go
@@ -33,4 +33,5 @@ type ChainSubmodule struct {
 	State   *cst.ChainStateReadWriter
 
 	validator consensus.BlockValidator
+	processor *consensus.DefaultProcessor
 }

--- a/plumbing/cst/chain_state.go
+++ b/plumbing/cst/chain_state.go
@@ -106,7 +106,7 @@ func (chn *ChainStateReadWriter) SampleRandomness(ctx context.Context, sampleHei
 	return sampling.SampleChainRandomness(sampleHeight, tipSetBuffer)
 }
 
-// GetActorCode returns an actor from the latest state on the chain
+// GetActor returns an actor from the latest state on the chain
 func (chn *ChainStateReadWriter) GetActor(ctx context.Context, addr address.Address) (*actor.Actor, error) {
 	return chn.GetActorAt(ctx, chn.readWriter.GetHead(), addr)
 }

--- a/plumbing/cst/chain_state.go
+++ b/plumbing/cst/chain_state.go
@@ -106,7 +106,7 @@ func (chn *ChainStateReadWriter) SampleRandomness(ctx context.Context, sampleHei
 	return sampling.SampleChainRandomness(sampleHeight, tipSetBuffer)
 }
 
-// GetActor returns an actor from the latest state on the chain
+// GetActorCode returns an actor from the latest state on the chain
 func (chn *ChainStateReadWriter) GetActor(ctx context.Context, addr address.Address) (*actor.Actor, error) {
 	return chn.GetActorAt(ctx, chn.readWriter.GetHead(), addr)
 }
@@ -150,7 +150,7 @@ func (chn *ChainStateReadWriter) GetActorSignature(ctx context.Context, actorAdd
 	}
 
 	// TODO: use chain height to determine protocol version
-	executable, err := chn.actors.GetBuiltinActorCode(actor.Code, 0)
+	executable, err := chn.actors.GetActorCode(actor.Code, 0)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load actor code")
 	}

--- a/plumbing/cst/chain_state.go
+++ b/plumbing/cst/chain_state.go
@@ -149,7 +149,7 @@ func (chn *ChainStateReadWriter) GetActorSignature(ctx context.Context, actorAdd
 		return nil, ErrNoActorImpl
 	}
 
-	// TODO: use chain height to determine protocol version
+	// TODO: use chain height to determine protocol version (#3360)
 	executable, err := chn.actors.GetActorCode(actor.Code, 0)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load actor code")

--- a/plumbing/cst/chain_state.go
+++ b/plumbing/cst/chain_state.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-hamt-ipld"
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/actor"
+	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
 	"github.com/filecoin-project/go-filecoin/exec"

--- a/plumbing/msg/previewer.go
+++ b/plumbing/msg/previewer.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
@@ -22,6 +21,11 @@ type previewerChainReader interface {
 	GetTipSet(types.TipSetKey) (types.TipSet, error)
 }
 
+type messagePreviewer interface {
+	// PreviewQueryMethod estimates the amount of gas that will be used by a method
+	PreviewQueryMethod(ctx context.Context, st state.Tree, vms vm.StorageMap, to address.Address, method string, params []byte, from address.Address, optBh *types.BlockHeight) (types.GasUnits, error)
+}
+
 // Previewer calculates the amount of Gas needed for a command
 type Previewer struct {
 	// To get the head tipset state root.
@@ -31,11 +35,11 @@ type Previewer struct {
 	// For vm storage.
 	bs bstore.Blockstore
 	// To to preview messages
-	processor consensus.Processor
+	processor messagePreviewer
 }
 
 // NewPreviewer constructs a Previewer.
-func NewPreviewer(chainReader previewerChainReader, cst *hamt.CborIpldStore, bs bstore.Blockstore, processor consensus.Processor) *Previewer {
+func NewPreviewer(chainReader previewerChainReader, cst *hamt.CborIpldStore, bs bstore.Blockstore, processor messagePreviewer) *Previewer {
 	return &Previewer{chainReader, cst, bs, processor}
 }
 

--- a/plumbing/msg/previewer.go
+++ b/plumbing/msg/previewer.go
@@ -30,11 +30,13 @@ type Previewer struct {
 	cst *hamt.CborIpldStore
 	// For vm storage.
 	bs bstore.Blockstore
+	// To to preview messages
+	processor consensus.Processor
 }
 
 // NewPreviewer constructs a Previewer.
-func NewPreviewer(chainReader previewerChainReader, cst *hamt.CborIpldStore, bs bstore.Blockstore) *Previewer {
-	return &Previewer{chainReader, cst, bs}
+func NewPreviewer(chainReader previewerChainReader, cst *hamt.CborIpldStore, bs bstore.Blockstore, processor consensus.Processor) *Previewer {
+	return &Previewer{chainReader, cst, bs, processor}
 }
 
 // Preview sends a read-only message to an actor.
@@ -58,7 +60,7 @@ func (p *Previewer) Preview(ctx context.Context, optFrom, to address.Address, me
 	}
 
 	vms := vm.NewStorageMap(p.bs)
-	usedGas, err := consensus.PreviewQueryMethod(ctx, st, vms, to, method, encodedParams, optFrom, types.NewBlockHeight(h))
+	usedGas, err := p.processor.PreviewQueryMethod(ctx, st, vms, to, method, encodedParams, optFrom, types.NewBlockHeight(h))
 	if err != nil {
 		return types.NewGasUnits(0), errors.Wrap(err, "query method returned an error")
 	}

--- a/plumbing/msg/previewer_test.go
+++ b/plumbing/msg/previewer_test.go
@@ -37,7 +37,7 @@ func TestPreview(t *testing.T) {
 		// the given address but doesn't set up the mapping from its code cid to
 		// actor implementation, so we do that here. Might be nice to handle this
 		// setup/teardown through genesis helpers.
-		actors := builtin.NewActorsBuilder().
+		actors := builtin.NewBuilder().
 			AddAll(builtin.DefaultActors).
 			Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 			Build()

--- a/plumbing/msg/previewer_test.go
+++ b/plumbing/msg/previewer_test.go
@@ -37,8 +37,10 @@ func TestPreview(t *testing.T) {
 		// the given address but doesn't set up the mapping from its code cid to
 		// actor implementation, so we do that here. Might be nice to handle this
 		// setup/teardown through genesis helpers.
-		builtin.Actors[fakeActorCodeCid] = &actor.FakeActor{}
-		defer delete(builtin.Actors, fakeActorCodeCid)
+		actors := builtin.BuiltinActorsExtender(builtin.DefaultActors).
+			Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
+			Build()
+		processor := consensus.NewConfiguredProcessor(consensus.NewDefaultMessageValidator(), consensus.NewDefaultBlockRewarder(), actors)
 		testGen := consensus.MakeGenesisFunc(
 			// Actor we will send the query to.
 			consensus.AddActor(fakeActorAddr, fakeActor),
@@ -47,7 +49,7 @@ func TestPreview(t *testing.T) {
 		)
 		deps := requireCommonDepsWithGifAndBlockstore(t, testGen, r, bs)
 
-		previewer := NewPreviewer(deps.chainStore, deps.cst, deps.blockstore)
+		previewer := NewPreviewer(deps.chainStore, deps.cst, deps.blockstore, processor)
 		returnValue, err := previewer.Preview(ctx, fromAddr, fakeActorAddr, "hasReturnValue")
 		require.NoError(t, err)
 		require.NotNil(t, returnValue)

--- a/plumbing/msg/previewer_test.go
+++ b/plumbing/msg/previewer_test.go
@@ -37,7 +37,8 @@ func TestPreview(t *testing.T) {
 		// the given address but doesn't set up the mapping from its code cid to
 		// actor implementation, so we do that here. Might be nice to handle this
 		// setup/teardown through genesis helpers.
-		actors := builtin.BuiltinActorsExtender(builtin.DefaultActors).
+		actors := builtin.NewActorsBuilder().
+			AddAll(builtin.DefaultActors).
 			Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 			Build()
 		processor := consensus.NewConfiguredProcessor(consensus.NewDefaultMessageValidator(), consensus.NewDefaultBlockRewarder(), actors)

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -633,7 +633,7 @@ func newMinerTestPorcelain(t *testing.T, minerPriceString string) *minerTestPorc
 }
 
 func (mtp *minerTestPorcelain) ActorGetSignature(ctx context.Context, actorAddr address.Address, method string) (_ *exec.FunctionSignature, err error) {
-	ea, error := builtin.DefaultActors.GetBuiltinActorCode(types.MinerActorCodeCid, 0)
+	ea, error := builtin.DefaultActors.GetActorCode(types.MinerActorCodeCid, 0)
 	if error != nil {
 		return nil, err
 	}

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -633,7 +633,11 @@ func newMinerTestPorcelain(t *testing.T, minerPriceString string) *minerTestPorc
 }
 
 func (mtp *minerTestPorcelain) ActorGetSignature(ctx context.Context, actorAddr address.Address, method string) (_ *exec.FunctionSignature, err error) {
-	return builtin.Actors[types.MinerActorCodeCid].Exports()[method], nil
+	ea, error := builtin.DefaultActors.GetBuiltinActorCode(types.MinerActorCodeCid, 0)
+	if error != nil {
+		return nil, err
+	}
+	return ea.Exports()[method], nil
 }
 
 func (mtp *minerTestPorcelain) MessageSend(ctx context.Context, from, to address.Address, val types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {

--- a/state/cached_tree.go
+++ b/state/cached_tree.go
@@ -22,11 +22,6 @@ func NewCachedStateTree(st Tree) *CachedTree {
 	}
 }
 
-// GetBuiltinActorCode simply delegates to the underlying tree
-//func (t *CachedTree) GetBuiltinActorCode(codePointer cid.Cid) (exec.ExecutableActor, error) {
-//	return t.st.GetBuiltinActorCode(codePointer)
-//}
-
 // GetActor retrieves an actor from the cache. If it's not found it will get it from the
 // underlying tree and then set it in the cache before returning it.
 func (t *CachedTree) GetActor(ctx context.Context, a address.Address) (*actor.Actor, error) {

--- a/state/cached_tree.go
+++ b/state/cached_tree.go
@@ -22,7 +22,7 @@ func NewCachedStateTree(st Tree) *CachedTree {
 	}
 }
 
-// GetActorCode retrieves an actor from the cache. If it's not found it will get it from the
+// GetActor retrieves an actor from the cache. If it's not found it will get it from the
 // underlying tree and then set it in the cache before returning it.
 func (t *CachedTree) GetActor(ctx context.Context, a address.Address) (*actor.Actor, error) {
 	var err error

--- a/state/cached_tree.go
+++ b/state/cached_tree.go
@@ -2,11 +2,9 @@ package state
 
 import (
 	"context"
-	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/vm/errors"
 )
 
@@ -25,9 +23,9 @@ func NewCachedStateTree(st Tree) *CachedTree {
 }
 
 // GetBuiltinActorCode simply delegates to the underlying tree
-func (t *CachedTree) GetBuiltinActorCode(codePointer cid.Cid) (exec.ExecutableActor, error) {
-	return t.st.GetBuiltinActorCode(codePointer)
-}
+//func (t *CachedTree) GetBuiltinActorCode(codePointer cid.Cid) (exec.ExecutableActor, error) {
+//	return t.st.GetBuiltinActorCode(codePointer)
+//}
 
 // GetActor retrieves an actor from the cache. If it's not found it will get it from the
 // underlying tree and then set it in the cache before returning it.

--- a/state/cached_tree.go
+++ b/state/cached_tree.go
@@ -22,7 +22,7 @@ func NewCachedStateTree(st Tree) *CachedTree {
 	}
 }
 
-// GetActor retrieves an actor from the cache. If it's not found it will get it from the
+// GetActorCode retrieves an actor from the cache. If it's not found it will get it from the
 // underlying tree and then set it in the cache before returning it.
 func (t *CachedTree) GetActor(ctx context.Context, a address.Address) (*actor.Actor, error) {
 	var err error

--- a/state/testing.go
+++ b/state/testing.go
@@ -66,7 +66,7 @@ func (m *MockStateTree) Flush(ctx context.Context) (c cid.Cid, err error) {
 	return
 }
 
-// GetActorCode implements StateTree.GetActorCode.
+// GetActor implements StateTree.GetActorCode.
 func (m *MockStateTree) GetActor(ctx context.Context, address address.Address) (a *actor.Actor, err error) {
 	if m.NoMocks {
 		return

--- a/state/testing.go
+++ b/state/testing.go
@@ -66,7 +66,7 @@ func (m *MockStateTree) Flush(ctx context.Context) (c cid.Cid, err error) {
 	return
 }
 
-// GetActor implements StateTree.GetActor.
+// GetActorCode implements StateTree.GetActorCode.
 func (m *MockStateTree) GetActor(ctx context.Context, address address.Address) (a *actor.Actor, err error) {
 	if m.NoMocks {
 		return
@@ -105,8 +105,8 @@ func (m *MockStateTree) Debug() {
 	panic("do not call me")
 }
 
-// GetBuiltinActorCode implements StateTree.GetBuiltinActorCode
-func (m *MockStateTree) GetBuiltinActorCode(c cid.Cid, protocol uint64) (exec.ExecutableActor, error) {
+// GetActorCode implements StateTree.GetActorCode
+func (m *MockStateTree) GetActorCode(c cid.Cid, protocol uint64) (exec.ExecutableActor, error) {
 	a, ok := m.BuiltinActors[c]
 	if !ok {
 		return nil, fmt.Errorf("unknown actor: %v", c.String())

--- a/state/testing.go
+++ b/state/testing.go
@@ -106,7 +106,7 @@ func (m *MockStateTree) Debug() {
 }
 
 // GetBuiltinActorCode implements StateTree.GetBuiltinActorCode
-func (m *MockStateTree) GetBuiltinActorCode(c cid.Cid) (exec.ExecutableActor, error) {
+func (m *MockStateTree) GetBuiltinActorCode(c cid.Cid, protocol uint64) (exec.ExecutableActor, error) {
 	a, ok := m.BuiltinActors[c]
 	if !ok {
 		return nil, fmt.Errorf("unknown actor: %v", c.String())

--- a/state/tree.go
+++ b/state/tree.go
@@ -41,8 +41,6 @@ type Tree interface {
 	SetActor(ctx context.Context, a address.Address, act *actor.Actor) error
 
 	ForEachActor(ctx context.Context, walkFn ActorWalkFn) error
-
-	//GetBuiltinActorCode(c cid.Cid) (exec.ExecutableActor, error)
 }
 
 var _ Tree = &tree{}
@@ -85,12 +83,6 @@ func NewEmptyStateTree(store *hamt.CborIpldStore) Tree {
 	return newEmptyStateTree(store)
 }
 
-// NewEmptyStateTreeWithActors instantiates a new state tree with no data in it, except for the passed in actors.
-//func NewEmptyStateTreeWithActors(store *hamt.CborIpldStore, builtinActors map[types.CodeVersion]exec.ExecutableActor) Tree {
-//	s := newEmptyStateTree(store)
-//	return s
-//}
-
 func newEmptyStateTree(store *hamt.CborIpldStore) *tree {
 	return &tree{
 		root:  hamt.NewNode(store, hamt.UseTreeBitWidth(TreeBitWidth)),
@@ -129,18 +121,6 @@ func (e actorNotFoundError) Error() string {
 func (e actorNotFoundError) ActorNotFound() bool {
 	return true
 }
-
-//func (t *tree) GetBuiltinActorCode(codePointer cid.Cid) (exec.ExecutableActor, error) {
-//	if !codePointer.Defined() {
-//		return nil, fmt.Errorf("missing code")
-//	}
-//	actor, ok := t.builtinActors[types.NewCodeVersion(codePointer, 0)]
-//	if !ok {
-//		return nil, fmt.Errorf("unknown code: %s", codePointer.String())
-//	}
-//
-//	return actor, nil
-//}
 
 // GetActor retrieves an actor by their address. If no actor
 // exists at the given address then an error will be returned

--- a/state/tree.go
+++ b/state/tree.go
@@ -101,7 +101,7 @@ func (t *tree) Flush(ctx context.Context) (cid.Cid, error) {
 }
 
 // IsActorNotFoundError is true of the error returned by
-// GetActor when no actor was found at the given address.
+// GetActorCode when no actor was found at the given address.
 func IsActorNotFoundError(err error) bool {
 	cause := errors.Cause(err)
 	e, ok := cause.(actornotfound)
@@ -122,7 +122,7 @@ func (e actorNotFoundError) ActorNotFound() bool {
 	return true
 }
 
-// GetActor retrieves an actor by their address. If no actor
+// GetActorCode retrieves an actor by their address. If no actor
 // exists at the given address then an error will be returned
 // for which IsActorNotFoundError(err) is true.
 func (t *tree) GetActor(ctx context.Context, a address.Address) (*actor.Actor, error) {

--- a/state/tree_test.go
+++ b/state/tree_test.go
@@ -48,7 +48,7 @@ func TestStatePutGet(t *testing.T) {
 	tcid, err := tree.Flush(ctx)
 	assert.NoError(t, err)
 
-	tree2, err := LoadStateTree(ctx, cst, tcid, nil)
+	tree2, err := LoadStateTree(ctx, cst, tcid)
 	assert.NoError(t, err)
 
 	act1out2, err := tree2.GetActor(ctx, addr1)
@@ -74,7 +74,7 @@ func TestStateErrors(t *testing.T) {
 	c, err := cid.V1Builder{Codec: cid.DagCBOR, MhType: mh.BLAKE2B_MIN + 31}.Sum([]byte("cats"))
 	assert.NoError(t, err)
 
-	tr2, err := LoadStateTree(ctx, cst, c, nil)
+	tr2, err := LoadStateTree(ctx, cst, c)
 	assert.Error(t, err)
 	assert.Nil(t, tr2)
 }

--- a/testhelpers/chain.go
+++ b/testhelpers/chain.go
@@ -47,7 +47,8 @@ func MkFakeChild(params FakeChildParams) (*types.Block, error) {
 	// Create consensus for reading the valid weight
 	bs := bstore.NewBlockstore(repo.NewInMemoryRepo().Datastore())
 	cst := hamt.NewCborStore()
-	actorState := consensus.NewActorStateStore(nil, cst, bs)
+	processor := consensus.NewDefaultProcessor()
+	actorState := consensus.NewActorStateStore(nil, cst, bs, processor)
 	con := consensus.NewExpected(cst,
 		bs,
 		NewFakeProcessor(),

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -13,7 +13,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/filecoin-project/go-filecoin/actor"
-	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
@@ -31,7 +30,7 @@ import (
 // the state tree, requiring that all its steps succeed.
 func RequireMakeStateTree(t *testing.T, cst *hamt.CborIpldStore, acts map[address.Address]*actor.Actor) (cid.Cid, state.Tree) {
 	ctx := context.Background()
-	tree := state.NewEmptyStateTreeWithActors(cst, builtin.Actors)
+	tree := state.NewEmptyStateTree(cst)
 
 	for addr, act := range acts {
 		err := tree.SetActor(ctx, addr, act)
@@ -178,7 +177,7 @@ func RequireCreateStorages(ctx context.Context, t *testing.T) (state.Tree, vm.St
 	blk, err := DefaultGenesis(cst, bs)
 	require.NoError(t, err)
 
-	st, err := state.LoadStateTree(ctx, cst, blk.StateRoot, builtin.Actors)
+	st, err := state.LoadStateTree(ctx, cst, blk.StateRoot)
 	require.NoError(t, err)
 
 	vms := vm.NewStorageMap(bs)

--- a/vm/context.go
+++ b/vm/context.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/vm/errors"
 )
 
+// ExecutableActorLookup provides a method to get an executable actor by code and protocol version
 type ExecutableActorLookup interface {
 	GetBuiltinActorCode(code cid.Cid, version uint64) (exec.ExecutableActor, error)
 }

--- a/vm/context.go
+++ b/vm/context.go
@@ -202,7 +202,7 @@ func (ctx *Context) CreateNewActor(addr address.Address, code cid.Cid, initializ
 	newActor.Code = code
 
 	childStorage := ctx.storageMap.NewStorage(addr, newActor)
-	// TODO: need to use blockheight derived version
+	// TODO: need to use blockheight derived version (#3360)
 	execActor, err := ctx.actors.GetActorCode(code, 0)
 	if err != nil {
 		return errors.NewRevertErrorf("attempt to create executable actor from non-existent code %s", code.String())

--- a/vm/context.go
+++ b/vm/context.go
@@ -18,6 +18,10 @@ import (
 	"github.com/filecoin-project/go-filecoin/vm/errors"
 )
 
+type ExecutableActorLookup interface {
+	GetBuiltinActorCode(code cid.Cid, version uint64) (exec.ExecutableActor, error)
+}
+
 // Context is the only thing exposed to an actor while executing.
 // All methods on the Context are ABI methods exposed to actors.
 type Context struct {
@@ -29,6 +33,7 @@ type Context struct {
 	gasTracker  *GasTracker
 	blockHeight *types.BlockHeight
 	ancestors   []types.TipSet
+	actors      ExecutableActorLookup
 
 	deps *deps // Inject external dependencies so we can unit test robustly.
 }
@@ -45,6 +50,7 @@ type NewContextParams struct {
 	GasTracker  *GasTracker
 	BlockHeight *types.BlockHeight
 	Ancestors   []types.TipSet
+	Actors      ExecutableActorLookup
 }
 
 // NewVMContext returns an initialized context.
@@ -58,6 +64,7 @@ func NewVMContext(params NewContextParams) *Context {
 		gasTracker:  params.GasTracker,
 		blockHeight: params.BlockHeight,
 		ancestors:   params.Ancestors,
+		actors:      params.Actors,
 		deps:        makeDeps(params.State),
 	}
 }
@@ -140,6 +147,7 @@ func (ctx *Context) Send(to address.Address, method string, value types.AttoFIL,
 		GasTracker:  ctx.gasTracker,
 		BlockHeight: ctx.blockHeight,
 		Ancestors:   ctx.ancestors,
+		Actors:      ctx.actors,
 	}
 	innerCtx := NewVMContext(innerParams)
 
@@ -193,7 +201,8 @@ func (ctx *Context) CreateNewActor(addr address.Address, code cid.Cid, initializ
 	newActor.Code = code
 
 	childStorage := ctx.storageMap.NewStorage(addr, newActor)
-	execActor, err := ctx.state.GetBuiltinActorCode(code)
+	// TODO: need to use blockheight derived version
+	execActor, err := ctx.actors.GetBuiltinActorCode(code, 0)
 	if err != nil {
 		return errors.NewRevertErrorf("attempt to create executable actor from non-existent code %s", code.String())
 	}

--- a/vm/context.go
+++ b/vm/context.go
@@ -20,7 +20,7 @@ import (
 
 // ExecutableActorLookup provides a method to get an executable actor by code and protocol version
 type ExecutableActorLookup interface {
-	GetBuiltinActorCode(code cid.Cid, version uint64) (exec.ExecutableActor, error)
+	GetActorCode(code cid.Cid, version uint64) (exec.ExecutableActor, error)
 }
 
 // Context is the only thing exposed to an actor while executing.
@@ -203,7 +203,7 @@ func (ctx *Context) CreateNewActor(addr address.Address, code cid.Cid, initializ
 
 	childStorage := ctx.storageMap.NewStorage(addr, newActor)
 	// TODO: need to use blockheight derived version
-	execActor, err := ctx.actors.GetBuiltinActorCode(code, 0)
+	execActor, err := ctx.actors.GetActorCode(code, 0)
 	if err != nil {
 		return errors.NewRevertErrorf("attempt to create executable actor from non-existent code %s", code.String())
 	}

--- a/vm/context_test.go
+++ b/vm/context_test.go
@@ -101,6 +101,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		StorageMap:  vms,
 		GasTracker:  NewGasTracker(),
 		BlockHeight: types.NewBlockHeight(0),
+		Actors:      &mockStateTree,
 	}
 
 	t.Run("failure to convert to ABI values results in fault error", func(t *testing.T) {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -43,7 +43,7 @@ func send(ctx context.Context, deps sendDeps, vmCtx *Context) ([][]byte, uint8, 
 	}
 
 	// TODO: use chain height based protocol version here
-	toExecutable, err := vmCtx.actors.GetBuiltinActorCode(vmCtx.to.Code, 0)
+	toExecutable, err := vmCtx.actors.GetActorCode(vmCtx.to.Code, 0)
 	if err != nil {
 		return nil, errors.ErrNoActorCode, errors.Errors[errors.ErrNoActorCode]
 	}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -42,7 +42,7 @@ func send(ctx context.Context, deps sendDeps, vmCtx *Context) ([][]byte, uint8, 
 		return nil, 0, nil
 	}
 
-	// TODO: use chain height based protocol version here
+	// TODO: use chain height based protocol version here (#3360)
 	toExecutable, err := vmCtx.actors.GetActorCode(vmCtx.to.Code, 0)
 	if err != nil {
 		return nil, errors.ErrNoActorCode, errors.Errors[errors.ErrNoActorCode]

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -42,7 +42,8 @@ func send(ctx context.Context, deps sendDeps, vmCtx *Context) ([][]byte, uint8, 
 		return nil, 0, nil
 	}
 
-	toExecutable, err := vmCtx.state.GetBuiltinActorCode(vmCtx.to.Code)
+	// TODO: use chain height based protocol version here
+	toExecutable, err := vmCtx.actors.GetBuiltinActorCode(vmCtx.to.Code, 0)
 	if err != nil {
 		return nil, errors.ErrNoActorCode, errors.Errors[errors.ErrNoActorCode]
 	}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -88,7 +88,8 @@ func TestSendErrorHandling(t *testing.T) {
 
 		deps := sendDeps{}
 
-		tree := state.NewCachedStateTree(&state.MockStateTree{NoMocks: true, BuiltinActors: map[cid.Cid]exec.ExecutableActor{}})
+		stateTree := &state.MockStateTree{NoMocks: true, BuiltinActors: map[cid.Cid]exec.ExecutableActor{}}
+		tree := state.NewCachedStateTree(stateTree)
 		vmCtxParams := NewContextParams{
 			From:        actor1,
 			To:          actor2,
@@ -97,6 +98,7 @@ func TestSendErrorHandling(t *testing.T) {
 			StorageMap:  vms,
 			GasTracker:  NewGasTracker(),
 			BlockHeight: types.NewBlockHeight(0),
+			Actors:      stateTree,
 		}
 		vmCtx := NewVMContext(vmCtxParams)
 		_, code, sendErr := send(context.Background(), deps, vmCtx)
@@ -115,9 +117,10 @@ func TestSendErrorHandling(t *testing.T) {
 
 		deps := sendDeps{}
 
-		tree := state.NewCachedStateTree(&state.MockStateTree{NoMocks: true, BuiltinActors: map[cid.Cid]exec.ExecutableActor{
+		stateTree := &state.MockStateTree{NoMocks: true, BuiltinActors: map[cid.Cid]exec.ExecutableActor{
 			actor2.Code: &actor.FakeActor{},
-		}})
+		}}
+		tree := state.NewCachedStateTree(stateTree)
 
 		vmCtxParams := NewContextParams{
 			From:        actor1,
@@ -127,6 +130,7 @@ func TestSendErrorHandling(t *testing.T) {
 			StorageMap:  vms,
 			GasTracker:  NewGasTracker(),
 			BlockHeight: types.NewBlockHeight(0),
+			Actors:      stateTree,
 		}
 		vmCtx := NewVMContext(vmCtxParams)
 		_, code, sendErr := send(context.Background(), deps, vmCtx)


### PR DESCRIPTION
### What is in this PR?

This is movement towards implementing protocol upgrades. One thing blocking that is that the builtin actor lookup has simply been a global variable containing a map. This is bad practice for many reasons. We have been passing it around in state trees for reasons I've never understood (probably expediency). This refactor make many improvements around builtin actors in preparation for upgrades.

1. `builtin.Actors` is now a struct that represents an immutable lookup of actors.
2. `builtin.Actors` is now constructed with a builder.
3. `builtin.Actors` supports the concept of a protocol version although it is currently always set to 0.
4. `CallQueryMethod` and `PreviewQueryMethod` are now methods on `DefaultProcessor`. This lets us dependency inject components (`builtin.Actors` for now) into the processor and use it in those methods rather than passing them in as parameters.
5. Remove `builtin.Actors` from `state.Tree`
6. Many alterations to tests to support these changes.