### PR TITLE
Feat/connect dispatcher

### DIFF
--- a/node/block.go
+++ b/node/block.go
@@ -28,8 +28,7 @@ func (node *Node) AddNewBlock(ctx context.Context, b *block.Block) (err error) {
 
 	log.Debugf("syncing new block: %s", b.Cid().String())
 
-	trusted := true // This block was mined by us, so we trust it.
-	if err := node.Chain.Syncer.HandleNewTipSet(ctx, block.NewChainInfo(node.Host().ID(), block.NewTipSetKey(blkCid), uint64(b.Height)), trusted); err != nil {
+	if err := node.Chain.SyncDispatch.ReceiveOwnBlock(block.NewChainInfo(node.Host().ID(), block.NewTipSetKey(blkCid), uint64(b.Height))); err != nil {
 		return err
 	}
 
@@ -62,10 +61,9 @@ func (node *Node) processBlock(ctx context.Context, pubSubMsg pubsub.Message) (e
 	// See https://github.com/filecoin-project/go-filecoin/issues/2962
 	// TODO Implement principled trusting of ChainInfo's
 	// to address in #2674
-	trusted := true
-	err = node.Chain.Syncer.HandleNewTipSet(ctx, block.NewChainInfo(from, block.NewTipSetKey(blk.Cid()), uint64(blk.Height)), trusted)
+	err = node.Chain.SyncDispatch.ReceiveGossipBlock(block.NewChainInfo(from, block.NewTipSetKey(blk.Cid()), uint64(blk.Height)), )
 	if err != nil {
-		return errors.Wrapf(err, "processing block %s from peer %s", blk.Cid(), from)
+		return errors.Wrapf(err, "recieve block %s from peer %s", blk.Cid(), from)
 	}
 
 	return nil

--- a/node/block.go
+++ b/node/block.go
@@ -28,7 +28,7 @@ func (node *Node) AddNewBlock(ctx context.Context, b *block.Block) (err error) {
 
 	log.Debugf("syncing new block: %s", b.Cid().String())
 
-	if err := node.Chain.SyncDispatch.ReceiveOwnBlock(block.NewChainInfo(node.Host().ID(), block.NewTipSetKey(blkCid), uint64(b.Height))); err != nil {
+	if err := node.Chain.SyncDispatch.SendOwnBlock(block.NewChainInfo(node.Host().ID(), block.NewTipSetKey(blkCid), uint64(b.Height))); err != nil {
 		return err
 	}
 
@@ -61,7 +61,7 @@ func (node *Node) processBlock(ctx context.Context, pubSubMsg pubsub.Message) (e
 	// See https://github.com/filecoin-project/go-filecoin/issues/2962
 	// TODO Implement principled trusting of ChainInfo's
 	// to address in #2674
-	err = node.Chain.SyncDispatch.ReceiveGossipBlock(block.NewChainInfo(from, block.NewTipSetKey(blk.Cid()), uint64(blk.Height)))
+	err = node.Chain.SyncDispatch.SendGossipBlock(block.NewChainInfo(from, block.NewTipSetKey(blk.Cid()), uint64(blk.Height)))
 	if err != nil {
 		return errors.Wrapf(err, "receive block %s from peer %s", blk.Cid(), from)
 	}

--- a/node/block.go
+++ b/node/block.go
@@ -61,9 +61,9 @@ func (node *Node) processBlock(ctx context.Context, pubSubMsg pubsub.Message) (e
 	// See https://github.com/filecoin-project/go-filecoin/issues/2962
 	// TODO Implement principled trusting of ChainInfo's
 	// to address in #2674
-	err = node.Chain.SyncDispatch.ReceiveGossipBlock(block.NewChainInfo(from, block.NewTipSetKey(blk.Cid()), uint64(blk.Height)), )
+	err = node.Chain.SyncDispatch.ReceiveGossipBlock(block.NewChainInfo(from, block.NewTipSetKey(blk.Cid()), uint64(blk.Height)))
 	if err != nil {
-		return errors.Wrapf(err, "recieve block %s from peer %s", blk.Cid(), from)
+		return errors.Wrapf(err, "receive block %s from peer %s", blk.Cid(), from)
 	}
 
 	return nil

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -108,6 +108,8 @@ func TestChainSync(t *testing.T) {
 	StartNodes(t, nodes)
 	defer StopNodes(nodes)
 
+	connect(t, nodes[0], nodes[1])
+
 	firstBlock := requireMineOnce(ctx, t, nodes[0])
 	secondBlock := requireMineOnce(ctx, t, nodes[0])
 	thirdBlock := requireMineOnce(ctx, t, nodes[0])
@@ -116,16 +118,6 @@ func TestChainSync(t *testing.T) {
 	assert.NoError(t, nodes[0].AddNewBlock(ctx, secondBlock))
 	assert.NoError(t, nodes[0].AddNewBlock(ctx, thirdBlock))
 
-	// Wait for node[0] to sync mined blocks to ensure there is no
-	// race where node[0] sends genesis to node[1] during hello
-	for i := 0; i < 10; i++ {
-		if nodes[0].Chain.SyncDispatch.ActiveRequests() == 0 {
-			break
-		}
-		time.Sleep(time.Millisecond * 20)
-	}
-
-	connect(t, nodes[0], nodes[1])
 	equal := false
 	for i := 0; i < 30; i++ {
 		otherHead := nodes[1].Chain.ChainReader.GetHead()

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -116,6 +116,15 @@ func TestChainSync(t *testing.T) {
 	assert.NoError(t, nodes[0].AddNewBlock(ctx, secondBlock))
 	assert.NoError(t, nodes[0].AddNewBlock(ctx, thirdBlock))
 
+	// Wait for node[0] to sync mined blocks to ensure there is no
+	// race where node[0] sends genesis to node[1] during hello
+	for i := 0; i < 10; i++ {
+		if nodes[0].Chain.SyncDispatch.ActiveRequests() == 0 {
+			break
+		}
+		time.Sleep(time.Millisecond * 20)
+	}
+
 	connect(t, nodes[0], nodes[1])
 	equal := false
 	for i := 0; i < 30; i++ {

--- a/node/builder.go
+++ b/node/builder.go
@@ -53,6 +53,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/proofs/verification"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/state"
+	"github.com/filecoin-project/go-filecoin/syncer"	
 	"github.com/filecoin-project/go-filecoin/util/moresync"
 	"github.com/filecoin-project/go-filecoin/version"
 	"github.com/filecoin-project/go-filecoin/wallet"
@@ -451,6 +452,7 @@ func (b *Builder) buildChain(ctx context.Context, blockstore *BlockstoreSubmodul
 
 	// only the syncer gets the storage which is online connected
 	chainSyncer := chain.NewSyncer(nodeConsensus, nodeChainSelector, chainStore, messageStore, fetcher, chainStatusReporter, b.Clock)
+	syncerDispatcher := syncer.NewDispatcher(chainSyncer)
 
 	chainState := cst.NewChainStateReadWriter(chainStore, messageStore, blockstore.cborStore, builtin.DefaultActors)
 
@@ -460,7 +462,7 @@ func (b *Builder) buildChain(ctx context.Context, blockstore *BlockstoreSubmodul
 		ChainSelector: nodeChainSelector,
 		ChainReader:   chainStore,
 		MessageStore:  messageStore,
-		Syncer:        chainSyncer,
+		SyncDispatch:  syncerDispatcher,
 		ActorState:    actorState,
 		// HeaviestTipSetCh: nil,
 		// cancelChainSync: nil,

--- a/node/builder.go
+++ b/node/builder.go
@@ -53,7 +53,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/proofs/verification"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/state"
-	"github.com/filecoin-project/go-filecoin/syncer"	
 	"github.com/filecoin-project/go-filecoin/syncer"
 	"github.com/filecoin-project/go-filecoin/util/moresync"
 	"github.com/filecoin-project/go-filecoin/version"

--- a/node/builder.go
+++ b/node/builder.go
@@ -54,6 +54,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/syncer"	
+	"github.com/filecoin-project/go-filecoin/syncer"
 	"github.com/filecoin-project/go-filecoin/util/moresync"
 	"github.com/filecoin-project/go-filecoin/version"
 	"github.com/filecoin-project/go-filecoin/wallet"

--- a/node/chain_submodule.go
+++ b/node/chain_submodule.go
@@ -19,6 +19,7 @@ type ChainSubmodule struct {
 	ChainReader   nodeChainReader
 	MessageStore  *chain.MessageStore
 	Syncer        nodeChainSyncer
+	SyncDispatch  nodeSyncDispatcher
 	ActorState    *consensus.ActorStateStore
 
 	// HeavyTipSetCh is a subscription to the heaviest tipset topic on the chain.

--- a/node/helpers.go
+++ b/node/helpers.go
@@ -32,6 +32,13 @@ type nodeChainSyncer interface {
 	Status() chain.Status
 }
 
+type nodeSyncDispatcher interface {
+	ReceiveHello(*types.ChainInfo) error
+	ReceiveOwnBlock(*types.ChainInfo) error
+	ReceiveGossipBlock(*types.ChainInfo) error
+	Start(context.Context)
+}
+
 type nodeChainSelector interface {
 	NewWeight(context.Context, block.TipSet, cid.Cid) (uint64, error)
 	Weight(context.Context, block.TipSet, cid.Cid) (uint64, error)

--- a/node/helpers.go
+++ b/node/helpers.go
@@ -33,9 +33,9 @@ type nodeChainSyncer interface {
 }
 
 type nodeSyncDispatcher interface {
-	ReceiveHello(*block.ChainInfo) error
-	ReceiveOwnBlock(*block.ChainInfo) error
-	ReceiveGossipBlock(*block.ChainInfo) error
+	SendHello(*block.ChainInfo) error
+	SendOwnBlock(*block.ChainInfo) error
+	SendGossipBlock(*block.ChainInfo) error
 	Start(context.Context)
 }
 

--- a/node/helpers.go
+++ b/node/helpers.go
@@ -33,9 +33,9 @@ type nodeChainSyncer interface {
 }
 
 type nodeSyncDispatcher interface {
-	ReceiveHello(*types.ChainInfo) error
-	ReceiveOwnBlock(*types.ChainInfo) error
-	ReceiveGossipBlock(*types.ChainInfo) error
+	ReceiveHello(*block.ChainInfo) error
+	ReceiveOwnBlock(*block.ChainInfo) error
+	ReceiveGossipBlock(*block.ChainInfo) error
 	Start(context.Context)
 	ActiveRequests() int
 }

--- a/node/helpers.go
+++ b/node/helpers.go
@@ -37,7 +37,6 @@ type nodeSyncDispatcher interface {
 	ReceiveOwnBlock(*block.ChainInfo) error
 	ReceiveGossipBlock(*block.ChainInfo) error
 	Start(context.Context)
-	ActiveRequests() int
 }
 
 type nodeChainSelector interface {

--- a/node/helpers.go
+++ b/node/helpers.go
@@ -37,6 +37,7 @@ type nodeSyncDispatcher interface {
 	ReceiveOwnBlock(*types.ChainInfo) error
 	ReceiveGossipBlock(*types.ChainInfo) error
 	Start(context.Context)
+	ActiveRequests() int
 }
 
 type nodeChainSelector interface {

--- a/node/node.go
+++ b/node/node.go
@@ -148,18 +148,18 @@ func (node *Node) Start(ctx context.Context) error {
 		// Start bootstrapper.
 		node.Network.Bootstrapper.Start(context.Background())
 
+		// Start syncing dispatch
+		node.Chain.SyncDispatch.Start(context.Background())
+
 		// Register peer tracker disconnect function with network.
 		net.TrackerRegisterDisconnect(node.Network.host.Network(), node.Network.PeerTracker)
 
 		// Start up 'hello' handshake service
 		helloCallback := func(ci *block.ChainInfo) {
 			node.Network.PeerTracker.Track(ci)
-			// TODO Implement principled trusting of ChainInfo's
-			// to address in #2674
-			trusted := true
-			err := node.Chain.Syncer.HandleNewTipSet(context.Background(), ci, trusted)
+			err := node.Chain.SyncDispatch.ReceiveHello(ci)
 			if err != nil {
-				log.Infof("error handling tipset from hello %s: %s", ci, err)
+				log.Errorf("error receiving chain info from hello %s: %s", ci, err)
 				return
 			}
 			// For now, consider the initial bootstrap done after the syncer has (synchronously)

--- a/node/node.go
+++ b/node/node.go
@@ -157,7 +157,7 @@ func (node *Node) Start(ctx context.Context) error {
 		// Start up 'hello' handshake service
 		helloCallback := func(ci *block.ChainInfo) {
 			node.Network.PeerTracker.Track(ci)
-			err := node.Chain.SyncDispatch.ReceiveHello(ci)
+			err := node.Chain.SyncDispatch.SendHello(ci)
 			if err != nil {
 				log.Errorf("error receiving chain info from hello %s: %s", ci, err)
 				return

--- a/syncer/dispatcher.go
+++ b/syncer/dispatcher.go
@@ -19,7 +19,7 @@ var errBadSet = errors.New("a programmer is not correctly maintaining the target
 
 // syncer is the interface of the logic syncing incoming chains
 type syncer interface {
-	HandleNewTipSet(context.Context, *types.ChainInfo, bool) error
+	HandleNewTipSet(context.Context, *block.ChainInfo, bool) error
 }
 
 // NewDispatcher creates a new syncing dispatcher.

--- a/syncer/dispatcher.go
+++ b/syncer/dispatcher.go
@@ -14,6 +14,8 @@ var log = logging.Logger("sync.dispatch")
 
 var errEmptyPop = errors.New("pop on empty targetQueue")
 
+// This is the size of the channel buffer used for receiving sync requests from
+// producers.
 const productionBufferSize = 5
 
 // syncer is the interface of the logic syncing incoming chains
@@ -24,27 +26,45 @@ type syncer interface {
 // NewDispatcher creates a new syncing dispatcher.
 func NewDispatcher(catchupSyncer syncer) *Dispatcher {
 	return &Dispatcher{
-		targetQ:           NewTargetQueue(),
-		catchupSyncer:     catchupSyncer,
-		productionChannel: make(chan *SyncRequest, productionBufferSize),
+		targetQ:             NewTargetQueue(),
+		catchupSyncer:       catchupSyncer,
+		production:          make(chan SyncRequest, productionBufferSize),
+		control:             make(chan interface{}),
+		onProcessedCountCbs: make([]onProcessedCountCb, 0),
 	}
+}
+
+// OnProcessedCountMessage registers a user callback to be fired once the
+// count of messages is processed.
+type onProcessedCountCb struct {
+	cb       func()
+	n, start uint64
 }
 
 // Dispatcher executes syncing requests
 type Dispatcher struct {
+	// The following fields handle syncer request dispatch
 	// The dispatcher maintains a targeting system for determining the
 	// current best syncing target
 	// targetQ is a priority queue of target tipsets
 	targetQ *TargetQueue
-
-	// productionChannel synchronizes adding sync requests to the dispatcher.
+	// production synchronizes adding sync requests to the dispatcher.
 	// The dispatcher relies on a single reader pulling from this.  Don't add
 	// another reader without care.
-	productionChannel chan *SyncRequest
-
+	production chan SyncRequest
 	// catchupSyncer is used for dispatching sync requests for chain heads
 	// during the CHAIN_CATCHUP mode of operation
 	catchupSyncer syncer
+
+	// The following fields allow outside processes to issue commands to
+	// the dispatcher, for example to synchronize with it or inspect state
+	onProcessedCountCbs []onProcessedCountCb
+	control             chan interface{}
+
+	// The following fields are diagnostics maintained by the dispatcher
+	// syncReqCount tracks the total number of sync requests dispatched to
+	// syncers.  We do not handle overflows.
+	syncReqCount uint64
 }
 
 // ReceiveHello handles chain information from bootstrap peers.
@@ -57,7 +77,7 @@ func (d *Dispatcher) ReceiveOwnBlock(ci *block.ChainInfo) error { return d.recei
 func (d *Dispatcher) ReceiveGossipBlock(ci *block.ChainInfo) error { return d.receive(ci) }
 
 func (d *Dispatcher) receive(ci *block.ChainInfo) error {
-	d.productionChannel <- &SyncRequest{ChainInfo: *ci}
+	d.production <- SyncRequest{ChainInfo: *ci}
 	return nil
 }
 
@@ -67,14 +87,18 @@ func (d *Dispatcher) receive(ci *block.ChainInfo) error {
 func (d *Dispatcher) Start(syncingCtx context.Context) {
 	go func() {
 		for {
-			var produced []*SyncRequest
+			// Begin by firing off any callbacks that are ready
+			d.maybeFireCbs()
+			var produced []SyncRequest
 			// If there's something on the target queue: read from
 			// the production queue without blocking.
 			if d.targetQ.Len() != 0 {
 				select {
-				case first := <-d.productionChannel:
+				case first := <-d.production:
 					produced = append(produced, first)
 					produced = append(produced, d.drainProduced()...)
+				case ctrl := <-d.control:
+					d.registerCtrl(ctrl)
 				case <-syncingCtx.Done():
 					return
 				default: // go straight to syncing
@@ -83,9 +107,11 @@ func (d *Dispatcher) Start(syncingCtx context.Context) {
 				// block until we have something from production
 				// queue.
 				select {
-				case first := <-d.productionChannel:
+				case first := <-d.production:
 					produced = append(produced, first)
 					produced = append(produced, d.drainProduced()...)
+				case ctrl := <-d.control:
+					d.registerCtrl(ctrl)
 				case <-syncingCtx.Done():
 					return
 				}
@@ -105,21 +131,64 @@ func (d *Dispatcher) Start(syncingCtx context.Context) {
 			err = d.catchupSyncer.HandleNewTipSet(syncingCtx, &syncReq.ChainInfo, true)
 			if err != nil {
 				log.Infof("error running sync request %s", err)
+				return
 			}
+			d.syncReqCount++
 		}
 	}()
 }
 
-func (d *Dispatcher) drainProduced() []*SyncRequest {
+func (d *Dispatcher) drainProduced() []SyncRequest {
 	// drain channel. Note this relies on a single reader of the production
 	// channel.
-	n := len(d.productionChannel)
-	var produced []*SyncRequest
+	n := len(d.production)
+	var produced []SyncRequest
 	for i := 0; i < n; i++ {
-		next := <-d.productionChannel
+		next := <-d.production
 		produced = append(produced, next)
 	}
 	return produced
+}
+
+// RegisterOnProcessedCount registers a callback on the dispatcher that
+// will fire after processing the provided number of sync requests.
+func (d *Dispatcher) RegisterOnProcessedCount(count uint64, cb func()) {
+	d.control <- onProcessedCountCb{n: count, cb: cb}
+}
+
+// registerCtrl takes a control message, determines its type, and registers
+// the provided callback with the dispatcher.
+func (d *Dispatcher) registerCtrl(i interface{}) {
+	// Using interfaces is overkill for now but is the way to make this
+	// extensible.  (Delete this comment if we add more than one control)
+	switch msg := i.(type) {
+	case onProcessedCountCb:
+		msg.start = d.syncReqCount
+		d.onProcessedCountCbs = append(d.onProcessedCountCbs, msg)
+	default:
+		// We don't know this type, log and ignore
+		log.Info("dispatcher control can not handle type %T", msg)
+	}
+}
+
+// maybeFireCbs fires all callbacks registered on the dispatcher that should
+// fire given the dispatcher's state.
+func (d *Dispatcher) maybeFireCbs() {
+	var removedIdxs []int
+	for i, opcCb := range d.onProcessedCountCbs {
+		if opcCb.start+opcCb.n <= d.syncReqCount {
+			removedIdxs = append(removedIdxs, i)
+			opcCb.cb()
+		}
+	}
+	for _, i := range removedIdxs {
+		// taken from here: https://yourbasic.org/golang/delete-element-slice/
+		// order doesn't matter.
+		n := len(d.onProcessedCountCbs)
+		d.onProcessedCountCbs[i] = d.onProcessedCountCbs[n-1]
+		d.onProcessedCountCbs[n-1] = onProcessedCountCb{}
+		d.onProcessedCountCbs = d.onProcessedCountCbs[:n-1]
+	}
 }
 
 // SyncRequest tracks a logical request of the syncing subsystem to run a
@@ -137,7 +206,7 @@ type SyncRequest struct {
 // height.
 //
 // rawQueue can panic so it shouldn't be used unwrapped
-type rawQueue []*SyncRequest
+type rawQueue []SyncRequest
 
 // Heavily inspired by https://golang.org/pkg/container/heap/
 func (rq rawQueue) Len() int { return len(rq) }
@@ -155,7 +224,7 @@ func (rq rawQueue) Swap(i, j int) {
 
 func (rq *rawQueue) Push(x interface{}) {
 	n := len(*rq)
-	syncReq := x.(*SyncRequest)
+	syncReq := x.(SyncRequest)
 	syncReq.index = n
 	*rq = append(*rq, syncReq)
 }
@@ -164,7 +233,6 @@ func (rq *rawQueue) Pop() interface{} {
 	old := *rq
 	n := len(old)
 	item := old[n-1]
-	old[n-1] = nil  // avoid memory leak
 	item.index = -1 // for safety
 	*rq = old[0 : n-1]
 	return item
@@ -190,7 +258,7 @@ func NewTargetQueue() *TargetQueue {
 }
 
 // Push adds a sync request to the target queue.
-func (tq *TargetQueue) Push(req *SyncRequest) {
+func (tq *TargetQueue) Push(req SyncRequest) {
 	// If already in queue drop quickly
 	if _, inQ := tq.targetSet[req.ChainInfo.Head.String()]; inQ {
 		return
@@ -202,11 +270,11 @@ func (tq *TargetQueue) Push(req *SyncRequest) {
 }
 
 // Pop removes and returns the highest priority syncing target.
-func (tq *TargetQueue) Pop() (*SyncRequest, error) {
+func (tq *TargetQueue) Pop() (SyncRequest, error) {
 	if tq.Len() == 0 {
-		return nil, errEmptyPop
+		return SyncRequest{}, errEmptyPop
 	}
-	req := heap.Pop(&tq.q).(*SyncRequest)
+	req := heap.Pop(&tq.q).(SyncRequest)
 	popKey := req.ChainInfo.Head.String()
 	delete(tq.targetSet, popKey)
 	return req, nil

--- a/syncer/dispatcher.go
+++ b/syncer/dispatcher.go
@@ -12,8 +12,6 @@ import (
 
 var log = logging.Logger("sync.dispatch")
 
-var errEmptyPop = errors.New("pop on empty targetQueue")
-
 // This is the size of the channel buffer used for receiving sync requests from
 // producers.
 const productionBufferSize = 5
@@ -88,12 +86,12 @@ func (d *Dispatcher) Start(syncingCtx context.Context) {
 	go func() {
 		var last *SyncRequest
 		for {
-			// Begin by firing off any callbacks that are ready			
+			// Begin by firing off any callbacks that are ready
 			d.maybeFireCbs()
 			// Handle shutdown
 			select {
 			case <-syncingCtx.Done():
-				return				
+				return
 			default:
 			}
 
@@ -129,7 +127,7 @@ func (d *Dispatcher) Start(syncingCtx context.Context) {
 				if err != nil {
 					log.Info("sync request could not complete: %s", err)
 				}
-				d.syncReqCount++				
+				d.syncReqCount++
 			} else {
 				// No work left, block until something shows up
 				select {
@@ -162,7 +160,7 @@ func (d *Dispatcher) RegisterOnProcessedCount(count uint64, cb func()) {
 }
 
 // receiveCtrl takes a control message, determines its type, and performs the
-// specified action. 
+// specified action.
 func (d *Dispatcher) receiveCtrl(i interface{}) {
 	// Using interfaces is overkill for now but is the way to make this
 	// extensible.  (Delete this comment if we add more than one control)
@@ -266,7 +264,7 @@ func (tq *TargetQueue) Push(req SyncRequest) {
 	return
 }
 
-// Pop removes and returns the highest priority syncing target. If there is 
+// Pop removes and returns the highest priority syncing target. If there is
 // nothing in the queue the second argument returns false
 func (tq *TargetQueue) Pop() (SyncRequest, bool) {
 	if tq.Len() == 0 {

--- a/syncer/dispatcher.go
+++ b/syncer/dispatcher.go
@@ -1,8 +1,6 @@
 package syncer
 
 import (
-
-	"fmt"
 	"container/heap"
 	"context"	
 	"errors"
@@ -16,6 +14,7 @@ var log = logging.Logger("sync.dispatch")
 
 var errBadPush = errors.New("a programmer is pushing the wrong type to a TargetQueue")
 var errBadPop = errors.New("a programmer is not checking targetQueue length before popping")
+var errBadSet = errors.New("a programmer is not correctly maintaining the targetSet")
 
 // syncer is the interface of the logic syncing incoming chains
 type syncer interface {
@@ -26,7 +25,6 @@ type syncer interface {
 func NewDispatcher(catchupSyncer syncer) *Dispatcher {
 
 	return &Dispatcher{
-		targetSet: make(map[string]struct{}),
 		targetQ:   NewTargetQueue(),
 		catchupSyncer: catchupSyncer,
 	}
@@ -62,16 +60,11 @@ func (d *Dispatcher) receive(ci *block.ChainInfo) error {
 	d.targetMu.Lock()
 	defer d.targetMu.Unlock()
 
-	_, targeting := d.targetSet[ci.Head.String()]
-	if targeting {
-		// already tracking drop quickly
-		return nil
-	}
 	err := d.targetQ.Push(&SyncRequest{ChainInfo: *ci})
 	if err != nil {
 		return err
 	}
-	d.targetSet[ci.Head.String()] = struct{}{}
+
 	return nil
 }
 
@@ -162,12 +155,13 @@ func (rq *rawQueue) Pop() interface{} {
 // All methods are threadsafe.  Concurrent pushes and pops are allowed.
 // Pop is a blocking call in the case the queue is empty.
 type TargetQueue struct {
-	q rawQueue
+	q         rawQueue
+	targetSet map[string]struct{}
 	
 	// the following fields ensure thread safety
 	// popMu ensures that a single popper will wait for the empty wg
 	popMu sync.Mutex
-	// rawMu ensures a single go-routine accesses rawQueue
+	// rawMu ensures a single go-routine accesses rawQueue and 
 	rawMu sync.Mutex
 	// empty signals when a queue is empty and no-longer empty
 	empty sync.WaitGroup
@@ -177,9 +171,15 @@ type TargetQueue struct {
 func NewTargetQueue() *TargetQueue {
 	rq := make(rawQueue, 0)
 	heap.Init(&rq)
-	var empty sync.WaitGroup
-	empty.Add(1) // queue starts off empty
-	return &TargetQueue{q: rq, empty: empty}
+	tq := &TargetQueue{
+		q: rq,
+		targetSet: make(map[string]struct{}),	
+	}
+	
+	// Important to add to waitgroup directly on struct, waitgroup internals
+	// rely on memory not moving!
+	tq.empty.Add(1)
+	return tq
 }
 
 // Push adds a sync request to the target queue.
@@ -187,16 +187,21 @@ func (tq *TargetQueue) Push(req *SyncRequest) (err error) {
 	tq.rawMu.Lock()
 	defer tq.rawMu.Unlock()
 	defer func() {
+		// This converts heap.Push panics to programmer errors
 		if r := recover(); r != nil {
-			fmt.Printf("r: %v\n", r)
 			err = errBadPush
 		}
 	}()
+	// If already in queue drop quickly
+	if _, inQ := tq.targetSet[req.ChainInfo.Head.String()]; inQ {
+		return nil
+	}
 	heap.Push(&tq.q, req)
 	if tq.q.Len() == 1 {
 		// Signal that the queue has gone from empty to non-empty
 		tq.empty.Done()
 	}
+	tq.targetSet[req.ChainInfo.Head.String()] = struct{}{}	
 	
 	return nil
 }
@@ -205,12 +210,12 @@ func (tq *TargetQueue) Push(req *SyncRequest) (err error) {
 func (tq *TargetQueue) Pop() (req *SyncRequest, err error) {
 	tq.popMu.Lock()
 	defer tq.popMu.Unlock()
-	// Wait for a non-empty queue	
+	// Wait for a non-empty queue
 	tq.empty.Wait()
-
 	tq.rawMu.Lock()
 	defer tq.rawMu.Unlock()
 	defer func() {
+		// This converts heap.Pop panics to programmer errors		
 		if r := recover(); r != nil {
 			req = nil
 			err = errBadPop
@@ -221,10 +226,17 @@ func (tq *TargetQueue) Pop() (req *SyncRequest, err error) {
 		// Signal that the queue has gone from non-empty to empty
 		tq.empty.Add(1)
 	}
+	popKey := req.ChainInfo.Head.String()
+	if _, inQ := tq.targetSet[popKey]; !inQ {
+		return nil, errBadSet
+	}
+	delete(tq.targetSet, popKey)
 	return req, err
 }
 
 // Len returns the number of targets in the queue.
 func (tq *TargetQueue) Len() int {
-	return len(tq.q)
+	tq.rawMu.Lock()
+	defer tq.rawMu.Unlock()	
+	return tq.q.Len()
 }

--- a/syncer/dispatcher_test.go
+++ b/syncer/dispatcher_test.go
@@ -11,11 +11,6 @@ import (
 	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 )
 
-func TestNewDispatcher(t *testing.T) {
-	tf.UnitTest(t)
-	syncer.NewDispatcher()
-}
-
 func TestQueueHappy(t *testing.T) {
 	tf.UnitTest(t)
 	testQ := syncer.NewTargetQueue()

--- a/syncer/dispatcher_test.go
+++ b/syncer/dispatcher_test.go
@@ -51,7 +51,7 @@ func TestDispatchStartHappy(t *testing.T) {
 	// receive requests before Start() to test deterministic order
 	go func() {
 		for _, ci := range cis {
-			assert.NoError(t, testDispatch.ReceiveHello(ci))
+			assert.NoError(t, testDispatch.SendHello(ci))
 		}
 	}()
 	allDone.Wait()

--- a/syncer/dispatcher_test.go
+++ b/syncer/dispatcher_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-filecoin/block"
-	"github.com/filecoin-project/go-filecoin/types"	
+	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,10 +17,10 @@ import (
 )
 
 type fakeSyncer struct {
-	headsCalled []types.TipSetKey
+	headsCalled []block.TipSetKey
 }
 
-func (fs *fakeSyncer) HandleNewTipSet(ctx context.Context, ci *types.ChainInfo, t bool) error {
+func (fs *fakeSyncer) HandleNewTipSet(ctx context.Context, ci *block.ChainInfo, t bool) error {
 	fs.headsCalled = append(fs.headsCalled, ci.Head)
 	return nil
 }
@@ -28,11 +28,11 @@ func (fs *fakeSyncer) HandleNewTipSet(ctx context.Context, ci *types.ChainInfo, 
 func TestDispatchStartHappy(t *testing.T) {
 	tf.UnitTest(t)
 	s := &fakeSyncer{
-		headsCalled: make([]types.TipSetKey, 0),
+		headsCalled: make([]block.TipSetKey, 0),
 	}
 	testDispatch := syncer.NewDispatcher(s)
 
-	cis := []*types.ChainInfo{
+	cis := []*block.ChainInfo{
 		chainInfoFromHeight(t, 0),
 		chainInfoFromHeight(t, 42),
 		chainInfoFromHeight(t, 3),
@@ -168,11 +168,11 @@ func requirePush(t *testing.T, req *syncer.SyncRequest, q *syncer.TargetQueue) {
 // chainInfoFromHeight is a helper that constructs a unique chain info off of
 // an int. The tipset key is a faked cid from the string of that integer and
 // the height is that integer.
-func chainInfoFromHeight(t *testing.T, h int) *types.ChainInfo {
+func chainInfoFromHeight(t *testing.T, h int) *block.ChainInfo {
 	hStr := strconv.Itoa(h)
 	c := types.CidFromString(t, hStr)
 	return &block.ChainInfo{
-		Head: types.NewTipSetKey(c),
+		Head:   block.NewTipSetKey(c),
 		Height: uint64(h),
 	}
 }

--- a/syncer/dispatcher_test.go
+++ b/syncer/dispatcher_test.go
@@ -137,15 +137,15 @@ func TestQueueEmptyPopErrors(t *testing.T) {
 	_ = requirePop(t, testQ)
 	assert.Equal(t, 0, testQ.Len())
 
-	_, err := testQ.Pop()
-	assert.Error(t, err)
+	_, popped := testQ.Pop()
+	assert.False(t, popped)
 
 }
 
 // requirePop is a helper requiring that pop does not error
 func requirePop(t *testing.T, q *syncer.TargetQueue) syncer.SyncRequest {
-	req, err := q.Pop()
-	require.NoError(t, err)
+	req, popped := q.Pop()
+	require.True(t, popped)
 	return req
 }
 


### PR DESCRIPTION
### Motivation
Clear ownership of essential syncing system responsibility so we can readily work on syncer scheduling when the need arises.  For now the need is called out directly in the spec 

### Proposed changes
* Improve dispatcher's targetQueue to 
(1) block on pop
(2) be thread safe
(3) handle filtering internally

*Introduce `Start` method to launch a run loop dispatching sync requests

* Connect syncer to dispatcher

* Connect network events providing chain infos to the dispatcher's receivers

Closes issue #3579 

