### PR TITLE
Introduce syncer dispatcher

### DIFF
--- a/syncer/dispatcher.go
+++ b/syncer/dispatcher.go
@@ -1,0 +1,157 @@
+package syncer
+
+import (
+	"errors"
+	"sync"
+	"container/heap"
+
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+var ErrBadPush = errors.New("a programmer is pushing the wrong type to a TargetQueue")
+var ErrBadPop = errors.New("a programmer is not checking targetQueue length before popping")
+
+// NewDispatcher creates a new syncing dispatcher.
+func NewDispatcher() *Dispatcher {
+	
+	return &Dispatcher{
+		targetSet: make(map[string]struct{}),
+		targetQ:   NewTargetQueue(),
+	}
+}
+
+// Dispatcher executes syncing requests 
+type Dispatcher struct {
+	// The dispatcher maintains a targetting system for determining the
+	// current best syncing target
+	// targetMu protects the targeting system
+	targetMu sync.Mutex
+	// targetSet tracks all tipsetkeys currently being targeted to prevent
+	// pushing duplicates to the target queue
+	targetSet map[string]struct{}
+	// targetQ is a priority queue of target tipsets
+	targetQ *TargetQueue
+}
+
+// ReceiveHello handles chain information from bootstrap peers.
+func (d *Dispatcher) ReceiveHello(ci types.ChainInfo) error {return d.receive(ci)}
+// RecieveOwnBlock handles chain info from a node's own mining system
+func (d *Dispatcher) ReceiveOwnBlock(ci types.ChainInfo) error {return d.receive(ci)}
+// ReceiveGossipBlock handles chain info from new blocks sent on pubsub
+func (d *Dispatcher) ReceiveGossipBlock(ci types.ChainInfo) error {return d.receive(ci)}
+
+func (d *Dispatcher) receive(ci types.ChainInfo) error {
+	d.targetMu.Lock()
+	defer d.targetMu.Unlock()
+
+	_, targeting := d.targetSet[ci.Head.String()]
+	if targeting {
+		// already tracking drop quickly
+		return nil
+	}
+	err := d.targetQ.Push(&SyncRequest{ChainInfo: ci})
+	if err != nil {
+		return err
+	}
+	d.targetSet[ci.Head.String()] = struct{}{}
+	return nil
+}
+
+// Start initialize the run loop that pops from the target queue and
+// dispatches syncRequests against the correct syncer.
+//
+// This method determines the default "business logic" of the syncing
+// subsystem.  It is responsible for interpreting information from the network 
+// and using it to securely update the node's chain state.
+func (d *Dispatcher) Start() {
+	// TODO: fill me in to link up existing syncer with dispatcher
+}
+
+// syncRequest tracks a logical request of the syncing subsystem to run a
+// syncing job against given inputs. syncRequests are created by the
+// Dispatcher by inspecting incoming hello messages from bootstrap peers
+// and gossipsub block propagations.
+type SyncRequest struct {
+	types.ChainInfo
+	// needed by internal container/heap methods for maintaining sort
+	index  int
+}
+
+// rawQueue orders the dispatchers syncRequests by a policy.
+// The current simple policy is to order syncing requests by claimed chain
+// height.
+//
+// rawQueue can panic so it shouldn't be used unwrapped
+type rawQueue []*SyncRequest
+
+// Heavily inspired by https://golang.org/pkg/container/heap/
+func (rq rawQueue) Len() int {return len(rq)}
+
+func (rq rawQueue) Less(i, j int) bool {
+	// We want Pop to give us the highest priority so we use greater than
+	return rq[i].Height > rq[j].Height
+}
+
+func (rq rawQueue) Swap(i, j int) {
+	rq[i], rq[j] = rq[j], rq[i]
+	rq[i].index = j
+	rq[j].index = i
+}
+
+func (rq *rawQueue) Push(x interface{}) {
+	n := len(*rq)
+	syncReq := x.(*SyncRequest)
+	syncReq.index = n
+	*rq = append(*rq, syncReq)
+}
+
+func (rq *rawQueue) Pop() interface{} {
+	old := *rq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil // avoid memory leak
+	item.index = -1 // for safety
+	*rq = old[0: n-1]
+	return item
+}
+
+// TargetQueue orders dispatcher syncRequests by the underlying rawQueue's
+// policy. It exposes programmer errors as return values instead of panicing.
+// Callers should check that length is greater than 0 before popping
+type TargetQueue struct {
+	q rawQueue
+}
+
+// NewTargetQueue returns a new target queue with an initialized rawQueue
+func NewTargetQueue() *TargetQueue {
+	rq := make(rawQueue, 0)
+	heap.Init(&rq)
+	return &TargetQueue{q: rq}
+}
+
+// Push adds a sync request to the target queue.
+func (tq *TargetQueue) Push(req *SyncRequest) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = ErrBadPush
+		}
+	}()
+	heap.Push(&tq.q, req)
+	return nil
+}
+
+// Pop removes and returns the highest priority syncing target.
+func (tq *TargetQueue) Pop() (req *SyncRequest, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			req = nil
+			err = ErrBadPop
+		}
+	}()
+	return heap.Pop(&tq.q).(*SyncRequest), nil
+}
+
+// Len returns the number of targets in the queue.
+func (tq *TargetQueue) Len() int {
+	return len(tq.q)
+}

