### PR TITLE
Separate syncer submodule

### DIFF
--- a/internal/app/go-filecoin/internal/submodule/chain_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/chain_submodule.go
@@ -2,66 +2,34 @@ package submodule
 
 import (
 	"context"
-	"time"
 
-	ps "github.com/cskr/pubsub"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/actor/builtin"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-graphsync"
-	"github.com/ipfs/go-graphsync/ipldbridge"
-	gsnet "github.com/ipfs/go-graphsync/network"
-	gsstoreutil "github.com/ipfs/go-graphsync/storeutil"
-	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/plumbing/cst"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/net"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/net/pubsub"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/state"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/syncer"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/util/moresync"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/version"
 )
 
 // ChainSubmodule enhances the `Node` with chain capabilities.
 type ChainSubmodule struct {
-	BlockSub      pubsub.Subscription
-	Consensus     consensus.Protocol
-	ChainSelector nodeChainSelector
-	ChainReader   nodeChainReader
-	MessageStore  *chain.MessageStore
-	Syncer        nodeChainSyncer
-	SyncDispatch  nodeSyncDispatcher
-	ActorState    *consensus.ActorStateStore
-
+	ChainReader  *chain.Store
+	MessageStore *chain.MessageStore
+	State        *cst.ChainStateReadWriter
 	// HeavyTipSetCh is a subscription to the heaviest tipset topic on the chain.
 	// https://github.com/filecoin-project/go-filecoin/issues/2309
 	HeaviestTipSetCh chan interface{}
-	// cancelChainSync cancels the context for chain sync subscriptions and handlers.
-	CancelChainSync context.CancelFunc
-	// ChainSynced is a latch that releases when a nodes chain reaches a caught-up state.
-	// It serves as a barrier to be released when the initial chain sync has completed.
-	// Services which depend on a more-or-less synced chain can wait for this before starting up.
-	ChainSynced *moresync.Latch
-	// Fetcher is the interface for fetching data from nodes.
-	Fetcher net.Fetcher
-	State   *cst.ChainStateReadWriter
 
-	validator consensus.BlockValidator
-	Processor *consensus.DefaultProcessor
+	ActorState *consensus.ActorStateStore
+	Processor  *consensus.DefaultProcessor
+
+	StatusReporter *chain.StatusReporter
 }
 
