### PR TITLE
Refactor/weight prep

### DIFF
--- a/chain/store_test.go
+++ b/chain/store_test.go
@@ -52,12 +52,6 @@ type HeadAndTipsetGetter interface {
 	GetTipSet(types.TipSetKey) (types.TipSet, error)
 }
 
-func requireHeadTipset(t *testing.T, chain HeadAndTipsetGetter) types.TipSet {
-	headTipSet, err := chain.GetTipSet(chain.GetHead())
-	require.NoError(t, err)
-	return headTipSet
-}
-
 func requirePutBlocksToCborStore(t *testing.T, cst *hamt.CborIpldStore, blocks ...*types.Block) {
 	for _, block := range blocks {
 		_, err := cst.Put(context.Background(), block)

--- a/chain/syncer.go
+++ b/chain/syncer.go
@@ -54,14 +54,16 @@ type syncerChainReaderWriter interface {
 	GetTipSetAndStatesByParentsAndHeight(pTsKey types.TipSetKey, h uint64) ([]*TipSetAndState, error)
 }
 
+type syncChainSelector interface {
+	// IsHeaver returns true if tipset a is heavier than tipset b and false if
+	// tipset b is heavier than tipset a.
+	IsHeavier(ctx context.Context, a, b types.TipSet, aStateID, bStateID cid.Cid) (bool, error)
+}
+
 type syncStateEvaluator interface {
 	// RunStateTransition returns the state root CID resulting from applying the input ts to the
 	// prior `stateRoot`.  It returns an error if the transition is invalid.
 	RunStateTransition(ctx context.Context, ts types.TipSet, tsMessages [][]*types.SignedMessage, tsReceipts [][]*types.MessageReceipt, ancestors []types.TipSet, stateID cid.Cid) (cid.Cid, error)
-
-	// IsHeaver tests whether tipset `a` is heavier than tipset `b`.
-	// The state IDs identify the state to which the tipset applies (i.e. prior to its messages).
-	IsHeavier(ctx context.Context, a, b types.TipSet, aStateID, bStateID cid.Cid) (bool, error)
 }
 
 // Syncer updates its chain.Store according to the methods of its
@@ -95,6 +97,8 @@ type Syncer struct {
 
 	// Evaluates tipset messages and stores the resulting states.
 	stateEvaluator syncStateEvaluator
+	// Selects the heaviest of two chains
+	chainSelector syncChainSelector
 	// Provides and stores validated tipsets and their state roots.
 	chainStore syncerChainReaderWriter
 	// Provides message collections given cids
@@ -107,13 +111,14 @@ type Syncer struct {
 }
 
 // NewSyncer constructs a Syncer ready for use.
-func NewSyncer(e syncStateEvaluator, s syncerChainReaderWriter, m MessageProvider, f net.Fetcher, sr Reporter, c clock.Clock) *Syncer {
+func NewSyncer(e syncStateEvaluator, cs syncChainSelector, s syncerChainReaderWriter, m MessageProvider, f net.Fetcher, sr Reporter, c clock.Clock) *Syncer {
 	return &Syncer{
 		fetcher: f,
 		badTipSets: &badTipSetCache{
 			bad: make(map[string]struct{}),
 		},
 		stateEvaluator:  e,
+		chainSelector:   cs,
 		chainStore:      s,
 		messageProvider: m,
 		clock:           c,
@@ -211,7 +216,7 @@ func (syncer *Syncer) syncOne(ctx context.Context, parent, next types.TipSet) er
 		}
 	}
 
-	heavier, err := syncer.stateEvaluator.IsHeavier(ctx, next, headTipSet, nextParentStateID, headParentStateID)
+	heavier, err := syncer.chainSelector.IsHeavier(ctx, next, headTipSet, nextParentStateID, headParentStateID)
 	if err != nil {
 		return err
 	}

--- a/chain/syncer_integration_test.go
+++ b/chain/syncer_integration_test.go
@@ -6,16 +6,12 @@ import (
 	"time"
 
 	bserv "github.com/ipfs/go-blockservice"
-	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-hamt-ipld"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/ipfs/go-ipfs-exchange-offline"
-	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/chain"
-	"github.com/filecoin-project/go-filecoin/consensus"
-	"github.com/filecoin-project/go-filecoin/gengen/util"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/state"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
@@ -50,7 +46,8 @@ func TestLoadFork(t *testing.T) {
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but
 	// *not* as the store, to which the syncer must ensure to put blocks.
 	eval := &chain.FakeStateEvaluator{}
-	syncer := chain.NewSyncer(eval, store, builder, builder, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
+	sel := &chain.FakeChainSelector{}
+	syncer := chain.NewSyncer(eval, sel, store, builder, builder, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 
 	base := builder.AppendManyOn(3, genesis)
 	left := builder.AppendManyOn(4, base)
@@ -78,7 +75,7 @@ func TestLoadFork(t *testing.T) {
 	newStore := chain.NewStore(repo.ChainDatastore(), &cborStore, &state.TreeStateLoader{}, chain.NewStatusReporter(), genesis.At(0).Cid())
 	require.NoError(t, newStore.Load(ctx))
 	fakeFetcher := th.NewTestFetcher()
-	offlineSyncer := chain.NewSyncer(eval, newStore, builder, fakeFetcher, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
+	offlineSyncer := chain.NewSyncer(eval, sel, newStore, builder, fakeFetcher, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 
 	assert.True(t, newStore.HasTipSetAndState(ctx, left.Key()))
 	assert.False(t, newStore.HasTipSetAndState(ctx, right.Key()))
@@ -109,270 +106,4 @@ func TestLoadFork(t *testing.T) {
 
 	// The left chain is ok without any fetching though.
 	assert.NoError(t, offlineSyncer.HandleNewTipSet(ctx, types.NewChainInfo("", left.Key(), heightFromTip(t, left)), true))
-}
-
-// Syncer handles PowerTableView weight comparisons.
-// Current issue: when creating miner mining with addr0, addr0's storage head isn't found in the blockstore
-// and I can't figure out why because we pass in the correct blockstore to createStorageMinerWithpower.
-func TestTipSetWeightDeep(t *testing.T) {
-	// This test takes many seconds, the bottleneck is gengen.
-	tf.IntegrationTest(t)
-
-	r := repo.NewInMemoryRepo()
-	bs := bstore.NewBlockstore(r.Datastore())
-	cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
-
-	ctx := context.Background()
-
-	// set up dstP.genesis block with power
-	genCfg := &gengen.GenesisCfg{
-		ProofsMode: types.TestProofsMode,
-		Keys:       4,
-		Miners: []*gengen.CreateStorageMinerConfig{
-			{
-				NumCommittedSectors: 0,
-				SectorSize:          types.OneKiBSectorSize.Uint64(),
-			},
-			{
-				NumCommittedSectors: 10,
-				SectorSize:          types.OneKiBSectorSize.Uint64(),
-			},
-			{
-				NumCommittedSectors: 10,
-				SectorSize:          types.OneKiBSectorSize.Uint64(),
-			},
-			{
-				NumCommittedSectors: 980,
-				SectorSize:          types.OneKiBSectorSize.Uint64(),
-			},
-		},
-		Network: "syncerIntegrationTest",
-	}
-
-	info, err := gengen.GenGen(ctx, genCfg, cst, bs, 0)
-	require.NoError(t, err)
-
-	minerWorker1, err := info.Keys[0].Address()
-	require.NoError(t, err)
-	minerWorker2 := minerWorker1
-	// Include gengen miner worker key so that we can correctly sign blocks
-	mockSigner := types.NewMockSigner([]types.KeyInfo{*info.Keys[0]})
-
-	var calcGenBlk types.Block
-	require.NoError(t, cst.Get(ctx, info.GenesisCid, &calcGenBlk))
-
-	chainStore := chain.NewStore(r.ChainDatastore(), cst, &state.TreeStateLoader{}, chain.NewStatusReporter(), calcGenBlk.Cid())
-	messageStore := chain.NewMessageStore(cst)
-	emptyMessagesCid, err := messageStore.StoreMessages(ctx, []*types.SignedMessage{})
-	require.NoError(t, err)
-	emptyReceiptsCid, err := messageStore.StoreReceipts(ctx, []*types.MessageReceipt{})
-	require.NoError(t, err)
-
-	// Initialize stores to contain dstP.genesis block and state
-	calcGenTS := th.RequireNewTipSet(t, &calcGenBlk)
-	genTsas := &chain.TipSetAndState{
-		TipSet:          calcGenTS,
-		TipSetStateRoot: calcGenBlk.StateRoot,
-	}
-	require.NoError(t, chainStore.PutTipSetAndState(ctx, genTsas))
-	err = chainStore.SetHead(ctx, calcGenTS) // Initialize chainStore with correct dstP.genesis
-	require.NoError(t, err)
-	requireHead(t, chainStore, calcGenTS)
-	requireTsAdded(t, chainStore, calcGenTS)
-
-	// Setup a fetcher for feeding blocks into the syncer.
-	blockSource := th.NewTestFetcher()
-
-	// Now sync the chainStore with consensus using a PowerTableView.
-	processor := consensus.NewDefaultProcessor()
-	as := consensus.NewActorStateStore(chainStore, cst, bs, processor)
-	con := consensus.NewExpected(cst, bs, th.NewFakeProcessor(), th.NewFakeBlockValidator(), as, calcGenBlk.Cid(), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
-	syncer := chain.NewSyncer(con, chainStore, messageStore, blockSource, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
-	baseTS := requireHeadTipset(t, chainStore) // this is the last block of the bootstrapping chain creating miners
-	require.Equal(t, 1, baseTS.Len())
-	bootstrapStateRoot := baseTS.ToSlice()[0].StateRoot
-	pSt, err := state.LoadStateTree(ctx, cst, baseTS.ToSlice()[0].StateRoot)
-	require.NoError(t, err)
-	/* Test chain diagram and weight calcs */
-	// (Note f1b1 = fork 1 block 1)
-	//
-	// f1b1 -> {f1b2a, f1b2b}
-	//
-	// f2b1 -> f2b2
-	//
-	//  sw=starting weight, apw=added parent weight, mw=miner weight, ew=expected weight
-	//  w({blk})          = sw + apw + mw      = sw + ew
-	//  w({fXb1})         = sw + 0   + 11      = sw + 11
-	//  w({f1b1, f2b1})   = sw + 0   + 11 * 2  = sw + 22
-	//  w({f1b2a, f1b2b}) = sw + 11  + 11 * 2  = sw + 33
-	//  w({f2b2})         = sw + 11  + 108 	   = sw + 119
-	startingWeight, err := con.Weight(ctx, baseTS, pSt)
-	require.NoError(t, err)
-
-	wFun := func(ts types.TipSet) (uint64, error) {
-		// No power-altering messages processed from here on out.
-		// And so bootstrapSt correctly retrives power table for all
-		// test blocks.
-		return con.Weight(ctx, ts, pSt)
-	}
-
-	fakeChildParams := th.FakeChildParams{
-		Parent:     baseTS,
-		GenesisCid: calcGenBlk.Cid(),
-		StateRoot:  bootstrapStateRoot,
-		Signer:     mockSigner,
-
-		MinerAddr:   info.Miners[1].Address,
-		MinerWorker: minerWorker1,
-	}
-
-	f1b1 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	var f1b1Ticket types.Ticket
-	f1b1.ElectionProof, f1b1Ticket = consensus.MakeFakeElectionProofForTest(), consensus.MakeFakeTicketForTest()
-	f1b1.Tickets = []types.Ticket{f1b1Ticket}
-	f1b1.Messages = emptyMessagesCid
-	f1b1.MessageReceipts = emptyReceiptsCid
-	f1b1.BlockSig, err = mockSigner.SignBytes(f1b1.SignatureData(), minerWorker1)
-	require.NoError(t, err)
-
-	fakeChildParams.MinerAddr = info.Miners[2].Address
-	f2b1 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	var f2b1Ticket types.Ticket
-	f2b1.ElectionProof, f2b1Ticket = consensus.MakeFakeElectionProofForTest(), consensus.MakeFakeTicketForTest()
-	f2b1.Tickets = []types.Ticket{f2b1Ticket}
-	f2b1.Messages = emptyMessagesCid
-	f2b1.MessageReceipts = emptyReceiptsCid
-	f2b1.BlockSig, err = mockSigner.SignBytes(f2b1.SignatureData(), minerWorker1)
-	require.NoError(t, err)
-
-	tsShared := th.RequireNewTipSet(t, f1b1, f2b1)
-
-	// Sync first tipset, should have weight 22 + starting
-	sharedCids := requirePutBlocks(t, blockSource, f1b1, f2b1)
-	err = syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), sharedCids, uint64(f1b1.Height)), true)
-	require.NoError(t, err)
-	assertHead(t, chainStore, tsShared)
-	measuredWeight, err := wFun(requireHeadTipset(t, chainStore))
-	require.NoError(t, err)
-	expectedWeight := startingWeight + uint64(22000)
-	assert.Equal(t, expectedWeight, measuredWeight)
-
-	// fork 1 is heavier than the old head.
-	fakeChildParams = th.FakeChildParams{
-		Parent:     th.RequireNewTipSet(t, f1b1),
-		GenesisCid: calcGenBlk.Cid(),
-		StateRoot:  bootstrapStateRoot,
-		Signer:     mockSigner,
-
-		MinerAddr:   info.Miners[1].Address,
-		MinerWorker: minerWorker1,
-	}
-	f1b2a := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	var f1b2aTicket types.Ticket
-	f1b2a.ElectionProof, f1b2aTicket = consensus.MakeFakeElectionProofForTest(), consensus.MakeFakeTicketForTest()
-	f1b2a.Tickets = []types.Ticket{f1b2aTicket}
-	f1b2a.Messages = emptyMessagesCid
-	f1b2a.MessageReceipts = emptyReceiptsCid
-	f1b2a.BlockSig, err = mockSigner.SignBytes(f1b2a.SignatureData(), minerWorker1)
-	require.NoError(t, err)
-
-	fakeChildParams.MinerAddr = info.Miners[2].Address
-	fakeChildParams.MinerWorker = minerWorker2
-	f1b2b := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	var f1b2bTicket types.Ticket
-	f1b2b.ElectionProof, f1b2bTicket = consensus.MakeFakeElectionProofForTest(), consensus.MakeFakeTicketForTest()
-	require.NoError(t, err)
-	f1b2b.Tickets = []types.Ticket{f1b2bTicket}
-	f1b2b.Messages = emptyMessagesCid
-	f1b2b.MessageReceipts = emptyReceiptsCid
-	f1b2b.BlockSig, err = mockSigner.SignBytes(f1b2b.SignatureData(), minerWorker1)
-	require.NoError(t, err)
-
-	f1 := th.RequireNewTipSet(t, f1b2a, f1b2b)
-	f1Cids := requirePutBlocks(t, blockSource, f1.ToSlice()...)
-
-	f1H, err := f1.Height()
-	require.NoError(t, err)
-	err = syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), f1Cids, f1H), true)
-	require.NoError(t, err)
-
-	assertHead(t, chainStore, f1)
-	measuredWeight, err = wFun(requireHeadTipset(t, chainStore))
-	require.NoError(t, err)
-	expectedWeight = startingWeight + uint64(33000)
-	assert.Equal(t, expectedWeight, measuredWeight)
-
-	// fork 2 has heavier weight because of addr3's power even though there
-	// are fewer blocks in the tipset than fork 1.
-	fakeChildParams = th.FakeChildParams{
-		Parent:     th.RequireNewTipSet(t, f2b1),
-		GenesisCid: calcGenBlk.Cid(),
-		Signer:     mockSigner,
-
-		StateRoot:   bootstrapStateRoot,
-		MinerAddr:   info.Miners[3].Address,
-		MinerWorker: minerWorker2,
-	}
-	f2b2 := th.RequireMkFakeChildCore(t, fakeChildParams, wFun)
-	var f2b2Ticket types.Ticket
-	f2b2.ElectionProof, f2b2Ticket = consensus.MakeFakeElectionProofForTest(), consensus.MakeFakeTicketForTest()
-	f2b2.Tickets = []types.Ticket{f2b2Ticket}
-	f2b2.Messages = emptyMessagesCid
-	f2b2.MessageReceipts = emptyReceiptsCid
-	f2b2.BlockSig, err = mockSigner.SignBytes(f2b2.SignatureData(), minerWorker2)
-	require.NoError(t, err)
-
-	f2 := th.RequireNewTipSet(t, f2b2)
-	f2Cids := requirePutBlocks(t, blockSource, f2.ToSlice()...)
-
-	f2H, err := f2.Height()
-	require.NoError(t, err)
-	err = syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), f2Cids, f2H), true)
-	require.NoError(t, err)
-
-	assertHead(t, chainStore, f2)
-	measuredWeight, err = wFun(requireHeadTipset(t, chainStore))
-	require.NoError(t, err)
-	expectedWeight = startingWeight + uint64(119000)
-	assert.Equal(t, expectedWeight, measuredWeight)
-}
-
-type requireTsAddedChainStore interface {
-	GetTipSet(types.TipSetKey) (types.TipSet, error)
-	GetTipSetAndStatesByParentsAndHeight(types.TipSetKey, uint64) ([]*chain.TipSetAndState, error)
-}
-
-func requireTsAdded(t *testing.T, chain requireTsAddedChainStore, ts types.TipSet) {
-	h, err := ts.Height()
-	require.NoError(t, err)
-	// Tip Index correctly updated
-	gotTs, err := chain.GetTipSet(ts.Key())
-	require.NoError(t, err)
-	require.Equal(t, ts, gotTs)
-	parent, err := ts.Parents()
-	require.NoError(t, err)
-	childTsasSlice, err := chain.GetTipSetAndStatesByParentsAndHeight(parent, h)
-
-	require.NoError(t, err)
-	require.True(t, containsTipSet(childTsasSlice, ts))
-}
-
-func requireHead(t *testing.T, chain HeadAndTipsetGetter, head types.TipSet) {
-	require.Equal(t, head, requireHeadTipset(t, chain))
-}
-
-func assertHead(t *testing.T, chain HeadAndTipsetGetter, head types.TipSet) {
-	headTipSet, err := chain.GetTipSet(chain.GetHead())
-	assert.NoError(t, err)
-	assert.Equal(t, head, headTipSet)
-}
-
-func requirePutBlocks(_ *testing.T, f *th.TestFetcher, blocks ...*types.Block) types.TipSetKey {
-	var cids []cid.Cid
-	for _, block := range blocks {
-		c := block.Cid()
-		cids = append(cids, c)
-	}
-	f.AddSourceBlocks(blocks...)
-	return types.NewTipSetKey(cids...)
 }

--- a/chain/syncer_test.go
+++ b/chain/syncer_test.go
@@ -177,7 +177,7 @@ func TestAcceptHeavierFork(t *testing.T) {
 	verifyTip(t, store, main4, builder.StateForKey(main4.Key()))
 	verifyHead(t, store, main4)
 
-	// Heavier fork updates hea3
+	// Heavier fork updates head3
 	assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), fork3.Key(), heightFromTip(t, fork3)), true))
 	verifyTip(t, store, fork1, builder.StateForKey(fork1.Key()))
 	verifyTip(t, store, fork2, builder.StateForKey(fork2.Key()))
@@ -194,7 +194,7 @@ func TestFarFutureTipsets(t *testing.T) {
 		genesis := builder.RequireTipSet(store.GetHead())
 		farHead := builder.AppendManyOn(chain.UntrustedChainHeightLimit+1, genesis)
 
-		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, builder, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
+		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, &chain.FakeChainSelector{}, store, builder, builder, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 		assert.NoError(t, syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), true))
 	})
 
