### PR TITLE
Stop fetching message receipts

### DIFF
--- a/internal/app/go-filecoin/internal/submodule/chain_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/chain_submodule.go
@@ -35,6 +35,7 @@ type ChainSubmodule struct {
 	GetTipSet(block.TipSetKey) (block.TipSet, error)
 	GetTipSetState(ctx context.Context, tsKey block.TipSetKey) (state.Tree, error)
 	GetTipSetStateRoot(tsKey block.TipSetKey) (cid.Cid, error)
+	GetTipSetReceiptsRoot(tsKey block.TipSetKey) (cid.Cid, error)
 	HeadEvents() *ps.PubSub
 	Load(context.Context) error
 	Stop()

--- a/internal/app/go-filecoin/plumbing/msg/waiter.go
+++ b/internal/app/go-filecoin/plumbing/msg/waiter.go
@@ -133,7 +133,14 @@ func (w *Waiter) waitForMessage(ctx context.Context, ch <-chan interface{}, msgC
 				log.Errorf("Waiter.Wait: %s", e)
 				return nil, false, e
 			case block.TipSet:
-				return w.receiptForTipset(ctx, raw, msgCid)
+				msg, found, err := w.receiptForTipset(ctx, raw, msgCid)
+				if err != nil {
+					return nil, false, err
+				}
+				if found {
+					return msg, found, nil
+				}
+				// otherwise continue waiting
 			default:
 				return nil, false, fmt.Errorf("unexpected type in channel: %T", raw)
 			}

--- a/internal/app/go-filecoin/plumbing/msg/waiter.go
+++ b/internal/app/go-filecoin/plumbing/msg/waiter.go
@@ -102,7 +102,7 @@ func (w *Waiter) Wait(ctx context.Context, msgCid cid.Cid, cb func(*block.Block,
 // if now block with the given CID exists in the chain.
 func (w *Waiter) findMessage(ctx context.Context, ts block.TipSet, msgCid cid.Cid) (*ChainMessage, bool, error) {
 	var err error
-	for iterator := chain.IterAncestors(ctx, w.chainReader, ts); !iterator.Complete(); err = iterator.Next() {
+	for iterator := chain.IterAncestors(ctx, w.chainReader, ts); err == nil && !iterator.Complete(); err = iterator.Next() {
 		msg, found, err := w.receiptForTipset(ctx, iterator.Value(), msgCid)
 		if err != nil {
 			log.Errorf("Waiter.Wait: %s", err)
@@ -112,7 +112,7 @@ func (w *Waiter) findMessage(ctx context.Context, ts block.TipSet, msgCid cid.Ci
 			return msg, true, nil
 		}
 	}
-	return nil, false, nil
+	return nil, false, err
 }
 
 // waitForMessage looks for a message CID in a channel of tipsets and returns

--- a/internal/app/go-filecoin/plumbing/msg/waiter.go
+++ b/internal/app/go-filecoin/plumbing/msg/waiter.go
@@ -180,12 +180,12 @@ func (w *Waiter) receiptForTipset(ctx context.Context, ts block.TipSet, msgCid c
 		for i, msg := range blkMsgs {
 			if cids[i].Equals(msgCid) {
 				// wrapped cid might be different from given cid
-				targetCid, err := msg.Cid()
+				wrappedCid, err := msg.Cid()
 				if err != nil {
 					return nil, false, err
 				}
 
-				recpt, err := w.receiptByIndex(ctx, ts.Key(), targetCid, tsMessages)
+				recpt, err := w.receiptByIndex(ctx, ts.Key(), wrappedCid, tsMessages)
 				if err != nil {
 					return nil, false, errors.Wrap(err, "error retrieving receipt from tipset")
 				}

--- a/internal/app/go-filecoin/plumbing/msg/waiter.go
+++ b/internal/app/go-filecoin/plumbing/msg/waiter.go
@@ -15,7 +15,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
 )
 

--- a/internal/app/go-filecoin/plumbing/msg/waiter.go
+++ b/internal/app/go-filecoin/plumbing/msg/waiter.go
@@ -103,11 +103,14 @@ func (w *Waiter) Wait(ctx context.Context, msgCid cid.Cid, cb func(*block.Block,
 func (w *Waiter) findMessage(ctx context.Context, ts block.TipSet, msgCid cid.Cid) (*ChainMessage, bool, error) {
 	var err error
 	for iterator := chain.IterAncestors(ctx, w.chainReader, ts); !iterator.Complete(); err = iterator.Next() {
+		msg, found, err := w.receiptForTipset(ctx, iterator.Value(), msgCid)
 		if err != nil {
 			log.Errorf("Waiter.Wait: %s", err)
 			return nil, false, err
 		}
-		return w.receiptForTipset(ctx, iterator.Value(), msgCid)
+		if found {
+			return msg, true, nil
+		}
 	}
 	return nil, false, nil
 }

--- a/internal/app/go-filecoin/plumbing/msg/waiter.go
+++ b/internal/app/go-filecoin/plumbing/msg/waiter.go
@@ -26,6 +26,7 @@ type waiterChainReader interface {
 	GetHead() block.TipSetKey
 	GetTipSet(block.TipSetKey) (block.TipSet, error)
 	GetTipSetState(context.Context, block.TipSetKey) (state.Tree, error)
+	GetTipSetReceiptsRoot(block.TipSetKey) (cid.Cid, error)
 	HeadEvents() *pubsub.PubSub
 }
 
@@ -106,26 +107,7 @@ func (w *Waiter) findMessage(ctx context.Context, ts block.TipSet, msgCid cid.Ci
 			log.Errorf("Waiter.Wait: %s", err)
 			return nil, false, err
 		}
-		for i := 0; i < iterator.Value().Len(); i++ {
-			blk := iterator.Value().At(i)
-			secpMsgs, _, err := w.messageProvider.LoadMessages(ctx, blk.Messages)
-			if err != nil {
-				return nil, false, err
-			}
-			for _, msg := range secpMsgs {
-				c, err := msg.Cid()
-				if err != nil {
-					return nil, false, err
-				}
-				if c.Equals(msgCid) {
-					recpt, err := w.receiptFromTipSet(ctx, msgCid, iterator.Value())
-					if err != nil {
-						return nil, false, errors.Wrap(err, "error retrieving receipt from tipset")
-					}
-					return &ChainMessage{msg, blk, recpt}, true, nil
-				}
-			}
-		}
+		return w.receiptForTipset(ctx, iterator.Value(), msgCid)
 	}
 	return nil, false, nil
 }
@@ -149,26 +131,7 @@ func (w *Waiter) waitForMessage(ctx context.Context, ch <-chan interface{}, msgC
 				log.Errorf("Waiter.Wait: %s", e)
 				return nil, false, e
 			case block.TipSet:
-				for i := 0; i < raw.Len(); i++ {
-					blk := raw.At(i)
-					secpMsgs, _, err := w.messageProvider.LoadMessages(ctx, blk.Messages)
-					if err != nil {
-						return nil, false, err
-					}
-					for _, msg := range secpMsgs {
-						c, err := msg.Cid()
-						if err != nil {
-							return nil, false, err
-						}
-						if c.Equals(msgCid) {
-							recpt, err := w.receiptFromTipSet(ctx, msgCid, raw)
-							if err != nil {
-								return nil, false, errors.Wrap(err, "error retrieving receipt from tipset")
-							}
-							return &ChainMessage{msg, blk, recpt}, true, nil
-						}
-					}
-				}
+				return w.receiptForTipset(ctx, raw, msgCid)
 			default:
 				return nil, false, fmt.Errorf("unexpected type in channel: %T", raw)
 			}
@@ -176,122 +139,86 @@ func (w *Waiter) waitForMessage(ctx context.Context, ch <-chan interface{}, msgC
 	}
 }
 
-// receiptFromTipSet finds the receipt for the message with msgCid in the
-// input tipset.  This can differ from the message's receipt as stored in its
-// parent block in the case that the message is in conflict with another
-// message of the tipset.
-func (w *Waiter) receiptFromTipSet(ctx context.Context, msgCid cid.Cid, ts block.TipSet) (*types.MessageReceipt, error) {
-	// Receipts always match block if tipset has only 1 member.
-	var rcpt *types.MessageReceipt
-	if ts.Len() == 1 {
-		b := ts.At(0)
-		// TODO #3194: this should return an error if a receipt doesn't exist.
-		// Right now doing so breaks tests because our test helpers
-		// don't correctly apply messages when making test chains.
-		//
-		j, err := w.msgIndexOfTipSet(ctx, msgCid, ts, make(map[cid.Cid]struct{}))
-		if err != nil {
-			return nil, err
-		}
-
-		receipts, err := w.messageProvider.LoadReceipts(ctx, b.MessageReceipts)
-		if err != nil {
-			return nil, err
-		}
-		if j < len(receipts) {
-			rcpt = receipts[j]
-		}
-		return rcpt, nil
-	}
-
-	// Apply all the tipset's messages to determine the correct receipts.
-	ids, err := ts.Parents()
-	if err != nil {
-		return nil, err
-	}
-	st, err := w.chainReader.GetTipSetState(ctx, ids)
-	if err != nil {
-		return nil, err
-	}
-
-	tsHeight, err := ts.Height()
-	if err != nil {
-		return nil, err
-	}
-	ancestorHeight := types.NewBlockHeight(tsHeight).Sub(types.NewBlockHeight(consensus.AncestorRoundsNeeded))
-	parentTs, err := w.chainReader.GetTipSet(ids)
-	if err != nil {
-		return nil, err
-	}
-	ancestors, err := chain.GetRecentAncestors(ctx, parentTs, w.chainReader, ancestorHeight)
-	if err != nil {
-		return nil, err
-	}
-
-	var tsMessages [][]*types.SignedMessage
+func (w *Waiter) receiptForTipset(ctx context.Context, ts block.TipSet, msgCid cid.Cid) (*ChainMessage, bool, error) {
+	tsMessages := make([][]*types.SignedMessage, ts.Len())
 	for i := 0; i < ts.Len(); i++ {
 		blk := ts.At(i)
-		secpMsgs, _, err := w.messageProvider.LoadMessages(ctx, blk.Messages)
+		secpMsgs, blsMsgs, err := w.messageProvider.LoadMessages(ctx, blk.Messages)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
-		tsMessages = append(tsMessages, secpMsgs)
-	}
 
-	res, err := consensus.NewDefaultProcessor().ProcessTipSet(ctx, st, vm.NewStorageMap(w.bs), ts, tsMessages, ancestors)
-	if err != nil {
-		return nil, err
-	}
-
-	// If this is a failing conflict message there is no application receipt.
-	_, failed := res.Failures[msgCid]
-	if failed {
-		return nil, nil
-	}
-
-	j, err := w.msgIndexOfTipSet(ctx, msgCid, ts, res.Failures)
-	if err != nil {
-		return nil, err
-	}
-	// TODO #3194: out of bounds receipt index should return an error.
-	if j < len(res.Results) {
-		rcpt = res.Results[j].Receipt
-	}
-	return rcpt, nil
-}
-
-// msgIndexOfTipSet returns the order in which msgCid appears in the canonical
-// message ordering of the given tipset, or an error if it is not in the
-// tipset.
-// TODO: find a better home for this method
-func (w *Waiter) msgIndexOfTipSet(ctx context.Context, msgCid cid.Cid, ts block.TipSet, fails map[cid.Cid]struct{}) (int, error) {
-	duplicates := make(map[cid.Cid]struct{})
-	var msgCnt int
-	for i := 0; i < ts.Len(); i++ {
-		secpMsgs, _, err := w.messageProvider.LoadMessages(ctx, ts.At(i).Messages)
-		if err != nil {
-			return -1, err
-		}
-		for _, msg := range secpMsgs {
+		cids := make([]cid.Cid, len(blsMsgs)+len(secpMsgs))
+		blkMsgs := make([]*types.SignedMessage, len(blsMsgs)+len(secpMsgs))
+		for j, msg := range blsMsgs {
 			c, err := msg.Cid()
 			if err != nil {
-				return -1, err
+				return nil, false, err
 			}
-			_, failed := fails[c]
-			if failed {
-				continue
+			cids[j] = c
+			blkMsgs[j] = &types.SignedMessage{Message: *msg}
+		}
+		for j, msg := range secpMsgs {
+			c, err := msg.Cid()
+			if err != nil {
+				return nil, false, err
 			}
-			_, isDup := duplicates[c]
-			if isDup {
-				continue
+			cids[len(blsMsgs)+j] = c
+			blkMsgs[len(blsMsgs)+j] = msg
+		}
+		tsMessages[i] = blkMsgs
+
+		for i, msg := range blkMsgs {
+			if cids[i].Equals(msgCid) {
+				// wrapped cid might be different from given cid
+				targetCid, err := msg.Cid()
+				if err != nil {
+					return nil, false, err
+				}
+
+				recpt, err := w.receiptByIndex(ctx, ts.Key(), targetCid, tsMessages)
+				if err != nil {
+					return nil, false, errors.Wrap(err, "error retrieving receipt from tipset")
+				}
+				return &ChainMessage{msg, blk, recpt}, true, nil
 			}
-			duplicates[c] = struct{}{}
-			if c.Equals(msgCid) {
-				return msgCnt, nil
-			}
-			msgCnt++
 		}
 	}
+	return nil, false, nil
+}
 
-	return -1, fmt.Errorf("message cid %s not in tipset", msgCid.String())
+func (w *Waiter) receiptByIndex(ctx context.Context, tsKey block.TipSetKey, targetCid cid.Cid, messages [][]*types.SignedMessage) (*types.MessageReceipt, error) {
+	receiptCid, err := w.chainReader.GetTipSetReceiptsRoot(tsKey)
+	if err != nil {
+		return nil, err
+	}
+
+	receipts, err := w.messageProvider.LoadReceipts(ctx, receiptCid)
+	if err != nil {
+		return nil, err
+	}
+
+	deduped, err := consensus.DeduppedMessages(messages)
+	if err != nil {
+		return nil, err
+	}
+
+	receiptIndex := 0
+	for _, blkMessages := range deduped {
+		for _, msg := range blkMessages {
+			msgCid, err := msg.Cid()
+			if err != nil {
+				return nil, err
+			}
+
+			if msgCid.Equals(targetCid) {
+				if receiptIndex >= len(receipts) {
+					return nil, errors.Errorf("could not find message receipt at index %d", receiptIndex)
+				}
+				return receipts[receiptIndex], nil
+			}
+			receiptIndex++
+		}
+	}
+	return nil, errors.Errorf("could not find message cid %s in dedupped messages", targetCid.String())
 }

--- a/internal/app/go-filecoin/plumbing/msg/waiter_test.go
+++ b/internal/app/go-filecoin/plumbing/msg/waiter_test.go
@@ -70,6 +70,7 @@ func testWaitExisting(ctx context.Context, t *testing.T, cst *hamt.CborIpldStore
 	require.NoError(t, chainStore.PutTipSetMetadata(ctx, &chain.TipSetMetadata{
 		TipSet:          ts,
 		TipSetStateRoot: ts.ToSlice()[0].StateRoot,
+		TipSetReceipts:  types.EmptyReceiptsCID,
 	}))
 	require.NoError(t, chainStore.SetHead(ctx, ts))
 
@@ -97,6 +98,7 @@ func testWaitNew(ctx context.Context, t *testing.T, cst *hamt.CborIpldStore, cha
 	require.NoError(t, chainStore.PutTipSetMetadata(ctx, &chain.TipSetMetadata{
 		TipSet:          ts,
 		TipSetStateRoot: ts.ToSlice()[0].StateRoot,
+		TipSetReceipts:  types.EmptyReceiptsCID,
 	}))
 	require.NoError(t, chainStore.SetHead(ctx, ts))
 

--- a/internal/app/go-filecoin/plumbing/msg/waiter_test.go
+++ b/internal/app/go-filecoin/plumbing/msg/waiter_test.go
@@ -67,7 +67,7 @@ func testWaitExisting(ctx context.Context, t *testing.T, cst *hamt.CborIpldStore
 	chainWithMsgs := newChainWithMessages(cst, msgStore, headTipSet, smsgsSet{smsgs{m1, m2}})
 	ts := chainWithMsgs[len(chainWithMsgs)-1]
 	require.Equal(t, 1, ts.Len())
-	require.NoError(t, chainStore.PutTipSetAndState(ctx, &chain.TipSetAndState{
+	require.NoError(t, chainStore.PutTipSetMetadata(ctx, &chain.TipSetMetadata{
 		TipSet:          ts,
 		TipSetStateRoot: ts.ToSlice()[0].StateRoot,
 	}))
@@ -94,7 +94,7 @@ func testWaitNew(ctx context.Context, t *testing.T, cst *hamt.CborIpldStore, cha
 
 	ts := chainWithMsgs[len(chainWithMsgs)-1]
 	require.Equal(t, 1, ts.Len())
-	require.NoError(t, chainStore.PutTipSetAndState(ctx, &chain.TipSetAndState{
+	require.NoError(t, chainStore.PutTipSetMetadata(ctx, &chain.TipSetMetadata{
 		TipSet:          ts,
 		TipSetStateRoot: ts.ToSlice()[0].StateRoot,
 	}))

--- a/internal/pkg/chain/car_test.go
+++ b/internal/pkg/chain/car_test.go
@@ -165,9 +165,8 @@ func TestChainImportExportMessages(t *testing.T) {
 		mm.NewSignedMessage(alice, 4),
 		mm.NewSignedMessage(alice, 5),
 	}
-	rcts := types.EmptyReceipts(5)
 	ts2 := cb.BuildOneOn(ts1, func(b *chain.BlockBuilder) {
-		b.AddMessages(msgs, []*types.UnsignedMessage{}, rcts)
+		b.AddMessages(msgs, []*types.UnsignedMessage{})
 	})
 
 	// export the car file to a buffer
@@ -198,12 +197,10 @@ func TestChainImportExportMultiTipSetWithMessages(t *testing.T) {
 		mm.NewSignedMessage(alice, 4),
 		mm.NewSignedMessage(alice, 5),
 	}
-	rcts := types.EmptyReceipts(5)
 	ts2 := cb.BuildOneOn(ts1, func(b *chain.BlockBuilder) {
 		b.AddMessages(
 			msgs,
 			[]*types.UnsignedMessage{},
-			rcts,
 		)
 	})
 

--- a/internal/pkg/chain/init.go
+++ b/internal/pkg/chain/init.go
@@ -30,11 +30,12 @@ func Init(ctx context.Context, r repo.Repo, bs bstore.Blockstore, cst *hamt.Cbor
 	chainStore := NewStore(r.ChainDatastore(), cst, &state.TreeStateLoader{}, NewStatusReporter(), genesis.Cid())
 
 	// Persist the genesis tipset to the repo.
-	genTsas := &TipSetAndState{
+	genTsas := &TipSetMetadata{
 		TipSet:          genTipSet,
 		TipSetStateRoot: genesis.StateRoot,
+		TipSetReceipts:  genesis.MessageReceipts,
 	}
-	if err = chainStore.PutTipSetAndState(ctx, genTsas); err != nil {
+	if err = chainStore.PutTipSetMetadata(ctx, genTsas); err != nil {
 		return nil, errors.Wrap(err, "failed to put genesis block in chain store")
 	}
 	if err = chainStore.SetHead(ctx, genTipSet); err != nil {

--- a/internal/pkg/chain/store.go
+++ b/internal/pkg/chain/store.go
@@ -277,6 +277,11 @@ func (store *Store) GetTipSetStateRoot(key block.TipSetKey) (cid.Cid, error) {
 	return store.tipIndex.GetTipSetStateRoot(key)
 }
 
+// GetTipSetReceiptsRoot returns the root CID of the message receipts for the tipset identified by `key`.
+func (store *Store) GetTipSetReceiptsRoot(key block.TipSetKey) (cid.Cid, error) {
+	return store.tipIndex.GetTipSetReceipts(key)
+}
+
 // HasTipSetAndState returns true iff the default store's tipindex is indexing
 // the tipset identified by `key`.
 func (store *Store) HasTipSetAndState(ctx context.Context, key block.TipSetKey) bool {

--- a/internal/pkg/chain/store.go
+++ b/internal/pkg/chain/store.go
@@ -19,6 +19,10 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
 )
 
+func init() {
+	encoding.RegisterIpldCborType(tsState{})
+}
+
 // NewHeadTopic is the topic used to publish new heads.
 const NewHeadTopic = "new-head"
 
@@ -35,9 +39,9 @@ type ipldSource struct {
 	cborStore state.IpldStore
 }
 
-type tsMetadata struct {
-	stateRoot cid.Cid
-	receipts  cid.Cid
+type tsState struct {
+	StateRoot cid.Cid
+	Reciepts  cid.Cid
 }
 
 func newSource(cst state.IpldStore) *ipldSource {
@@ -218,13 +222,13 @@ func (store *Store) loadStateRootAndReceipts(ts block.TipSet) (cid.Cid, cid.Cid,
 		return cid.Undef, cid.Undef, errors.Wrapf(err, "failed to read tipset key %s", ts.String())
 	}
 
-	var metadata tsMetadata
+	var metadata tsState
 	err = encoding.Decode(bb, &metadata)
 	if err != nil {
 		return cid.Undef, cid.Undef, errors.Wrapf(err, "failed to decode tip set metadata %s", ts.String())
 	}
 
-	return metadata.stateRoot, metadata.receipts, nil
+	return metadata.StateRoot, metadata.Reciepts, nil
 }
 
 // PutTipSetMetadata persists the blocks of a tipset and the tipset index.
@@ -358,9 +362,9 @@ func (store *Store) writeTipSetMetadata(tsm *TipSetMetadata) error {
 		return errors.New("attempting to write receipts cid.Undef")
 	}
 
-	metadata := tsMetadata{
-		stateRoot: tsm.TipSetStateRoot,
-		receipts:  tsm.TipSetReceipts,
+	metadata := tsState{
+		StateRoot: tsm.TipSetStateRoot,
+		Reciepts:  tsm.TipSetReceipts,
 	}
 	val, err := encoding.Encode(metadata)
 	if err != nil {

--- a/internal/pkg/chain/store.go
+++ b/internal/pkg/chain/store.go
@@ -279,7 +279,7 @@ func (store *Store) GetTipSetStateRoot(key block.TipSetKey) (cid.Cid, error) {
 
 // GetTipSetReceiptsRoot returns the root CID of the message receipts for the tipset identified by `key`.
 func (store *Store) GetTipSetReceiptsRoot(key block.TipSetKey) (cid.Cid, error) {
-	return store.tipIndex.GetTipSetReceipts(key)
+	return store.tipIndex.GetTipSetReceiptsRoot(key)
 }
 
 // HasTipSetAndState returns true iff the default store's tipindex is indexing

--- a/internal/pkg/chain/store.go
+++ b/internal/pkg/chain/store.go
@@ -35,6 +35,11 @@ type ipldSource struct {
 	cborStore state.IpldStore
 }
 
+type tsMetadata struct {
+	stateRoot cid.Cid
+	receipts  cid.Cid
+}
+
 func newSource(cst state.IpldStore) *ipldSource {
 	return &ipldSource{
 		cborStore: cst,
@@ -155,13 +160,14 @@ func (store *Store) Load(ctx context.Context) (err error) {
 		if logStatusEvery != 0 && (height%logStatusEvery) == 0 {
 			logStore.Infof("load tipset: %s, height: %v", iterator.Value().String(), height)
 		}
-		stateRoot, err := store.loadStateRoot(iterator.Value())
+		stateRoot, receipts, err := store.loadStateRootAndReceipts(iterator.Value())
 		if err != nil {
 			return err
 		}
-		err = store.PutTipSetAndState(ctx, &TipSetAndState{
+		err = store.PutTipSetMetadata(ctx, &TipSetMetadata{
 			TipSet:          iterator.Value(),
 			TipSetStateRoot: stateRoot,
+			TipSetReceipts:  receipts,
 		})
 		if err != nil {
 			return err
@@ -201,34 +207,35 @@ func (store *Store) loadHead() (block.TipSetKey, error) {
 	return cids, nil
 }
 
-func (store *Store) loadStateRoot(ts block.TipSet) (cid.Cid, error) {
+func (store *Store) loadStateRootAndReceipts(ts block.TipSet) (cid.Cid, cid.Cid, error) {
 	h, err := ts.Height()
 	if err != nil {
-		return cid.Undef, err
+		return cid.Undef, cid.Undef, err
 	}
 	key := datastore.NewKey(makeKey(ts.String(), h))
 	bb, err := store.ds.Get(key)
 	if err != nil {
-		return cid.Undef, errors.Wrapf(err, "failed to read tipset key %s", ts.String())
+		return cid.Undef, cid.Undef, errors.Wrapf(err, "failed to read tipset key %s", ts.String())
 	}
 
-	var stateRoot cid.Cid
-	err = encoding.Decode(bb, &stateRoot)
+	var metadata tsMetadata
+	err = encoding.Decode(bb, &metadata)
 	if err != nil {
-		return cid.Undef, errors.Wrapf(err, "failed to cast state root of tipset %s", ts.String())
+		return cid.Undef, cid.Undef, errors.Wrapf(err, "failed to decode tip set metadata %s", ts.String())
 	}
-	return stateRoot, nil
+
+	return metadata.stateRoot, metadata.receipts, nil
 }
 
-// PutTipSetAndState persists the blocks of a tipset and the tipset index.
-func (store *Store) PutTipSetAndState(ctx context.Context, tsas *TipSetAndState) error {
+// PutTipSetMetadata persists the blocks of a tipset and the tipset index.
+func (store *Store) PutTipSetMetadata(ctx context.Context, tsm *TipSetMetadata) error {
 	// Update tipindex.
-	err := store.tipIndex.Put(tsas)
+	err := store.tipIndex.Put(tsm)
 	if err != nil {
 		return err
 	}
 	// Persist the state mapping.
-	if err = store.writeTipSetAndState(tsas); err != nil {
+	if err = store.writeTipSetMetadata(tsm); err != nil {
 		return err
 	}
 
@@ -274,7 +281,7 @@ func (store *Store) HasTipSetAndState(ctx context.Context, key block.TipSetKey) 
 
 // GetTipSetAndStatesByParentsAndHeight returns the the tipsets and states tracked by
 // the default store's tipIndex that have parents identified by `parentKey`.
-func (store *Store) GetTipSetAndStatesByParentsAndHeight(parentKey block.TipSetKey, h uint64) ([]*TipSetAndState, error) {
+func (store *Store) GetTipSetAndStatesByParentsAndHeight(parentKey block.TipSetKey, h uint64) ([]*TipSetMetadata, error) {
 	return store.tipIndex.GetByParentsAndHeight(parentKey, h)
 }
 
@@ -340,24 +347,32 @@ func (store *Store) writeHead(ctx context.Context, cids block.TipSetKey) error {
 	return store.ds.Put(headKey, val)
 }
 
-// writeTipSetAndState writes the tipset key and the state root id to the
+// writeTipSetMetadata writes the tipset key and the state root id to the
 // datastore.
-func (store *Store) writeTipSetAndState(tsas *TipSetAndState) error {
-	if tsas.TipSetStateRoot == cid.Undef {
+func (store *Store) writeTipSetMetadata(tsm *TipSetMetadata) error {
+	if tsm.TipSetStateRoot == cid.Undef {
 		return errors.New("attempting to write state root cid.Undef")
 	}
 
-	val, err := encoding.Encode(tsas.TipSetStateRoot)
+	if tsm.TipSetReceipts == cid.Undef {
+		return errors.New("attempting to write receipts cid.Undef")
+	}
+
+	metadata := tsMetadata{
+		stateRoot: tsm.TipSetStateRoot,
+		receipts:  tsm.TipSetReceipts,
+	}
+	val, err := encoding.Encode(metadata)
 	if err != nil {
 		return err
 	}
 
 	// datastore keeps key:stateRoot (k,v) pairs.
-	h, err := tsas.TipSet.Height()
+	h, err := tsm.TipSet.Height()
 	if err != nil {
 		return err
 	}
-	key := datastore.NewKey(makeKey(tsas.TipSet.String(), h))
+	key := datastore.NewKey(makeKey(tsm.TipSet.String(), h))
 	return store.ds.Put(key, val)
 }
 

--- a/internal/pkg/chain/store_test.go
+++ b/internal/pkg/chain/store_test.go
@@ -34,15 +34,15 @@ func newChainStore(r repo.Repo, genCid cid.Cid) *chain.Store {
 func requirePutTestChain(ctx context.Context, t *testing.T, chainStore *chain.Store, head block.TipSetKey, source *chain.Builder, count int) {
 	tss := source.RequireTipSets(head, count)
 	for _, ts := range tss {
-		tsas := &chain.TipSetAndState{
+		tsas := &chain.TipSetMetadata{
 			TipSet:          ts,
 			TipSetStateRoot: ts.At(0).StateRoot,
 		}
-		require.NoError(t, chainStore.PutTipSetAndState(ctx, tsas))
+		require.NoError(t, chainStore.PutTipSetMetadata(ctx, tsas))
 	}
 }
 
-func requireGetTsasByParentAndHeight(t *testing.T, chain *chain.Store, pKey block.TipSetKey, h uint64) []*chain.TipSetAndState {
+func requireGetTsasByParentAndHeight(t *testing.T, chain *chain.Store, pKey block.TipSetKey, h uint64) []*chain.TipSetMetadata {
 	tsasSlice, err := chain.GetTipSetAndStatesByParentsAndHeight(pKey, h)
 	require.NoError(t, err)
 	return tsasSlice
@@ -72,11 +72,11 @@ func TestPutTipSet(t *testing.T) {
 	r := repo.NewInMemoryRepo()
 	cs := newChainStore(r, genTS.At(0).Cid())
 
-	genTsas := &chain.TipSetAndState{
+	genTsas := &chain.TipSetMetadata{
 		TipSet:          genTS,
 		TipSetStateRoot: genTS.At(0).StateRoot,
 	}
-	err := cs.PutTipSetAndState(ctx, genTsas)
+	err := cs.PutTipSetMetadata(ctx, genTsas)
 	assert.NoError(t, err)
 }
 
@@ -155,7 +155,7 @@ func TestGetTipSetState(t *testing.T) {
 	store := chain.NewStore(ds, cst, &state.TreeStateLoader{}, chain.NewStatusReporter(), gen.At(0).Cid())
 
 	// add tipset and state to chain store
-	require.NoError(t, store.PutTipSetAndState(ctx, &chain.TipSetAndState{
+	require.NoError(t, store.PutTipSetMetadata(ctx, &chain.TipSetMetadata{
 		TipSet:          testTs,
 		TipSetStateRoot: root,
 	}))
@@ -232,11 +232,11 @@ func TestGetMultipleByParent(t *testing.T) {
 	// Add extra children to the genesis tipset
 	otherLink1 := builder.AppendOn(genTS, 1)
 	otherRoot1 := types.CidFromString(t, "otherState")
-	newChildTsas := &chain.TipSetAndState{
+	newChildTsas := &chain.TipSetMetadata{
 		TipSet:          otherLink1,
 		TipSetStateRoot: otherRoot1,
 	}
-	require.NoError(t, cs.PutTipSetAndState(ctx, newChildTsas))
+	require.NoError(t, cs.PutTipSetMetadata(ctx, newChildTsas))
 	gotNew1 := requireGetTsasByParentAndHeight(t, cs, genTS.Key(), uint64(1))
 	require.Equal(t, 2, len(gotNew1))
 	for _, tsas := range gotNew1 {

--- a/internal/pkg/chain/store_test.go
+++ b/internal/pkg/chain/store_test.go
@@ -37,6 +37,7 @@ func requirePutTestChain(ctx context.Context, t *testing.T, chainStore *chain.St
 		tsas := &chain.TipSetMetadata{
 			TipSet:          ts,
 			TipSetStateRoot: ts.At(0).StateRoot,
+			TipSetReceipts:  types.EmptyReceiptsCID,
 		}
 		require.NoError(t, chainStore.PutTipSetMetadata(ctx, tsas))
 	}
@@ -75,6 +76,7 @@ func TestPutTipSet(t *testing.T) {
 	genTsas := &chain.TipSetMetadata{
 		TipSet:          genTS,
 		TipSetStateRoot: genTS.At(0).StateRoot,
+		TipSetReceipts:  types.EmptyReceiptsCID,
 	}
 	err := cs.PutTipSetMetadata(ctx, genTsas)
 	assert.NoError(t, err)
@@ -158,6 +160,7 @@ func TestGetTipSetState(t *testing.T) {
 	require.NoError(t, store.PutTipSetMetadata(ctx, &chain.TipSetMetadata{
 		TipSet:          testTs,
 		TipSetStateRoot: root,
+		TipSetReceipts:  types.EmptyReceiptsCID,
 	}))
 
 	// verify output of GetTipSetState
@@ -235,6 +238,7 @@ func TestGetMultipleByParent(t *testing.T) {
 	newChildTsas := &chain.TipSetMetadata{
 		TipSet:          otherLink1,
 		TipSetStateRoot: otherRoot1,
+		TipSetReceipts:  types.EmptyReceiptsCID,
 	}
 	require.NoError(t, cs.PutTipSetMetadata(ctx, newChildTsas))
 	gotNew1 := requireGetTsasByParentAndHeight(t, cs, genTS.Key(), uint64(1))

--- a/internal/pkg/chain/testing.go
+++ b/internal/pkg/chain/testing.go
@@ -403,7 +403,7 @@ type FakeStateEvaluator struct {
 }
 
 // RunStateTransition delegates to StateBuilder.ComputeState.
-func (e *FakeStateEvaluator) RunStateTransition(ctx context.Context, tip block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, receipts [][]*types.MessageReceipt, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error) {
+func (e *FakeStateEvaluator) RunStateTransition(ctx context.Context, tip block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error) {
 	return e.ComputeState(stateID, blsMessages, secpMessages)
 }
 

--- a/internal/pkg/chain/testing.go
+++ b/internal/pkg/chain/testing.go
@@ -211,7 +211,7 @@ func (f *Builder) Build(parent block.TipSet, width int, build func(b *BlockBuild
 		prevState := f.StateForKey(parent.Key())
 		smsgs, umsgs, err := f.messages.LoadMessages(ctx, b.Messages)
 		require.NoError(f.t, err)
-		b.StateRoot, err = f.stateBuilder.ComputeState(prevState, [][]*types.UnsignedMessage{umsgs}, [][]*types.SignedMessage{smsgs})
+		b.StateRoot, _, err = f.stateBuilder.ComputeState(prevState, [][]*types.UnsignedMessage{umsgs}, [][]*types.SignedMessage{smsgs})
 		require.NoError(f.t, err)
 
 		// add block to cstore
@@ -249,7 +249,7 @@ func (f *Builder) ComputeState(tip block.TipSet) cid.Cid {
 	require.NoError(f.t, err)
 	// Load the state of the parent tipset and compute the required state (recursively).
 	prev := f.StateForKey(parentKey)
-	state, err := f.stateBuilder.ComputeState(prev, [][]*types.UnsignedMessage{}, f.tipMessages(tip))
+	state, _, err := f.stateBuilder.ComputeState(prev, [][]*types.UnsignedMessage{}, f.tipMessages(tip))
 	require.NoError(f.t, err)
 	return state
 }
@@ -323,7 +323,7 @@ func (bb *BlockBuilder) SetStateRoot(root cid.Cid) {
 
 // StateBuilder abstracts the computation of state root CIDs from the chain builder.
 type StateBuilder interface {
-	ComputeState(prev cid.Cid, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage) (cid.Cid, error)
+	ComputeState(prev cid.Cid, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage) (cid.Cid, []*types.MessageReceipt, error)
 	Weigh(tip block.TipSet, state cid.Cid) (uint64, error)
 }
 
@@ -336,14 +336,14 @@ type FakeStateBuilder struct {
 // is the same as the input state.
 // This differs from the true state transition function in that messages that are duplicated
 // between blocks in the tipset are not ignored.
-func (FakeStateBuilder) ComputeState(prev cid.Cid, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage) (cid.Cid, error) {
+func (FakeStateBuilder) ComputeState(prev cid.Cid, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage) (cid.Cid, []*types.MessageReceipt, error) {
 	// Accumulate the cids of the previous state and of all messages in the tipset.
 	inputs := []cid.Cid{prev}
 	for _, blockMessages := range blsMessages {
 		for _, msg := range blockMessages {
 			mCId, err := msg.Cid()
 			if err != nil {
-				return cid.Undef, err
+				return cid.Undef, []*types.MessageReceipt{}, err
 			}
 			inputs = append(inputs, mCId)
 		}
@@ -352,7 +352,7 @@ func (FakeStateBuilder) ComputeState(prev cid.Cid, blsMessages [][]*types.Unsign
 		for _, msg := range blockMessages {
 			mCId, err := msg.Cid()
 			if err != nil {
-				return cid.Undef, err
+				return cid.Undef, []*types.MessageReceipt{}, err
 			}
 			inputs = append(inputs, mCId)
 		}
@@ -360,9 +360,14 @@ func (FakeStateBuilder) ComputeState(prev cid.Cid, blsMessages [][]*types.Unsign
 
 	if len(inputs) == 1 {
 		// If there are no messages, the state doesn't change!
-		return prev, nil
+		return prev, []*types.MessageReceipt{}, nil
 	}
-	return makeCid(inputs)
+
+	root, err := makeCid(inputs)
+	if err != nil {
+		return cid.Undef, []*types.MessageReceipt{}, err
+	}
+	return root, []*types.MessageReceipt{}, nil
 }
 
 // Weigh computes a tipset's weight as its parent weight plus one for each block in the tipset.
@@ -386,7 +391,7 @@ type FakeStateEvaluator struct {
 }
 
 // RunStateTransition delegates to StateBuilder.ComputeState.
-func (e *FakeStateEvaluator) RunStateTransition(ctx context.Context, tip block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, receipts [][]*types.MessageReceipt, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, error) {
+func (e *FakeStateEvaluator) RunStateTransition(ctx context.Context, tip block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, receipts [][]*types.MessageReceipt, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error) {
 	return e.ComputeState(stateID, blsMessages, secpMessages)
 }
 
@@ -524,6 +529,11 @@ func (f *Builder) LoadMessages(ctx context.Context, meta types.TxMeta) ([]*types
 // LoadReceipts returns the message collections tracked by the builder.
 func (f *Builder) LoadReceipts(ctx context.Context, c cid.Cid) ([]*types.MessageReceipt, error) {
 	return f.messages.LoadReceipts(ctx, c)
+}
+
+// StoreReceipts stores message receipts and returns a commitment.
+func (f *Builder) StoreReceipts(ctx context.Context, receipts []*types.MessageReceipt) (cid.Cid, error) {
+	return f.messages.StoreReceipts(ctx, receipts)
 }
 
 ///// Internals /////

--- a/internal/pkg/chain/testing.go
+++ b/internal/pkg/chain/testing.go
@@ -301,17 +301,13 @@ func (bb *BlockBuilder) IncHeight(nullBlocks types.Uint64) {
 }
 
 // AddMessages adds a message & receipt collection to the block.
-func (bb *BlockBuilder) AddMessages(secpmsgs []*types.SignedMessage, blsMsgs []*types.UnsignedMessage, rcpts []*types.MessageReceipt) {
+func (bb *BlockBuilder) AddMessages(secpmsgs []*types.SignedMessage, blsMsgs []*types.UnsignedMessage) {
 	ctx := context.Background()
 
 	meta, err := bb.messages.StoreMessages(ctx, secpmsgs, blsMsgs)
 	require.NoError(bb.t, err)
 
-	cR, err := bb.messages.StoreReceipts(ctx, rcpts)
-	require.NoError(bb.t, err)
-
 	bb.block.Messages = meta
-	bb.block.MessageReceipts = cR
 }
 
 // SetStateRoot sets the block's state root.

--- a/internal/pkg/chain/tip_index.go
+++ b/internal/pkg/chain/tip_index.go
@@ -14,7 +14,7 @@ var (
 	ErrNotFound = errors.New("Key not found in tipindex")
 )
 
-// TipSetMetadata (tsas) is the type stored at the leaves of the TipIndex.  It contains
+// TipSetMetadata is the type stored at the leaves of the TipIndex.  It contains
 // a tipset pointing to blocks, the root cid of the chain's state after
 // applying the messages in this tipset to it's parent state, and the cid of the receipts
 // for these messages.
@@ -29,7 +29,7 @@ type TipSetMetadata struct {
 	TipSetReceipts cid.Cid
 }
 
-type tsasByTipSetID map[string]*TipSetMetadata
+type tsmByTipSetID map[string]*TipSetMetadata
 
 // TipIndex tracks tipsets and their states by tipset block ids and parent
 // block ids.  All methods are threadsafe as shared data is guarded by a
@@ -37,15 +37,15 @@ type tsasByTipSetID map[string]*TipSetMetadata
 type TipIndex struct {
 	mu sync.Mutex
 	// tsasByParents allows lookup of all TipSetAndStates with the same parent IDs.
-	tsasByParentsAndHeight map[string]tsasByTipSetID
+	tsasByParentsAndHeight map[string]tsmByTipSetID
 	// tsasByID allows lookup of recorded TipSetAndStates by TipSet ID.
-	tsasByID tsasByTipSetID
+	tsasByID tsmByTipSetID
 }
 
 // NewTipIndex is the TipIndex constructor.
 func NewTipIndex() *TipIndex {
 	return &TipIndex{
-		tsasByParentsAndHeight: make(map[string]tsasByTipSetID),
+		tsasByParentsAndHeight: make(map[string]tsmByTipSetID),
 		tsasByID:               make(map[string]*TipSetMetadata),
 	}
 }
@@ -109,8 +109,8 @@ func (ti *TipIndex) GetTipSetStateRoot(tsKey block.TipSetKey) (cid.Cid, error) {
 	return tsas.TipSetStateRoot, nil
 }
 
-// GetTipSetReceipts returns the tipsetReceipts from func (ti *TipIndex) Get(tsKey string).
-func (ti *TipIndex) GetTipSetReceipts(tsKey block.TipSetKey) (cid.Cid, error) {
+// GetTipSetReceiptsRoot returns the tipsetReceipts from func (ti *TipIndex) Get(tsKey string).
+func (ti *TipIndex) GetTipSetReceiptsRoot(tsKey block.TipSetKey) (cid.Cid, error) {
 	tsas, err := ti.Get(tsKey)
 	if err != nil {
 		return cid.Cid{}, err

--- a/internal/pkg/chain/tip_index.go
+++ b/internal/pkg/chain/tip_index.go
@@ -14,16 +14,22 @@ var (
 	ErrNotFound = errors.New("Key not found in tipindex")
 )
 
-// TipSetAndState (tsas) is the type stored at the leaves of the TipIndex.  It contains
-// a tipset pointing to blocks and the root cid of the chain's state after
-// applying the messages in this tipset to it's parent state.
-type TipSetAndState struct {
-	// root of aggregate state after applying tipset
+// TipSetMetadata (tsas) is the type stored at the leaves of the TipIndex.  It contains
+// a tipset pointing to blocks, the root cid of the chain's state after
+// applying the messages in this tipset to it's parent state, and the cid of the receipts
+// for these messages.
+type TipSetMetadata struct {
+	// TipSetStateRoot is the root of aggregate state after applying tipset
 	TipSetStateRoot cid.Cid
-	TipSet          block.TipSet
+
+	// TipSet is the set of blocks that forms the tip set
+	TipSet block.TipSet
+
+	// TipSetReceipts receipts from all message contained within this tipset
+	TipSetReceipts cid.Cid
 }
 
-type tsasByTipSetID map[string]*TipSetAndState
+type tsasByTipSetID map[string]*TipSetMetadata
 
 // TipIndex tracks tipsets and their states by tipset block ids and parent
 // block ids.  All methods are threadsafe as shared data is guarded by a
@@ -40,14 +46,14 @@ type TipIndex struct {
 func NewTipIndex() *TipIndex {
 	return &TipIndex{
 		tsasByParentsAndHeight: make(map[string]tsasByTipSetID),
-		tsasByID:               make(map[string]*TipSetAndState),
+		tsasByID:               make(map[string]*TipSetMetadata),
 	}
 }
 
 // Put adds an entry to both of TipIndex's internal indexes.
-// After this call the input TipSetAndState can be looked up by the ID of
+// After this call the input TipSetMetadata can be looked up by the ID of
 // the tipset, or the tipset's parent.
-func (ti *TipIndex) Put(tsas *TipSetAndState) error {
+func (ti *TipIndex) Put(tsas *TipSetMetadata) error {
 	ti.mu.Lock()
 	defer ti.mu.Unlock()
 	tsKey := tsas.TipSet.String()
@@ -67,7 +73,7 @@ func (ti *TipIndex) Put(tsas *TipSetAndState) error {
 	key := makeKey(pKey, h)
 	tsasByID, ok := ti.tsasByParentsAndHeight[key]
 	if !ok {
-		tsasByID = make(map[string]*TipSetAndState)
+		tsasByID = make(map[string]*TipSetMetadata)
 		ti.tsasByParentsAndHeight[key] = tsasByID
 	}
 	tsasByID[tsKey] = tsas
@@ -75,7 +81,7 @@ func (ti *TipIndex) Put(tsas *TipSetAndState) error {
 }
 
 // Get returns the tipset given by the input ID and its state.
-func (ti *TipIndex) Get(tsKey block.TipSetKey) (*TipSetAndState, error) {
+func (ti *TipIndex) Get(tsKey block.TipSetKey) (*TipSetMetadata, error) {
 	ti.mu.Lock()
 	defer ti.mu.Unlock()
 	tsas, ok := ti.tsasByID[tsKey.String()]
@@ -103,6 +109,15 @@ func (ti *TipIndex) GetTipSetStateRoot(tsKey block.TipSetKey) (cid.Cid, error) {
 	return tsas.TipSetStateRoot, nil
 }
 
+// GetTipSetReceipts returns the tipsetReceipts from func (ti *TipIndex) Get(tsKey string).
+func (ti *TipIndex) GetTipSetReceipts(tsKey block.TipSetKey) (cid.Cid, error) {
+	tsas, err := ti.Get(tsKey)
+	if err != nil {
+		return cid.Cid{}, err
+	}
+	return tsas.TipSetReceipts, nil
+}
+
 // Has returns true iff the tipset with the input ID is stored in
 // the TipIndex.
 func (ti *TipIndex) Has(tsKey block.TipSetKey) bool {
@@ -114,7 +129,7 @@ func (ti *TipIndex) Has(tsKey block.TipSetKey) bool {
 
 // GetByParentsAndHeight returns the all tipsets and states stored in the TipIndex
 // such that the parent ID of these tipsets equals the input.
-func (ti *TipIndex) GetByParentsAndHeight(pKey block.TipSetKey, h uint64) ([]*TipSetAndState, error) {
+func (ti *TipIndex) GetByParentsAndHeight(pKey block.TipSetKey, h uint64) ([]*TipSetMetadata, error) {
 	key := makeKey(pKey.String(), h)
 	ti.mu.Lock()
 	defer ti.mu.Unlock()
@@ -122,7 +137,7 @@ func (ti *TipIndex) GetByParentsAndHeight(pKey block.TipSetKey, h uint64) ([]*Ti
 	if !ok {
 		return nil, ErrNotFound
 	}
-	var ret []*TipSetAndState
+	var ret []*TipSetMetadata
 	for _, tsas := range tsasByID {
 		ret = append(ret, tsas)
 	}

--- a/internal/pkg/chainsync/chainsync.go
+++ b/internal/pkg/chainsync/chainsync.go
@@ -25,7 +25,7 @@ type Manager struct {
 }
 
 // NewManager creates a new chain sync manager.
-func NewManager(e syncer.SemanticValidator, cs syncer.ChainSelector, s syncer.ChainReaderWriter, m chain.MessageProvider, f syncer.Fetcher, c clock.Clock) Manager {
+func NewManager(e syncer.SemanticValidator, cs syncer.ChainSelector, s syncer.ChainReaderWriter, m *chain.MessageStore, f syncer.Fetcher, c clock.Clock) Manager {
 	syncer := syncer.NewSyncer(e, cs, s, m, f, status.NewReporter(), c)
 	dispatcher := dispatcher.NewDispatcher(syncer)
 	return Manager{

--- a/internal/pkg/chainsync/internal/syncer/syncer.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer.go
@@ -107,7 +107,7 @@ type ChainSelector interface {
 type SemanticValidator interface {
 	// RunStateTransition returns the state root CID resulting from applying the input ts to the
 	// prior `stateRoot`.  It returns an error if the transition is invalid.
-	RunStateTransition(ctx context.Context, ts block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, tsReceipts [][]*types.MessageReceipt, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error)
+	RunStateTransition(ctx context.Context, ts block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error)
 	// ValidateSemantic validates conditions on a block header that can be
 	// checked with the parent header but not parent state.
 	ValidateSemantic(ctx context.Context, header *block.Block, parents block.TipSet) error
@@ -226,21 +226,15 @@ func (syncer *Syncer) syncOne(ctx context.Context, grandParent, parent, next blo
 	// Gather tipset messages
 	var nextSecpMessages [][]*types.SignedMessage
 	var nextBlsMessages [][]*types.UnsignedMessage
-	var nextReceipts [][]*types.MessageReceipt
 	for i := 0; i < next.Len(); i++ {
 		blk := next.At(i)
 		secpMsgs, blsMsgs, err := syncer.messageProvider.LoadMessages(ctx, blk.Messages)
 		if err != nil {
 			return errors.Wrapf(err, "syncing tip %s failed loading message list %s for block %s", next.Key(), blk.Messages, blk.Cid())
 		}
-		rcpts, err := syncer.messageProvider.LoadReceipts(ctx, blk.MessageReceipts)
-		if err != nil {
-			return errors.Wrapf(err, "syncing tip %s failed loading receipts list %s for block %s", next.Key(), blk.MessageReceipts, blk.Cid())
-		}
 
 		nextBlsMessages = append(nextBlsMessages, blsMsgs)
 		nextSecpMessages = append(nextSecpMessages, secpMsgs)
-		nextReceipts = append(nextReceipts, rcpts)
 	}
 
 	// Gather validated parent weight
@@ -251,7 +245,7 @@ func (syncer *Syncer) syncOne(ctx context.Context, grandParent, parent, next blo
 
 	// Run a state transition to validate the tipset and compute
 	// a new state to add to the store.
-	root, receipts, err := syncer.validator.RunStateTransition(ctx, next, nextBlsMessages, nextSecpMessages, nextReceipts, ancestors, parentWeight, stateRoot)
+	root, receipts, err := syncer.validator.RunStateTransition(ctx, next, nextBlsMessages, nextSecpMessages, ancestors, parentWeight, stateRoot)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/chainsync/internal/syncer/syncer.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer.go
@@ -20,6 +20,12 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
+type messageStore interface {
+	LoadMessages(context.Context, types.TxMeta) ([]*types.SignedMessage, []*types.UnsignedMessage, error)
+	LoadReceipts(context.Context, cid.Cid) ([]*types.MessageReceipt, error)
+	StoreReceipts(context.Context, []*types.MessageReceipt) (cid.Cid, error)
+}
+
 // Syncer updates its chain.Store according to the methods of its
 // consensus.Protocol.  It uses a bad tipset cache and a limit on new
 // blocks to traverse during chain collection.  The Syncer can query the
@@ -56,7 +62,7 @@ type Syncer struct {
 	// Provides and stores validated tipsets and their state roots.
 	chainStore ChainReaderWriter
 	// Provides message collections given cids
-	messageProvider chain.MessageProvider
+	messageProvider messageStore
 
 	clock clock.Clock
 
@@ -82,10 +88,10 @@ type ChainReaderWriter interface {
 	GetTipSet(tsKey block.TipSetKey) (block.TipSet, error)
 	GetTipSetStateRoot(tsKey block.TipSetKey) (cid.Cid, error)
 	HasTipSetAndState(ctx context.Context, tsKey block.TipSetKey) bool
-	PutTipSetAndState(ctx context.Context, tsas *chain.TipSetAndState) error
+	PutTipSetMetadata(ctx context.Context, tsas *chain.TipSetMetadata) error
 	SetHead(ctx context.Context, s block.TipSet) error
 	HasTipSetAndStatesWithParentsAndHeight(pTsKey block.TipSetKey, h uint64) bool
-	GetTipSetAndStatesByParentsAndHeight(pTsKey block.TipSetKey, h uint64) ([]*chain.TipSetAndState, error)
+	GetTipSetAndStatesByParentsAndHeight(pTsKey block.TipSetKey, h uint64) ([]*chain.TipSetMetadata, error)
 }
 
 // ChainSelector chooses the heaviest between chains.
@@ -101,7 +107,7 @@ type ChainSelector interface {
 type SemanticValidator interface {
 	// RunStateTransition returns the state root CID resulting from applying the input ts to the
 	// prior `stateRoot`.  It returns an error if the transition is invalid.
-	RunStateTransition(ctx context.Context, ts block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, tsReceipts [][]*types.MessageReceipt, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, error)
+	RunStateTransition(ctx context.Context, ts block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, tsReceipts [][]*types.MessageReceipt, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error)
 	// ValidateSemantic validates conditions on a block header that can be
 	// checked with the parent header but not parent state.
 	ValidateSemantic(ctx context.Context, header *block.Block, parents block.TipSet) error
@@ -134,7 +140,7 @@ func init() {
 var logSyncer = logging.Logger("chainsync.syncer")
 
 // NewSyncer constructs a Syncer ready for use.
-func NewSyncer(e SemanticValidator, cs ChainSelector, s ChainReaderWriter, m chain.MessageProvider, f Fetcher, sr status.Reporter, c clock.Clock) *Syncer {
+func NewSyncer(e SemanticValidator, cs ChainSelector, s ChainReaderWriter, m messageStore, f Fetcher, sr status.Reporter, c clock.Clock) *Syncer {
 	return &Syncer{
 		fetcher: f,
 		badTipSets: &BadTipSetCache{
@@ -245,13 +251,20 @@ func (syncer *Syncer) syncOne(ctx context.Context, grandParent, parent, next blo
 
 	// Run a state transition to validate the tipset and compute
 	// a new state to add to the store.
-	root, err := syncer.validator.RunStateTransition(ctx, next, nextBlsMessages, nextSecpMessages, nextReceipts, ancestors, parentWeight, stateRoot)
+	root, receipts, err := syncer.validator.RunStateTransition(ctx, next, nextBlsMessages, nextSecpMessages, nextReceipts, ancestors, parentWeight, stateRoot)
 	if err != nil {
 		return err
 	}
-	err = syncer.chainStore.PutTipSetAndState(ctx, &chain.TipSetAndState{
+
+	receiptCid, err := syncer.messageProvider.StoreReceipts(ctx, receipts)
+	if err != nil {
+		return errors.Wrapf(err, "could not store message rerceipts for tip set %s", next.String())
+	}
+
+	err = syncer.chainStore.PutTipSetMetadata(ctx, &chain.TipSetMetadata{
 		TipSet:          next,
 		TipSetStateRoot: root,
+		TipSetReceipts:  receiptCid,
 	})
 	if err != nil {
 		return err

--- a/internal/pkg/chainsync/internal/syncer/syncer_integration_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_integration_test.go
@@ -238,7 +238,7 @@ type integrationStateEvaluator struct {
 	c512 cid.Cid
 }
 
-func (n *integrationStateEvaluator) RunStateTransition(_ context.Context, ts block.TipSet, _ [][]*types.UnsignedMessage, _ [][]*types.SignedMessage, _ [][]*types.MessageReceipt, _ []block.TipSet, _ uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error) {
+func (n *integrationStateEvaluator) RunStateTransition(_ context.Context, ts block.TipSet, _ [][]*types.UnsignedMessage, _ [][]*types.SignedMessage, _ []block.TipSet, _ uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error) {
 	for i := 0; i < ts.Len(); i++ {
 		if ts.At(i).StateRoot.Equals(n.c512) {
 			return n.c512, []*types.MessageReceipt{}, nil

--- a/internal/pkg/chainsync/internal/syncer/syncer_integration_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_integration_test.go
@@ -45,7 +45,7 @@ func TestLoadFork(t *testing.T) {
 	bs := bstore.NewBlockstore(repo.Datastore())
 	cborStore := hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
 	store := chain.NewStore(repo.ChainDatastore(), &cborStore, &state.TreeStateLoader{}, chain.NewStatusReporter(), genesis.At(0).Cid())
-	require.NoError(t, store.PutTipSetMetadata(ctx, &chain.TipSetMetadata{TipSetStateRoot: genStateRoot, TipSet: genesis}))
+	require.NoError(t, store.PutTipSetMetadata(ctx, &chain.TipSetMetadata{TipSetStateRoot: genStateRoot, TipSet: genesis, TipSetReceipts: types.EmptyReceiptsCID}))
 	require.NoError(t, store.SetHead(ctx, genesis))
 
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but
@@ -157,7 +157,7 @@ func TestSyncerWeighsPower(t *testing.T) {
 	as := newForkSnapshotGen(t, types.NewBytesAmount(1), types.NewBytesAmount(512), isb.c512)
 	dumpBlocksToCborStore(t, builder, cst, head1, head2)
 	store := chain.NewStore(repo.NewInMemoryRepo().ChainDatastore(), cst, &state.TreeStateLoader{}, chain.NewStatusReporter(), gen.At(0).Cid())
-	require.NoError(t, store.PutTipSetMetadata(ctx, &chain.TipSetMetadata{TipSetStateRoot: gen.At(0).StateRoot, TipSet: gen}))
+	require.NoError(t, store.PutTipSetMetadata(ctx, &chain.TipSetMetadata{TipSetStateRoot: gen.At(0).StateRoot, TipSet: gen, TipSetReceipts: gen.At(0).MessageReceipts}))
 	require.NoError(t, store.SetHead(ctx, gen))
 	syncer := syncer.NewSyncer(&integrationStateEvaluator{c512: isb.c512}, consensus.NewChainSelector(cst, as, gen.At(0).Cid()), store, builder, builder, status.NewReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 
@@ -196,13 +196,13 @@ func newIntegrationStateBuilder(t *testing.T, cst *hamt.CborIpldStore) *integrat
 	}
 }
 
-func (isb *integrationStateBuilder) ComputeState(prev cid.Cid, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage) (cid.Cid, error) {
+func (isb *integrationStateBuilder) ComputeState(prev cid.Cid, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage) (cid.Cid, []*types.MessageReceipt, error) {
 	// setup genesis with a state we can fetch from cborstor
 	if prev.Equals(types.CidFromString(isb.t, "null")) {
 		treeGen := state.TreeFromString(isb.t, "1Power", isb.cst)
 		genRoot, err := treeGen.Flush(context.Background())
 		require.NoError(isb.t, err)
-		return genRoot, nil
+		return genRoot, []*types.MessageReceipt{}, nil
 	}
 	// Setup fork with state we associate with more power.
 	// This fork is distiguished by a block with a single secp message.
@@ -211,9 +211,9 @@ func (isb *integrationStateBuilder) ComputeState(prev cid.Cid, blsMessages [][]*
 		forkRoot, err := treeFork.Flush(context.Background())
 		require.NoError(isb.t, err)
 		isb.c512 = forkRoot
-		return forkRoot, nil
+		return forkRoot, []*types.MessageReceipt{}, nil
 	}
-	return prev, nil
+	return prev, []*types.MessageReceipt{}, nil
 }
 
 func (isb *integrationStateBuilder) Weigh(tip block.TipSet, pstate cid.Cid) (uint64, error) {
@@ -238,13 +238,13 @@ type integrationStateEvaluator struct {
 	c512 cid.Cid
 }
 
-func (n *integrationStateEvaluator) RunStateTransition(_ context.Context, ts block.TipSet, _ [][]*types.UnsignedMessage, _ [][]*types.SignedMessage, _ [][]*types.MessageReceipt, _ []block.TipSet, _ uint64, stateID cid.Cid) (cid.Cid, error) {
+func (n *integrationStateEvaluator) RunStateTransition(_ context.Context, ts block.TipSet, _ [][]*types.UnsignedMessage, _ [][]*types.SignedMessage, _ [][]*types.MessageReceipt, _ []block.TipSet, _ uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error) {
 	for i := 0; i < ts.Len(); i++ {
 		if ts.At(i).StateRoot.Equals(n.c512) {
-			return n.c512, nil
+			return n.c512, []*types.MessageReceipt{}, nil
 		}
 	}
-	return ts.At(0).StateRoot, nil
+	return ts.At(0).StateRoot, []*types.MessageReceipt{}, nil
 }
 
 func (n *integrationStateEvaluator) ValidateSemantic(_ context.Context, _ *block.Block, _ block.TipSet) error {

--- a/internal/pkg/chainsync/internal/syncer/syncer_integration_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_integration_test.go
@@ -45,7 +45,7 @@ func TestLoadFork(t *testing.T) {
 	bs := bstore.NewBlockstore(repo.Datastore())
 	cborStore := hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
 	store := chain.NewStore(repo.ChainDatastore(), &cborStore, &state.TreeStateLoader{}, chain.NewStatusReporter(), genesis.At(0).Cid())
-	require.NoError(t, store.PutTipSetAndState(ctx, &chain.TipSetAndState{TipSetStateRoot: genStateRoot, TipSet: genesis}))
+	require.NoError(t, store.PutTipSetMetadata(ctx, &chain.TipSetMetadata{TipSetStateRoot: genStateRoot, TipSet: genesis}))
 	require.NoError(t, store.SetHead(ctx, genesis))
 
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but
@@ -157,7 +157,7 @@ func TestSyncerWeighsPower(t *testing.T) {
 	as := newForkSnapshotGen(t, types.NewBytesAmount(1), types.NewBytesAmount(512), isb.c512)
 	dumpBlocksToCborStore(t, builder, cst, head1, head2)
 	store := chain.NewStore(repo.NewInMemoryRepo().ChainDatastore(), cst, &state.TreeStateLoader{}, chain.NewStatusReporter(), gen.At(0).Cid())
-	require.NoError(t, store.PutTipSetAndState(ctx, &chain.TipSetAndState{TipSetStateRoot: gen.At(0).StateRoot, TipSet: gen}))
+	require.NoError(t, store.PutTipSetMetadata(ctx, &chain.TipSetMetadata{TipSetStateRoot: gen.At(0).StateRoot, TipSet: gen}))
 	require.NoError(t, store.SetHead(ctx, gen))
 	syncer := syncer.NewSyncer(&integrationStateEvaluator{c512: isb.c512}, consensus.NewChainSelector(cst, as, gen.At(0).Cid()), store, builder, builder, status.NewReporter(), th.NewFakeClock(time.Unix(1234567890, 0)))
 

--- a/internal/pkg/chainsync/internal/syncer/syncer_integration_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_integration_test.go
@@ -134,11 +134,8 @@ func TestSyncerWeighsPower(t *testing.T) {
 			mm := types.NewMessageMaker(t, keys)
 			addr := mm.Addresses()[0]
 			bb.AddMessages(
-				[]*types.SignedMessage{
-					mm.NewSignedMessage(addr, 1),
-				},
+				[]*types.SignedMessage{mm.NewSignedMessage(addr, 1)},
 				[]*types.UnsignedMessage{},
-				types.EmptyReceipts(1),
 			)
 		}
 	})

--- a/internal/pkg/chainsync/internal/syncer/syncer_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_test.go
@@ -492,9 +492,7 @@ func TestStoresMessageReceipts(t *testing.T) {
 	mm := types.NewMessageMaker(t, keys)
 	alice := mm.Addresses()[0]
 	t1 := builder.Build(genesis, 4, func(b *chain.BlockBuilder, i int) {
-		b.AddMessages([]*types.SignedMessage{},
-			[]*types.UnsignedMessage{mm.NewUnsignedMessage(alice, uint64(i))},
-			[]*types.MessageReceipt{}) // let syncer handle the receipts (this is going away)
+		b.AddMessages([]*types.SignedMessage{}, []*types.UnsignedMessage{mm.NewUnsignedMessage(alice, uint64(i))})
 	})
 	assert.NoError(t, syncer.HandleNewTipSet(ctx, block.NewChainInfo(peer.ID(""), "", t1.Key(), heightFromTip(t, t1)), true))
 

--- a/internal/pkg/chainsync/internal/syncer/syncer_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_test.go
@@ -498,7 +498,7 @@ func setupWithValidator(ctx context.Context, t *testing.T, val syncer.SemanticVa
 
 	store := chain.NewStore(repo.NewInMemoryRepo().ChainDatastore(), hamt.NewCborStore(), &state.TreeStateLoader{}, chain.NewStatusReporter(), genesis.At(0).Cid())
 	// Initialize chainStore store genesis state and tipset as head.
-	require.NoError(t, store.PutTipSetAndState(ctx, &chain.TipSetAndState{TipSetStateRoot: genStateRoot, TipSet: genesis}))
+	require.NoError(t, store.PutTipSetMetadata(ctx, &chain.TipSetMetadata{TipSetStateRoot: genStateRoot, TipSet: genesis}))
 	require.NoError(t, store.SetHead(ctx, genesis))
 
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but
@@ -516,7 +516,7 @@ type syncStoreReader interface {
 	GetHead() block.TipSetKey
 	GetTipSet(block.TipSetKey) (block.TipSet, error)
 	GetTipSetStateRoot(tsKey block.TipSetKey) (cid.Cid, error)
-	GetTipSetAndStatesByParentsAndHeight(block.TipSetKey, uint64) ([]*chain.TipSetAndState, error)
+	GetTipSetAndStatesByParentsAndHeight(block.TipSetKey, uint64) ([]*chain.TipSetMetadata, error)
 }
 
 // Verifies that a tipset and associated state root are stored in the chain store.
@@ -545,7 +545,7 @@ func verifyHead(t *testing.T, store syncStoreReader, head block.TipSet) {
 	assert.Equal(t, head, headTipSet)
 }
 
-func containsTipSet(tsasSlice []*chain.TipSetAndState, ts block.TipSet) bool {
+func containsTipSet(tsasSlice []*chain.TipSetMetadata, ts block.TipSet) bool {
 	for _, tsas := range tsasSlice {
 		if tsas.TipSet.String() == ts.String() { //bingo
 			return true

--- a/internal/pkg/chainsync/internal/syncer/syncer_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_test.go
@@ -496,7 +496,7 @@ func TestStoresMessageReceipts(t *testing.T) {
 			[]*types.UnsignedMessage{mm.NewUnsignedMessage(alice, uint64(i))},
 			[]*types.MessageReceipt{}) // let syncer handle the receipts (this is going away)
 	})
-	assert.NoError(t, syncer.HandleNewTipSet(ctx, block.NewChainInfo(peer.ID(""), t1.Key(), heightFromTip(t, t1)), true))
+	assert.NoError(t, syncer.HandleNewTipSet(ctx, block.NewChainInfo(peer.ID(""), "", t1.Key(), heightFromTip(t, t1)), true))
 
 	receiptsCid, err := store.GetTipSetReceiptsRoot(t1.Key())
 	require.NoError(t, err)
@@ -524,7 +524,7 @@ func setupWithValidator(ctx context.Context, t *testing.T, val syncer.SemanticVa
 
 	store := chain.NewStore(repo.NewInMemoryRepo().ChainDatastore(), hamt.NewCborStore(), &state.TreeStateLoader{}, chain.NewStatusReporter(), genesis.At(0).Cid())
 	// Initialize chainStore store genesis state and tipset as head.
-	require.NoError(t, store.PutTipSetMetadata(ctx, &chain.TipSetMetadata{TipSetStateRoot: genStateRoot, TipSet: genesis, TipSetReceipts: types.EmptyReceiptsCID}}))
+	require.NoError(t, store.PutTipSetMetadata(ctx, &chain.TipSetMetadata{TipSetStateRoot: genStateRoot, TipSet: genesis, TipSetReceipts: types.EmptyReceiptsCID}))
 	require.NoError(t, store.SetHead(ctx, genesis))
 
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but

--- a/internal/pkg/chainsync/internal/syncer/syncer_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chainsync/internal/syncer"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chainsync/status"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-hamt-ipld"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -498,7 +499,7 @@ func setupWithValidator(ctx context.Context, t *testing.T, val syncer.SemanticVa
 
 	store := chain.NewStore(repo.NewInMemoryRepo().ChainDatastore(), hamt.NewCborStore(), &state.TreeStateLoader{}, chain.NewStatusReporter(), genesis.At(0).Cid())
 	// Initialize chainStore store genesis state and tipset as head.
-	require.NoError(t, store.PutTipSetMetadata(ctx, &chain.TipSetMetadata{TipSetStateRoot: genStateRoot, TipSet: genesis}))
+	require.NoError(t, store.PutTipSetMetadata(ctx, &chain.TipSetMetadata{TipSetStateRoot: genStateRoot, TipSet: genesis, TipSetReceipts: types.EmptyReceiptsCID}}))
 	require.NoError(t, store.SetHead(ctx, genesis))
 
 	// Note: the chain builder is passed as the fetcher, from which blocks may be requested, but

--- a/internal/pkg/consensus/expected_test.go
+++ b/internal/pkg/consensus/expected_test.go
@@ -112,9 +112,9 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), th.NewFakeBlockValidator(), as, genesisBlock.Cid(), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
 
-		emptyBLSMessages, emptyMessages, emptyReceipts := emptyMessagesAndReceipts(len(blocks))
+		emptyBLSMessages, emptyMessages := emptyMessages(len(blocks))
 
-		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
 		assert.NoError(t, err)
 	})
 
@@ -133,9 +133,9 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		tipSet := th.RequireNewTipSet(t, blocks...)
 
-		emptyBLSMessages, emptyMessages, emptyReceipts := emptyMessagesAndReceipts(len(blocks))
+		emptyBLSMessages, emptyMessages := emptyMessages(len(blocks))
 
-		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), genesisBlock.StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), genesisBlock.StateRoot)
 		assert.EqualError(t, err, "block author did not win election")
 	})
 
@@ -153,7 +153,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), th.NewFakeBlockValidator(), as, genesisBlock.Cid(), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
 
-		_, emptyMessages, emptyReceipts := emptyMessagesAndReceipts(len(blocks))
+		_, emptyMessages := emptyMessages(len(blocks))
 
 		// Create BLS messages but do not update signature
 		blsKey := bls.PrivateKeyPublicKey(bls.PrivateKeyGenerate())
@@ -164,7 +164,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		msg := types.NewUnsignedMessage(blsAddr, address.TestAddress2, 0, types.NewAttoFILFromFIL(0), "", []byte{})
 		blsMessages[0] = append(blsMessages[0], msg)
 
-		_, _, err = exp.RunStateTransition(ctx, tipSet, blsMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, blsMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "block BLS signature does not validate")
 	})
@@ -183,7 +183,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), th.NewFakeBlockValidator(), as, genesisBlock.Cid(), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
 
-		emptyBLSMessages, _, emptyReceipts := emptyMessagesAndReceipts(len(blocks))
+		emptyBLSMessages, _ := emptyMessages(len(blocks))
 
 		// Create secp message with invalid signature
 		keys := types.MustGenerateKeyInfo(1, 42)
@@ -198,7 +198,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		}
 		secpMessages[0] = append(secpMessages[0], smsg)
 
-		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, secpMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, secpMessages, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "secp message signature invalid")
 	})
@@ -219,9 +219,9 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		tipSet := th.RequireNewTipSet(t, blocks...)
 
-		emptyBLSMessages, emptyMessages, emptyReceipts := emptyMessagesAndReceipts(len(blocks))
+		emptyBLSMessages, emptyMessages := emptyMessages(len(blocks))
 
-		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), genesisBlock.StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), genesisBlock.StateRoot)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "invalid ticket")
 	})
@@ -241,9 +241,9 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), th.NewFakeBlockValidator(), as, genesisBlock.Cid(), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
 
-		emptyBLSMessages, emptyMessages, emptyReceipts := emptyMessagesAndReceipts(len(blocks))
+		emptyBLSMessages, emptyMessages := emptyMessages(len(blocks))
 
-		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
 		assert.EqualError(t, err, "block signature invalid")
 	})
 
@@ -260,23 +260,21 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		invalidParentWeight := uint64(6)
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), th.NewFakeBlockValidator(), as, genesisBlock.Cid(), th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
 
-		emptyBLSMessages, emptyMessages, emptyReceipts := emptyMessagesAndReceipts(len(blocks))
+		emptyBLSMessages, emptyMessages := emptyMessages(len(blocks))
 
-		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, invalidParentWeight, blocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, invalidParentWeight, blocks[0].StateRoot)
 		assert.Contains(t, err.Error(), "invalid parent weight")
 	})
 }
 
-func emptyMessagesAndReceipts(numBlocks int) ([][]*types.UnsignedMessage, [][]*types.SignedMessage, [][]*types.MessageReceipt) {
+func emptyMessages(numBlocks int) ([][]*types.UnsignedMessage, [][]*types.SignedMessage) {
 	var emptyBLSMessages [][]*types.UnsignedMessage
 	var emptyMessages [][]*types.SignedMessage
-	var emptyReceipts [][]*types.MessageReceipt
 	for i := 0; i < numBlocks; i++ {
 		emptyBLSMessages = append(emptyBLSMessages, []*types.UnsignedMessage{})
 		emptyMessages = append(emptyMessages, []*types.SignedMessage{})
-		emptyReceipts = append(emptyReceipts, []*types.MessageReceipt{})
 	}
-	return emptyBLSMessages, emptyMessages, emptyReceipts
+	return emptyBLSMessages, emptyMessages
 }
 
 func setupCborBlockstore() (*hamt.CborIpldStore, blockstore.Blockstore) {

--- a/internal/pkg/consensus/expected_test.go
+++ b/internal/pkg/consensus/expected_test.go
@@ -114,7 +114,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		emptyBLSMessages, emptyMessages, emptyReceipts := emptyMessagesAndReceipts(len(blocks))
 
-		_, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
 		assert.NoError(t, err)
 	})
 
@@ -135,7 +135,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		emptyBLSMessages, emptyMessages, emptyReceipts := emptyMessagesAndReceipts(len(blocks))
 
-		_, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), genesisBlock.StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), genesisBlock.StateRoot)
 		assert.EqualError(t, err, "block author did not win election")
 	})
 
@@ -164,7 +164,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		msg := types.NewUnsignedMessage(blsAddr, address.TestAddress2, 0, types.NewAttoFILFromFIL(0), "", []byte{})
 		blsMessages[0] = append(blsMessages[0], msg)
 
-		_, err = exp.RunStateTransition(ctx, tipSet, blsMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, blsMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "block BLS signature does not validate")
 	})
@@ -198,7 +198,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		}
 		secpMessages[0] = append(secpMessages[0], smsg)
 
-		_, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, secpMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, secpMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "secp message signature invalid")
 	})
@@ -221,7 +221,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		emptyBLSMessages, emptyMessages, emptyReceipts := emptyMessagesAndReceipts(len(blocks))
 
-		_, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), genesisBlock.StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), genesisBlock.StateRoot)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "invalid ticket")
 	})
@@ -243,7 +243,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		emptyBLSMessages, emptyMessages, emptyReceipts := emptyMessagesAndReceipts(len(blocks))
 
-		_, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, uint64(blocks[0].ParentWeight), blocks[0].StateRoot)
 		assert.EqualError(t, err, "block signature invalid")
 	})
 
@@ -262,7 +262,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		emptyBLSMessages, emptyMessages, emptyReceipts := emptyMessagesAndReceipts(len(blocks))
 
-		_, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, invalidParentWeight, blocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, emptyReceipts, []block.TipSet{pTipSet}, invalidParentWeight, blocks[0].StateRoot)
 		assert.Contains(t, err.Error(), "invalid parent weight")
 	})
 }

--- a/internal/pkg/consensus/protocol.go
+++ b/internal/pkg/consensus/protocol.go
@@ -27,7 +27,7 @@ import (
 type Protocol interface {
 	// RunStateTransition returns the state root CID resulting from applying the input ts to the
 	// prior `stateID`.  It returns an error if the transition is invalid.
-	RunStateTransition(ctx context.Context, ts block.TipSet, blsMsgs [][]*types.UnsignedMessage, secpMsgs [][]*types.SignedMessage, tsReceipts [][]*types.MessageReceipt, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, error)
+	RunStateTransition(ctx context.Context, ts block.TipSet, blsMsgs [][]*types.UnsignedMessage, secpMsgs [][]*types.SignedMessage, tsReceipts [][]*types.MessageReceipt, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error)
 
 	// ValidateSyntax validates a single block is correctly formed.
 	ValidateSyntax(ctx context.Context, b *block.Block) error

--- a/internal/pkg/consensus/protocol.go
+++ b/internal/pkg/consensus/protocol.go
@@ -27,7 +27,7 @@ import (
 type Protocol interface {
 	// RunStateTransition returns the state root CID resulting from applying the input ts to the
 	// prior `stateID`.  It returns an error if the transition is invalid.
-	RunStateTransition(ctx context.Context, ts block.TipSet, blsMsgs [][]*types.UnsignedMessage, secpMsgs [][]*types.SignedMessage, tsReceipts [][]*types.MessageReceipt, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error)
+	RunStateTransition(ctx context.Context, ts block.TipSet, blsMsgs [][]*types.UnsignedMessage, secpMsgs [][]*types.SignedMessage, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error)
 
 	// ValidateSyntax validates a single block is correctly formed.
 	ValidateSyntax(ctx context.Context, b *block.Block) error

--- a/internal/pkg/message/handler_integration_test.go
+++ b/internal/pkg/message/handler_integration_test.go
@@ -68,7 +68,7 @@ func TestNewHeadHandlerIntegration(t *testing.T) {
 
 		// Receive the message in a block.
 		left := provider.BuildOneOn(root, func(b *chain.BlockBuilder) {
-			b.AddMessages([]*types.SignedMessage{msg1}, []*types.UnsignedMessage{}, types.EmptyReceipts(1))
+			b.AddMessages([]*types.SignedMessage{msg1}, []*types.UnsignedMessage{})
 		})
 		require.NoError(t, handler.HandleNewHead(ctx, left))
 		assert.Equal(t, 0, len(outbox.Queue().List(sender))) // Gone from queue.

--- a/internal/pkg/message/inbox_test.go
+++ b/internal/pkg/message/inbox_test.go
@@ -468,6 +468,6 @@ func requireChainWithMessages(t *testing.T, builder *chain.Builder, root block.T
 func msgBuild(t *testing.T, msgSet [][]*types.SignedMessage) func(*chain.BlockBuilder, int) {
 	return func(bb *chain.BlockBuilder, i int) {
 		require.True(t, i <= len(msgSet))
-		bb.AddMessages(msgSet[i], []*types.UnsignedMessage{}, types.EmptyReceipts(len(msgSet[i])))
+		bb.AddMessages(msgSet[i], []*types.UnsignedMessage{})
 	}
 }

--- a/internal/pkg/message/policy_test.go
+++ b/internal/pkg/message/policy_test.go
@@ -95,7 +95,6 @@ func TestMessageQueuePolicy(t *testing.T) {
 			b.AddMessages(
 				[]*types.SignedMessage{msgs[0]},
 				[]*types.UnsignedMessage{},
-				types.EmptyReceipts(1),
 			)
 		})
 
@@ -116,7 +115,6 @@ func TestMessageQueuePolicy(t *testing.T) {
 			b.AddMessages(
 				[]*types.SignedMessage{msgs[1], msgs[3]},
 				[]*types.UnsignedMessage{},
-				types.EmptyReceipts(2),
 			)
 		})
 		err = policy.HandleNewHead(ctx, q, nil, []block.TipSet{b3})
@@ -129,7 +127,6 @@ func TestMessageQueuePolicy(t *testing.T) {
 			b.AddMessages(
 				[]*types.SignedMessage{msgs[2]},
 				[]*types.UnsignedMessage{},
-				types.EmptyReceipts(1),
 			)
 		})
 		err = policy.HandleNewHead(ctx, q, nil, []block.TipSet{b4})
@@ -195,7 +192,6 @@ func TestMessageQueuePolicy(t *testing.T) {
 			b.AddMessages(
 				[]*types.SignedMessage{msgs[1]},
 				[]*types.UnsignedMessage{},
-				types.EmptyReceipts(1),
 			)
 		})
 		err := policy.HandleNewHead(ctx, q, nil, []block.TipSet{b1})

--- a/internal/pkg/types/message.go
+++ b/internal/pkg/types/message.go
@@ -150,67 +150,6 @@ func (msg *UnsignedMessage) Equals(other *UnsignedMessage) bool {
 		bytes.Equal(msg.Params, other.Params)
 }
 
-// SignedMessageCollection tracks a group of messages and assigns it a cid.
-type SignedMessageCollection []*SignedMessage
-
-// DecodeSignedMessages decodes raw bytes into an array of signed messages
-func DecodeSignedMessages(b []byte) ([]*SignedMessage, error) {
-	var out SignedMessageCollection
-	if err := encoding.Decode(b, &out); err != nil {
-		return nil, err
-	}
-
-	return []*SignedMessage(out), nil
-}
-
-// TODO #3078 the panics here and in types.Block should go away.  We need to
-// keep them in order to use the ipld cborstore with the default hash function
-// because we need to implement hamt.cidProvider which doesn't handle errors.
-// We can clean all this up when we can use our own CborIpldStore with the hamt.
-
-// Cid returns the cid of the message collection.
-func (mC SignedMessageCollection) Cid() cid.Cid {
-	return mC.ToNode().Cid()
-}
-
-// ToNode converts the collection to an IPLD node.
-func (mC SignedMessageCollection) ToNode() ipld.Node {
-	obj, err := cbor.WrapObject(mC, DefaultHashFunction, -1)
-	if err != nil {
-		panic(err)
-	}
-
-	return obj
-}
-
-// MessageCollection tracks a group of messages and assigns it a cid.
-type MessageCollection []*UnsignedMessage
-
-// DecodeMessages decodes raw bytes into an array of metered messages
-func DecodeMessages(b []byte) ([]*UnsignedMessage, error) {
-	var out MessageCollection
-	if err := encoding.Decode(b, &out); err != nil {
-		return nil, err
-	}
-
-	return []*UnsignedMessage(out), nil
-}
-
-// Cid returns the cid of the message collection.
-func (mC MessageCollection) Cid() cid.Cid {
-	return mC.ToNode().Cid()
-}
-
-// ToNode converts the collection to an IPLD node.
-func (mC MessageCollection) ToNode() ipld.Node {
-	obj, err := cbor.WrapObject(mC, DefaultHashFunction, -1)
-	if err != nil {
-		panic(err)
-	}
-
-	return obj
-}
-
 // NewGasPrice constructs a gas price (in AttoFIL) from the given number.
 func NewGasPrice(price int64) AttoFIL {
 	return NewAttoFIL(big.NewInt(price))

--- a/internal/pkg/types/message.go
+++ b/internal/pkg/types/message.go
@@ -211,34 +211,6 @@ func (mC MessageCollection) ToNode() ipld.Node {
 	return obj
 }
 
-// ReceiptCollection tracks a group of receipts and assigns it a cid.
-type ReceiptCollection []*MessageReceipt
-
-// DecodeReceipts decodes raw bytes into an array of message receipts
-func DecodeReceipts(b []byte) ([]*MessageReceipt, error) {
-	var out ReceiptCollection
-	if err := encoding.Decode(b, &out); err != nil {
-		return nil, err
-	}
-
-	return []*MessageReceipt(out), nil
-}
-
-// Cid returns the cid of the receipt collection.
-func (rC ReceiptCollection) Cid() cid.Cid {
-	return rC.ToNode().Cid()
-}
-
-// ToNode converts the collection to an IPLD node.
-func (rC ReceiptCollection) ToNode() ipld.Node {
-	obj, err := cbor.WrapObject(rC, DefaultHashFunction, -1)
-	if err != nil {
-		panic(err)
-	}
-
-	return obj
-}
-
 // NewGasPrice constructs a gas price (in AttoFIL) from the given number.
 func NewGasPrice(price int64) AttoFIL {
 	return NewAttoFIL(big.NewInt(price))

--- a/internal/pkg/types/testing_messages.go
+++ b/internal/pkg/types/testing_messages.go
@@ -42,13 +42,13 @@ func (mm *MessageMaker) Signer() *MockSigner {
 	return mm.signer
 }
 
-// NewSignedMessage creates a new message.
-func (mm *MessageMaker) NewSignedMessage(from address.Address, nonce uint64) *SignedMessage {
+// NewUnsignedMessage creates a new message.
+func (mm *MessageMaker) NewUnsignedMessage(from address.Address, nonce uint64) *UnsignedMessage {
 	seq := mm.seq
 	mm.seq++
 	to, err := address.NewActorAddress([]byte("destination"))
 	require.NoError(mm.t, err)
-	msg := NewMeteredMessage(
+	return NewMeteredMessage(
 		from,
 		to,
 		nonce,
@@ -57,6 +57,11 @@ func (mm *MessageMaker) NewSignedMessage(from address.Address, nonce uint64) *Si
 		[]byte("params"),
 		mm.DefaultGasPrice,
 		mm.DefaultGasUnits)
+}
+
+// NewSignedMessage creates a new signed message.
+func (mm *MessageMaker) NewSignedMessage(from address.Address, nonce uint64) *SignedMessage {
+	msg := mm.NewUnsignedMessage(from, nonce)
 	signed, err := NewSignedMessage(*msg, mm.signer)
 	require.NoError(mm.t, err)
 	return signed

--- a/tools/migration/migrations/repo-1-2/migration.go
+++ b/tools/migration/migrations/repo-1-2/migration.go
@@ -140,7 +140,7 @@ func (m *MetadataFormatJSONtoCBOR) Validate(oldRepoPath, newRepoPath string) err
 
 // convertJSONtoCBOR is adapted from chain Store.Load:
 //     1. stripped out logging
-//     2. instead of calling Store.PutTipSetAndState it just calls
+//     2. instead of calling Store.PutTipSetMetadata it just calls
 //        writeTipSetAndStateAsCBOR, because block format is unchanged.
 //     3. then calls writeHeadAsCBOR, instead of store.SetHead which also publishes an event
 //        and does some logging
@@ -178,7 +178,7 @@ func (m *MetadataFormatJSONtoCBOR) convertJSONtoCBOR(ctx context.Context) error 
 		if err != nil {
 			return err
 		}
-		tipSetAndState := &chain.TipSetAndState{
+		tipSetAndState := &chain.TipSetMetadata{
 			TipSet:          iter.Value(),
 			TipSetStateRoot: stateRoot,
 		}
@@ -210,7 +210,7 @@ func (m *MetadataFormatJSONtoCBOR) writeHeadAsCBOR(ctx context.Context, cids blo
 
 // writeTipSetAndStateAsCBOR writes the tipset key and the state root id to the
 // datastore. (taken from Store.writeTipSetAndState)
-func (m *MetadataFormatJSONtoCBOR) writeTipSetAndStateAsCBOR(tsas *chain.TipSetAndState) error {
+func (m *MetadataFormatJSONtoCBOR) writeTipSetAndStateAsCBOR(tsas *chain.TipSetMetadata) error {
 	if tsas.TipSetStateRoot == cid.Undef {
 		return errors.New("attempting to write state root cid.Undef")
 	}


### PR DESCRIPTION
### Motivation

We want to move from blocks that contain the state root and receipt CID AFTER applying their messages, to storing the state root and receipts cid of the tipset it is built upon.

### Proposed changes

This PR transitions message receipts from a data structure transmitted with individual blocks to a collection only generated when a Tipset is processed and stored locally. This transition has a few consequences:

1. We need to save the receipt root as well as the state root after running a state transition on a TipSet. This happens in `syncer.syncOne`. In a future PR this will be used to populate and validate the parent receipt root in block headers.
2. We stop retrieving receipts in graphsync fetcher.
3. The waiter must now locate a receipt by first locating the message by Cid and then find the receipt that corresponds to the index of the message when run in the tipset. This necessitates a refactor in processor that extracts the message deduplication in TipSet processing so that it may be reused in waiter.