--- a/syncer/dispatcher.go
+++ b/syncer/dispatcher.go
@@ -59,16 +59,6 @@ func (d *Dispatcher) receive(ci types.ChainInfo) error {
 	return nil
 }
 
-// Start initialize the run loop that pops from the target queue and
-// dispatches syncRequests against the correct syncer.
-//
-// This method determines the default "business logic" of the syncing
-// subsystem.  It is responsible for interpreting information from the network
-// and using it to securely update the node's chain state.
-func (d *Dispatcher) Start() {
-	// TODO: fill me in to link up existing syncer with dispatcher
-}
-
 // SyncRequest tracks a logical request of the syncing subsystem to run a
 // syncing job against given inputs. syncRequests are created by the
 // Dispatcher by inspecting incoming hello messages from bootstrap peers

--- a/syncer/dispatcher_test.go
+++ b/syncer/dispatcher_test.go
@@ -7,14 +7,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/syncer"
+	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
 func TestNewDispatcher(t *testing.T) {
+	tf.UnitTest(t)
 	syncer.NewDispatcher()
 }
 
 func TestQueueHappy(t *testing.T) {
+	tf.UnitTest(t)
 	testQ := syncer.NewTargetQueue()
 
 	// Add syncRequests out of order
@@ -44,19 +47,8 @@ func TestQueueHappy(t *testing.T) {
 	assert.Equal(t, 0, testQ.Len())
 }
 
-// requirePop is a helper requiring that pop does not error
-func requirePop(t *testing.T, q *syncer.TargetQueue) *syncer.SyncRequest {
-	req, err := q.Pop()
-	require.NoError(t, err)
-	return req
-}
-
-// requirePush is a helper requiring that push does not error
-func requirePush(t *testing.T, req *syncer.SyncRequest, q *syncer.TargetQueue) {
-	require.NoError(t, q.Push(req))
-}
-
 func TestQueueDuplicates(t *testing.T) {
+	tf.UnitTest(t)
 	testQ := syncer.NewTargetQueue()
 
 	// Add syncRequests with same height
@@ -78,6 +70,7 @@ func TestQueueDuplicates(t *testing.T) {
 }
 
 func TestQueueEmptyPop(t *testing.T) {
+	tf.UnitTest(t)
 	testQ := syncer.NewTargetQueue()
 	sR0 := &syncer.SyncRequest{ChainInfo: types.ChainInfo{Height: 0}}
 	sR47 := &syncer.SyncRequest{ChainInfo: types.ChainInfo{Height: 47}}
@@ -96,4 +89,16 @@ func TestQueueEmptyPop(t *testing.T) {
 	_, err := testQ.Pop()
 	assert.Error(t, err)
 	assert.Equal(t, 0, testQ.Len())
+}
+
+// requirePop is a helper requiring that pop does not error
+func requirePop(t *testing.T, q *syncer.TargetQueue) *syncer.SyncRequest {
+	req, err := q.Pop()
+	require.NoError(t, err)
+	return req
+}
+
+// requirePush is a helper requiring that push does not error
+func requirePush(t *testing.T, req *syncer.SyncRequest, q *syncer.TargetQueue) {
+	require.NoError(t, q.Push(req))
 }

--- a/syncer/dispatcher_test.go
+++ b/syncer/dispatcher_test.go
@@ -1,15 +1,14 @@
 package syncer_test
 
-import(
+import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"	
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/syncer"
-	"github.com/filecoin-project/go-filecoin/types"	
+	"github.com/filecoin-project/go-filecoin/types"
 )
-
 
 func TestNewDispatcher(t *testing.T) {
 	syncer.NewDispatcher()
@@ -40,8 +39,8 @@ func TestQueueHappy(t *testing.T) {
 	assert.Equal(t, uint64(47), out0.ChainInfo.Height)
 	assert.Equal(t, uint64(2), out1.ChainInfo.Height)
 	assert.Equal(t, uint64(1), out2.ChainInfo.Height)
-	assert.Equal(t, uint64(0), out3.ChainInfo.Height)	
-	
+	assert.Equal(t, uint64(0), out3.ChainInfo.Height)
+
 	assert.Equal(t, 0, testQ.Len())
 }
 
@@ -57,7 +56,6 @@ func requirePush(t *testing.T, req *syncer.SyncRequest, q *syncer.TargetQueue) {
 	require.NoError(t, q.Push(req))
 }
 
-
 func TestQueueDuplicates(t *testing.T) {
 	testQ := syncer.NewTargetQueue()
 
@@ -69,14 +67,14 @@ func TestQueueDuplicates(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = testQ.Push(sR0dup)
-	assert.NoError(t, err)	
-	
+	assert.NoError(t, err)
+
 	// Pop twice
 	first := requirePop(t, testQ)
-	second := requirePop(t, testQ)	
-	
+	second := requirePop(t, testQ)
+
 	assert.Equal(t, uint64(0), first.ChainInfo.Height)
-	assert.Equal(t, uint64(0), second.ChainInfo.Height)	
+	assert.Equal(t, uint64(0), second.ChainInfo.Height)
 }
 
 func TestQueueEmptyPop(t *testing.T) {
@@ -97,5 +95,5 @@ func TestQueueEmptyPop(t *testing.T) {
 
 	_, err := testQ.Pop()
 	assert.Error(t, err)
-	assert.Equal(t, 0, testQ.Len())	
+	assert.Equal(t, 0, testQ.Len())
 }

--- a/syncer/dispatcher_test.go
+++ b/syncer/dispatcher_test.go
@@ -1,0 +1,101 @@
+package syncer_test
+
+import(
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"	
+
+	"github.com/filecoin-project/go-filecoin/syncer"
+	"github.com/filecoin-project/go-filecoin/types"	
+)
+
+
+func TestNewDispatcher(t *testing.T) {
+	syncer.NewDispatcher()
+}
+
+func TestQueueHappy(t *testing.T) {
+	testQ := syncer.NewTargetQueue()
+
+	// Add syncRequests out of order
+	sR0 := &syncer.SyncRequest{ChainInfo: types.ChainInfo{Height: 0}}
+	sR1 := &syncer.SyncRequest{ChainInfo: types.ChainInfo{Height: 1}}
+	sR2 := &syncer.SyncRequest{ChainInfo: types.ChainInfo{Height: 2}}
+	sR47 := &syncer.SyncRequest{ChainInfo: types.ChainInfo{Height: 47}}
+
+	requirePush(t, sR2, testQ)
+	requirePush(t, sR47, testQ)
+	requirePush(t, sR0, testQ)
+	requirePush(t, sR1, testQ)
+
+	assert.Equal(t, 4, testQ.Len())
+
+	// Pop in order
+	out0 := requirePop(t, testQ)
+	out1 := requirePop(t, testQ)
+	out2 := requirePop(t, testQ)
+	out3 := requirePop(t, testQ)
+
+	assert.Equal(t, uint64(47), out0.ChainInfo.Height)
+	assert.Equal(t, uint64(2), out1.ChainInfo.Height)
+	assert.Equal(t, uint64(1), out2.ChainInfo.Height)
+	assert.Equal(t, uint64(0), out3.ChainInfo.Height)	
+	
+	assert.Equal(t, 0, testQ.Len())
+}
+
+// requirePop is a helper requiring that pop does not error
+func requirePop(t *testing.T, q *syncer.TargetQueue) *syncer.SyncRequest {
+	req, err := q.Pop()
+	require.NoError(t, err)
+	return req
+}
+
+// requirePush is a helper requiring that push does not error
+func requirePush(t *testing.T, req *syncer.SyncRequest, q *syncer.TargetQueue) {
+	require.NoError(t, q.Push(req))
+}
+
+
+func TestQueueDuplicates(t *testing.T) {
+	testQ := syncer.NewTargetQueue()
+
+	// Add syncRequests with same height
+	sR0 := &syncer.SyncRequest{ChainInfo: types.ChainInfo{Height: 0}}
+	sR0dup := &syncer.SyncRequest{ChainInfo: types.ChainInfo{Height: 0}}
+
+	err := testQ.Push(sR0)
+	assert.NoError(t, err)
+
+	err = testQ.Push(sR0dup)
+	assert.NoError(t, err)	
+	
+	// Pop twice
+	first := requirePop(t, testQ)
+	second := requirePop(t, testQ)	
+	
+	assert.Equal(t, uint64(0), first.ChainInfo.Height)
+	assert.Equal(t, uint64(0), second.ChainInfo.Height)	
+}
+
+func TestQueueEmptyPop(t *testing.T) {
+	testQ := syncer.NewTargetQueue()
+	sR0 := &syncer.SyncRequest{ChainInfo: types.ChainInfo{Height: 0}}
+	sR47 := &syncer.SyncRequest{ChainInfo: types.ChainInfo{Height: 47}}
+
+	// Push 2
+	requirePush(t, sR47, testQ)
+	requirePush(t, sR0, testQ)
+
+	// Pop 3
+	assert.Equal(t, 2, testQ.Len())
+	_ = requirePop(t, testQ)
+	assert.Equal(t, 1, testQ.Len())
+	_ = requirePop(t, testQ)
+	assert.Equal(t, 0, testQ.Len())
+
+	_, err := testQ.Pop()
+	assert.Error(t, err)
+	assert.Equal(t, 0, testQ.Len())	
+}


### PR DESCRIPTION
This PR introduces the syncer dispatcher.
It includes a basic priority queue subcomponent for explicitly tracking target chains

### Motivation
This is part of bringing chain sync up to spec

### Proposed changes
Add syncer package
Add unused dispatcher abstraction
Outfit dispatcher with a nice priority queue

After this PR others will shortly follow that hook the dispatcher up to incoming network traffic and put it in charge of issuing `HandleNewTipset` calls.

Closes issue # (still haven't written it up, coming soon)

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

As this is pretty disconnected from existing code either @acruikshank or @icorderi are equally equipped to review.  Whoever gets to it first.