@@ -203,7 +203,7 @@ func TestFarFutureTipsets(t *testing.T) {
 		genesis := builder.RequireTipSet(store.GetHead())
 		farHead := builder.AppendManyOn(chain.UntrustedChainHeightLimit+1, genesis)
 
-		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, builder, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
+		syncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, &chain.FakeChainSelector{}, store, builder, builder, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 		err := syncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), farHead.Key(), heightFromTip(t, farHead)), false)
 		assert.Error(t, err)
 	})
@@ -221,7 +221,7 @@ func TestNoUncessesaryFetch(t *testing.T) {
 	// A new syncer unable to fetch blocks from the network can handle a tipset that's already
 	// in the store and linked to genesis.
 	emptyFetcher := chain.NewBuilder(t, address.Undef)
-	newSyncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, store, builder, emptyFetcher, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
+	newSyncer := chain.NewSyncer(&chain.FakeStateEvaluator{}, &chain.FakeChainSelector{}, store, builder, emptyFetcher, chain.NewStatusReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 	assert.NoError(t, newSyncer.HandleNewTipSet(ctx, types.NewChainInfo(peer.ID(""), head.Key(), heightFromTip(t, head)), true))
 }
 
@@ -471,7 +471,8 @@ func setup(ctx context.Context, t *testing.T) (*chain.Builder, *chain.Store, *ch
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but
 	// *not* as the store, to which the syncer must ensure to put blocks.
 	eval := &chain.FakeStateEvaluator{}
-	syncer := chain.NewSyncer(eval, store, builder, builder, sr, th.NewFakeClock(time.Unix(1234567890, 0)))
+	sel := &chain.FakeChainSelector{}
+	syncer := chain.NewSyncer(eval, sel, store, builder, builder, sr, th.NewFakeClock(time.Unix(1234567890, 0)))
 
 	return builder, store, syncer
 }

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -345,7 +345,7 @@ func (FakeStateBuilder) Weigh(tip types.TipSet, state cid.Cid) (uint64, error) {
 
 ///// State evaluator /////
 
-// FakeStateEvaluator is a syncStateEvaluator delegates to the FakeStateBuilder.
+// FakeStateEvaluator is a syncStateEvaluator that delegates to the FakeStateBuilder.
 type FakeStateEvaluator struct {
 	FakeStateBuilder
 }
@@ -355,8 +355,15 @@ func (e *FakeStateEvaluator) RunStateTransition(ctx context.Context, tip types.T
 	return e.ComputeState(stateID, messages)
 }
 
+///// Chain selector /////
+
+// FakeChainSelector is a syncChainSelector that delegates to the FakeStateBuilder
+type FakeChainSelector struct {
+	FakeStateBuilder
+}
+
 // IsHeavier compares chains weighed with StateBuilder.Weigh.
-func (e *FakeStateEvaluator) IsHeavier(ctx context.Context, a, b types.TipSet, aStateID, bStateID cid.Cid) (bool, error) {
+func (e *FakeChainSelector) IsHeavier(ctx context.Context, a, b types.TipSet, aStateID, bStateID cid.Cid) (bool, error) {
 	aw, err := e.Weigh(a, aStateID)
 	if err != nil {
 		return false, err

--- a/consensus/chain_selector.go
+++ b/consensus/chain_selector.go
@@ -1,0 +1,151 @@
+package consensus
+
+// This is to implement Expected Consensus protocol
+// See: https://github.com/filecoin-project/specs/blob/master/expected-consensus.md
+
+import (
+	"bytes"
+	"context"
+	"math/big"
+	"strings"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-hamt-ipld"
+
+	"github.com/filecoin-project/go-filecoin/state"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// ChainSelector weighs and compares chains according to the Storage Power
+// Consensus Protocol
+type ChainSelector struct {
+	cstore     *hamt.CborIpldStore
+	actorState SnapshotGenerator
+	genesisCid cid.Cid
+}
+
+// NewChainSelector is the constructor for chain selection module.
+func NewChainSelector(cs *hamt.CborIpldStore, actorState SnapshotGenerator, gCid cid.Cid) *ChainSelector {
+	return &ChainSelector{
+		cstore:     cs,
+		actorState: actorState,
+		genesisCid: gCid,
+	}
+}
+
+// Weight returns the expected consensus weight of this TipSet in uint64
+// encoded fixed point representation.
+func (c *ChainSelector) Weight(ctx context.Context, ts types.TipSet, pSt state.Tree) (uint64, error) {
+	ctx = log.Start(ctx, "Expected.Weight")
+	log.LogKV(ctx, "Weight", ts.String())
+	if ts.Len() == 1 && ts.At(0).Cid().Equals(c.genesisCid) {
+		return uint64(0), nil
+	}
+	// Compute parent weight.
+	parentW, err := ts.ParentWeight()
+	if err != nil {
+		return uint64(0), err
+	}
+
+	w, err := types.FixedToBig(parentW)
+	if err != nil {
+		return uint64(0), err
+	}
+
+	powerTableView := c.createPowerTableView(pSt)
+
+	// Each block in the tipset adds ECV + ECPrm * miner_power to parent weight.
+	totalBytes, err := powerTableView.Total(ctx)
+	if err != nil {
+		return uint64(0), err
+	}
+	floatTotalBytes := new(big.Float).SetInt(totalBytes.BigInt())
+	floatECV := new(big.Float).SetInt64(int64(ECV))
+	floatECPrM := new(big.Float).SetInt64(int64(ECPrM))
+	for _, blk := range ts.ToSlice() {
+		minerBytes, err := powerTableView.Miner(ctx, blk.Miner)
+		if err != nil {
+			return uint64(0), err
+		}
+		floatOwnBytes := new(big.Float).SetInt(minerBytes.BigInt())
+		wBlk := new(big.Float)
+		wBlk.Quo(floatOwnBytes, floatTotalBytes)
+		wBlk.Mul(wBlk, floatECPrM) // Power addition
+		wBlk.Add(wBlk, floatECV)   // Constant addition
+		w.Add(w, wBlk)
+	}
+	return types.BigToFixed(w)
+}
+
+// IsHeavier returns true if tipset a is heavier than tipset b, and false
+// vice versa.  In the rare case where two tipsets have the same weight ties
+// are broken by taking the tipset with the smallest ticket.  In the event that
+// tickets are the same, IsHeavier will break ties by comparing the
+// concatenation of block cids in the tipset.
+// TODO BLOCK CID CONCAT TIE BREAKER IS NOT IN THE SPEC AND SHOULD BE
+// EVALUATED BEFORE GETTING TO PRODUCTION.
+func (c *ChainSelector) IsHeavier(ctx context.Context, a, b types.TipSet, aStateID, bStateID cid.Cid) (bool, error) {
+	var aSt, bSt state.Tree
+	var err error
+	if aStateID.Defined() {
+		aSt, err = c.loadStateTree(ctx, aStateID)
+		if err != nil {
+			return false, err
+		}
+	}
+	if bStateID.Defined() {
+		bSt, err = c.loadStateTree(ctx, bStateID)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	aW, err := c.Weight(ctx, a, aSt)
+	if err != nil {
+		return false, err
+	}
+	bW, err := c.Weight(ctx, b, bSt)
+	if err != nil {
+		return false, err
+	}
+
+	// Without ties pass along the comparison.
+	if aW != bW {
+		return aW > bW, nil
+	}
+
+	// To break ties compare the min tickets.
+	aTicket, err := a.MinTicket()
+	if err != nil {
+		return false, err
+	}
+	bTicket, err := b.MinTicket()
+	if err != nil {
+		return false, err
+	}
+
+	cmp := bytes.Compare(bTicket.VRFProof, aTicket.VRFProof)
+	if cmp != 0 {
+		// a is heavier if b's ticket is greater than a's ticket.
+		return cmp == 1, nil
+	}
+
+	// Tie break on cid ids.
+	// TODO: I think this is drastically impacted by number of blocks in tipset
+	// i.e. bigger tipset is always heavier.  Not sure if this is ok, need to revist.
+	cmp = strings.Compare(a.String(), b.String())
+	if cmp == 0 {
+		// Caller is mistakenly calling on two identical tipsets.
+		return false, ErrUnorderedTipSets
+	}
+	return cmp == 1, nil
+}
+
+func (c *ChainSelector) createPowerTableView(st state.Tree) PowerTableView {
+	snapshot := c.actorState.StateTreeSnapshot(st, nil)
+	return NewPowerTableView(snapshot)
+}
+
+func (c *ChainSelector) loadStateTree(ctx context.Context, id cid.Cid) (state.Tree, error) {
+	return state.LoadStateTree(ctx, c.cstore, id)
+}

--- a/consensus/expected.go
+++ b/consensus/expected.go
@@ -4,10 +4,8 @@ package consensus
 // See: https://github.com/filecoin-project/specs/blob/master/expected-consensus.md
 
 import (
-	"bytes"
 	"context"
 	"math/big"
-	"strings"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -146,114 +144,6 @@ func NewExpected(cs *hamt.CborIpldStore, bs blockstore.Blockstore, processor Pro
 // BlockTime returns the block time used by the consensus protocol.
 func (c *Expected) BlockTime() time.Duration {
 	return c.blockTime
-}
-
-// Weight returns the EC weight of this TipSet in uint64 encoded fixed point
-// representation.
-func (c *Expected) Weight(ctx context.Context, ts types.TipSet, pSt state.Tree) (uint64, error) {
-	ctx = log.Start(ctx, "Expected.Weight")
-	log.LogKV(ctx, "Weight", ts.String())
-	if ts.Len() == 1 && ts.At(0).Cid().Equals(c.genesisCid) {
-		return uint64(0), nil
-	}
-	// Compute parent weight.
-	parentW, err := ts.ParentWeight()
-	if err != nil {
-		return uint64(0), err
-	}
-
-	w, err := types.FixedToBig(parentW)
-	if err != nil {
-		return uint64(0), err
-	}
-
-	powerTableView := c.createPowerTableView(pSt)
-
-	// Each block in the tipset adds ECV + ECPrm * miner_power to parent weight.
-	totalBytes, err := powerTableView.Total(ctx)
-	if err != nil {
-		return uint64(0), err
-	}
-	floatTotalBytes := new(big.Float).SetInt(totalBytes.BigInt())
-	floatECV := new(big.Float).SetInt64(int64(ECV))
-	floatECPrM := new(big.Float).SetInt64(int64(ECPrM))
-	for _, blk := range ts.ToSlice() {
-		minerBytes, err := powerTableView.Miner(ctx, blk.Miner)
-		if err != nil {
-			return uint64(0), err
-		}
-		floatOwnBytes := new(big.Float).SetInt(minerBytes.BigInt())
-		wBlk := new(big.Float)
-		wBlk.Quo(floatOwnBytes, floatTotalBytes)
-		wBlk.Mul(wBlk, floatECPrM) // Power addition
-		wBlk.Add(wBlk, floatECV)   // Constant addition
-		w.Add(w, wBlk)
-	}
-	return types.BigToFixed(w)
-}
-
-// IsHeavier returns true if tipset a is heavier than tipset b, and false
-// vice versa.  In the rare case where two tipsets have the same weight ties
-// are broken by taking the tipset with the smallest ticket.  In the event that
-// tickets are the same, IsHeavier will break ties by comparing the
-// concatenation of block cids in the tipset.
-// TODO BLOCK CID CONCAT TIE BREAKER IS NOT IN THE SPEC AND SHOULD BE
-// EVALUATED BEFORE GETTING TO PRODUCTION.
-func (c *Expected) IsHeavier(ctx context.Context, a, b types.TipSet, aStateID, bStateID cid.Cid) (bool, error) {
-	var aSt, bSt state.Tree
-	var err error
-	if aStateID.Defined() {
-		aSt, err = c.loadStateTree(ctx, aStateID)
-		if err != nil {
-			return false, err
-		}
-	}
-	if bStateID.Defined() {
-		bSt, err = c.loadStateTree(ctx, bStateID)
-		if err != nil {
-			return false, err
-		}
-	}
-
-	aW, err := c.Weight(ctx, a, aSt)
-	if err != nil {
-		return false, err
-	}
-	bW, err := c.Weight(ctx, b, bSt)
-	if err != nil {
-		return false, err
-	}
-
-	// Without ties pass along the comparison.
-	if aW != bW {
-		return aW > bW, nil
-	}
-
-	// To break ties compare the min tickets.
-	aTicket, err := a.MinTicket()
-	if err != nil {
-		return false, err
-	}
-	bTicket, err := b.MinTicket()
-	if err != nil {
-		return false, err
-	}
-
-	cmp := bytes.Compare(bTicket.VRFProof, aTicket.VRFProof)
-	if cmp != 0 {
-		// a is heavier if b's ticket is greater than a's ticket.
-		return cmp == 1, nil
-	}
-
-	// Tie break on cid ids.
-	// TODO: I think this is drastically impacted by number of blocks in tipset
-	// i.e. bigger tipset is always heavier.  Not sure if this is ok, need to revist.
-	cmp = strings.Compare(a.String(), b.String())
-	if cmp == 0 {
-		// Caller is mistakenly calling on two identical tipsets.
-		return false, ErrUnorderedTipSets
-	}
-	return cmp == 1, nil
 }
 
 // RunStateTransition applies the messages in a tipset to a state, and persists that new state.

--- a/consensus/protocol.go
+++ b/consensus/protocol.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/ipfs/go-cid"
 
-	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -25,13 +24,6 @@ import (
 // the most theoretically obvious or pleasing and should not be considered
 // finalized.
 type Protocol interface {
-	// Weight returns the weight given to the input ts by this consensus protocol.
-	Weight(ctx context.Context, ts types.TipSet, pSt state.Tree) (uint64, error)
-
-	// IsHeaver returns 1 if tipset a is heavier than tipset b and -1 if
-	// tipset b is heavier than tipset a.
-	IsHeavier(ctx context.Context, a, b types.TipSet, aStateID, bStateID cid.Cid) (bool, error)
-
 	// RunStateTransition returns the state root CID resulting from applying the input ts to the
 	// prior `stateID`.  It returns an error if the transition is invalid.
 	RunStateTransition(ctx context.Context, ts types.TipSet, tsMessages [][]*types.SignedMessage, tsReceipts [][]*types.MessageReceipt, ancestors []types.TipSet, stateID cid.Cid) (cid.Cid, error)

--- a/node/chain_submodule.go
+++ b/node/chain_submodule.go
@@ -13,12 +13,14 @@ import (
 
 // ChainSubmodule enhances the `Node` with chain capabilities.
 type ChainSubmodule struct {
-	BlockSub     pubsub.Subscription
-	Consensus    consensus.Protocol
-	ChainReader  nodeChainReader
-	MessageStore *chain.MessageStore
-	Syncer       nodeChainSyncer
-	ActorState   *consensus.ActorStateStore
+	BlockSub      pubsub.Subscription
+	Consensus     consensus.Protocol
+	ChainSelector nodeChainSelector
+	ChainReader   nodeChainReader
+	MessageStore  *chain.MessageStore
+	Syncer        nodeChainSyncer
+	ActorState    *consensus.ActorStateStore
+
 	// HeavyTipSetCh is a subscription to the heaviest tipset topic on the chain.
 	// https://github.com/filecoin-project/go-filecoin/issues/2309
 	HeaviestTipSetCh chan interface{}

--- a/node/helpers.go
+++ b/node/helpers.go
@@ -31,6 +31,11 @@ type nodeChainSyncer interface {
 	Status() chain.Status
 }
 
+type nodeChainSelector interface {
+	Weight(context.Context, types.TipSet, state.Tree) (uint64, error)
+	IsHeavier(ctx context.Context, a, b types.TipSet, aStateID, bStateID cid.Cid) (bool, error)
+}
+
 // storageFaultSlasher is the interface for needed FaultSlasher functionality
 type storageFaultSlasher interface {
 	OnNewHeaviestTipSet(context.Context, types.TipSet) error

--- a/node/node.go
+++ b/node/node.go
@@ -801,13 +801,13 @@ func (node *Node) getWeight(ctx context.Context, ts types.TipSet) (uint64, error
 	}
 	// TODO handle genesis cid more gracefully
 	if parent.Len() == 0 {
-		return node.Chain.Consensus.Weight(ctx, ts, nil)
+		return node.Chain.ChainSelector.Weight(ctx, ts, nil)
 	}
 	pSt, err := node.Chain.ChainReader.GetTipSetState(ctx, parent)
 	if err != nil {
 		return uint64(0), err
 	}
-	return node.Chain.Consensus.Weight(ctx, ts, pSt)
+	return node.Chain.ChainSelector.Weight(ctx, ts, pSt)
 }
 
 // getAncestors is the default GetAncestors function for the mining worker.


### PR DESCRIPTION
In preparation for the weight protocol upgrade this PR refactors the consensus component by moving the chain selection logic into its own object.  It also removes TestTipSetWeightDeep.  A modern version of this test is introduced in a later PR.