### PR TITLE
add syncer back to chain submodule

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -471,6 +471,7 @@ func (b *Builder) buildChain(ctx context.Context, blockstore *BlockstoreSubmodul
 		ChainSynced: moresync.NewLatch(1),
 		Fetcher:     fetcher,
 		State:       chainState,
+		Syncer:      chainSyncer,
 		validator:   blkValid,
 		processor:   processor,
 	}, nil


### PR DESCRIPTION
### Motivation
Without this change cli commands that use the syncer will panic as the syncer is nil.