-type nodeChainSelector interface {
-	NewWeight(context.Context, block.TipSet, cid.Cid) (uint64, error)
-	Weight(context.Context, block.TipSet, cid.Cid) (uint64, error)
-	IsHeavier(ctx context.Context, a, b block.TipSet, aStateID, bStateID cid.Cid) (bool, error)
-}
-
-type nodeChainReader interface {
+// xxx go back to using an interface here
+/*type nodeChainReader interface {
 	GenesisCid() cid.Cid
 	GetHead() block.TipSetKey
 	GetTipSet(block.TipSetKey) (block.TipSet, error)
@@ -71,32 +39,18 @@ type nodeChainReader interface {
 	Load(context.Context) error
 	Stop()
 }
-
-type nodeChainSyncer interface {
-	HandleNewTipSet(ctx context.Context, ci *block.ChainInfo, trusted bool) error
-	Status() chain.Status
-}
-
-type nodeSyncDispatcher interface {
-	SendHello(*block.ChainInfo) error
-	SendOwnBlock(*block.ChainInfo) error
-	SendGossipBlock(*block.ChainInfo) error
-	Start(context.Context)
-}
-
+*/
 type chainRepo interface {
 	ChainDatastore() repo.Datastore
 }
 
 type chainConfig interface {
 	GenesisCid() cid.Cid
-	Clock() clock.Clock
 	Rewarder() consensus.BlockRewarder
-	BlockTime() time.Duration
 }
 
 // NewChainSubmodule creates a new chain submodule.
-func NewChainSubmodule(ctx context.Context, config chainConfig, repo chainRepo, blockstore *BlockstoreSubmodule, network *NetworkSubmodule, discovery *DiscoverySubmodule, pvt *version.ProtocolVersionTable) (ChainSubmodule, error) {
+func NewChainSubmodule(ctx context.Context, config chainConfig, repo chainRepo, blockstore *BlockstoreSubmodule) (ChainSubmodule, error) {
 	// initialize chain store
 	chainStatusReporter := chain.NewStatusReporter()
 	chainStore := chain.NewStore(repo.ChainDatastore(), blockstore.CborStore, &state.TreeStateLoader{}, chainStatusReporter, config.GenesisCid())
@@ -108,52 +62,17 @@ func NewChainSubmodule(ctx context.Context, config chainConfig, repo chainRepo, 
 	} else {
 		processor = consensus.NewConfiguredProcessor(consensus.NewDefaultMessageValidator(), config.Rewarder(), builtin.DefaultActors)
 	}
-
-	// setup block validation
-	// TODO when #2961 is resolved do the needful here.
-	blkValid := consensus.NewDefaultBlockValidator(config.BlockTime(), config.Clock(), pvt)
-
-	// register block validation on floodsub
-	btv := net.NewBlockTopicValidator(blkValid)
-	if err := network.fsub.RegisterTopicValidator(btv.Topic(network.NetworkName), btv.Validator(), btv.Opts()...); err != nil {
-		return ChainSubmodule{}, errors.Wrap(err, "failed to register block validator")
-	}
-
-	// set up consensus
 	actorState := consensus.NewActorStateStore(chainStore, blockstore.CborStore, blockstore.Blockstore, processor)
-	nodeConsensus := consensus.NewExpected(blockstore.CborStore, blockstore.Blockstore, processor, blkValid, actorState, config.GenesisCid(), config.BlockTime(), consensus.ElectionMachine{}, consensus.TicketMachine{})
-	nodeChainSelector := consensus.NewChainSelector(blockstore.CborStore, actorState, config.GenesisCid(), pvt)
-
-	// setup fecher
-	graphsyncNetwork := gsnet.NewFromLibp2pHost(network.host)
-	bridge := ipldbridge.NewIPLDBridge()
-	loader := gsstoreutil.LoaderForBlockstore(blockstore.Blockstore)
-	storer := gsstoreutil.StorerForBlockstore(blockstore.Blockstore)
-	gsync := graphsync.New(ctx, graphsyncNetwork, bridge, loader, storer)
-	fetcher := net.NewGraphSyncFetcher(ctx, gsync, blockstore.Blockstore, blkValid, config.Clock(), discovery.PeerTracker)
-
 	messageStore := chain.NewMessageStore(blockstore.Blockstore)
-
-	// only the syncer gets the storage which is online connected
-	chainSyncer := chain.NewSyncer(nodeConsensus, nodeChainSelector, chainStore, messageStore, fetcher, chainStatusReporter, config.Clock())
-	syncerDispatcher := syncer.NewDispatcher(chainSyncer)
-
 	chainState := cst.NewChainStateReadWriter(chainStore, messageStore, blockstore.CborStore, builtin.DefaultActors)
 
 	return ChainSubmodule{
-		// BlockSub: nil,
-		Consensus:     nodeConsensus,
-		ChainSelector: nodeChainSelector,
-		ChainReader:   chainStore,
-		MessageStore:  messageStore,
-		SyncDispatch:  syncerDispatcher,
-		ActorState:    actorState,
-		// HeaviestTipSetCh: nil,
-		// cancelChainSync: nil,
-		ChainSynced: moresync.NewLatch(1),
-		Fetcher:     fetcher,
-		State:       chainState,
-		validator:   blkValid,
-		Processor:   processor,
+		ChainReader:  chainStore,
+		MessageStore: messageStore,
+		// HeaviestTipSetCh nil
+		ActorState:     actorState,
+		State:          chainState,
+		Processor:      processor,
+		StatusReporter: chainStatusReporter,
 	}, nil
 }

--- a/internal/app/go-filecoin/internal/submodule/chain_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/chain_submodule.go
@@ -76,3 +76,12 @@ func NewChainSubmodule(ctx context.Context, config chainConfig, repo chainRepo, 
 		StatusReporter: chainStatusReporter,
 	}, nil
 }
+
+type chainNode interface {
+	Chain() ChainSubmodule
+}
+
+// Start loads the chain from disk.
+func (c *ChainSubmodule) Start(ctx context.Context, node chainNode) error {
+	return node.Chain().ChainReader.Load(ctx)
+}

--- a/internal/app/go-filecoin/internal/submodule/discovery_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/discovery_submodule.go
@@ -63,6 +63,7 @@ func NewDiscoverySubmodule(ctx context.Context, config discoveryConfig, bsConfig
 type discoveryNode interface {
 	Network() NetworkSubmodule
 	Chain() ChainSubmodule
+	Syncer() SyncerSubmodule
 }
 
 // Start starts the discovery submodule for a node.
@@ -76,7 +77,7 @@ func (m *DiscoverySubmodule) Start(node discoveryNode) error {
 	// Start up 'hello' handshake service
 	peerDiscoveredCallback := func(ci *block.ChainInfo) {
 		m.PeerTracker.Track(ci)
-		err := node.Chain().SyncDispatch.SendHello(ci)
+		err := node.Syncer().SyncDispatch.SendHello(ci)
 		if err != nil {
 			log.Errorf("error receiving chain info from hello %s: %s", ci, err)
 			return
@@ -91,7 +92,7 @@ func (m *DiscoverySubmodule) Start(node discoveryNode) error {
 		// sync done until it's caught up enough that it will accept blocks from pubsub.
 		// This might require additional rounds of hello.
 		// See https://github.com/filecoin-project/go-filecoin/issues/1105
-		node.Chain().ChainSynced.Done()
+		node.Syncer().ChainSynced.Done()
 	}
 
 	// chain head callback

--- a/internal/app/go-filecoin/internal/submodule/discovery_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/discovery_submodule.go
@@ -82,17 +82,6 @@ func (m *DiscoverySubmodule) Start(node discoveryNode) error {
 			log.Errorf("error receiving chain info from hello %s: %s", ci, err)
 			return
 		}
-		// For now, consider the initial bootstrap done after the syncer has (synchronously)
-		// processed the chain up to the head reported by the first peer to respond to hello.
-		// This is an interim sequence until a secure network bootstrap is implemented:
-		// https://github.com/filecoin-project/go-filecoin/issues/2674.
-		// For now, we trust that the first node to respond will be a configured bootstrap node
-		// and that we trust that node to inform us of the chain head.
-		// TODO: when the syncer rejects too-far-ahead blocks received over pubsub, don't consider
-		// sync done until it's caught up enough that it will accept blocks from pubsub.
-		// This might require additional rounds of hello.
-		// See https://github.com/filecoin-project/go-filecoin/issues/1105
-		node.Syncer().ChainSynced.Done()
 	}
 
 	// chain head callback

--- a/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
@@ -1,0 +1,108 @@
+package submodule
+
+import (
+	"context"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-graphsync"
+	"github.com/ipfs/go-graphsync/ipldbridge"
+	gsnet "github.com/ipfs/go-graphsync/network"
+	gsstoreutil "github.com/ipfs/go-graphsync/storeutil"
+	"github.com/pkg/errors"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/net"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/net/pubsub"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/syncer"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/util/moresync"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/version"
+)
+
+type syncerConfig interface {
+	GenesisCid() cid.Cid
+	BlockTime() time.Duration
+	Clock() clock.Clock
+}
+
+type nodeChainSyncer interface {
+	HandleNewTipSet(ctx context.Context, ci *block.ChainInfo, trusted bool) error
+	Status() chain.Status
+}
+
+type nodeSyncDispatcher interface {
+	SendHello(*block.ChainInfo) error
+	SendOwnBlock(*block.ChainInfo) error
+	SendGossipBlock(*block.ChainInfo) error
+	Start(context.Context)
+}
+
+type nodeChainSelector interface {
+	NewWeight(context.Context, block.TipSet, cid.Cid) (uint64, error)
+	Weight(context.Context, block.TipSet, cid.Cid) (uint64, error)
+	IsHeavier(ctx context.Context, a, b block.TipSet, aStateID, bStateID cid.Cid) (bool, error)
+}
+
+type SyncerSubmodule struct {
+	BlockSub      pubsub.Subscription
+	ChainSelector nodeChainSelector
+	Consensus     consensus.Protocol
+	Syncer        nodeChainSyncer
+	SyncDispatch  nodeSyncDispatcher
+
+	// cancelChainSync cancels the context for chain sync subscriptions and handlers.
+	CancelChainSync context.CancelFunc
+
+	// ChainSynced is a latch that releases when a nodes chain reaches a caught-up state.
+	// It serves as a barrier to be released when the initial chain sync has completed.
+	// Services which depend on a more-or-less synced chain can wait for this before starting up.
+	ChainSynced *moresync.Latch
+	// Fetcher is the interface for fetching data from nodes.
+	Fetcher net.Fetcher
+
+	validator consensus.BlockValidator
+}
+
+// NewSyncerSubmodule creates a new chain submodule.
+func NewSyncerSubmodule(ctx context.Context, config syncerConfig, repo chainRepo, blockstore *BlockstoreSubmodule, network *NetworkSubmodule, discovery *DiscoverySubmodule, chn *ChainSubmodule, pvt *version.ProtocolVersionTable) (SyncerSubmodule, error) {
+	// setup block validation
+	// TODO when #2961 is resolved do the needful here.
+	blkValid := consensus.NewDefaultBlockValidator(config.BlockTime(), config.Clock(), pvt)
+
+	// register block validation on floodsub
+	btv := net.NewBlockTopicValidator(blkValid)
+	if err := network.fsub.RegisterTopicValidator(btv.Topic(network.NetworkName), btv.Validator(), btv.Opts()...); err != nil {
+		return SyncerSubmodule{}, errors.Wrap(err, "failed to register block validator")
+	}
+
+	// set up consensus
+	nodeConsensus := consensus.NewExpected(blockstore.CborStore, blockstore.Blockstore, chn.Processor, blkValid, chn.ActorState, config.GenesisCid(), config.BlockTime(), consensus.ElectionMachine{}, consensus.TicketMachine{})
+	nodeChainSelector := consensus.NewChainSelector(blockstore.CborStore, chn.ActorState, config.GenesisCid(), pvt)
+
+	// setup fecher
+	graphsyncNetwork := gsnet.NewFromLibp2pHost(network.host)
+	bridge := ipldbridge.NewIPLDBridge()
+	loader := gsstoreutil.LoaderForBlockstore(blockstore.Blockstore)
+	storer := gsstoreutil.StorerForBlockstore(blockstore.Blockstore)
+	gsync := graphsync.New(ctx, graphsyncNetwork, bridge, loader, storer)
+	fetcher := net.NewGraphSyncFetcher(ctx, gsync, blockstore.Blockstore, blkValid, config.Clock(), discovery.PeerTracker)
+
+	// only the syncer gets the storage which is online connected
+	// xxx: need chain store, not just chain reader
+	chainSyncer := chain.NewSyncer(nodeConsensus, nodeChainSelector, chn.ChainReader, chn.MessageStore, fetcher, chn.StatusReporter, config.Clock())
+	syncerDispatcher := syncer.NewDispatcher(chainSyncer)
+
+	return SyncerSubmodule{
+		// BlockSub: nil,
+		Consensus:     nodeConsensus,
+		ChainSelector: nodeChainSelector,
+		SyncDispatch:  syncerDispatcher,
+		// cancelChainSync: nil,
+		ChainSynced: moresync.NewLatch(1),
+		Fetcher:     fetcher,
+		validator:   blkValid,
+	}, nil
+}

--- a/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
@@ -18,7 +18,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/net"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/net/pubsub"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/syncer"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/util/moresync"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/version"
 )
 
@@ -46,6 +45,7 @@ type nodeChainSelector interface {
 	IsHeavier(ctx context.Context, a, b block.TipSet, aStateID, bStateID cid.Cid) (bool, error)
 }
 
+// SyncerSubmodule enhances the node with chain syncing capabilities
 type SyncerSubmodule struct {
 	BlockSub      pubsub.Subscription
 	ChainSelector nodeChainSelector
@@ -56,10 +56,6 @@ type SyncerSubmodule struct {
 	// cancelChainSync cancels the context for chain sync subscriptions and handlers.
 	CancelChainSync context.CancelFunc
 
-	// ChainSynced is a latch that releases when a nodes chain reaches a caught-up state.
-	// It serves as a barrier to be released when the initial chain sync has completed.
-	// Services which depend on a more-or-less synced chain can wait for this before starting up.
-	ChainSynced *moresync.Latch
 	// Fetcher is the interface for fetching data from nodes.
 	Fetcher net.Fetcher
 
@@ -101,8 +97,7 @@ func NewSyncerSubmodule(ctx context.Context, config syncerConfig, repo chainRepo
 		ChainSelector: nodeChainSelector,
 		SyncDispatch:  syncerDispatcher,
 		// cancelChainSync: nil,
-		ChainSynced: moresync.NewLatch(1),
-		Fetcher:     fetcher,
-		validator:   blkValid,
+		Fetcher:   fetcher,
+		validator: blkValid,
 	}, nil
 }

--- a/internal/app/go-filecoin/node/block.go
+++ b/internal/app/go-filecoin/node/block.go
@@ -28,7 +28,7 @@ func (node *Node) AddNewBlock(ctx context.Context, b *block.Block) (err error) {
 
 	log.Debugf("syncing new block: %s", b.Cid().String())
 
-	if err := node.chain.SyncDispatch.SendOwnBlock(block.NewChainInfo(node.Host().ID(), block.NewTipSetKey(blkCid), uint64(b.Height))); err != nil {
+	if err := node.syncer.SyncDispatch.SendOwnBlock(block.NewChainInfo(node.Host().ID(), block.NewTipSetKey(blkCid), uint64(b.Height))); err != nil {
 		return err
 	}
 
@@ -61,7 +61,7 @@ func (node *Node) processBlock(ctx context.Context, pubSubMsg pubsub.Message) (e
 	// See https://github.com/filecoin-project/go-filecoin/issues/2962
 	// TODO Implement principled trusting of ChainInfo's
 	// to address in #2674
-	err = node.chain.SyncDispatch.SendGossipBlock(block.NewChainInfo(from, block.NewTipSetKey(blk.Cid()), uint64(blk.Height)))
+	err = node.syncer.SyncDispatch.SendGossipBlock(block.NewChainInfo(from, block.NewTipSetKey(blk.Cid()), uint64(blk.Height)))
 	if err != nil {
 		return errors.Wrapf(err, "receive block %s from peer %s", blk.Cid(), from)
 	}

--- a/internal/app/go-filecoin/node/builder.go
+++ b/internal/app/go-filecoin/node/builder.go
@@ -184,9 +184,14 @@ func (b *Builder) build(ctx context.Context) (*Node, error) {
 		return nil, errors.Wrap(err, "failed to build node.Blockservice")
 	}
 
-	nd.chain, err = submodule.NewChainSubmodule(ctx, (*builder)(b), b.repo, &nd.Blockstore, &nd.network, &nd.Discovery, nd.VersionTable)
+	nd.chain, err = submodule.NewChainSubmodule(ctx, (*builder)(b), b.repo, &nd.Blockstore)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build node.Chain")
+	}
+
+	nd.syncer, err = submodule.NewSyncerSubmodule(ctx, (*builder)(b), b.repo, &nd.Blockstore, &nd.network, &nd.Discovery, &nd.chain, nd.VersionTable)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.Syncer")
 	}
 
 	nd.Wallet, err = submodule.NewWalletSubmodule(ctx, b.repo)
@@ -232,11 +237,11 @@ func (b *Builder) build(ctx context.Context) (*Node, error) {
 	nd.PorcelainAPI = porcelain.New(plumbing.New(&plumbing.APIDeps{
 		Bitswap:       nd.network.Bitswap,
 		Chain:         nd.chain.State,
-		Sync:          cst.NewChainSyncProvider(nd.chain.Syncer),
+		Sync:          cst.NewChainSyncProvider(nd.syncer.Syncer),
 		Config:        cfg.NewConfig(b.repo),
 		DAG:           dag.NewDAG(merkledag.NewDAGService(nd.Blockservice.Blockservice)),
 		Deals:         strgdls.New(b.repo.DealsDatastore()),
-		Expected:      nd.chain.Consensus,
+		Expected:      nd.syncer.Consensus,
 		MsgPool:       nd.Messaging.MsgPool,
 		MsgPreviewer:  msg.NewPreviewer(nd.chain.ChainReader, nd.Blockstore.CborStore, nd.Blockstore.Blockstore, nd.chain.Processor),
 		ActState:      nd.chain.ActorState,

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -171,9 +171,7 @@ func (node *Node) Start(ctx context.Context) error {
 			return err
 		}
 
-		// Start syncing dispatch
-		node.syncer.SyncDispatch.Start(syncCtx)
-
+		node.syncer.Start(syncCtx, node)
 	}
 
 	return nil

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -113,8 +113,8 @@ func (node *Node) Start(ctx context.Context) error {
 		return errors.Wrap(err, "failed to setup tracing")
 	}
 
-	var err error
-	if err = node.chain.ChainReader.Load(ctx); err != nil {
+	err := node.chain.Start(ctx, node)
+	if err != nil {
 		return err
 	}
 

--- a/internal/pkg/discovery/bootstrap.go
+++ b/internal/pkg/discovery/bootstrap.go
@@ -102,18 +102,6 @@ func (b *Bootstrapper) Stop() {
 	}
 }
 
-// PeerDiscovered signals to the bootstrapper that a filecoin peer has been
-// discovered.
-func (b *Bootstrapper) PeerDiscovered() {
-	b.filecoinPeers.Done()
-}
-
-// Ready blocks until the bootstrapper meets the required security conditions:
-// https://filecoin-project.github.io/specs/#chainsync-fsm-bootstrap
-func (b *Bootstrapper) Ready() {
-	b.filecoinPeers.Wait()
-}
-
 // bootstrap does the actual work. If the number of connected peers
 // has fallen below b.MinPeerThreshold it will attempt to connect to
 // a random subset of its bootstrap peers.


### PR DESCRIPTION
### Motivation
We need to get syncing and bootstrapping properly ordered per new spec changes.  We should also do some cleanup along the way.

### Proposed changes
- Separate out syncer submodule from chain
- syncer dispatcher start wrapped within syncerSubmodule.Start(), chain.Load() wrapped in chainsubmodule.Start().  discovery submodule start blocks on bootstrapper start meeting security conditions.
- chain.Start --> discovery.Start --> syncer.Start
- pubsub no longer waits on first syncer invocation so remove the latch


Closes issue #3582 

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

