### PR TITLE
Separate BLS and Secp messages in block header.

### DIFF
--- a/chain/message_store.go
+++ b/chain/message_store.go
@@ -49,7 +49,7 @@ func (ms *MessageStore) LoadMessages(ctx context.Context, meta types.TxMeta) ([]
 	err = ms.ipldStore.Get(ctx, meta.BLSRoot, &bls)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to load bls messages %s", meta.BLSRoot.String())
-	}	
+	}
 	return []*types.SignedMessage(secp), []*types.SignedMessage(bls), nil
 }
 
@@ -70,7 +70,7 @@ func (ms *MessageStore) StoreMessages(ctx context.Context, secpMessages, blsMess
 	if err != nil {
 		return ret, err
 	}
-	
+
 	ret.SecpRoot = secpRoot
 	ret.BLSRoot = blsRoot
 	return ret, nil

--- a/chain/message_store.go
+++ b/chain/message_store.go
@@ -13,14 +13,14 @@ import (
 // MessageProvider is an interface exposing the load methods of the
 // MessageStore.
 type MessageProvider interface {
-	LoadMessages(context.Context, cid.Cid) ([]*types.SignedMessage, error)
+	LoadMessages(context.Context, types.TxMeta) ([]*types.SignedMessage, []*types.SignedMessage, error)
 	LoadReceipts(context.Context, cid.Cid) ([]*types.MessageReceipt, error)
 }
 
 // MessageWriter is an interface exposing the write methods of the
 // MessageStore.
 type MessageWriter interface {
-	StoreMessages(context.Context, []*types.SignedMessage) (cid.Cid, error)
+	StoreMessages(ctx context.Context, secpMessages, blsMessages []*types.SignedMessage) (types.TxMeta, error)
 	StoreReceipts(context.Context, []*types.MessageReceipt) (cid.Cid, error)
 }
 
@@ -38,23 +38,42 @@ func NewMessageStore(cst *hamt.CborIpldStore) *MessageStore {
 
 // LoadMessages loads the signed messages in the collection with cid c from ipld
 // storage.
-func (ms *MessageStore) LoadMessages(ctx context.Context, c cid.Cid) ([]*types.SignedMessage, error) {
+func (ms *MessageStore) LoadMessages(ctx context.Context, meta types.TxMeta) ([]*types.SignedMessage, []*types.SignedMessage, error) {
 	// TODO #1324 message collection shouldn't be a slice
-	var out types.MessageCollection
-	err := ms.ipldStore.Get(ctx, c, &out)
+	var secp types.MessageCollection
+	err := ms.ipldStore.Get(ctx, meta.SecpRoot, &secp)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load messages %s", c.String())
+		return nil, nil, errors.Wrapf(err, "failed to load secp messages %s", meta.SecpRoot.String())
 	}
-	return []*types.SignedMessage(out), nil
+	var bls types.MessageCollection
+	err = ms.ipldStore.Get(ctx, meta.BLSRoot, &bls)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to load bls messages %s", meta.BLSRoot.String())
+	}	
+	return []*types.SignedMessage(secp), []*types.SignedMessage(bls), nil
 }
 
 // StoreMessages puts the input signed messages to a collection and then writes
 // this collection to ipld storage.  The cid of the collection is returned.
-func (ms *MessageStore) StoreMessages(ctx context.Context, msgs []*types.SignedMessage) (cid.Cid, error) {
+func (ms *MessageStore) StoreMessages(ctx context.Context, secpMessages, blsMessages []*types.SignedMessage) (types.TxMeta, error) {
 	// For now the collection is just a slice (cbor array)
 	// TODO #1324 put these messages in a merkelized collection
-	msgCollection := types.MessageCollection(msgs)
-	return ms.ipldStore.Put(ctx, msgCollection)
+	var ret types.TxMeta
+	secpMsgCollection := types.MessageCollection(secpMessages)
+	secpRoot, err := ms.ipldStore.Put(ctx, secpMsgCollection)
+	if err != nil {
+		return ret, err
+	}
+
+	blsMsgCollection := types.MessageCollection(blsMessages)
+	blsRoot, err := ms.ipldStore.Put(ctx, blsMsgCollection)
+	if err != nil {
+		return ret, err
+	}
+	
+	ret.SecpRoot = secpRoot
+	ret.BLSRoot = blsRoot
+	return ret, nil
 }
 
 // LoadReceipts loads the signed messages in the collection with cid c from ipld

--- a/chain/message_store_test.go
+++ b/chain/message_store_test.go
@@ -31,10 +31,10 @@ func TestMessageStoreMessagesHappy(t *testing.T) {
 	}
 
 	ms := chain.NewMessageStore(hamt.NewCborStore())
-	msgsCid, err := ms.StoreMessages(ctx, msgs)
+	msgsCid, err := ms.StoreMessages(ctx, msgs, []*types.SignedMessage{})
 	assert.NoError(t, err)
 
-	rtMsgs, err := ms.LoadMessages(ctx, msgsCid)
+	rtMsgs, _, err := ms.LoadMessages(ctx, msgsCid)
 	assert.NoError(t, err)
 
 	assert.Equal(t, msgs, rtMsgs)

--- a/chain/syncer.go
+++ b/chain/syncer.go
@@ -169,7 +169,7 @@ func (syncer *Syncer) syncOne(ctx context.Context, grandParent, parent, next typ
 	var nextReceipts [][]*types.MessageReceipt
 	for i := 0; i < next.Len(); i++ {
 		blk := next.At(i)
-		msgs, err := syncer.messageProvider.LoadMessages(ctx, blk.Messages)
+		msgs, err := syncer.messageProvider.LoadMessages(ctx, blk.Messages.SecpMessages)
 		if err != nil {
 			return errors.Wrapf(err, "syncing tip %s failed loading message list %s for block %s", next.Key(), blk.Messages, blk.Cid())
 		}

--- a/chain/syncer.go
+++ b/chain/syncer.go
@@ -169,7 +169,7 @@ func (syncer *Syncer) syncOne(ctx context.Context, grandParent, parent, next typ
 	var nextReceipts [][]*types.MessageReceipt
 	for i := 0; i < next.Len(); i++ {
 		blk := next.At(i)
-		msgs, err := syncer.messageProvider.LoadMessages(ctx, blk.Messages.SecpMessages)
+		secpMsgs, _, err := syncer.messageProvider.LoadMessages(ctx, blk.Messages)
 		if err != nil {
 			return errors.Wrapf(err, "syncing tip %s failed loading message list %s for block %s", next.Key(), blk.Messages, blk.Cid())
 		}
@@ -177,7 +177,7 @@ func (syncer *Syncer) syncOne(ctx context.Context, grandParent, parent, next typ
 		if err != nil {
 			return errors.Wrapf(err, "syncing tip %s failed loading receipts list %s for block %s", next.Key(), blk.MessageReceipts, blk.Cid())
 		}
-		nextMessages = append(nextMessages, msgs)
+		nextMessages = append(nextMessages, secpMsgs)
 		nextReceipts = append(nextReceipts, rcpts)
 	}
 

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -32,7 +32,7 @@ type Builder struct {
 	seq          uint64 // For unique tickets
 
 	blocks   map[cid.Cid]*types.Block
-	messages map[cid.Cid][]*types.SignedMessage
+	messages map[types.TxMeta][]*types.SignedMessage
 	receipts map[cid.Cid][]*types.MessageReceipt
 	// Cache of the state root CID computed for each tipset key.
 	tipStateCids map[string]cid.Cid
@@ -63,12 +63,12 @@ func NewBuilderWithState(t *testing.T, miner address.Address, sb StateBuilder) *
 		stateBuilder: sb,
 		blocks:       make(map[cid.Cid]*types.Block),
 		tipStateCids: make(map[string]cid.Cid),
-		messages:     make(map[cid.Cid][]*types.SignedMessage),
+		messages:     make(map[types.TxMeta][]*types.SignedMessage),
 		receipts:     make(map[cid.Cid][]*types.MessageReceipt),
 	}
 
-	b.messages[types.EmptyMessagesCID] = []*types.SignedMessage{}
-	b.receipts[types.EmptyReceiptsCID] = []*types.MessageReceipt{}
+	b.messages[types.TxMeta{types.EmptyMessagesCID, types.EmptyMessagesCID}] = []*types.SignedMessage{}
+	b.receipts[types.EmptyMessagesCID] = []*types.MessageReceipt{}
 
 	nullState := types.CidFromString(t, "null")
 	b.tipStateCids[types.NewTipSetKey().String()] = nullState
@@ -179,7 +179,7 @@ func (f *Builder) Build(parent types.TipSet, width int, build func(b *BlockBuild
 			ParentWeight:    types.Uint64(parentWeight),
 			Parents:         parent.Key(),
 			Height:          height,
-			Messages:        types.EmptyMessagesCID,
+			Messages:        types.TxMeta{types.EmptyMessagesCID, types.EmptyMessagesCID},
 			MessageReceipts: types.EmptyReceiptsCID,
 			// Omitted fields below
 			//StateRoot:       stateRoot,
@@ -259,7 +259,7 @@ type BlockBuilder struct {
 	block *types.Block
 	t     *testing.T
 	// These maps should be set to share data with the builder.
-	messages map[cid.Cid][]*types.SignedMessage
+	messages map[types.TxMeta][]*types.SignedMessage
 	receipts map[cid.Cid][]*types.MessageReceipt
 }
 
@@ -283,12 +283,13 @@ func (bb *BlockBuilder) IncHeight(nullBlocks types.Uint64) {
 func (bb *BlockBuilder) AddMessages(msgs []*types.SignedMessage, rcpts []*types.MessageReceipt) {
 	cM, err := makeCid(msgs)
 	require.NoError(bb.t, err)
-	bb.messages[cM] = msgs
+	meta := types.TxMeta{SecpRoot: cM, BLSRoot: types.EmptyMessagesCID}
+	bb.messages[meta] = msgs
 	cR, err := makeCid(rcpts)
 	require.NoError(bb.t, err)
 	bb.receipts[cR] = rcpts
 
-	bb.block.Messages = cM
+	bb.block.Messages = meta
 	bb.block.MessageReceipts = cR
 }
 
@@ -476,12 +477,12 @@ func (f *Builder) RequireTipSets(head types.TipSetKey, count int) []types.TipSet
 }
 
 // LoadMessages returns the message collections tracked by the builder.
-func (f *Builder) LoadMessages(ctx context.Context, c cid.Cid) ([]*types.SignedMessage, error) {
-	msgs, ok := f.messages[c]
+func (f *Builder) LoadMessages(ctx context.Context, meta types.TxMeta) ([]*types.SignedMessage, []*types.SignedMessage, error) {
+	msgs, ok := f.messages[meta]
 	if !ok {
-		return nil, errors.Errorf("no message for %s", c)
+		return nil, nil, errors.Errorf("no message for %s", meta.SecpRoot)
 	}
-	return msgs, nil
+	return msgs, []*types.SignedMessage{}, nil
 }
 
 // LoadReceipts returns the message collections tracked by the builder.

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -67,7 +67,7 @@ func NewBuilderWithState(t *testing.T, miner address.Address, sb StateBuilder) *
 		receipts:     make(map[cid.Cid][]*types.MessageReceipt),
 	}
 
-	b.messages[types.TxMeta{types.EmptyMessagesCID, types.EmptyMessagesCID}] = []*types.SignedMessage{}
+	b.messages[types.TxMeta{SecpRoot: types.EmptyMessagesCID, BLSRoot: types.EmptyMessagesCID}] = []*types.SignedMessage{}
 	b.receipts[types.EmptyMessagesCID] = []*types.MessageReceipt{}
 
 	nullState := types.CidFromString(t, "null")
@@ -179,7 +179,7 @@ func (f *Builder) Build(parent types.TipSet, width int, build func(b *BlockBuild
 			ParentWeight:    types.Uint64(parentWeight),
 			Parents:         parent.Key(),
 			Height:          height,
-			Messages:        types.TxMeta{types.EmptyMessagesCID, types.EmptyMessagesCID},
+			Messages:        types.TxMeta{SecpRoot: types.EmptyMessagesCID, BLSRoot: types.EmptyMessagesCID},
 			MessageReceipts: types.EmptyReceiptsCID,
 			// Omitted fields below
 			//StateRoot:       stateRoot,

--- a/commands/message_daemon_test.go
+++ b/commands/message_daemon_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -124,7 +123,7 @@ func TestMessageSendBlockGasLimit(t *testing.T) {
 
 	doubleTheBlockGasLimit := strconv.Itoa(int(types.BlockGasLimit) * 2)
 	halfTheBlockGasLimit := strconv.Itoa(int(types.BlockGasLimit) / 2)
-	result := struct{ Messages cid.Cid }{}
+	result := struct{ Messages types.TxMeta }{}
 
 	t.Run("when the gas limit is above the block limit, the message fails", func(t *testing.T) {
 		d.RunFail("block gas limit",
@@ -146,7 +145,7 @@ func TestMessageSendBlockGasLimit(t *testing.T) {
 		blockInfo := d.RunSuccess("show", "header", blockCid, "--enc", "json").ReadStdoutTrimNewlines()
 
 		require.NoError(t, json.Unmarshal([]byte(blockInfo), &result))
-		assert.NotEmpty(t, result.Messages, "msg under the block gas limit passes validation and is run in the block")
+		assert.NotEmpty(t, result.Messages.SecpRoot, "msg under the block gas limit passes validation and is run in the block")
 	})
 }
 

--- a/commands/show.go
+++ b/commands/show.go
@@ -157,7 +157,10 @@ the filecoin block header.`,
 			return err
 		}
 
-		messages, err := GetPorcelainAPI(env).ChainGetMessages(req.Context, cid)
+		messages, err := GetPorcelainAPI(env).ChainGetMessages(
+			req.Context,
+			types.TxMeta{SecpRoot: cid, BLSRoot: types.EmptyMessagesCID},
+		)
 		if err != nil {
 			return err
 		}

--- a/commands/show_test.go
+++ b/commands/show_test.go
@@ -177,7 +177,7 @@ func TestBlockDaemon(t *testing.T) {
 		assert.Equal(t, uint8(0), blockGetBlock.Receipts[0].ExitCode)
 
 		// Full block matches show messages
-		messagesGetLine := th.RunSuccessFirstLine(d, "show", "messages", blockGetBlock.Header.Messages.String(), "--enc", "json")
+		messagesGetLine := th.RunSuccessFirstLine(d, "show", "messages", blockGetBlock.Header.Messages.SecpRoot.String(), "--enc", "json")
 		var messages []*types.SignedMessage
 		require.NoError(t, json.Unmarshal([]byte(messagesGetLine), &messages))
 		assert.Equal(t, blockGetBlock.Messages, messages)

--- a/consensus/genesis.go
+++ b/consensus/genesis.go
@@ -203,7 +203,7 @@ func MakeGenesisFunc(opts ...GenOption) GenesisInitFunc {
 
 		genesis := &types.Block{
 			StateRoot:       c,
-			Messages:        emptyMessagesCid,
+			Messages:        types.TxMeta{emptyMessagesCid, emptyMessagesCid},
 			MessageReceipts: emptyReceiptsCid,
 			Tickets:         []types.Ticket{{VRFProof: []byte{0xec}, VDFResult: []byte{0xec}}},
 		}

--- a/consensus/genesis.go
+++ b/consensus/genesis.go
@@ -203,7 +203,7 @@ func MakeGenesisFunc(opts ...GenOption) GenesisInitFunc {
 
 		genesis := &types.Block{
 			StateRoot:       c,
-			Messages:        types.TxMeta{emptyMessagesCid, emptyMessagesCid},
+			Messages:        types.TxMeta{SecpRoot: emptyMessagesCid, BLSRoot: emptyMessagesCid},
 			MessageReceipts: emptyReceiptsCid,
 			Tickets:         []types.Ticket{{VRFProof: []byte{0xec}, VDFResult: []byte{0xec}}},
 		}

--- a/consensus/processor_test.go
+++ b/consensus/processor_test.go
@@ -133,7 +133,7 @@ func TestProcessTipSetSuccess(t *testing.T) {
 		Height:    20,
 		StateRoot: stCid,
 		Miner:     minerAddr,
-		Messages:  cidGetter(),
+		Messages:  types.TxMeta{SecpRoot: cidGetter(), BLSRoot: types.EmptyMessagesCID},
 		Tickets:   []types.Ticket{{VRFProof: []byte{0x1}}},
 	}
 
@@ -145,7 +145,7 @@ func TestProcessTipSetSuccess(t *testing.T) {
 		Height:    20,
 		StateRoot: stCid,
 		Miner:     minerAddr,
-		Messages:  cidGetter(),
+		Messages:  types.TxMeta{SecpRoot: cidGetter(), BLSRoot: types.EmptyMessagesCID},
 		Tickets:   []types.Ticket{{VRFProof: []byte{0x2}}},
 	}
 

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -168,7 +168,7 @@ func GenGen(ctx context.Context, cfg *GenesisCfg, cst *hamt.CborIpldStore, bs bl
 
 	geneblk := &types.Block{
 		StateRoot:       stateRoot,
-		Messages:        types.TxMeta{emptyMessagesCid, emptyMessagesCid},
+		Messages:        types.TxMeta{SecpRoot: emptyMessagesCid, BLSRoot: emptyMessagesCid},
 		MessageReceipts: emptyReceiptsCid,
 		Tickets:         []types.Ticket{{VRFProof: []byte{0xec}, VDFResult: []byte{0xec}}},
 	}

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -168,7 +168,7 @@ func GenGen(ctx context.Context, cfg *GenesisCfg, cst *hamt.CborIpldStore, bs bl
 
 	geneblk := &types.Block{
 		StateRoot:       stateRoot,
-		Messages:        emptyMessagesCid,
+		Messages:        types.TxMeta{emptyMessagesCid, emptyMessagesCid},
 		MessageReceipts: emptyReceiptsCid,
 		Tickets:         []types.Ticket{{VRFProof: []byte{0xec}, VDFResult: []byte{0xec}}},
 	}

--- a/message/policy.go
+++ b/message/policy.go
@@ -65,11 +65,11 @@ func (p *DefaultQueuePolicy) HandleNewHead(ctx context.Context, target PolicyTar
 	chain.Reverse(newTips)
 	for _, tipset := range newTips {
 		for i := 0; i < tipset.Len(); i++ {
-			msgs, err := p.messageProvider.LoadMessages(ctx, tipset.At(i).Messages)
+			secpMsgs, _, err := p.messageProvider.LoadMessages(ctx, tipset.At(i).Messages)
 			if err != nil {
 				return err
 			}
-			for _, minedMsg := range msgs {
+			for _, minedMsg := range secpMsgs {
 				removed, found, err := target.RemoveNext(ctx, minedMsg.From, uint64(minedMsg.Nonce))
 				if err != nil {
 					return err
@@ -93,11 +93,11 @@ func (p *DefaultQueuePolicy) HandleNewHead(ctx context.Context, target PolicyTar
 	// Traverse these in descending height order.
 	for _, tipset := range oldTips {
 		for i := 0; i < tipset.Len(); i++ {
-			msgs, err := p.messageProvider.LoadMessages(ctx, tipset.At(i).Messages)
+			secpMsgs, _, err := p.messageProvider.LoadMessages(ctx, tipset.At(i).Messages)
 			if err != nil {
 				return err
 			}
-			for _, restoredMsg := range msgs {
+			for _, restoredMsg := range secpMsgs {
 				err := target.Requeue(ctx, restoredMsg, chainHeight)
 				if err != nil {
 					return err

--- a/message/policy_test.go
+++ b/message/policy_test.go
@@ -224,7 +224,7 @@ func TestMessageQueuePolicy(t *testing.T) {
 				types.EmptyReceipts(1),
 			)
 			b.SetTicket([]byte{1})
-			b.SetTimestamp(1)
+			b.SetTimestamp(2)
 		})
 		b2 := blocks.BuildOnBlock(root, func(b *chain.BlockBuilder) {
 			b.AddMessages(
@@ -232,7 +232,7 @@ func TestMessageQueuePolicy(t *testing.T) {
 				types.EmptyReceipts(1),
 			)
 			b.SetTicket([]byte{2})
-			b.SetTimestamp(6) // Tweak if necessary to force CID ordering opposite ticket ordering.
+			b.SetTimestamp(17) // Tweak if necessary to force CID ordering opposite ticket ordering.
 		})
 
 		assert.True(t, bytes.Compare(b1.Cid().Bytes(), b2.Cid().Bytes()) > 0)

--- a/metrics/heartbeat_test.go
+++ b/metrics/heartbeat_test.go
@@ -191,7 +191,7 @@ func mustMakeTipset(t *testing.T, height types.Uint64) types.TipSet {
 		ParentWeight:    0,
 		Height:          height,
 		MessageReceipts: types.EmptyMessagesCID,
-		Messages:        types.EmptyReceiptsCID,
+		Messages:        types.TxMeta{SecpRoot: types.EmptyReceiptsCID, BLSRoot: types.EmptyMessagesCID},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/mining/block_generate.go
+++ b/mining/block_generate.go
@@ -89,7 +89,7 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 	}
 
 	// Persist messages to ipld storage
-	msgsCid, err := w.messageStore.StoreMessages(ctx, minedMessages)
+	txMeta, err := w.messageStore.StoreMessages(ctx, minedMessages, []*types.SignedMessage{})
 	if err != nil {
 		return nil, errors.Wrap(err, "error persisting messages")
 	}
@@ -101,7 +101,7 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 	next := &types.Block{
 		Miner:           w.minerAddr,
 		Height:          types.Uint64(blockHeight),
-		Messages:        types.TxMeta{SecpRoot: msgsCid, BLSRoot: types.EmptyMessagesCID},
+		Messages:        txMeta,
 		MessageReceipts: rcptsCid,
 		Parents:         baseTipSet.Key(),
 		ParentWeight:    types.Uint64(weight),

--- a/mining/block_generate.go
+++ b/mining/block_generate.go
@@ -101,7 +101,7 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 	next := &types.Block{
 		Miner:           w.minerAddr,
 		Height:          types.Uint64(blockHeight),
-		Messages:        msgsCid,
+		Messages:        types.TxMeta{SecpRoot: msgsCid, BLSRoot: types.EmptyMessagesCID},
 		MessageReceipts: rcptsCid,
 		Parents:         baseTipSet.Key(),
 		ParentWeight:    types.Uint64(weight),

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -312,7 +312,7 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, types.EmptyMessagesCID, blk.Messages)
+	assert.Equal(t, types.EmptyMessagesCID, blk.Messages.SecpRoot)
 	assert.Equal(t, types.EmptyReceiptsCID, blk.MessageReceipts)
 	assert.Equal(t, types.Uint64(101), blk.Height)
 	assert.Equal(t, types.Uint64(120), blk.ParentWeight)
@@ -416,7 +416,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 
 	// message and receipts can be loaded from message store and have
 	// length 1.
-	msgs, err := messages.LoadMessages(ctx, blk.Messages)
+	msgs, _, err := messages.LoadMessages(ctx, blk.Messages)
 	require.NoError(t, err)
 	assert.Len(t, msgs, 1) // This is the good message
 	rcpts, err := messages.LoadReceipts(ctx, blk.MessageReceipts)
@@ -538,7 +538,7 @@ func TestGenerateWithoutMessages(t *testing.T) {
 
 	assert.Len(t, pool.Pending(), 0) // This is the temporary failure.
 
-	assert.Equal(t, types.MessageCollection{}.Cid(), blk.Messages)
+	assert.Equal(t, types.MessageCollection{}.Cid(), blk.Messages.SecpRoot)
 	assert.Equal(t, types.ReceiptCollection{}.Cid(), blk.MessageReceipts)
 }
 

--- a/net/graphsync_fetcher.go
+++ b/net/graphsync_fetcher.go
@@ -314,7 +314,7 @@ func (gsf *GraphSyncFetcher) loadAndVerify(ctx context.Context, key types.TipSet
 	}
 
 	err = gsf.loadAndVerifySubComponents(ctx, tip, incomplete,
-		func(blk *types.Block) cid.Cid { return blk.Messages }, func(rawBlock blocks.Block) error {
+		func(blk *types.Block) cid.Cid { return blk.Messages.SecpRoot }, func(rawBlock blocks.Block) error {
 			messages, err := types.DecodeMessages(rawBlock.RawData())
 			if err != nil {
 				return errors.Wrapf(err, "fetched data (cid %s) was not a message collection", rawBlock.Cid().String())

--- a/net/graphsync_fetcher.go
+++ b/net/graphsync_fetcher.go
@@ -148,7 +148,6 @@ func (gsf *GraphSyncFetcher) fetchFirstTipset(ctx context.Context, key types.Tip
 		if err != nil {
 			return types.UndefTipSet, err
 		}
-		fmt.Printf("verifiedTip: %v, blocksToFetch %v\n", verifiedTip, blocksToFetch)
 		if len(blocksToFetch) == 0 {
 			return verifiedTip, nil
 		}

--- a/net/graphsync_fetcher.go
+++ b/net/graphsync_fetcher.go
@@ -224,7 +224,7 @@ func (gsf *GraphSyncFetcher) fetchRemainingTipsets(ctx context.Context, starting
 // non-recursively
 func (gsf *GraphSyncFetcher) fetchBlocks(ctx context.Context, cids []cid.Cid, targetPeer peer.ID) error {
 	selector := gsf.ssb.ExploreFields(func(efsb selectorbuilder.ExploreFieldsSpecBuilder) {
-		efsb.Insert("messages", gsf.ssb.Matcher())
+		efsb.Insert("messages.secpRoot", gsf.ssb.Matcher())
 		efsb.Insert("messageReceipts", gsf.ssb.Matcher())
 	}).Node()
 	var wg sync.WaitGroup

--- a/net/graphsync_fetcher.go
+++ b/net/graphsync_fetcher.go
@@ -225,7 +225,9 @@ func (gsf *GraphSyncFetcher) fetchRemainingTipsets(ctx context.Context, starting
 // non-recursively
 func (gsf *GraphSyncFetcher) fetchBlocks(ctx context.Context, cids []cid.Cid, targetPeer peer.ID) error {
 	selector := gsf.ssb.ExploreFields(func(efsb selectorbuilder.ExploreFieldsSpecBuilder) {
-		efsb.Insert("messages", gsf.ssb.Matcher())
+		efsb.Insert("messages", gsf.ssb.ExploreFields(func(messagesSelector selectorbuilder.ExploreFieldsSpecBuilder) {
+			messagesSelector.Insert("secpRoot", gsf.ssb.Matcher())
+		}))
 		efsb.Insert("messageReceipts", gsf.ssb.Matcher())
 	}).Node()
 	var wg sync.WaitGroup
@@ -290,7 +292,9 @@ func (gsf *GraphSyncFetcher) fetchBlocksRecursively(ctx context.Context, baseCid
 		efsb.Insert("parents", gsf.ssb.ExploreUnion(
 			gsf.ssb.ExploreAll(
 				gsf.ssb.ExploreFields(func(efsb selectorbuilder.ExploreFieldsSpecBuilder) {
-					efsb.Insert("messages", gsf.ssb.Matcher())
+					efsb.Insert("messages", gsf.ssb.ExploreFields(func(messagesSelector selectorbuilder.ExploreFieldsSpecBuilder) {
+						messagesSelector.Insert("secpRoot", gsf.ssb.Matcher())
+					}))
 					efsb.Insert("messageReceipts", gsf.ssb.Matcher())
 				}),
 			),

--- a/net/graphsync_fetcher.go
+++ b/net/graphsync_fetcher.go
@@ -148,6 +148,7 @@ func (gsf *GraphSyncFetcher) fetchFirstTipset(ctx context.Context, key types.Tip
 		if err != nil {
 			return types.UndefTipSet, err
 		}
+		fmt.Printf("verifiedTip: %v, blocksToFetch %v\n", verifiedTip, blocksToFetch)
 		if len(blocksToFetch) == 0 {
 			return verifiedTip, nil
 		}
@@ -224,7 +225,7 @@ func (gsf *GraphSyncFetcher) fetchRemainingTipsets(ctx context.Context, starting
 // non-recursively
 func (gsf *GraphSyncFetcher) fetchBlocks(ctx context.Context, cids []cid.Cid, targetPeer peer.ID) error {
 	selector := gsf.ssb.ExploreFields(func(efsb selectorbuilder.ExploreFieldsSpecBuilder) {
-		efsb.Insert("messages.secpRoot", gsf.ssb.Matcher())
+		efsb.Insert("messages", gsf.ssb.Matcher())
 		efsb.Insert("messageReceipts", gsf.ssb.Matcher())
 	}).Node()
 	var wg sync.WaitGroup

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -147,8 +147,8 @@ func (api *API) ChainGetBlock(ctx context.Context, id cid.Cid) (*types.Block, er
 }
 
 // ChainGetMessages gets a message collection by CID
-func (api *API) ChainGetMessages(ctx context.Context, id cid.Cid) ([]*types.SignedMessage, error) {
-	return api.chain.GetMessages(ctx, id)
+func (api *API) ChainGetMessages(ctx context.Context, meta types.TxMeta) ([]*types.SignedMessage, error) {
+	return api.chain.GetMessages(ctx, meta)
 }
 
 // ChainGetReceipts gets a receipt collection by CID

--- a/plumbing/cst/chain_state.go
+++ b/plumbing/cst/chain_state.go
@@ -82,8 +82,12 @@ func (chn *ChainStateReadWriter) GetBlock(ctx context.Context, id cid.Cid) (*typ
 }
 
 // GetMessages gets a message collection by CID.
-func (chn *ChainStateReadWriter) GetMessages(ctx context.Context, id cid.Cid) ([]*types.SignedMessage, error) {
-	return chn.messageProvider.LoadMessages(ctx, id)
+func (chn *ChainStateReadWriter) GetMessages(ctx context.Context, meta types.TxMeta) ([]*types.SignedMessage, error) {
+	secp, _, err := chn.messageProvider.LoadMessages(ctx, meta)
+	if err != nil {
+		return []*types.SignedMessage{}, err
+	}
+	return secp, nil
 }
 
 // GetReceipts gets a receipt collection by CID.

--- a/plumbing/msg/waiter.go
+++ b/plumbing/msg/waiter.go
@@ -109,11 +109,11 @@ func (w *Waiter) findMessage(ctx context.Context, ts types.TipSet, msgCid cid.Ci
 		}
 		for i := 0; i < iterator.Value().Len(); i++ {
 			blk := iterator.Value().At(i)
-			msgs, err := w.messageProvider.LoadMessages(ctx, blk.Messages)
+			secpMsgs, _, err := w.messageProvider.LoadMessages(ctx, blk.Messages)
 			if err != nil {
 				return nil, false, err
 			}
-			for _, msg := range msgs {
+			for _, msg := range secpMsgs {
 				c, err := msg.Cid()
 				if err != nil {
 					return nil, false, err
@@ -152,11 +152,11 @@ func (w *Waiter) waitForMessage(ctx context.Context, ch <-chan interface{}, msgC
 			case types.TipSet:
 				for i := 0; i < raw.Len(); i++ {
 					blk := raw.At(i)
-					msgs, err := w.messageProvider.LoadMessages(ctx, blk.Messages)
+					secpMsgs, _, err := w.messageProvider.LoadMessages(ctx, blk.Messages)
 					if err != nil {
 						return nil, false, err
 					}
-					for _, msg := range msgs {
+					for _, msg := range secpMsgs {
 						c, err := msg.Cid()
 						if err != nil {
 							return nil, false, err
@@ -232,11 +232,11 @@ func (w *Waiter) receiptFromTipSet(ctx context.Context, msgCid cid.Cid, ts types
 	var tsMessages [][]*types.SignedMessage
 	for i := 0; i < ts.Len(); i++ {
 		blk := ts.At(i)
-		msgs, err := w.messageProvider.LoadMessages(ctx, blk.Messages)
+		secpMsgs, _, err := w.messageProvider.LoadMessages(ctx, blk.Messages)
 		if err != nil {
 			return nil, err
 		}
-		tsMessages = append(tsMessages, msgs)
+		tsMessages = append(tsMessages, secpMsgs)
 	}
 
 	res, err := consensus.NewDefaultProcessor().ProcessTipSet(ctx, st, vm.NewStorageMap(w.bs), ts, tsMessages, ancestors)
@@ -269,11 +269,11 @@ func (w *Waiter) msgIndexOfTipSet(ctx context.Context, msgCid cid.Cid, ts types.
 	duplicates := make(map[cid.Cid]struct{})
 	var msgCnt int
 	for i := 0; i < ts.Len(); i++ {
-		messages, err := w.messageProvider.LoadMessages(ctx, ts.At(i).Messages)
+		secpMsgs, _, err := w.messageProvider.LoadMessages(ctx, ts.At(i).Messages)
 		if err != nil {
 			return -1, err
 		}
-		for _, msg := range messages {
+		for _, msg := range secpMsgs {
 			c, err := msg.Cid()
 			if err != nil {
 				return -1, err

--- a/plumbing/msg/waiter_test.go
+++ b/plumbing/msg/waiter_test.go
@@ -172,7 +172,7 @@ func newChainWithMessages(store *hamt.CborIpldStore, msgStore *chain.MessageStor
 		height, _ = parents.Height()
 		height++
 	}
-	emptyMessagesCid, err := msgStore.StoreMessages(context.Background(), []*types.SignedMessage{})
+	emptyMessagesCid, err := msgStore.StoreMessages(context.Background(), []*types.SignedMessage{}, []*types.SignedMessage{})
 	if err != nil {
 		panic(err)
 	}
@@ -196,7 +196,7 @@ func newChainWithMessages(store *hamt.CborIpldStore, msgStore *chain.MessageStor
 			blocks = append(blocks, child)
 		}
 		for _, msgs := range tsMsgs {
-			msgsCid, err := msgStore.StoreMessages(context.Background(), msgs)
+			msgsCid, err := msgStore.StoreMessages(context.Background(), msgs, []*types.SignedMessage{})
 			if err != nil {
 				panic(err)
 			}

--- a/porcelain/chain.go
+++ b/porcelain/chain.go
@@ -20,7 +20,7 @@ func ChainHead(plumbing chainHeadPlumbing) (types.TipSet, error) {
 
 type fullBlockPlumbing interface {
 	ChainGetBlock(context.Context, cid.Cid) (*types.Block, error)
-	ChainGetMessages(context.Context, cid.Cid) ([]*types.SignedMessage, error)
+	ChainGetMessages(context.Context, types.TxMeta) ([]*types.SignedMessage, error)
 	ChainGetReceipts(context.Context, cid.Cid) ([]*types.MessageReceipt, error)
 }
 

--- a/tools/fast/series/wait_for_chain_message.go
+++ b/tools/fast/series/wait_for_chain_message.go
@@ -52,7 +52,7 @@ func WaitForChainMessage(ctx context.Context, node *fast.Filecoin, fn MsgSearchF
 
 func findMessageInBlockSlice(ctx context.Context, node *fast.Filecoin, blks []types.Block, fn MsgSearchFn) (*MsgInfo, error) {
 	for _, blk := range blks {
-		msgs, err := node.ShowMessages(ctx, blk.Messages)
+		msgs, err := node.ShowMessages(ctx, blk.Messages.SecpRoot)
 		if err != nil {
 			return nil, err
 		}

--- a/types/block.go
+++ b/types/block.go
@@ -36,7 +36,7 @@ type Block struct {
 
 	// Messages is the set of messages included in this block
 	// TODO: should be a merkletree-ish thing
-	Messages cid.Cid `json:"messages,omitempty" refmt:",omitempty"`
+	Messages TxMeta `json:"messages,omitempty" refmt:",omitempty"`
 
 	// StateRoot is a cid pointer to the state tree after application of the
 	// transactions state transitions.

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -64,7 +64,7 @@ func TestTriangleEncoding(t *testing.T) {
 			Miner:           newAddress(),
 			Tickets:         []Ticket{{VRFProof: []byte{0x01, 0x02, 0x03}}},
 			Height:          Uint64(2),
-			Messages:        CidFromString(t, "somecid"),
+			Messages:        TxMeta{SecpRoot: CidFromString(t, "somecid"), BLSRoot: EmptyMessagesCID},
 			MessageReceipts: CidFromString(t, "somecid"),
 			Parents:         NewTipSetKey(CidFromString(t, "somecid")),
 			ParentWeight:    Uint64(1000),
@@ -128,7 +128,7 @@ func TestDecodeBlock(t *testing.T) {
 			Tickets:         []Ticket{{VRFProof: []uint8{}}},
 			Parents:         NewTipSetKey(c1),
 			Height:          2,
-			Messages:        cM,
+			Messages:        TxMeta{SecpRoot: cM, BLSRoot: EmptyMessagesCID},
 			StateRoot:       c2,
 			MessageReceipts: cR,
 		}
@@ -212,7 +212,7 @@ func TestBlockJsonMarshal(t *testing.T) {
 	child.Parents = NewTipSetKey(parent.Cid())
 	child.StateRoot = parent.Cid()
 
-	child.Messages = CidFromString(t, "somecid")
+	child.Messages = TxMeta{SecpRoot: CidFromString(t, "somecid"), BLSRoot: EmptyMessagesCID}
 	child.MessageReceipts = CidFromString(t, "somecid")
 
 	marshalled, e1 := json.Marshal(&child)
@@ -221,7 +221,7 @@ func TestBlockJsonMarshal(t *testing.T) {
 
 	assert.Contains(t, str, child.Miner.String())
 	assert.Contains(t, str, parent.Cid().String())
-	assert.Contains(t, str, child.Messages.String())
+	assert.Contains(t, str, child.Messages.SecpRoot.String())
 	assert.Contains(t, str, child.MessageReceipts.String())
 
 	// marshal/unmarshal symmetry
@@ -242,7 +242,7 @@ func TestSignatureData(t *testing.T) {
 		Miner:           newAddress(),
 		Tickets:         []Ticket{{VRFProof: []byte{0x01, 0x02, 0x03}}},
 		Height:          Uint64(2),
-		Messages:        CidFromString(t, "somecid"),
+		Messages:        TxMeta{SecpRoot: CidFromString(t, "somecid"), BLSRoot: EmptyMessagesCID},
 		MessageReceipts: CidFromString(t, "somecid"),
 		Parents:         NewTipSetKey(CidFromString(t, "somecid")),
 		ParentWeight:    Uint64(1000),
@@ -256,7 +256,7 @@ func TestSignatureData(t *testing.T) {
 		Miner:           newAddress(),
 		Tickets:         []Ticket{{VRFProof: []byte{0x03, 0x01, 0x02}}},
 		Height:          Uint64(3),
-		Messages:        CidFromString(t, "someothercid"),
+		Messages:        TxMeta{SecpRoot: CidFromString(t, "someothercid"), BLSRoot: EmptyMessagesCID},
 		MessageReceipts: CidFromString(t, "someothercid"),
 		Parents:         NewTipSetKey(CidFromString(t, "someothercid")),
 		ParentWeight:    Uint64(1001),

--- a/types/message.go
+++ b/types/message.go
@@ -174,3 +174,9 @@ func (rC ReceiptCollection) ToNode() ipld.Node {
 
 	return obj
 }
+
+// TxMeta tracks the merkleroots of both secp and bls messages separately
+type TxMeta struct {
+	SecpRoot cid.Cid `json:"secpRoot"`
+	BLSRoot cid.Cid `json:"blsRoot"`
+}

--- a/types/message.go
+++ b/types/message.go
@@ -16,6 +16,7 @@ import (
 
 func init() {
 	cbor.RegisterCborType(Message{})
+	cbor.RegisterCborType(TxMeta{})
 }
 
 var (
@@ -179,4 +180,9 @@ func (rC ReceiptCollection) ToNode() ipld.Node {
 type TxMeta struct {
 	SecpRoot cid.Cid `json:"secpRoot"`
 	BLSRoot cid.Cid `json:"blsRoot"`
+}
+
+// String returns a readable printing string of TxMeta
+func (m TxMeta) String() string {
+	return fmt.Sprintf("secp: %s, bls: %s", m.SecpRoot.String(), m.BLSRoot.String())
 }

--- a/types/message.go
+++ b/types/message.go
@@ -179,7 +179,7 @@ func (rC ReceiptCollection) ToNode() ipld.Node {
 // TxMeta tracks the merkleroots of both secp and bls messages separately
 type TxMeta struct {
 	SecpRoot cid.Cid `json:"secpRoot"`
-	BLSRoot cid.Cid `json:"blsRoot"`
+	BLSRoot  cid.Cid `json:"blsRoot"`
 }
 
 // String returns a readable printing string of TxMeta

--- a/types/tipset_test.go
+++ b/types/tipset_test.go
@@ -33,7 +33,7 @@ func block(t *testing.T, ticket []byte, height int, parentCid cid.Cid, parentWei
 		Parents:         NewTipSetKey(parentCid),
 		ParentWeight:    Uint64(parentWeight),
 		Height:          Uint64(42 + uint64(height)),
-		Messages:        cidGetter(),
+		Messages:        TxMeta{SecpRoot: cidGetter(), BLSRoot: EmptyMessagesCID},
 		StateRoot:       cidGetter(),
 		MessageReceipts: cidGetter(),
 		Timestamp:       Uint64(timestamp),


### PR DESCRIPTION
### Why this PR?

This PR is a step towards BLS message signature support.

We need to support both BLS and Secp (elliptic curve) signed messages. The mechanism for this is to maintain separate data structures for each. The BLS messages will have a single signature in the block header, while the Secp messages will each have their own signature. The spec defines a TxMeta struct to contain the keys forr both these structures that replaces a single key for the Secp messages.

### What is in this PR?

This PR introduces the `TxMeta` struct in the block header. It contains a `SecpRoot` that points to the messages, and a `BLSRoot` which, for now, always points to an empty message list. All the rest of the work in this PR exists to permit access to the Secp messages through this new structure.