### PR TITLE
Change ApplyMessagesAndPayRewards to accept unsigned messages

### DIFF
--- a/internal/pkg/consensus/block_validation.go
+++ b/internal/pkg/consensus/block_validation.go
@@ -41,6 +41,7 @@ type BlockSyntaxValidator interface {
 type MessageSyntaxValidator interface {
 	ValidateMessagesSyntax(ctx context.Context, messages []*types.SignedMessage) error
 	ValidateUnsignedMessagesSyntax(ctx context.Context, messages []*types.UnsignedMessage) error
+	// TODO: Remove receipt validation when they're no longer fetched, #3489
 	ValidateReceiptsSyntax(ctx context.Context, receipts []*types.MessageReceipt) error
 }
 

--- a/internal/pkg/consensus/testing.go
+++ b/internal/pkg/consensus/testing.go
@@ -90,13 +90,11 @@ func NewFakePowerTableView(minerPower *types.BytesAmount, totalPower *types.Byte
 	return NewPowerTableView(tq)
 }
 
-// FakeSignedMessageValidator is a validator that doesn't validate to simplify message creation in tests.
-type FakeSignedMessageValidator struct{}
-
-var _ SignedMessageValidator = (*FakeSignedMessageValidator)(nil)
+// FakeMessageValidator is a validator that doesn't validate to simplify message creation in tests.
+type FakeMessageValidator struct{}
 
 // Validate always returns nil
-func (tsmv *FakeSignedMessageValidator) Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor) error {
+func (tsmv *FakeMessageValidator) Validate(ctx context.Context, msg *types.UnsignedMessage, fromActor *actor.Actor) error {
 	return nil
 }
 
@@ -112,7 +110,7 @@ func (tbr *FakeBlockRewarder) BlockReward(ctx context.Context, st state.Tree, mi
 }
 
 // GasReward is a noop
-func (tbr *FakeBlockRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr address.Address, msg *types.SignedMessage, gas types.AttoFIL) error {
+func (tbr *FakeBlockRewarder) GasReward(ctx context.Context, st state.Tree, minerOwnerAddr address.Address, msg *types.UnsignedMessage, cost types.AttoFIL) error {
 	// do nothing to keep state root the same
 	return nil
 }
@@ -120,9 +118,9 @@ func (tbr *FakeBlockRewarder) GasReward(ctx context.Context, st state.Tree, mine
 // NewFakeProcessor creates a processor with a test validator and test rewarder
 func NewFakeProcessor(actors builtin.Actors) *DefaultProcessor {
 	return &DefaultProcessor{
-		signedMessageValidator: &FakeSignedMessageValidator{},
-		blockRewarder:          &FakeBlockRewarder{},
-		actors:                 actors,
+		validator:     &FakeMessageValidator{},
+		blockRewarder: &FakeBlockRewarder{},
+		actors:        actors,
 	}
 }
 

--- a/internal/pkg/consensus/validation_test.go
+++ b/internal/pkg/consensus/validation_test.go
@@ -89,6 +89,7 @@ func TestMessageValidator(t *testing.T) {
 
 func TestBLSSignatureValidationConfiguration(t *testing.T) {
 	tf.UnitTest(t)
+	ctx := context.Background()
 
 	// create bls address
 	pubKey := bls.PrivateKeyPublicKey(bls.PrivateKeyGenerate())
@@ -99,15 +100,7 @@ func TestBLSSignatureValidationConfiguration(t *testing.T) {
 	unsigned := &types.SignedMessage{Message: *msg}
 	actor := newActor(t, 1000, 0)
 
-	ctx := context.Background()
-	t.Run("default validator ignores bls signatures", func(t *testing.T) {
-		validator := consensus.NewDefaultMessageValidator()
-
-		err := validator.Validate(ctx, unsigned, actor)
-		assert.NoError(t, err)
-	})
-
-	t.Run("ingestion validator does not ignore bls signature", func(t *testing.T) {
+	t.Run("ingestion validator does not ignore missing signature", func(t *testing.T) {
 		api := NewMockIngestionValidatorAPI()
 		api.ActorAddr = from
 		api.Actor = actor
@@ -154,19 +147,36 @@ func TestIngestionValidator(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Validates extreme nonce gaps", func(t *testing.T) {
-		msg := newMessage(t, alice, bob, 100, 5, 1, 0)
+		msg, err := types.NewSignedMessage(*newMessage(t, alice, bob, 100, 5, 1, 0), signer)
+		require.NoError(t, err)
 		assert.NoError(t, validator.Validate(ctx, msg))
 
 		highNonce := uint64(act.Nonce + mpoolCfg.MaxNonceGap + 10)
-		msg = newMessage(t, alice, bob, highNonce, 5, 1, 0)
-		err := validator.Validate(ctx, msg)
+		msg, err = types.NewSignedMessage(*newMessage(t, alice, bob, highNonce, 5, 1, 0), signer)
+		require.NoError(t, err)
+		err = validator.Validate(ctx, msg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "too much greater than actor nonce")
 	})
 
 	t.Run("Actor not found is not an error", func(t *testing.T) {
-		msg := newMessage(t, bob, alice, 0, 0, 1, 0)
+		msg, err := types.NewSignedMessage(*newMessage(t, bob, alice, 0, 0, 1, 0), signer)
+		require.NoError(t, err)
 		assert.NoError(t, validator.Validate(ctx, msg))
+	})
+
+	t.Run("ingestion validator does not ignore missing signature", func(t *testing.T) {
+		// create bls address
+		pubKey := bls.PrivateKeyPublicKey(bls.PrivateKeyGenerate())
+		from, err := address.NewBLSAddress(pubKey[:])
+		require.NoError(t, err)
+
+		msg := newMessage(t, from, addresses[1], 0, 0, 1, 300)
+		unsigned := &types.SignedMessage{Message: *msg}
+
+		err = validator.Validate(ctx, unsigned)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid signature")
 	})
 }
 
@@ -178,10 +188,10 @@ func newActor(t *testing.T, balanceAF int, nonce uint64) *actor.Actor {
 }
 
 func newMessage(t *testing.T, from, to address.Address, nonce uint64, valueAF int,
-	gasPrice int64, gasLimit uint64) *types.SignedMessage {
+	gasPrice int64, gasLimit uint64) *types.UnsignedMessage {
 	val, ok := types.NewAttoFILFromString(fmt.Sprintf("%d", valueAF), 10)
 	require.True(t, ok, "invalid attofil")
-	msg := types.NewMeteredMessage(
+	return types.NewMeteredMessage(
 		from,
 		to,
 		nonce,
@@ -191,9 +201,6 @@ func newMessage(t *testing.T, from, to address.Address, nonce uint64, valueAF in
 		types.NewGasPrice(gasPrice),
 		types.NewGasUnits(gasLimit),
 	)
-	signed, err := types.NewSignedMessage(*msg, signer)
-	require.NoError(t, err)
-	return signed
 }
 
 func attoFil(v int) types.AttoFIL {

--- a/internal/pkg/message/testing.go
+++ b/internal/pkg/message/testing.go
@@ -85,7 +85,7 @@ type FakeValidator struct {
 }
 
 // Validate returns an error only if `RejectMessages` is true.
-func (v FakeValidator) Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor) error {
+func (v FakeValidator) Validate(ctx context.Context, msg *types.UnsignedMessage, fromActor *actor.Actor) error {
 	if v.RejectMessages {
 		return errors.New("rejected for testing")
 	}

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -67,7 +67,7 @@ type MessageSource interface {
 // A MessageApplier processes all the messages in a message pool.
 type MessageApplier interface {
 	// ApplyMessagesAndPayRewards applies all state transitions related to a set of messages.
-	ApplyMessagesAndPayRewards(ctx context.Context, st state.Tree, vms vm.StorageMap, messages []*types.SignedMessage, minerOwnerAddr address.Address, bh *types.BlockHeight, ancestors []block.TipSet) (consensus.ApplyMessagesResponse, error)
+	ApplyMessagesAndPayRewards(ctx context.Context, st state.Tree, vms vm.StorageMap, messages []*types.UnsignedMessage, minerOwnerAddr address.Address, bh *types.BlockHeight, ancestors []block.TipSet) ([]*consensus.ApplyMessageResult, error)
 }
 
 type workerPorcelainAPI interface {

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -220,40 +220,30 @@ func TestApplyMessagesForSuccessTempAndPermFailures(t *testing.T) {
 	// If a given message's category changes in the future, it needs to be replaced here in tests by another so we fully
 	// exercise the categorization.
 	// addr2 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
-	msg1 := types.NewMeteredMessage(addr2, addr1, 0, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), types.NewGasUnits(0))
-	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner)
-	require.NoError(t, err)
+	msg0 := types.NewMeteredMessage(addr2, addr1, 0, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), types.NewGasUnits(0))
 
 	// This is actually okay and should result in a receipt
-	msg2 := types.NewMeteredMessage(addr1, addr2, 0, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), types.NewGasUnits(0))
-	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner)
-	require.NoError(t, err)
+	msg1 := types.NewMeteredMessage(addr1, addr2, 0, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), types.NewGasUnits(0))
 
 	// The following two are sending to self -- errSelfSend, a permanent error.
-	msg3 := types.NewMeteredMessage(addr1, addr1, 1, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), types.NewGasUnits(0))
-	smsg3, err := types.NewSignedMessage(*msg3, &mockSigner)
-	require.NoError(t, err)
+	msg2 := types.NewMeteredMessage(addr1, addr1, 1, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), types.NewGasUnits(0))
+	msg3 := types.NewMeteredMessage(addr2, addr2, 1, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), types.NewGasUnits(0))
 
-	msg4 := types.NewMeteredMessage(addr2, addr2, 1, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), types.NewGasUnits(0))
-	smsg4, err := types.NewSignedMessage(*msg4, &mockSigner)
-	require.NoError(t, err)
-
-	messages := []*types.SignedMessage{smsg1, smsg2, smsg3, smsg4}
+	messages := []*types.UnsignedMessage{msg0, msg1, msg2, msg3}
 
 	res, err := consensus.NewDefaultProcessor().ApplyMessagesAndPayRewards(ctx, st, vms, messages, addr1, types.NewBlockHeight(0), nil)
+	assert.NoError(t, err)
 	require.NotNil(t, res)
 
-	assert.Len(t, res.PermanentFailures, 2)
-	assert.Contains(t, res.PermanentFailures, smsg3)
-	assert.Contains(t, res.PermanentFailures, smsg4)
+	assert.Error(t, res[0].Failure)
+	assert.False(t, res[0].FailureIsPermanent)
 
-	assert.Len(t, res.TemporaryFailures, 1)
-	assert.Contains(t, res.TemporaryFailures, smsg1)
+	assert.Nil(t, res[1].Failure)
 
-	assert.Len(t, res.Results, 1)
-	assert.Contains(t, res.SuccessfulMessages, smsg2)
-
-	assert.NoError(t, err)
+	assert.Error(t, res[2].Failure)
+	assert.True(t, res[2].FailureIsPermanent)
+	assert.Error(t, res[3].Failure)
+	assert.True(t, res[3].FailureIsPermanent)
 }
 
 func TestApplyBLSMessages(t *testing.T) {

--- a/internal/pkg/types/signed_message.go
+++ b/internal/pkg/types/signed_message.go
@@ -47,6 +47,15 @@ func NewSignedMessage(msg UnsignedMessage, s Signer) (*SignedMessage, error) {
 	}, nil
 }
 
+// UnwrapSigned returns the unsigned messages from a slice of signed messages.
+func UnwrapSigned(smsgs []*SignedMessage) []*UnsignedMessage {
+	unsigned := make([]*UnsignedMessage, len(smsgs))
+	for i, sm := range smsgs {
+		unsigned[i] = &sm.Message
+	}
+	return unsigned
+}
+
 // Unmarshal a SignedMessage from the given bytes.
 func (smsg *SignedMessage) Unmarshal(b []byte) error {
 	return encoding.Decode(b, smsg)

--- a/internal/pkg/vm/actor/builtin/miner/miner_test.go
+++ b/internal/pkg/vm/actor/builtin/miner/miner_test.go
@@ -166,7 +166,7 @@ func TestChangeWorker(t *testing.T) {
 		gasLimit := types.NewGasUnits(10)
 		msg := types.NewMeteredMessage(mockSigner.Addresses[0], minerAddr, 0, types.ZeroAttoFIL, ChangeWorker, pdata, gasPrice, gasLimit)
 
-		result, err := th.ApplyTestMessageWithGas(builtin.DefaultActors, st, vms, msg, types.NewBlockHeight(1), &mockSigner, mockSigner.Addresses[0])
+		result, err := th.ApplyTestMessageWithGas(builtin.DefaultActors, st, vms, msg, types.NewBlockHeight(1), mockSigner.Addresses[0])
 		assert.NoError(t, err)
 
 		require.Error(t, result.ExecutionError)
@@ -1295,7 +1295,7 @@ func TestActorSlashStorageFault(t *testing.T) {
 		gasLimit := types.NewGasUnits(10)
 		msg := types.NewMeteredMessage(mockSigner.Addresses[0], minerAddr, 0, types.ZeroAttoFIL, SlashStorageFault, []byte{}, gasPrice, gasLimit)
 
-		result, err := th.ApplyTestMessageWithGas(builtin.DefaultActors, st, vms, msg, types.NewBlockHeight(1), &mockSigner, mockSigner.Addresses[0])
+		result, err := th.ApplyTestMessageWithGas(builtin.DefaultActors, st, vms, msg, types.NewBlockHeight(1), mockSigner.Addresses[0])
 		require.NoError(t, err)
 
 		require.Error(t, result.ExecutionError)

--- a/internal/pkg/vm/gas_tracker.go
+++ b/internal/pkg/vm/gas_tracker.go
@@ -22,7 +22,7 @@ func NewGasTracker() *GasTracker {
 }
 
 // ResetForNewMessage will reset the per-message gas accumulator and set the MsgGasLimit to that of the message.
-func (gasTracker *GasTracker) ResetForNewMessage(message types.UnsignedMessage) {
+func (gasTracker *GasTracker) ResetForNewMessage(message *types.UnsignedMessage) {
 	gasTracker.MsgGasLimit = message.GasLimit
 	gasTracker.gasConsumedByMessage = types.NewGasUnits(0)
 }

--- a/tools/gengen/util/gengen.go
+++ b/tools/gengen/util/gengen.go
@@ -21,7 +21,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/storagemarket"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
-	typegen "github.com/whyrusleeping/cbor-gen"
 
 	bserv "github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-car"
@@ -33,7 +32,7 @@ import (
 	dag "github.com/ipfs/go-merkledag"
 	"github.com/libp2p/go-libp2p-core/peer"
 	mh "github.com/multiformats/go-multihash"
-	"github.com/pkg/errors"
+	"github.com/whyrusleeping/cbor-gen"
 )
 
 // CreateStorageMinerConfig holds configuration options used to create a storage
@@ -347,38 +346,22 @@ func applyMessageDirect(ctx context.Context, st state.Tree, vms vm.StorageMap, f
 	// this should never fail due to lack of gas since gas doesn't have meaning here
 	gasLimit := types.BlockGasLimit
 	msg := types.NewMeteredMessage(from, to, 0, value, method, pdata, types.NewGasPrice(0), gasLimit)
-	smsg, err := types.NewSignedMessage(*msg, &signer{})
-	if err != nil {
-		return nil, err
-	}
 
 	// create new processor that doesn't reward and doesn't validate
-	applier := consensus.NewConfiguredProcessor(&messageValidator{}, &blockRewarder{}, builtin.DefaultActors)
+	applier := consensus.NewConfiguredProcessor(&consensus.FakeMessageValidator{}, &blockRewarder{}, builtin.DefaultActors)
 
-	res, err := applier.ApplyMessagesAndPayRewards(ctx, st, vms, []*types.SignedMessage{smsg}, address.Undef, types.NewBlockHeight(0), nil)
+	res, err := applier.ApplyMessagesAndPayRewards(ctx, st, vms, []*types.UnsignedMessage{msg}, address.Undef, types.NewBlockHeight(0), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(res.Results) == 0 {
-		return nil, errors.New("GenGen message did not produce a result")
+	if res[0].Failure != nil {
+		return nil, res[0].Failure
 	}
-
-	if res.Results[0].ExecutionError != nil {
-		return nil, res.Results[0].ExecutionError
+	if res[0].ExecutionError != nil {
+		return nil, res[0].ExecutionError
 	}
-
-	return res.Results[0].Receipt.Return, nil
-}
-
-// GenGenMessageValidator is a validator that doesn't validate to simplify message creation in tests.
-type messageValidator struct{}
-
-var _ consensus.SignedMessageValidator = (*messageValidator)(nil)
-
-// Validate always returns nil
-func (ggmv *messageValidator) Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor) error {
-	return nil
+	return res[0].Receipt.Return, nil
 }
 
 // blockRewarder is a rewarder that doesn't actually add any rewards to simplify state tracking in tests
@@ -392,7 +375,7 @@ func (gbr *blockRewarder) BlockReward(ctx context.Context, st state.Tree, minerA
 }
 
 // GasReward is a noop
-func (gbr *blockRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr address.Address, msg *types.SignedMessage, cost types.AttoFIL) error {
+func (gbr *blockRewarder) GasReward(ctx context.Context, st state.Tree, minerOwnerAddr address.Address, msg *types.UnsignedMessage, cost types.AttoFIL) error {
 	return nil
 }
 


### PR DESCRIPTION
# Motivation
The processor doesn't use the signatures. Signatures in a message or block must be validated before passing to the processor, as part of block syntax validation (BLS message signatures can only be validated in aggregate, not individually) or before the message pool.

This removes signatures from the processor.

Note that blocks and messages fetched by graphsync aren't validated at all! #3312 (cc @ZenGround0)

### Proposed changes

Change DefaultProcessor methods to accept `UnsignedMessage`s.

