### PR TITLE
Remove protocol upgrade and deprecated Weight()

### DIFF
--- a/internal/app/go-filecoin/node/builder.go
+++ b/internal/app/go-filecoin/node/builder.go
@@ -189,7 +189,7 @@ func (b *Builder) build(ctx context.Context) (*Node, error) {
 		return nil, errors.Wrap(err, "failed to build node.Chain")
 	}
 
-	nd.syncer, err = submodule.NewSyncerSubmodule(ctx, (*builder)(b), b.repo, &nd.Blockstore, &nd.network, &nd.Discovery, &nd.chain, nd.VersionTable)
+	nd.syncer, err = submodule.NewSyncerSubmodule(ctx, (*builder)(b), b.repo, &nd.Blockstore, &nd.network, &nd.Discovery, &nd.chain)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build node.Syncer")
 	}

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -748,34 +748,19 @@ func (node *Node) getStateTree(ctx context.Context, ts block.TipSet) (state.Tree
 
 // getWeight is the default GetWeight function for the mining worker.
 func (node *Node) getWeight(ctx context.Context, ts block.TipSet) (uint64, error) {
-	h, err := ts.Height()
-	if err != nil {
-		return 0, err
-	}
-	var wFun func(context.Context, block.TipSet, cid.Cid) (uint64, error)
-	v, err := node.VersionTable.VersionAt(types.NewBlockHeight(h))
-	if err != nil {
-		return 0, err
-	}
-	if v >= version.Protocol1 {
-		wFun = node.syncer.ChainSelector.NewWeight
-	} else {
-		wFun = node.syncer.ChainSelector.Weight
-	}
-
 	parent, err := ts.Parents()
 	if err != nil {
 		return uint64(0), err
 	}
 	// TODO handle genesis cid more gracefully
 	if parent.Len() == 0 {
-		return wFun(ctx, ts, cid.Undef)
+		return node.syncer.ChainSelector.Weight(ctx, ts, cid.Undef)
 	}
 	root, err := node.chain.ChainReader.GetTipSetStateRoot(parent)
 	if err != nil {
 		return uint64(0), err
 	}
-	return wFun(ctx, ts, root)
+	return node.syncer.ChainSelector.Weight(ctx, ts, root)
 }
 
 // getAncestors is the default GetAncestors function for the mining worker.

--- a/internal/pkg/chain/syncer.go
+++ b/internal/pkg/chain/syncer.go
@@ -59,8 +59,8 @@ type syncChainSelector interface {
 	// IsHeavier returns true if tipset a is heavier than tipset b and false if
 	// tipset b is heavier than tipset a.
 	IsHeavier(ctx context.Context, a, b block.TipSet, aStateID, bStateID cid.Cid) (bool, error)
-	// NewWeight returns the weight of a tipset after the upgrade to version 1
-	NewWeight(ctx context.Context, ts block.TipSet, stRoot cid.Cid) (uint64, error)
+	// Weight returns the weight of a tipset
+	Weight(ctx context.Context, ts block.TipSet, stRoot cid.Cid) (uint64, error)
 }
 
 type syncStateEvaluator interface {
@@ -250,13 +250,13 @@ func (syncer *Syncer) syncOne(ctx context.Context, grandParent, parent, next blo
 // from disk just like aggregate state roots.
 func (syncer *Syncer) calculateParentWeight(ctx context.Context, parent, grandParent block.TipSet) (uint64, error) {
 	if grandParent.Equals(block.UndefTipSet) {
-		return syncer.chainSelector.NewWeight(ctx, parent, cid.Undef)
+		return syncer.chainSelector.Weight(ctx, parent, cid.Undef)
 	}
 	gpStRoot, err := syncer.chainStore.GetTipSetStateRoot(grandParent.Key())
 	if err != nil {
 		return 0, err
 	}
-	return syncer.chainSelector.NewWeight(ctx, parent, gpStRoot)
+	return syncer.chainSelector.Weight(ctx, parent, gpStRoot)
 }
 
 // ancestorsFromStore returns the parent and grandparent tipsets of `ts`

--- a/internal/pkg/chain/testing.go
+++ b/internal/pkg/chain/testing.go
@@ -412,8 +412,8 @@ func (e *FakeChainSelector) IsHeavier(ctx context.Context, a, b block.TipSet, aS
 	return aw > bw, nil
 }
 
-// NewWeight delegates to the statebuilder
-func (e *FakeChainSelector) NewWeight(ctx context.Context, ts block.TipSet, stID cid.Cid) (uint64, error) {
+// Weight delegates to the statebuilder
+func (e *FakeChainSelector) Weight(ctx context.Context, ts block.TipSet, stID cid.Cid) (uint64, error) {
 	return e.Weigh(ts, stID)
 }
 

--- a/internal/pkg/consensus/chain_selector.go
+++ b/internal/pkg/consensus/chain_selector.go
@@ -16,22 +16,12 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/version"
 )
 
-// Parameters used by the latest weight function "NewWeight"
+// Parameters used by the weighting funcion
 const (
 	// newECV is the constant V defined in the EC spec.
 	newECV uint64 = 2
-)
-
-// Parameters used by the deprecated weight function before the alphanet upgrade
-const (
-	// ecV is the constant V defined in the EC spec.
-	ecV uint64 = 10
-
-	// ecPrM is the power ratio magnitude defined in the EC spec.
-	ecPrM uint64 = 100
 )
 
 // ChainSelector weighs and compares chains according to the deprecated v0
@@ -40,26 +30,23 @@ type ChainSelector struct {
 	cstore     *hamt.CborIpldStore
 	actorState SnapshotGenerator
 	genesisCid cid.Cid
-
-	pvt *version.ProtocolVersionTable
 }
 
 // NewChainSelector is the constructor for chain selection module.
-func NewChainSelector(cs *hamt.CborIpldStore, actorState SnapshotGenerator, gCid cid.Cid, pvt *version.ProtocolVersionTable) *ChainSelector {
+func NewChainSelector(cs *hamt.CborIpldStore, actorState SnapshotGenerator, gCid cid.Cid) *ChainSelector {
 	return &ChainSelector{
 		cstore:     cs,
 		actorState: actorState,
 		genesisCid: gCid,
-		pvt:        pvt,
 	}
 }
 
-// NewWeight returns the EC weight of this TipSet in uint64 encoded fixed point
+// Weight returns the EC weight of this TipSet in uint64 encoded fixed point
 // representation.
 //
 // w(i) = w(i-1) + V * num_blks + X
 // X = log_2(total_storage(pSt))
-func (c *ChainSelector) NewWeight(ctx context.Context, ts block.TipSet, pStateID cid.Cid) (uint64, error) {
+func (c *ChainSelector) Weight(ctx context.Context, ts block.TipSet, pStateID cid.Cid) (uint64, error) {
 	if ts.Len() > 0 && ts.At(0).Cid().Equals(c.genesisCid) {
 		return uint64(0), nil
 	}
@@ -100,55 +87,6 @@ func (c *ChainSelector) NewWeight(ctx context.Context, ts block.TipSet, pStateID
 	return types.BigToFixed(w)
 }
 
-// Weight returns the EC weight of this TipSet in uint64 encoded fixed point
-// representation.
-func (c *ChainSelector) Weight(ctx context.Context, ts block.TipSet, pStateID cid.Cid) (uint64, error) {
-	if ts.Len() == 1 && ts.At(0).Cid().Equals(c.genesisCid) {
-		return uint64(0), nil
-	}
-
-	// Compute parent weight.
-	parentW, err := ts.ParentWeight()
-	if err != nil {
-		return uint64(0), err
-	}
-	w, err := types.FixedToBig(parentW)
-	if err != nil {
-		return uint64(0), err
-	}
-
-	if !pStateID.Defined() {
-		return uint64(0), errors.New("undefined state passed to chain selector weight")
-	}
-	pSt, err := c.loadStateTree(ctx, pStateID)
-	if err != nil {
-		return uint64(0), err
-	}
-	powerTableView := c.createPowerTableView(pSt)
-
-	// Each block in the tipset adds ecV + ecPrm * miner_power to parent weight.
-	totalBytes, err := powerTableView.Total(ctx)
-	if err != nil {
-		return uint64(0), err
-	}
-	floatTotalBytes := new(big.Float).SetInt(totalBytes.BigInt())
-	floatECV := new(big.Float).SetInt64(int64(ecV))
-	floatECPrM := new(big.Float).SetInt64(int64(ecPrM))
-	for _, blk := range ts.ToSlice() {
-		minerBytes, err := powerTableView.Miner(ctx, blk.Miner)
-		if err != nil {
-			return uint64(0), err
-		}
-		floatOwnBytes := new(big.Float).SetInt(minerBytes.BigInt())
-		wBlk := new(big.Float)
-		wBlk.Quo(floatOwnBytes, floatTotalBytes)
-		wBlk.Mul(wBlk, floatECPrM) // Power addition
-		wBlk.Add(wBlk, floatECV)   // Constant addition
-		w.Add(w, wBlk)
-	}
-	return types.BigToFixed(w)
-}
-
 // IsHeavier returns true if tipset a is heavier than tipset b, and false
 // vice versa.  In the rare case where two tipsets have the same weight ties
 // are broken by taking the tipset with the smallest ticket.  In the event that
@@ -157,22 +95,11 @@ func (c *ChainSelector) Weight(ctx context.Context, ts block.TipSet, pStateID ci
 // TODO BLOCK CID CONCAT TIE BREAKER IS NOT IN THE SPEC AND SHOULD BE
 // EVALUATED BEFORE GETTING TO PRODUCTION.
 func (c *ChainSelector) IsHeavier(ctx context.Context, a, b block.TipSet, aStateID, bStateID cid.Cid) (bool, error) {
-	// Select weighting function based on protocol version
-	aWfun, err := c.chooseWeightFunc(a)
+	aW, err := c.Weight(ctx, a, aStateID)
 	if err != nil {
 		return false, err
 	}
-
-	bWfun, err := c.chooseWeightFunc(b)
-	if err != nil {
-		return false, err
-	}
-
-	aW, err := aWfun(ctx, a, aStateID)
-	if err != nil {
-		return false, err
-	}
-	bW, err := bWfun(ctx, b, bStateID)
+	bW, err := c.Weight(ctx, b, bStateID)
 	if err != nil {
 		return false, err
 	}
@@ -206,22 +133,6 @@ func (c *ChainSelector) IsHeavier(ctx context.Context, a, b block.TipSet, aState
 		return false, ErrUnorderedTipSets
 	}
 	return cmp == 1, nil
-}
-
-func (c *ChainSelector) chooseWeightFunc(ts block.TipSet) (func(context.Context, block.TipSet, cid.Cid) (uint64, error), error) {
-	wFun := c.Weight
-	h, err := ts.Height()
-	if err != nil {
-		return nil, err
-	}
-	v, err := c.pvt.VersionAt(types.NewBlockHeight(h))
-	if err != nil {
-		return nil, err
-	}
-	if v >= version.Protocol1 {
-		wFun = c.NewWeight
-	}
-	return wFun, nil
 }
 
 func (c *ChainSelector) createPowerTableView(st state.Tree) PowerTableView {

--- a/internal/pkg/consensus/weight_test.go
+++ b/internal/pkg/consensus/weight_test.go
@@ -15,16 +15,13 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/version"
 )
 
-func TestNewWeight(t *testing.T) {
+func TestWeight(t *testing.T) {
 	cst := hamt.NewCborStore()
 	ctx := context.Background()
-	fakeTree := state.TreeFromString(t, "test-NewWeight-StateCid", cst)
+	fakeTree := state.TreeFromString(t, "test-Weight-StateCid", cst)
 	fakeRoot, err := fakeTree.Flush(ctx)
-	require.NoError(t, err)
-	pvt, err := version.ConfigureProtocolVersions(version.TEST)
 	require.NoError(t, err)
 	// We only care about total power for the weight function
 	// Total is 16, so bitlen is 5
@@ -34,11 +31,11 @@ func TestNewWeight(t *testing.T) {
 		ParentWeight: 0,
 		Ticket:       ticket,
 	})
-	sel := consensus.NewChainSelector(cst, as, types.CidFromString(t, "genesisCid"), pvt)
+	sel := consensus.NewChainSelector(cst, as, types.CidFromString(t, "genesisCid"))
 
 	t.Run("basic happy path", func(t *testing.T) {
 		// 0 + 1[2*1 + 5] = 7
-		fixWeight, err := sel.NewWeight(ctx, toWeigh, fakeRoot)
+		fixWeight, err := sel.Weight(ctx, toWeigh, fakeRoot)
 		assert.NoError(t, err)
 		assertEqualInt(t, 7, fixWeight)
 	})
@@ -49,20 +46,20 @@ func TestNewWeight(t *testing.T) {
 		asHigherX := consensus.NewFakeActorStateStore(types.NewBytesAmount(1), types.NewBytesAmount(32), make(map[address.Address]address.Address))
 
 		// Weight is 1 lower than total = 16 with total = 15
-		selLower := consensus.NewChainSelector(cst, asLowerX, types.CidFromString(t, "genesisCid"), pvt)
-		fixWeight, err := selLower.NewWeight(ctx, toWeigh, fakeRoot)
+		selLower := consensus.NewChainSelector(cst, asLowerX, types.CidFromString(t, "genesisCid"))
+		fixWeight, err := selLower.Weight(ctx, toWeigh, fakeRoot)
 		assert.NoError(t, err)
 		assertEqualInt(t, 6, fixWeight)
 
 		// Weight is same as total = 16 with total = 31
-		selSame := consensus.NewChainSelector(cst, asSameX, types.CidFromString(t, "genesisCid"), pvt)
-		fixWeight, err = selSame.NewWeight(ctx, toWeigh, fakeRoot)
+		selSame := consensus.NewChainSelector(cst, asSameX, types.CidFromString(t, "genesisCid"))
+		fixWeight, err = selSame.Weight(ctx, toWeigh, fakeRoot)
 		assert.NoError(t, err)
 		assertEqualInt(t, 7, fixWeight)
 
 		// Weight is 1 higher than total = 16 with total = 32
-		selHigher := consensus.NewChainSelector(cst, asHigherX, types.CidFromString(t, "genesisCid"), pvt)
-		fixWeight, err = selHigher.NewWeight(ctx, toWeigh, fakeRoot)
+		selHigher := consensus.NewChainSelector(cst, asHigherX, types.CidFromString(t, "genesisCid"))
+		fixWeight, err = selHigher.Weight(ctx, toWeigh, fakeRoot)
 		assert.NoError(t, err)
 		assertEqualInt(t, 8, fixWeight)
 	})
@@ -76,7 +73,7 @@ func TestNewWeight(t *testing.T) {
 		})
 
 		// 49 + 1[2*1 + 5] = 56
-		fixWeight, err := sel.NewWeight(ctx, toWeighWithParent, fakeRoot)
+		fixWeight, err := sel.Weight(ctx, toWeighWithParent, fakeRoot)
 		assert.NoError(t, err)
 		assertEqualInt(t, 56, fixWeight)
 	})
@@ -100,7 +97,7 @@ func TestNewWeight(t *testing.T) {
 			},
 		)
 		// 0 + 1[2*3 + 5] = 11
-		fixWeight, err := sel.NewWeight(ctx, toWeighThreeBlock, fakeRoot)
+		fixWeight, err := sel.Weight(ctx, toWeighThreeBlock, fakeRoot)
 		assert.NoError(t, err)
 		assertEqualInt(t, 11, fixWeight)
 	})

--- a/internal/pkg/net/graphsync_fetcher_test.go
+++ b/internal/pkg/net/graphsync_fetcher_test.go
@@ -38,7 +38,6 @@ import (
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/version"
 )
 
 const visitsPerBlock = 18
@@ -57,9 +56,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 	ctx := context.Background()
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 	clock := th.NewFakeClock(time.Now())
-	pvt, err := version.ConfigureProtocolVersions(version.TEST)
-	require.NoError(t, err)
-	bv := consensus.NewDefaultBlockValidator(5*time.Millisecond, clock, pvt)
+	bv := consensus.NewDefaultBlockValidator(5*time.Millisecond, clock)
 	pid0 := th.RequireIntPeerID(t, 0)
 	builder := chain.NewBuilder(t, address.Undef)
 	keys := types.MustGenerateKeyInfo(2, 42)
@@ -743,9 +740,7 @@ func TestHeadersOnlyGraphsyncFetch(t *testing.T) {
 	ctx := context.Background()
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 	clock := th.NewFakeClock(time.Now())
-	pvt, err := version.ConfigureProtocolVersions(version.TEST)
-	require.NoError(t, err)
-	bv := consensus.NewDefaultBlockValidator(5*time.Millisecond, clock, pvt)
+	bv := consensus.NewDefaultBlockValidator(5*time.Millisecond, clock)
 	pid0 := th.RequireIntPeerID(t, 0)
 	builder := chain.NewBuilder(t, address.Undef)
 	keys := types.MustGenerateKeyInfo(1, 42)

--- a/internal/pkg/net/validators_test.go
+++ b/internal/pkg/net/validators_test.go
@@ -20,7 +20,6 @@ import (
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/version"
 )
 
 func TestBlockTopicValidator(t *testing.T) {
@@ -64,10 +63,7 @@ func TestBlockPubSubValidation(t *testing.T) {
 	blocktime := time.Second * 1
 
 	// setup a block validator and a topic validator
-	pvt, err := version.ConfigureProtocolVersions(version.TEST)
-	require.NoError(t, err)
-
-	bv := consensus.NewDefaultBlockValidator(blocktime, mclock, pvt)
+	bv := consensus.NewDefaultBlockValidator(blocktime, mclock)
 	btv := net.NewBlockTopicValidator(bv)
 
 	// setup a floodsub instance on the host and register the topic validator


### PR DESCRIPTION
### Motivation
We want to reset the alphanet soon.  We don't want to carry along the baggage of the old broken weighting function.

### Proposed changes
- Remove old weight function
- Remove protocol version table from code no longer checking it
- Remove tests testing for upgrade behavior

Closes issue #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

