### PR TITLE
Pull message signature validation higher up the call tree

### DIFF
--- a/internal/app/go-filecoin/plumbing/msg/waiter.go
+++ b/internal/app/go-filecoin/plumbing/msg/waiter.go
@@ -228,14 +228,14 @@ func (w *Waiter) receiptFromTipSet(ctx context.Context, msgCid cid.Cid, ts block
 		return nil, err
 	}
 
-	var tsMessages [][]*types.SignedMessage
+	var tsMessages [][]*types.UnsignedMessage
 	for i := 0; i < ts.Len(); i++ {
 		blk := ts.At(i)
 		secpMsgs, _, err := w.messageProvider.LoadMessages(ctx, blk.Messages)
 		if err != nil {
 			return nil, err
 		}
-		tsMessages = append(tsMessages, secpMsgs)
+		tsMessages = append(tsMessages, types.UnwrapSigned(secpMsgs))
 	}
 
 	res, err := consensus.NewDefaultProcessor().ProcessTipSet(ctx, st, vm.NewStorageMap(w.bs), ts, tsMessages, ancestors)

--- a/internal/pkg/consensus/block_validation.go
+++ b/internal/pkg/consensus/block_validation.go
@@ -41,6 +41,7 @@ type BlockSyntaxValidator interface {
 type MessageSyntaxValidator interface {
 	ValidateMessagesSyntax(ctx context.Context, messages []*types.SignedMessage) error
 	ValidateUnsignedMessagesSyntax(ctx context.Context, messages []*types.UnsignedMessage) error
+	// TODO: Remove receipt validation when they're no longer fetched, #3489
 	ValidateReceiptsSyntax(ctx context.Context, receipts []*types.MessageReceipt) error
 }
 

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-hamt-ipld"
 	"github.com/ipfs/go-ipfs-blockstore"
@@ -16,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/metrics/tracing"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
@@ -41,8 +41,6 @@ func init() {
 var (
 	// ErrStateRootMismatch is returned when the computed state root doesn't match the expected result.
 	ErrStateRootMismatch = errors.New("blocks state root does not match computed result")
-	// ErrInvalidBase is returned when the chain doesn't connect back to a known good block.
-	ErrInvalidBase = errors.New("block does not connect to a known good chain")
 	// ErrUnorderedTipSets is returned when weight and minticket are the same between two tipsets.
 	ErrUnorderedTipSets = errors.New("trying to order two identical tipsets")
 )
@@ -64,10 +62,10 @@ const AncestorRoundsNeeded = miner.LargestSectorSizeProvingPeriodBlocks + miner.
 // A Processor processes all the messages in a block or tip set.
 type Processor interface {
 	// ProcessBlock processes all messages in a block.
-	ProcessBlock(context.Context, state.Tree, vm.StorageMap, *block.Block, []*types.SignedMessage, []block.TipSet) ([]*ApplicationResult, error)
+	ProcessBlock(context.Context, state.Tree, vm.StorageMap, *block.Block, []*types.UnsignedMessage, []block.TipSet) ([]*ApplicationResult, error)
 
 	// ProcessTipSet processes all messages in a tip set.
-	ProcessTipSet(context.Context, state.Tree, vm.StorageMap, block.TipSet, [][]*types.SignedMessage, []block.TipSet) (*ProcessTipSetResponse, error)
+	ProcessTipSet(context.Context, state.Tree, vm.StorageMap, block.TipSet, [][]*types.UnsignedMessage, []block.TipSet) (*ProcessTipSetResponse, error)
 }
 
 // TicketValidator validates that an input ticket is valid.
@@ -162,7 +160,7 @@ func (c *Expected) RunStateTransition(ctx context.Context, ts block.TipSet, blsM
 	}
 
 	vms := vm.NewStorageMap(c.bstore)
-	st, err := c.runMessages(ctx, priorState, vms, ts, blsMessages, secpMessages, tsReceipts, ancestors)
+	st, err := c.runMessages(ctx, priorState, vms, ts, blsMessages, unwrap2(secpMessages), tsReceipts, ancestors)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -246,7 +244,7 @@ func (c *Expected) validateMining(ctx context.Context, st state.Tree, ts block.T
 // An error is returned if individual blocks contain messages that do not
 // lead to successful state transitions.  An error is also returned if the node
 // faults while running aggregate state computation.
-func (c *Expected) runMessages(ctx context.Context, st state.Tree, vms vm.StorageMap, ts block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, tsReceipts [][]*types.MessageReceipt, ancestors []block.TipSet) (state.Tree, error) {
+func (c *Expected) runMessages(ctx context.Context, st state.Tree, vms vm.StorageMap, ts block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.UnsignedMessage, tsReceipts [][]*types.MessageReceipt, ancestors []block.TipSet) (state.Tree, error) {
 	var cpySt state.Tree
 
 	// TODO: don't process messages twice
@@ -262,8 +260,8 @@ func (c *Expected) runMessages(ctx context.Context, st state.Tree, vms vm.Storag
 			return nil, errors.Wrap(err, "error validating block state")
 		}
 
-		// wrap bls messages and combine to process bls messages first
-		msgs := append(wrapMessages(blsMessages[i]), secpMessages[i]...)
+		// Combine messages to process BLS first.
+		msgs := append(blsMessages[i], secpMessages[i]...)
 		receipts, err := c.processor.ProcessBlock(ctx, cpySt, vms, blk, msgs, ancestors)
 		if err != nil {
 			return nil, errors.Wrap(err, "error validating block state")
@@ -289,7 +287,7 @@ func (c *Expected) runMessages(ctx context.Context, st state.Tree, vms vm.Storag
 	// NOTE: It is possible to optimize further by applying block validation
 	// in sorted order to reuse first block transitions as the starting state
 	// for the tipSetProcessor.
-	allMessages := combineMessages(blsMessages, secpMessages)
+	allMessages := append(blsMessages, secpMessages...)
 	_, err := c.processor.ProcessTipSet(ctx, st, vms, ts, allMessages, ancestors)
 	if err != nil {
 		return nil, errors.Wrap(err, "error validating tipset")
@@ -324,21 +322,11 @@ func verifyBLSMessageAggregate(sig types.Signature, msgs []*types.UnsignedMessag
 	return nil
 }
 
-func combineMessages(blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage) [][]*types.SignedMessage {
-	messages := [][]*types.SignedMessage{}
-	for _, msgs := range blsMessages {
-		messages = append(messages, wrapMessages(msgs))
+// Unwraps nested slices of signed messages.
+func unwrap2(smsgs [][]*types.SignedMessage) [][]*types.UnsignedMessage {
+	unsigned := make([][]*types.UnsignedMessage, len(smsgs))
+	for i, inner := range smsgs {
+		unsigned[i] = types.UnwrapSigned(inner)
 	}
-	for _, msgs := range secpMessages {
-		messages = append(messages, msgs)
-	}
-	return messages
-}
-
-func wrapMessages(blsMessages []*types.UnsignedMessage) []*types.SignedMessage {
-	signed := []*types.SignedMessage{}
-	for _, msg := range blsMessages {
-		signed = append(signed, &types.SignedMessage{Message: *msg})
-	}
-	return signed
+	return unsigned
 }

--- a/internal/pkg/consensus/processor.go
+++ b/internal/pkg/consensus/processor.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"math/big"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/ipfs/go-cid"
 	"go.opencensus.io/tag"
 	"go.opencensus.io/trace"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/metrics"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/metrics/tracing"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
@@ -30,13 +30,19 @@ var (
 	pbTimer = metrics.NewTimerMs("consensus/process_block", "Duration of block processing in milliseconds")
 )
 
+// MessageValidator validates the syntax and semantics of a message before it is applied.
+type MessageValidator interface {
+	// Validate checks a message for validity.
+	Validate(ctx context.Context, msg *types.UnsignedMessage, fromActor *actor.Actor) error
+}
+
 // BlockRewarder applies all rewards due to the miner's owner for processing a block including block reward and gas
 type BlockRewarder interface {
 	// BlockReward pays out the mining reward
 	BlockReward(ctx context.Context, st state.Tree, minerOwnerAddr address.Address) error
 
 	// GasReward pays gas from the sender to the miner
-	GasReward(ctx context.Context, st state.Tree, minerOwnerAddr address.Address, msg *types.SignedMessage, cost types.AttoFIL) error
+	GasReward(ctx context.Context, st state.Tree, minerOwnerAddr address.Address, msg *types.UnsignedMessage, cost types.AttoFIL) error
 }
 
 // ApplicationResult contains the result of successfully applying one message.
@@ -59,9 +65,9 @@ type ProcessTipSetResponse struct {
 
 // DefaultProcessor handles all block processing.
 type DefaultProcessor struct {
-	signedMessageValidator SignedMessageValidator
-	blockRewarder          BlockRewarder
-	actors                 builtin.Actors
+	validator     MessageValidator
+	blockRewarder BlockRewarder
+	actors        builtin.Actors
 }
 
 var _ Processor = (*DefaultProcessor)(nil)
@@ -69,18 +75,18 @@ var _ Processor = (*DefaultProcessor)(nil)
 // NewDefaultProcessor creates a default processor from the given state tree and vms.
 func NewDefaultProcessor() *DefaultProcessor {
 	return &DefaultProcessor{
-		signedMessageValidator: NewDefaultMessageValidator(),
-		blockRewarder:          NewDefaultBlockRewarder(),
-		actors:                 builtin.DefaultActors,
+		validator:     NewDefaultMessageValidator(),
+		blockRewarder: NewDefaultBlockRewarder(),
+		actors:        builtin.DefaultActors,
 	}
 }
 
 // NewConfiguredProcessor creates a default processor with custom validation and rewards.
-func NewConfiguredProcessor(validator SignedMessageValidator, rewarder BlockRewarder, actors builtin.Actors) *DefaultProcessor {
+func NewConfiguredProcessor(validator MessageValidator, rewarder BlockRewarder, actors builtin.Actors) *DefaultProcessor {
 	return &DefaultProcessor{
-		signedMessageValidator: validator,
-		blockRewarder:          rewarder,
-		actors:                 actors,
+		validator:     validator,
+		blockRewarder: rewarder,
+		actors:        actors,
 	}
 }
 
@@ -111,15 +117,13 @@ func NewConfiguredProcessor(validator SignedMessageValidator, rewarder BlockRewa
 // will in many cases be successfully applied even though an
 // error was thrown causing any state changes to be rolled back.
 // See comments on ApplyMessage for specific intent.
-func (p *DefaultProcessor) ProcessBlock(ctx context.Context, st state.Tree, vms vm.StorageMap, blk *block.Block, blkMessages []*types.SignedMessage, ancestors []block.TipSet) (results []*ApplicationResult, err error) {
+func (p *DefaultProcessor) ProcessBlock(ctx context.Context, st state.Tree, vms vm.StorageMap, blk *block.Block, blkMessages []*types.UnsignedMessage, ancestors []block.TipSet) (results []*ApplicationResult, err error) {
 	ctx, span := trace.StartSpan(ctx, "DefaultProcessor.ProcessBlock")
 	span.AddAttributes(trace.StringAttribute("block", blk.Cid().String()))
 	defer tracing.AddErrorEndSpan(ctx, span, &err)
 
 	pbsw := pbTimer.Start(ctx)
 	defer pbsw.Stop(ctx)
-
-	var emptyResults []*ApplicationResult
 
 	// find miner's owner address
 	minerOwnerAddr, err := p.minerOwnerAddress(ctx, st, vms, blk.Miner)
@@ -128,17 +132,18 @@ func (p *DefaultProcessor) ProcessBlock(ctx context.Context, st state.Tree, vms 
 	}
 
 	bh := types.NewBlockHeight(uint64(blk.Height))
-	res, faultErr := p.ApplyMessagesAndPayRewards(ctx, st, vms, blkMessages, minerOwnerAddr, bh, ancestors)
-	if faultErr != nil {
-		return emptyResults, faultErr
+	res, err := p.ApplyMessagesAndPayRewards(ctx, st, vms, blkMessages, minerOwnerAddr, bh, ancestors)
+	if err != nil {
+		return nil, err
 	}
-	if len(res.PermanentErrors) > 0 {
-		return emptyResults, res.PermanentErrors[0]
+
+	for _, r := range res {
+		if r.Failure != nil {
+			return nil, r.Failure
+		}
+		results = append(results, &r.ApplicationResult)
 	}
-	if len(res.TemporaryErrors) > 0 {
-		return emptyResults, res.TemporaryErrors[0]
-	}
-	return res.Results, nil
+	return results, nil
 }
 
 // ProcessTipSet computes the state transition specified by the messages in all
@@ -150,77 +155,66 @@ func (p *DefaultProcessor) ProcessBlock(ctx context.Context, st state.Tree, vms 
 // coming from calls to ApplyMessage can be traced to different blocks in the
 // TipSet containing conflicting messages and are ignored.  Blocks are applied
 // in the sorted order of their tickets.
-func (p *DefaultProcessor) ProcessTipSet(ctx context.Context, st state.Tree, vms vm.StorageMap, ts block.TipSet, tsMessages [][]*types.SignedMessage, ancestors []block.TipSet) (response *ProcessTipSetResponse, err error) {
+func (p *DefaultProcessor) ProcessTipSet(ctx context.Context, st state.Tree, vms vm.StorageMap, ts block.TipSet, tsMessages [][]*types.UnsignedMessage, ancestors []block.TipSet) (tsResult *ProcessTipSetResponse, err error) {
 	ctx, span := trace.StartSpan(ctx, "DefaultProcessor.ProcessTipSet")
 	span.AddAttributes(trace.StringAttribute("tipset", ts.String()))
 	defer tracing.AddErrorEndSpan(ctx, span, &err)
 
+	tsResult = &ProcessTipSetResponse{
+		Failures:  make(map[cid.Cid]struct{}),
+		Successes: make(map[cid.Cid]struct{}),
+	}
+
 	h, err := ts.Height()
 	if err != nil {
-		return &ProcessTipSetResponse{}, errors.FaultErrorWrap(err, "processing empty tipset")
+		return nil, errors.FaultErrorWrap(err, "processing empty tipset")
 	}
 	bh := types.NewBlockHeight(h)
 	msgFilter := make(map[string]struct{})
 
-	var res ProcessTipSetResponse
-	res.Failures = make(map[cid.Cid]struct{})
-	res.Successes = make(map[cid.Cid]struct{})
-
 	// TODO: this can be made slightly more efficient by reusing the validation
 	// transition of the first validated block (change would reach here and
 	// consensus functions).
-	for i := 0; i < ts.Len(); i++ {
-		blk := ts.At(i)
+	for blkIndex := 0; blkIndex < ts.Len(); blkIndex++ {
+		blk := ts.At(blkIndex)
 		// find miner's owner address
 		minerOwnerAddr, err := p.minerOwnerAddress(ctx, st, vms, blk.Miner)
 		if err != nil {
-			return &ProcessTipSetResponse{}, err
+			return nil, err
 		}
 
-		// filter out duplicates within TipSet
-		var msgs []*types.SignedMessage
-		for _, msg := range tsMessages[i] {
+		// Accumulate unique messages and their CIDs.
+		msgs := make([]*types.UnsignedMessage, len(tsMessages[blkIndex]))
+		cids := make([]cid.Cid, len(msgs))
+		for i, msg := range tsMessages[blkIndex] {
 			mCid, err := msg.Cid()
 			if err != nil {
-				return &ProcessTipSetResponse{}, errors.FaultErrorWrap(err, "error getting message cid")
+				return nil, errors.FaultErrorWrap(err, "error getting message cid")
 			}
-			if _, ok := msgFilter[mCid.String()]; ok {
+			if _, found := msgFilter[mCid.String()]; found {
 				continue
 			}
-			msgs = append(msgs, msg)
-			// filter all messages that we attempted to apply
-			// TODO is there ever a reason to try a duplicate failed message again within the same tipset?
+			msgs[i] = msg
+			cids[i] = mCid
 			msgFilter[mCid.String()] = struct{}{}
 		}
-		amRes, err := p.ApplyMessagesAndPayRewards(ctx, st, vms, msgs, minerOwnerAddr, bh, ancestors)
+		results, err := p.ApplyMessagesAndPayRewards(ctx, st, vms, msgs, minerOwnerAddr, bh, ancestors)
 		if err != nil {
-			return &ProcessTipSetResponse{}, err
+			return nil, err
 		}
-		res.Results = append(res.Results, amRes.Results...)
-		for _, msg := range amRes.SuccessfulMessages {
-			mCid, err := msg.Cid()
-			if err != nil {
-				return &ProcessTipSetResponse{}, errors.FaultErrorWrap(err, "error getting message cid")
+
+		for i, result := range results {
+			if result.Failure == nil {
+				tsResult.Results = append(tsResult.Results, &result.ApplicationResult)
+				tsResult.Successes[cids[i]] = struct{}{}
+			} else {
+				tsResult.Failures[cids[i]] = struct{}{}
+
 			}
-			res.Successes[mCid] = struct{}{}
-		}
-		for _, msg := range amRes.PermanentFailures {
-			mCid, err := msg.Cid()
-			if err != nil {
-				return &ProcessTipSetResponse{}, errors.FaultErrorWrap(err, "error getting message cid")
-			}
-			res.Failures[mCid] = struct{}{}
-		}
-		for _, msg := range amRes.TemporaryFailures {
-			mCid, err := msg.Cid()
-			if err != nil {
-				return &ProcessTipSetResponse{}, errors.FaultErrorWrap(err, "error getting message cid")
-			}
-			res.Failures[mCid] = struct{}{}
 		}
 	}
 
-	return &res, nil
+	return
 }
 
 // ApplyMessage attempts to apply a message to a state tree. It is the
@@ -284,13 +278,13 @@ func (p *DefaultProcessor) ProcessTipSet(ctx context.Context, st state.Tree, vms
 //       revert errors.
 //   - everything else: successfully applied (include, keep changes)
 //
-func (p *DefaultProcessor) ApplyMessage(ctx context.Context, st state.Tree, vms vm.StorageMap, msg *types.SignedMessage, minerOwnerAddr address.Address, bh *types.BlockHeight, gasTracker *vm.GasTracker, ancestors []block.TipSet) (result *ApplicationResult, err error) {
+func (p *DefaultProcessor) ApplyMessage(ctx context.Context, st state.Tree, vms vm.StorageMap, msg *types.UnsignedMessage, minerOwnerAddr address.Address, bh *types.BlockHeight, gasTracker *vm.GasTracker, ancestors []block.TipSet) (result *ApplicationResult, err error) {
 	msgCid, err := msg.Cid()
 	if err != nil {
 		return nil, errors.FaultErrorWrap(err, "could not get message cid")
 	}
 
-	tagMethod := msg.Message.Method
+	tagMethod := msg.Method
 	if tagMethod == "" {
 		tagMethod = "sendFIL"
 	}
@@ -346,12 +340,12 @@ func (p *DefaultProcessor) ApplyMessage(ctx context.Context, st state.Tree, vms 
 
 	// At this point we consider the message successfully applied so inc
 	// the nonce.
-	fromActor, err := st.GetActor(ctx, msg.Message.From)
+	fromActor, err := st.GetActor(ctx, msg.From)
 	if err != nil {
 		return nil, errors.FaultErrorWrap(err, "couldn't load from actor")
 	}
 	fromActor.IncNonce()
-	if err := st.SetActor(ctx, msg.Message.From, fromActor); err != nil {
+	if err := st.SetActor(ctx, msg.From, fromActor); err != nil {
 		return nil, errors.FaultErrorWrap(err, "could not set from actor after inc nonce")
 	}
 
@@ -459,8 +453,8 @@ func (p *DefaultProcessor) PreviewQueryMethod(ctx context.Context, st state.Tree
 // should deal with trying to apply the message to the state tree whereas
 // ApplyMessage should deal with any side effects and how it should be presented
 // to the caller. attemptApplyMessage should only be called from ApplyMessage.
-func (p *DefaultProcessor) attemptApplyMessage(ctx context.Context, st *state.CachedTree, store vm.StorageMap, msg *types.SignedMessage, bh *types.BlockHeight, gasTracker *vm.GasTracker, ancestors []block.TipSet) (*types.MessageReceipt, error) {
-	gasTracker.ResetForNewMessage(msg.Message)
+func (p *DefaultProcessor) attemptApplyMessage(ctx context.Context, st *state.CachedTree, store vm.StorageMap, msg *types.UnsignedMessage, bh *types.BlockHeight, gasTracker *vm.GasTracker, ancestors []block.TipSet) (*types.MessageReceipt, error) {
+	gasTracker.ResetForNewMessage(msg)
 	if err := blockGasLimitError(gasTracker); err != nil {
 		return &types.MessageReceipt{
 			ExitCode:   errors.CodeError(err),
@@ -468,17 +462,17 @@ func (p *DefaultProcessor) attemptApplyMessage(ctx context.Context, st *state.Ca
 		}, err
 	}
 
-	fromActor, err := st.GetActor(ctx, msg.Message.From)
+	fromActor, err := st.GetActor(ctx, msg.From)
 	if state.IsActorNotFoundError(err) {
 		return &types.MessageReceipt{
 			ExitCode:   errors.CodeError(err),
 			GasAttoFIL: types.ZeroAttoFIL,
 		}, errFromAccountNotFound
 	} else if err != nil {
-		return nil, errors.FaultErrorWrapf(err, "failed to get From actor %s", msg.Message.From)
+		return nil, errors.FaultErrorWrapf(err, "failed to get From actor %s", msg.From)
 	}
 
-	err = p.signedMessageValidator.Validate(ctx, msg, fromActor)
+	err = p.validator.Validate(ctx, msg, fromActor)
 	if err != nil {
 		return &types.MessageReceipt{
 			ExitCode:   errors.CodeError(err),
@@ -494,7 +488,7 @@ func (p *DefaultProcessor) attemptApplyMessage(ctx context.Context, st *state.Ca
 		}
 	}
 
-	toActor, err := st.GetOrCreateActor(ctx, msg.Message.To, func() (*actor.Actor, error) {
+	toActor, err := st.GetOrCreateActor(ctx, msg.To, func() (*actor.Actor, error) {
 		// Addresses are deterministic so sending a message to a non-existent address must not install an actor,
 		// else actors could be installed ahead of address activation. So here we create the empty, upgradable
 		// actor to collect any balance that may be transferred.
@@ -507,7 +501,7 @@ func (p *DefaultProcessor) attemptApplyMessage(ctx context.Context, st *state.Ca
 	vmCtxParams := vm.NewContextParams{
 		From:        fromActor,
 		To:          toActor,
-		Message:     &msg.Message,
+		Message:     msg,
 		State:       st,
 		StorageMap:  store,
 		GasTracker:  gasTracker,
@@ -523,7 +517,7 @@ func (p *DefaultProcessor) attemptApplyMessage(ctx context.Context, st *state.Ca
 	}
 
 	// compute gas charge
-	gasCharge := msg.Message.GasPrice.MulBigInt(big.NewInt(int64(vmCtx.GasUnits())))
+	gasCharge := msg.GasPrice.MulBigInt(big.NewInt(int64(vmCtx.GasUnits())))
 
 	receipt := &types.MessageReceipt{
 		ExitCode:   exitCode,
@@ -535,57 +529,44 @@ func (p *DefaultProcessor) attemptApplyMessage(ctx context.Context, st *state.Ca
 	return receipt, vmErr
 }
 
-// ApplyMessagesResponse is the output struct of ApplyMessages.  It exists to
-// prevent callers from mistakenly mixing up outputs of the same type.
-type ApplyMessagesResponse struct {
-	Results            []*ApplicationResult
-	PermanentFailures  []*types.SignedMessage
-	TemporaryFailures  []*types.SignedMessage
-	SuccessfulMessages []*types.SignedMessage
-
-	// Application Errors
-	PermanentErrors []error
-	TemporaryErrors []error
+// ApplyMessageResult is the result of applying a single message.
+type ApplyMessageResult struct {
+	ApplicationResult        // Application-level result, if error is nil.
+	Failure            error // Failure to apply the message
+	FailureIsPermanent bool  // Whether failure is permanent, has no chance of succeeding later.
 }
 
-// ApplyMessagesAndPayRewards begins by paying the block mining reward to the miner's owner. It then applies messages to a state tree.
-// It returns an ApplyMessagesResponse which wraps the results of message application,
-// groupings of messages with permanent failures, temporary failures, and
-// successes, and the permanent and temporary errors raised during application.
-// ApplyMessages will return an error iff a fault message occurs.
-// Precondition: signatures of messages are checked by the caller.
-func (p *DefaultProcessor) ApplyMessagesAndPayRewards(ctx context.Context, st state.Tree, vms vm.StorageMap, messages []*types.SignedMessage, minerOwnerAddr address.Address, bh *types.BlockHeight, ancestors []block.TipSet) (ApplyMessagesResponse, error) {
-	var emptyRet ApplyMessagesResponse
-	var ret ApplyMessagesResponse
+// ApplyMessagesAndPayRewards pays the block mining reward to the miner's owner and then applies
+// messages, in order, to a state tree.
+// Returns a message application result for each message.
+func (p *DefaultProcessor) ApplyMessagesAndPayRewards(ctx context.Context, st state.Tree, vms vm.StorageMap,
+	messages []*types.UnsignedMessage, minerOwnerAddr address.Address, bh *types.BlockHeight,
+	ancestors []block.TipSet) ([]*ApplyMessageResult, error) {
+	var results []*ApplyMessageResult
 
-	// transfer block reward to miner's owner from network address.
+	// Pay block reward.
 	if err := p.blockRewarder.BlockReward(ctx, st, minerOwnerAddr); err != nil {
-		return ApplyMessagesResponse{}, err
+		return nil, err
 	}
 
+	// Process all messages.
 	gasTracker := vm.NewGasTracker()
-
-	// process all messages
-	for _, smsg := range messages {
-		r, err := p.ApplyMessage(ctx, st, vms, smsg, minerOwnerAddr, bh, gasTracker, ancestors)
-		// If the message should not have been in the block, bail somehow.
+	for _, msg := range messages {
+		r, err := p.ApplyMessage(ctx, st, vms, msg, minerOwnerAddr, bh, gasTracker, ancestors)
 		switch {
 		case errors.IsFault(err):
-			return emptyRet, err
+			return nil, err
 		case errors.IsApplyErrorPermanent(err):
-			ret.PermanentFailures = append(ret.PermanentFailures, smsg)
-			ret.PermanentErrors = append(ret.PermanentErrors, err)
+			results = append(results, &ApplyMessageResult{ApplicationResult{}, err, true})
 		case errors.IsApplyErrorTemporary(err):
-			ret.TemporaryFailures = append(ret.TemporaryFailures, smsg)
-			ret.TemporaryErrors = append(ret.TemporaryErrors, err)
+			results = append(results, &ApplyMessageResult{ApplicationResult{}, err, false})
 		case err != nil:
 			panic("someone is a bad programmer: error is neither fault, perm or temp")
 		default:
-			ret.SuccessfulMessages = append(ret.SuccessfulMessages, smsg)
-			ret.Results = append(ret.Results, r)
+			results = append(results, &ApplyMessageResult{*r, nil, false})
 		}
 	}
-	return ret, nil
+	return results, nil
 }
 
 // DefaultBlockRewarder pays the block reward from the network actor to the miner's owner.
@@ -608,9 +589,9 @@ func (br *DefaultBlockRewarder) BlockReward(ctx context.Context, st state.Tree, 
 }
 
 // GasReward transfers the gas cost reward from the sender actor to the minerOwnerAddr
-func (br *DefaultBlockRewarder) GasReward(ctx context.Context, st state.Tree, minerOwnerAddr address.Address, msg *types.SignedMessage, gas types.AttoFIL) error {
+func (br *DefaultBlockRewarder) GasReward(ctx context.Context, st state.Tree, minerOwnerAddr address.Address, msg *types.UnsignedMessage, cost types.AttoFIL) error {
 	cachedTree := state.NewCachedStateTree(st)
-	if err := rewardTransfer(ctx, msg.Message.From, minerOwnerAddr, gas, cachedTree); err != nil {
+	if err := rewardTransfer(ctx, msg.From, minerOwnerAddr, cost, cachedTree); err != nil {
 		return errors.FaultErrorWrap(err, "Error attempting to pay gas reward")
 	}
 	return cachedTree.Commit(ctx)

--- a/internal/pkg/consensus/processor_test.go
+++ b/internal/pkg/consensus/processor_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-hamt-ipld"
@@ -12,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	. "github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
@@ -66,10 +66,8 @@ func TestProcessBlockSuccess(t *testing.T) {
 	})
 
 	msg := types.NewMeteredMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(550), "", nil, types.NewGasPrice(1), types.NewGasUnits(0))
-	smsg, err := types.NewSignedMessage(*msg, &mockSigner)
-	require.NoError(t, err)
 
-	msgs := []*types.SignedMessage{smsg}
+	msgs := []*types.UnsignedMessage{msg}
 	blk := &block.Block{
 		Height:    20,
 		StateRoot: stCid,
@@ -125,10 +123,8 @@ func TestProcessTipSetSuccess(t *testing.T) {
 	require.NoError(t, err)
 	stCid, miner := mustCreateStorageMiner(ctx, t, st, vms, minerAddr, minerOwner)
 
-	msg1 := types.NewMeteredMessage(fromAddr1, toAddr, 0, types.NewAttoFILFromFIL(550), "", nil, types.NewGasPrice(1), types.NewGasUnits(0))
-	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner)
-	require.NoError(t, err)
-	msgs1 := []*types.SignedMessage{smsg1}
+	msgs1 := []*types.UnsignedMessage{types.NewMeteredMessage(fromAddr1, toAddr, 0,
+		types.NewAttoFILFromFIL(550), "", nil, types.NewGasPrice(1), types.NewGasUnits(0))}
 	cidGetter := types.NewCidForTestGetter()
 	blk1 := &block.Block{
 		Height:    20,
@@ -138,10 +134,8 @@ func TestProcessTipSetSuccess(t *testing.T) {
 		Ticket:    block.Ticket{VRFProof: []byte{0x1}},
 	}
 
-	msg2 := types.NewMeteredMessage(fromAddr2, toAddr, 0, types.NewAttoFILFromFIL(50), "", nil, types.NewGasPrice(1), types.NewGasUnits(0))
-	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner)
-	require.NoError(t, err)
-	msgs2 := []*types.SignedMessage{smsg2}
+	msgs2 := []*types.UnsignedMessage{types.NewMeteredMessage(fromAddr2, toAddr, 0,
+		types.NewAttoFILFromFIL(50), "", nil, types.NewGasPrice(1), types.NewGasUnits(0))}
 	blk2 := &block.Block{
 		Height:    20,
 		StateRoot: stCid,
@@ -150,7 +144,7 @@ func TestProcessTipSetSuccess(t *testing.T) {
 		Ticket:    block.Ticket{VRFProof: []byte{0x2}},
 	}
 
-	tsMsgs := [][]*types.SignedMessage{msgs1, msgs2}
+	tsMsgs := [][]*types.UnsignedMessage{msgs1, msgs2}
 	res, err := NewDefaultProcessor().ProcessTipSet(ctx, st, vms, th.RequireNewTipSet(t, blk1, blk2), tsMsgs, nil)
 	assert.NoError(t, err)
 	assert.Len(t, res.Results, 2)
@@ -198,10 +192,8 @@ func TestProcessTipsConflicts(t *testing.T) {
 	require.NoError(t, err)
 	stCid, miner := mustCreateStorageMiner(ctx, t, st, vms, minerAddr, minerOwner)
 
-	msg1 := types.NewMeteredMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(501), "", nil, types.NewGasPrice(1), types.NewGasUnits(0))
-	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner)
-	require.NoError(t, err)
-	msgs1 := []*types.SignedMessage{smsg1}
+	msgs1 := []*types.UnsignedMessage{types.NewMeteredMessage(fromAddr, toAddr, 0,
+		types.NewAttoFILFromFIL(501), "", nil, types.NewGasPrice(1), types.NewGasUnits(0))}
 	blk1 := &block.Block{
 		Height:    20,
 		StateRoot: stCid,
@@ -209,10 +201,8 @@ func TestProcessTipsConflicts(t *testing.T) {
 		Miner:     minerAddr,
 	}
 
-	msg2 := types.NewMeteredMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(502), "", nil, types.NewGasPrice(1), types.NewGasUnits(0))
-	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner)
-	require.NoError(t, err)
-	msgs2 := []*types.SignedMessage{smsg2}
+	msgs2 := []*types.UnsignedMessage{types.NewMeteredMessage(fromAddr, toAddr, 0,
+		types.NewAttoFILFromFIL(502), "", nil, types.NewGasPrice(1), types.NewGasUnits(0))}
 	blk2 := &block.Block{
 		Height:    20,
 		StateRoot: stCid,
@@ -220,7 +210,7 @@ func TestProcessTipsConflicts(t *testing.T) {
 		Miner:     minerAddr,
 	}
 
-	tsMsgs := [][]*types.SignedMessage{msgs1, msgs2}
+	tsMsgs := [][]*types.UnsignedMessage{msgs1, msgs2}
 	res, err := NewDefaultProcessor().ProcessTipSet(ctx, st, vms, th.RequireNewTipSet(t, blk1, blk2), tsMsgs, nil)
 	assert.NoError(t, err)
 	assert.Len(t, res.Results, 1)
@@ -272,7 +262,7 @@ func TestProcessBlockReward(t *testing.T) {
 		Height:    20,
 		StateRoot: stCid,
 	}
-	ret, err := NewDefaultProcessor().ProcessBlock(ctx, st, vms, blk, []*types.SignedMessage{}, nil)
+	ret, err := NewDefaultProcessor().ProcessBlock(ctx, st, vms, blk, []*types.UnsignedMessage{}, nil)
 	require.NoError(t, err)
 	assert.Nil(t, ret)
 
@@ -314,10 +304,8 @@ func TestProcessBlockVMErrors(t *testing.T) {
 
 	stCid, miner := mustCreateStorageMiner(ctx, t, st, vms, minerAddr, minerOwnerAddr)
 
-	msg := types.NewMeteredMessage(fromAddr, toAddr, 0, types.ZeroAttoFIL, "returnRevertError", nil, types.NewGasPrice(1), types.NewGasUnits(0))
-	smsg, err := types.NewSignedMessage(*msg, &mockSigner)
-	require.NoError(t, err)
-	msgs := []*types.SignedMessage{smsg}
+	msgs := []*types.UnsignedMessage{types.NewMeteredMessage(fromAddr, toAddr, 0, types.ZeroAttoFIL,
+		"returnRevertError", nil, types.NewGasPrice(1), types.NewGasUnits(0))}
 	blk := &block.Block{
 		Height:    20,
 		StateRoot: stCid,
@@ -424,10 +412,8 @@ func TestApplyMessagesValidation(t *testing.T) {
 			addr2: act2,
 		})
 		msg := types.NewMeteredMessage(addr1, addr2, 5, types.NewAttoFILFromFIL(550), "", []byte{}, types.NewGasPrice(1), types.NewGasUnits(0))
-		smsg, err := types.NewSignedMessage(*msg, mockSigner)
-		require.NoError(t, err)
 
-		_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
+		_, err := NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), msg, addr2, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
 		assert.Error(t, err)
 		assert.Equal(t, "nonce too high", err.(*errors.ApplyErrorTemporary).Cause().Error())
 	})
@@ -449,22 +435,18 @@ func TestApplyMessagesValidation(t *testing.T) {
 			addr2: act2,
 		})
 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(550), "", []byte{}, types.NewGasPrice(1), types.NewGasUnits(0))
-		smsg, err := types.NewSignedMessage(*msg, mockSigner)
-		require.NoError(t, err)
 
-		_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
+		_, err := NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), msg, addr2, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
 		assert.Error(t, err)
 		assert.Equal(t, "nonce too low", err.(*errors.ApplyErrorPermanent).Cause().Error())
 	})
 
 	t.Run("errors when specifying a gas limit in excess of balance", func(t *testing.T) {
-		addr1, _, addr2, _, st, mockSigner := mustSetup2Actors(t, types.NewAttoFILFromFIL(1000), types.NewAttoFILFromFIL(10000))
+		addr1, _, addr2, _, st, _ := mustSetup2Actors(t, types.NewAttoFILFromFIL(1000), types.NewAttoFILFromFIL(10000))
 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(550), "", []byte{}, types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
-		smsg, err := types.NewSignedMessage(*msg, mockSigner)
-		require.NoError(t, err)
 
 		// the maximum gas charge (10*50 = 500) is greater than the sender balance minus the message value (1000-550 = 450)
-		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
+		_, err := NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), msg, addr2, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
 		require.Error(t, err)
 		assert.Equal(t, "balance insufficient to cover transfer+gas", err.(*errors.ApplyErrorPermanent).Cause().Error())
 	})
@@ -479,10 +461,8 @@ func TestApplyMessagesValidation(t *testing.T) {
 		require.NoError(t, err)
 
 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.ZeroAttoFIL, "", []byte{}, types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
-		smsg, err := types.NewSignedMessage(*msg, mockSigner)
-		require.NoError(t, err)
 
-		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
+		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), msg, addr2, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
 		require.Error(t, err)
 		assert.Equal(t, "message from non-account actor", err.(*errors.ApplyErrorPermanent).Cause().Error())
 	})
@@ -498,10 +478,8 @@ func TestApplyMessagesValidation(t *testing.T) {
 		_, st := requireMakeStateTree(t, cst, map[address.Address]*actor.Actor{addr2: act2})
 
 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.ZeroAttoFIL, "", []byte{}, types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
-		smsg, err := types.NewSignedMessage(*msg, mockSigner)
-		require.NoError(t, err)
 
-		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, addr2,
+		_, err := NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), msg, addr2,
 			types.NewBlockHeight(0), vm.NewGasTracker(), nil)
 		require.Error(t, err)
 		assert.Equal(t, "from (sender) account not found", err.(*errors.ApplyErrorTemporary).Cause().Error())
@@ -527,34 +505,28 @@ func TestApplyMessagesValidation(t *testing.T) {
 		require.True(t, ok)
 
 		msg := types.NewMeteredMessage(addr1, addr2, 0, someval, "", []byte{}, types.NewGasPrice(1), types.NewGasUnits(0))
-		smsg, err := types.NewSignedMessage(*msg, mockSigner)
-		require.NoError(t, err)
 
-		_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
+		_, err := NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), msg, addr2, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
 		assert.Error(t, err)
 		assert.Contains(t, "negative value", err.(*errors.ApplyErrorPermanent).Cause().Error())
 	})
 
 	t.Run("errors when attempting to send to self", func(t *testing.T) {
-		addr1, _, addr2, _, st, mockSigner := mustSetup2Actors(t, types.NewAttoFILFromFIL(1000), types.NewAttoFILFromFIL(10000))
+		addr1, _, addr2, _, st, _ := mustSetup2Actors(t, types.NewAttoFILFromFIL(1000), types.NewAttoFILFromFIL(10000))
 		msg := types.NewMeteredMessage(addr1, addr1, 0, types.NewAttoFILFromFIL(550), "", []byte{}, types.NewAttoFILFromFIL(10), types.NewGasUnits(0))
-		smsg, err := types.NewSignedMessage(*msg, mockSigner)
-		require.NoError(t, err)
 
 		// the maximum gas charge (10*50 = 500) is greater than the sender balance minus the message value (1000-550 = 450)
-		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
+		_, err := NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), msg, addr2, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
 		require.Error(t, err)
 		assert.Equal(t, "cannot send to self", err.(*errors.ApplyErrorPermanent).Cause().Error())
 	})
 
 	t.Run("errors when specifying a gas limit in excess of balance", func(t *testing.T) {
-		addr1, _, addr2, _, st, mockSigner := mustSetup2Actors(t, types.NewAttoFILFromFIL(1000), types.NewAttoFILFromFIL(10000))
+		addr1, _, addr2, _, st, _ := mustSetup2Actors(t, types.NewAttoFILFromFIL(1000), types.NewAttoFILFromFIL(10000))
 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(550), "", []byte{}, types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
-		smsg, err := types.NewSignedMessage(*msg, mockSigner)
-		require.NoError(t, err)
 
 		// the maximum gas charge (10*50 = 500) is greater than the sender balance minus the message value (1000-550 = 450)
-		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, address.Undef, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
+		_, err := NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), msg, address.Undef, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
 		require.Error(t, err)
 		assert.Equal(t, "balance insufficient to cover transfer+gas", err.(*errors.ApplyErrorPermanent).Cause().Error())
 	})
@@ -676,16 +648,12 @@ func TestSendToNonexistentAddressThenSpendFromIt(t *testing.T) {
 
 	// send 500 from addr1 to addr2
 	msg := types.NewMeteredMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(500), "", []byte{}, types.NewGasPrice(1), types.NewGasUnits(0))
-	smsg, err := types.NewSignedMessage(*msg, mockSigner)
-	require.NoError(t, err)
-	_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, addr4, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
+	_, err := NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), msg, addr4, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
 	require.NoError(t, err)
 
 	// send 250 along from addr2 to addr3
 	msg = types.NewMeteredMessage(addr2, addr3, 0, types.NewAttoFILFromFIL(300), "", []byte{}, types.NewGasPrice(1), types.NewGasUnits(0))
-	smsg, err = types.NewSignedMessage(*msg, mockSigner)
-	require.NoError(t, err)
-	_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, addr4, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
+	_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), msg, addr4, types.NewBlockHeight(0), vm.NewGasTracker(), nil)
 	require.NoError(t, err)
 
 	// get all 3 actors
@@ -761,7 +729,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 		Build()
 
 	t.Run("ApplyMessage charges gas on success", func(t *testing.T) {
-		addresses, st, mockSigner := setupActorsForGasTest(t, vms, fakeActorCodeCid, 1000)
+		addresses, st := setupActorsForGasTest(t, vms, fakeActorCodeCid, 1000)
 		addr0 := addresses[0]
 		addr1 := addresses[1]
 		minerAddr := addresses[2]
@@ -770,7 +738,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 		gasLimit := types.NewGasUnits(200)
 		msg := types.NewMeteredMessage(addr0, addr1, 0, types.ZeroAttoFIL, "hasReturnValue", nil, gasPrice, gasLimit)
 
-		appResult, err := th.ApplyTestMessageWithGas(actors, st, th.VMStorage(), msg, types.NewBlockHeight(0), mockSigner, minerAddr)
+		appResult, err := th.ApplyTestMessageWithGas(actors, st, th.VMStorage(), msg, types.NewBlockHeight(0), minerAddr)
 		assert.NoError(t, err)
 		assert.NoError(t, appResult.ExecutionError)
 
@@ -785,7 +753,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 	})
 
 	t.Run("ApplyMessage charges gas on message execution failure", func(t *testing.T) {
-		addresses, st, mockSigner := setupActorsForGasTest(t, vms, fakeActorCodeCid, 1000)
+		addresses, st := setupActorsForGasTest(t, vms, fakeActorCodeCid, 1000)
 		addr0 := addresses[0]
 		addr1 := addresses[1]
 		minerAddr := addresses[2]
@@ -794,7 +762,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 		gasLimit := types.NewGasUnits(200)
 		msg := types.NewMeteredMessage(addr0, addr1, 0, types.ZeroAttoFIL, "chargeGasAndRevertError", nil, gasPrice, gasLimit)
 
-		appResult, err := th.ApplyTestMessageWithGas(actors, st, th.VMStorage(), msg, types.NewBlockHeight(0), mockSigner, minerAddr)
+		appResult, err := th.ApplyTestMessageWithGas(actors, st, th.VMStorage(), msg, types.NewBlockHeight(0), minerAddr)
 		assert.NoError(t, err)
 		assert.EqualError(t, appResult.ExecutionError, "boom")
 
@@ -811,7 +779,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 	t.Run("ApplyMessage charges the gas limit when limit is exceeded", func(t *testing.T) {
 		// provide a gas limit less than the method charges.
 		// call the method, expect an error and that gasLimit*gasPrice has been transferred to the miner.
-		addresses, st, mockSigner := setupActorsForGasTest(t, vms, fakeActorCodeCid, 1000)
+		addresses, st := setupActorsForGasTest(t, vms, fakeActorCodeCid, 1000)
 		addr0 := addresses[0]
 		addr1 := addresses[1]
 		minerAddr := addresses[2]
@@ -820,7 +788,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 		gasLimit := types.NewGasUnits(50)
 		msg := types.NewMeteredMessage(addr0, addr1, 0, types.ZeroAttoFIL, "hasReturnValue", nil, gasPrice, gasLimit)
 
-		appResult, err := th.ApplyTestMessageWithGas(actors, st, th.VMStorage(), msg, types.NewBlockHeight(0), mockSigner, minerAddr)
+		appResult, err := th.ApplyTestMessageWithGas(actors, st, th.VMStorage(), msg, types.NewBlockHeight(0), minerAddr)
 		assert.NoError(t, err)
 		assert.EqualError(t, appResult.ExecutionError, "Insufficient gas: gas cost exceeds gas limit")
 
@@ -837,7 +805,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 	})
 
 	t.Run("ApplyMessage when sending another message, with sufficient gas gets charged all the gas", func(t *testing.T) {
-		addresses, st, mockSigner := setupActorsForGasTest(t, vms, fakeActorCodeCid, 2000)
+		addresses, st := setupActorsForGasTest(t, vms, fakeActorCodeCid, 2000)
 		addr0 := addresses[0]
 		addr1 := addresses[1]
 		addr2 := addresses[2]
@@ -850,7 +818,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 		gasLimit := types.NewGasUnits(600)
 		msg := types.NewMeteredMessage(addr0, addr1, 0, types.ZeroAttoFIL, "runsAnotherMessage", params, gasPrice, gasLimit)
 
-		appResult, err := th.ApplyTestMessageWithGas(actors, st, th.VMStorage(), msg, types.NewBlockHeight(0), mockSigner, minerAddr)
+		appResult, err := th.ApplyTestMessageWithGas(actors, st, th.VMStorage(), msg, types.NewBlockHeight(0), minerAddr)
 		assert.NoError(t, err)
 		assert.NoError(t, appResult.ExecutionError)
 		minerActor, err := st.GetActor(ctx, minerAddr)
@@ -868,7 +836,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 	t.Run("ApplyMessage when it sends another message with insufficient gas fails with correct message", func(t *testing.T) {
 		// provide a gas limit that is sufficient for the outer method's call, but insufficient for the inner
 		// assert that it behaves as if the limit was exceeded after a single call.
-		addresses, st, mockSigner := setupActorsForGasTest(t, vms, fakeActorCodeCid, 1000)
+		addresses, st := setupActorsForGasTest(t, vms, fakeActorCodeCid, 1000)
 		addr0 := addresses[0]
 		addr1 := addresses[1]
 		addr2 := addresses[2]
@@ -881,7 +849,7 @@ func TestApplyMessageChargesGas(t *testing.T) {
 		gasLimit := types.NewGasUnits(50)
 		msg := types.NewMeteredMessage(addr0, addr1, 0, types.ZeroAttoFIL, "runsAnotherMessage", params, gasPrice, gasLimit)
 
-		appResult, err := th.ApplyTestMessageWithGas(actors, st, th.VMStorage(), msg, types.NewBlockHeight(0), mockSigner, minerAddr)
+		appResult, err := th.ApplyTestMessageWithGas(actors, st, th.VMStorage(), msg, types.NewBlockHeight(0), minerAddr)
 		assert.NoError(t, err)
 		assert.EqualError(t, appResult.ExecutionError, "Insufficient gas: gas cost exceeds gas limit")
 
@@ -907,7 +875,7 @@ func TestBlockGasLimitBehavior(t *testing.T) {
 		Add(fakeActorCodeCid, 0, &actor.FakeActor{}).
 		Build()
 
-	actors, stateTree, signer := setupActorsForGasTest(t, th.VMStorage(), fakeActorCodeCid, 0)
+	actors, stateTree := setupActorsForGasTest(t, th.VMStorage(), fakeActorCodeCid, 0)
 	sender := actors[1]
 	receiver := actors[2]
 	processor := NewFakeProcessor(builtinActors)
@@ -915,69 +883,53 @@ func TestBlockGasLimitBehavior(t *testing.T) {
 
 	t.Run("A single message whose gas limit is greater than the block gas limit fails permanently", func(t *testing.T) {
 		msg := types.NewMeteredMessage(sender, receiver, 0, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{}, types.ZeroAttoFIL, types.BlockGasLimit*2)
-		sgnedMsg, err := types.NewSignedMessage(*msg, signer)
+
+		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.UnsignedMessage{msg}, sender, types.NewBlockHeight(0), nil)
 		require.NoError(t, err)
 
-		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg}, sender, types.NewBlockHeight(0), nil)
-		require.NoError(t, err)
-
-		assert.Contains(t, result.PermanentFailures, sgnedMsg)
+		assert.Error(t, result[0].Failure)
+		assert.True(t, result[0].FailureIsPermanent)
 	})
 
 	t.Run("2 msgs both succeed when sum of limits > block limit, but 1st usage + 2nd limit < block limit", func(t *testing.T) {
 		msg1 := types.NewMeteredMessage(sender, receiver, 0, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{}, types.ZeroAttoFIL, types.BlockGasLimit*5/8)
-		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer)
-		require.NoError(t, err)
-
 		msg2 := types.NewMeteredMessage(sender, receiver, 1, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{}, types.ZeroAttoFIL, types.BlockGasLimit*5/8)
-		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer)
+
+		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.UnsignedMessage{msg1, msg2}, sender, types.NewBlockHeight(0), nil)
 		require.NoError(t, err)
 
-		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg1, sgnedMsg2}, sender, types.NewBlockHeight(0), nil)
-		require.NoError(t, err)
-
-		assert.Contains(t, result.SuccessfulMessages, sgnedMsg1)
-		assert.Contains(t, result.SuccessfulMessages, sgnedMsg2)
+		assert.Nil(t, result[0].Failure)
+		assert.Nil(t, result[1].Failure)
 	})
 
 	t.Run("2nd message delayed when 1st usage + 2nd limit > block limit", func(t *testing.T) {
 		msg1 := types.NewMeteredMessage(sender, receiver, 0, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{}, types.ZeroAttoFIL, types.BlockGasLimit*3/8)
-		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer)
-		require.NoError(t, err)
-
 		msg2 := types.NewMeteredMessage(sender, receiver, 1, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{}, types.ZeroAttoFIL, types.BlockGasLimit*7/8)
-		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer)
+
+		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.UnsignedMessage{msg1, msg2}, sender, types.NewBlockHeight(0), nil)
 		require.NoError(t, err)
 
-		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg1, sgnedMsg2}, sender, types.NewBlockHeight(0), nil)
-		require.NoError(t, err)
-
-		assert.Contains(t, result.SuccessfulMessages, sgnedMsg1)
-		assert.Contains(t, result.TemporaryFailures, sgnedMsg2)
+		assert.Nil(t, result[0].Failure)
+		assert.Error(t, result[1].Failure)
+		assert.False(t, result[0].FailureIsPermanent)
 	})
 
 	t.Run("message with high gas limit does not block messages with lower limits from being included in block", func(t *testing.T) {
 		msg1 := types.NewMeteredMessage(sender, receiver, 0, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{}, types.ZeroAttoFIL, types.BlockGasLimit*3/8)
-		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer)
-		require.NoError(t, err)
-
 		msg2 := types.NewMeteredMessage(sender, receiver, 1, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{}, types.ZeroAttoFIL, types.BlockGasLimit*7/8)
-		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer)
-		require.NoError(t, err)
-
 		msg3 := types.NewMeteredMessage(sender, receiver, 2, types.ZeroAttoFIL, "blockLimitTestMethod", []byte{}, types.ZeroAttoFIL, types.BlockGasLimit*3/8)
-		sgnedMsg3, err := types.NewSignedMessage(*msg3, signer)
+
+		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.UnsignedMessage{msg1, msg2, msg3}, sender, types.NewBlockHeight(0), nil)
 		require.NoError(t, err)
 
-		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg1, sgnedMsg2, sgnedMsg3}, sender, types.NewBlockHeight(0), nil)
-		require.NoError(t, err)
-
-		assert.Contains(t, result.SuccessfulMessages, sgnedMsg1, sgnedMsg3)
-		assert.Contains(t, result.TemporaryFailures, sgnedMsg2)
+		assert.Nil(t, result[0].Failure)
+		assert.Error(t, result[1].Failure)
+		assert.False(t, result[0].FailureIsPermanent)
+		assert.Nil(t, result[2].Failure)
 	})
 }
 
-func setupActorsForGasTest(t *testing.T, vms vm.StorageMap, fakeActorCodeCid cid.Cid, senderBalance uint64) ([]address.Address, state.Tree, *types.MockSigner) {
+func setupActorsForGasTest(t *testing.T, vms vm.StorageMap, fakeActorCodeCid cid.Cid, senderBalance uint64) ([]address.Address, state.Tree) {
 	addressGenerator := address.NewForTestGetter()
 
 	mockSigner, _ := types.NewMockSignersAndKeyInfo(3)
@@ -986,7 +938,7 @@ func setupActorsForGasTest(t *testing.T, vms vm.StorageMap, fakeActorCodeCid cid
 		mockSigner.Addresses[0], // addr0
 		mockSigner.Addresses[1], // addr1
 		mockSigner.Addresses[2], // addr2
-		addressGenerator()}      // minerAddr
+		addressGenerator()} // minerAddr
 
 	var actors []*actor.Actor
 	// act0 sender account actor
@@ -1014,7 +966,7 @@ func setupActorsForGasTest(t *testing.T, vms vm.StorageMap, fakeActorCodeCid cid
 	})
 	require.NotNil(t, cid)
 
-	return addresses, st, &mockSigner
+	return addresses, st
 }
 
 func mustSetup2Actors(t *testing.T, balance1 types.AttoFIL, balance2 types.AttoFIL) (address.Address, *actor.Actor, address.Address, *actor.Actor, state.Tree, types.MockSigner) {

--- a/internal/pkg/consensus/testing.go
+++ b/internal/pkg/consensus/testing.go
@@ -86,13 +86,11 @@ func NewFakePowerTableView(minerPower *types.BytesAmount, totalPower *types.Byte
 	return NewPowerTableView(tq)
 }
 
-// FakeSignedMessageValidator is a validator that doesn't validate to simplify message creation in tests.
-type FakeSignedMessageValidator struct{}
-
-var _ SignedMessageValidator = (*FakeSignedMessageValidator)(nil)
+// FakeMessageValidator is a validator that doesn't validate to simplify message creation in tests.
+type FakeMessageValidator struct{}
 
 // Validate always returns nil
-func (tsmv *FakeSignedMessageValidator) Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor) error {
+func (tsmv *FakeMessageValidator) Validate(ctx context.Context, msg *types.UnsignedMessage, fromActor *actor.Actor) error {
 	return nil
 }
 
@@ -108,7 +106,7 @@ func (tbr *FakeBlockRewarder) BlockReward(ctx context.Context, st state.Tree, mi
 }
 
 // GasReward is a noop
-func (tbr *FakeBlockRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr address.Address, msg *types.SignedMessage, gas types.AttoFIL) error {
+func (tbr *FakeBlockRewarder) GasReward(ctx context.Context, st state.Tree, minerOwnerAddr address.Address, msg *types.UnsignedMessage, cost types.AttoFIL) error {
 	// do nothing to keep state root the same
 	return nil
 }
@@ -116,9 +114,9 @@ func (tbr *FakeBlockRewarder) GasReward(ctx context.Context, st state.Tree, mine
 // NewFakeProcessor creates a processor with a test validator and test rewarder
 func NewFakeProcessor(actors builtin.Actors) *DefaultProcessor {
 	return &DefaultProcessor{
-		signedMessageValidator: &FakeSignedMessageValidator{},
-		blockRewarder:          &FakeBlockRewarder{},
-		actors:                 actors,
+		validator:     &FakeMessageValidator{},
+		blockRewarder: &FakeBlockRewarder{},
+		actors:        actors,
 	}
 }
 

--- a/internal/pkg/message/testing.go
+++ b/internal/pkg/message/testing.go
@@ -85,7 +85,7 @@ type FakeValidator struct {
 }
 
 // Validate returns an error only if `RejectMessages` is true.
-func (v FakeValidator) Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor) error {
+func (v FakeValidator) Validate(ctx context.Context, msg *types.UnsignedMessage, fromActor *actor.Actor) error {
 	if v.RejectMessages {
 		return errors.New("rejected for testing")
 	}

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -67,7 +67,7 @@ type MessageSource interface {
 // A MessageApplier processes all the messages in a message pool.
 type MessageApplier interface {
 	// ApplyMessagesAndPayRewards applies all state transitions related to a set of messages.
-	ApplyMessagesAndPayRewards(ctx context.Context, st state.Tree, vms vm.StorageMap, messages []*types.SignedMessage, minerOwnerAddr address.Address, bh *types.BlockHeight, ancestors []block.TipSet) (consensus.ApplyMessagesResponse, error)
+	ApplyMessagesAndPayRewards(ctx context.Context, st state.Tree, vms vm.StorageMap, messages []*types.UnsignedMessage, minerOwnerAddr address.Address, bh *types.BlockHeight, ancestors []block.TipSet) ([]*consensus.ApplyMessageResult, error)
 }
 
 type workerPorcelainAPI interface {

--- a/internal/pkg/types/signed_message.go
+++ b/internal/pkg/types/signed_message.go
@@ -47,6 +47,15 @@ func NewSignedMessage(msg UnsignedMessage, s Signer) (*SignedMessage, error) {
 	}, nil
 }
 
+// UnwrapSigned returns the unsigned messages from a slice of signed messages.
+func UnwrapSigned(smsgs []*SignedMessage) []*UnsignedMessage {
+	unsigned := make([]*UnsignedMessage, len(smsgs))
+	for i, sm := range smsgs {
+		unsigned[i] = &sm.Message
+	}
+	return unsigned
+}
+
 // Unmarshal a SignedMessage from the given bytes.
 func (smsg *SignedMessage) Unmarshal(b []byte) error {
 	return encoding.Decode(b, smsg)

--- a/internal/pkg/vm/actor/builtin/miner/miner_test.go
+++ b/internal/pkg/vm/actor/builtin/miner/miner_test.go
@@ -164,7 +164,7 @@ func TestChangeWorker(t *testing.T) {
 		gasLimit := types.NewGasUnits(10)
 		msg := types.NewMeteredMessage(mockSigner.Addresses[0], minerAddr, 0, types.ZeroAttoFIL, "changeWorker", pdata, gasPrice, gasLimit)
 
-		result, err := th.ApplyTestMessageWithGas(builtin.DefaultActors, st, vms, msg, types.NewBlockHeight(1), &mockSigner, mockSigner.Addresses[0])
+		result, err := th.ApplyTestMessageWithGas(builtin.DefaultActors, st, vms, msg, types.NewBlockHeight(1), mockSigner.Addresses[0])
 		assert.NoError(t, err)
 
 		require.Error(t, result.ExecutionError)
@@ -1293,7 +1293,7 @@ func TestActorSlashStorageFault(t *testing.T) {
 		gasLimit := types.NewGasUnits(10)
 		msg := types.NewMeteredMessage(mockSigner.Addresses[0], minerAddr, 0, types.ZeroAttoFIL, "slashStorageFault", []byte{}, gasPrice, gasLimit)
 
-		result, err := th.ApplyTestMessageWithGas(builtin.DefaultActors, st, vms, msg, types.NewBlockHeight(1), &mockSigner, mockSigner.Addresses[0])
+		result, err := th.ApplyTestMessageWithGas(builtin.DefaultActors, st, vms, msg, types.NewBlockHeight(1), mockSigner.Addresses[0])
 		require.NoError(t, err)
 
 		require.Error(t, result.ExecutionError)

--- a/internal/pkg/vm/gas_tracker.go
+++ b/internal/pkg/vm/gas_tracker.go
@@ -22,7 +22,7 @@ func NewGasTracker() *GasTracker {
 }
 
 // ResetForNewMessage will reset the per-message gas accumulator and set the MsgGasLimit to that of the message.
-func (gasTracker *GasTracker) ResetForNewMessage(message types.UnsignedMessage) {
+func (gasTracker *GasTracker) ResetForNewMessage(message *types.UnsignedMessage) {
 	gasTracker.MsgGasLimit = message.GasLimit
 	gasTracker.gasConsumedByMessage = types.NewGasUnits(0)
 }


### PR DESCRIPTION
### Motivation
Validation (and probably other future test code) wants to be able to invoke the processor with a message, assuming the signature has already been checked or is otherwise irrelevant.

### Proposed changes
This pulls the signature validation up the call tree, then passes the MeteredMessage to ApplyMessage (which validation code can then also call directly, bypassing signature validation).

WIP, nearly done. FYI @frrist @acruikshank, but I'm also thinking about the opposite approach of forcing signed messages in validation tools.