### PR TITLE
Election works off of a lookback hardcoded to 5

### DIFF
--- a/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
@@ -55,7 +55,7 @@ func NewSyncerSubmodule(ctx context.Context, config syncerConfig, repo chainRepo
 	}
 
 	// set up consensus
-	nodeConsensus := consensus.NewExpected(blockstore.CborStore, blockstore.Blockstore, chn.Processor, blkValid, chn.ActorState, config.GenesisCid(), config.BlockTime(), consensus.ElectionMachine{}, consensus.TicketMachine{})
+	nodeConsensus := consensus.NewExpected(blockstore.CborStore, blockstore.Blockstore, chn.Processor, chn.ActorState, config.BlockTime(), consensus.ElectionMachine{}, consensus.TicketMachine{})
 	nodeChainSelector := consensus.NewChainSelector(blockstore.CborStore, chn.ActorState, config.GenesisCid())
 
 	// setup fecher
@@ -66,7 +66,7 @@ func NewSyncerSubmodule(ctx context.Context, config syncerConfig, repo chainRepo
 	gsync := graphsync.New(ctx, graphsyncNetwork, bridge, loader, storer)
 	fetcher := fetcher.NewGraphSyncFetcher(ctx, gsync, blockstore.Blockstore, blkValid, config.Clock(), discovery.PeerTracker)
 
-	chainSyncManager := chainsync.NewManager(nodeConsensus, nodeChainSelector, chn.ChainReader, chn.MessageStore, fetcher, config.Clock())
+	chainSyncManager := chainsync.NewManager(nodeConsensus, blkValid, nodeChainSelector, chn.ChainReader, chn.MessageStore, fetcher, config.Clock())
 
 	return SyncerSubmodule{
 		// BlockSub: nil,

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -742,7 +742,7 @@ func (node *Node) getWeight(ctx context.Context, ts block.TipSet) (uint64, error
 
 // getAncestors is the default GetAncestors function for the mining worker.
 func (node *Node) getAncestors(ctx context.Context, ts block.TipSet, newBlockHeight *types.BlockHeight) ([]block.TipSet, error) {
-	ancestorHeight := newBlockHeight.Sub(types.NewBlockHeight(consensus.AncestorRoundsNeeded))
+	ancestorHeight := newBlockHeight.Sub(types.NewBlockHeight(uint64(consensus.AncestorRoundsNeeded)))
 	return chain.GetRecentAncestors(ctx, ts, node.chain.ChainReader, ancestorHeight)
 }
 

--- a/internal/pkg/chainsync/chainsync.go
+++ b/internal/pkg/chainsync/chainsync.go
@@ -25,8 +25,8 @@ type Manager struct {
 }
 
 // NewManager creates a new chain sync manager.
-func NewManager(e syncer.SemanticValidator, cs syncer.ChainSelector, s syncer.ChainReaderWriter, m *chain.MessageStore, f syncer.Fetcher, c clock.Clock) Manager {
-	syncer := syncer.NewSyncer(e, cs, s, m, f, status.NewReporter(), c)
+func NewManager(fv syncer.FullBlockValidator, hv syncer.HeaderValidator, cs syncer.ChainSelector, s syncer.ChainReaderWriter, m *chain.MessageStore, f syncer.Fetcher, c clock.Clock) Manager {
+	syncer := syncer.NewSyncer(fv, hv, cs, s, m, f, status.NewReporter(), c)
 	dispatcher := dispatcher.NewDispatcher(syncer)
 	return Manager{
 		syncer:     syncer,

--- a/internal/pkg/consensus/protocol.go
+++ b/internal/pkg/consensus/protocol.go
@@ -29,12 +29,6 @@ type Protocol interface {
 	// prior `stateID`.  It returns an error if the transition is invalid.
 	RunStateTransition(ctx context.Context, ts block.TipSet, blsMsgs [][]*types.UnsignedMessage, secpMsgs [][]*types.SignedMessage, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error)
 
-	// ValidateSyntax validates a single block is correctly formed.
-	ValidateSyntax(ctx context.Context, b *block.Block) error
-
-	// ValidateSemantic validates a block is correctly derived from its parent.
-	ValidateSemantic(ctx context.Context, child *block.Block, parents block.TipSet) error
-
 	// BlockTime returns the block time used by the consensus protocol.
 	BlockTime() time.Duration
 }

--- a/internal/pkg/consensus/testing.go
+++ b/internal/pkg/consensus/testing.go
@@ -268,3 +268,49 @@ func SeedLoserInNRounds(t *testing.T, n int, ki *types.KeyInfo, minerPower, tota
 		require.NoError(t, err)
 	}
 }
+
+// MockTicketMachine allows a test to set a function to be called upon ticket
+// generation and validation
+type MockTicketMachine struct {
+	fn func(block.Ticket)
+}
+
+// NewMockTicketMachine creates a mock given a callback
+func NewMockTicketMachine(f func(block.Ticket)) *MockTicketMachine {
+	return &MockTicketMachine{fn: f}
+}
+
+// NextTicket calls the registered callback and returns a fake ticket
+func (mtm *MockTicketMachine) NextTicket(ticket block.Ticket, genAddr address.Address, signer types.Signer) (block.Ticket, error) {
+	mtm.fn(ticket)
+	return MakeFakeTicketForTest(), nil
+}
+
+// IsValidTicket calls the registered callback and returns true
+func (mtm *MockTicketMachine) IsValidTicket(parent, ticket block.Ticket, signerAddr address.Address) bool {
+	mtm.fn(ticket)
+	return true
+}
+
+// MockElectionMachine allows a test to set a function to be called upon
+// election running and validation
+type MockElectionMachine struct {
+	fn func(block.Ticket)
+}
+
+// NewMockElectionMachine creates a mock given a callback
+func NewMockElectionMachine(f func(block.Ticket)) *MockElectionMachine {
+	return &MockElectionMachine{fn: f}
+}
+
+// RunElection calls the registered callback and returns a fake proof
+func (mem *MockElectionMachine) RunElection(ticket block.Ticket, candidateAddr address.Address, signer types.Signer, nullCount uint64) (block.VRFPi, error) {
+	mem.fn(ticket)
+	return MakeFakeElectionProofForTest(), nil
+}
+
+// IsElectionWinner calls the registered callback and returns true
+func (mem *MockElectionMachine) IsElectionWinner(ctx context.Context, ptv PowerTableView, ticket block.Ticket, nullCount uint64, electionProof block.VRFPi, signerAddr, minerAddr address.Address) (bool, error) {
+	mem.fn(ticket)
+	return true, nil
+}

--- a/internal/pkg/mining/scheduler_test.go
+++ b/internal/pkg/mining/scheduler_test.go
@@ -68,7 +68,7 @@ func TestMineOnce10Null(t *testing.T) {
 		return st, nil
 	}
 	getAncestors := func(ctx context.Context, ts block.TipSet, newBlockHeight *types.BlockHeight) ([]block.TipSet, error) {
-		return nil, nil
+		return []block.TipSet{baseTs}, nil
 	}
 	messages := chain.NewMessageStore(bs)
 

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/sampling"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
@@ -81,7 +82,7 @@ type electionUtil interface {
 	IsElectionWinner(context.Context, consensus.PowerTableView, block.Ticket, uint64, block.VRFPi, address.Address, address.Address) (bool, error)
 }
 
-// ticketGenerator creates and finalizes tickets.
+// ticketGenerator creates tickets.
 type ticketGenerator interface {
 	NextTicket(block.Ticket, address.Address, types.Signer) (block.Ticket, error)
 }
@@ -175,7 +176,7 @@ func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCoun
 		return
 	}
 
-	// Create the next ticket.
+	// lookback consensus.ElectionLookback
 	prevTicket, err := base.MinTicket()
 	if err != nil {
 		log.Warnf("Worker.Mine couldn't read parent ticket %s", err)
@@ -206,8 +207,28 @@ func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCoun
 	case <-done:
 	}
 
+	// lookback consensus.ElectionLookback for the election ticket
+	baseHeight, err := base.Height()
+	if err != nil {
+		log.Warnf("Worker.Mine couldn't read base height %s", err)
+		outCh <- Output{Err: err}
+		return
+	}
+	ancestors, err := w.getAncestors(ctx, base, types.NewBlockHeight(baseHeight+nullBlkCount+1))
+	if err != nil {
+		log.Warnf("Worker.Mine couldn't get ancestorst %s", err)
+		outCh <- Output{Err: err}
+		return
+	}
+	electionTicket, err := sampling.SampleNthTicket(consensus.ElectionLookback-1, ancestors)
+	if err != nil {
+		log.Warnf("Worker.Mine couldn't read parent ticket %s", err)
+		outCh <- Output{Err: err}
+		return
+	}
+
 	// Run an election to check if this miner has won the right to mine
-	electionProof, err := w.election.RunElection(prevTicket, workerAddr, w.workerSigner, nullBlkCount)
+	electionProof, err := w.election.RunElection(electionTicket, workerAddr, w.workerSigner, nullBlkCount)
 	if err != nil {
 		log.Errorf("failed to run local election: %s", err)
 		outCh <- Output{Err: err}
@@ -219,7 +240,7 @@ func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCoun
 		outCh <- Output{Err: err}
 		return
 	}
-	weHaveAWinner, err := w.election.IsElectionWinner(ctx, powerTable, prevTicket, nullBlkCount, electionProof, workerAddr, w.minerAddr)
+	weHaveAWinner, err := w.election.IsElectionWinner(ctx, powerTable, electionTicket, nullBlkCount, electionProof, workerAddr, w.minerAddr)
 	if err != nil {
 		log.Errorf("Worker.Mine couldn't run election: %s", err.Error())
 		outCh <- Output{Err: err}
@@ -236,7 +257,6 @@ func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCoun
 		won = true
 		return
 	}
-
 	return
 }
 

--- a/internal/pkg/sampling/chain_randomness.go
+++ b/internal/pkg/sampling/chain_randomness.go
@@ -7,6 +7,30 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
+// SampleNthTicket produces a ticket sampled from the nth tipset in the
+// provided ancestor slice.  It handles sampling from genesis.
+func SampleNthTicket(n int, tipSetsDescending []block.TipSet) (block.Ticket, error) {
+	if len(tipSetsDescending) == 0 {
+		return block.Ticket{}, errors.New("can't sample empty chain segment")
+	}
+	lastIdx := len(tipSetsDescending) - 1
+	if n > lastIdx {
+		// Handle chain startup
+		lowestAvailableHeight, err := tipSetsDescending[lastIdx].Height()
+		if err != nil {
+			return block.Ticket{}, errors.Wrap(err, "failed to read chain segment height")
+		}
+		// Return genesis ticket if this is the edge case where
+		// tipSetsDescending run all the way back to genesis
+		if lowestAvailableHeight == 0 {
+			return tipSetsDescending[lastIdx].MinTicket()
+		}
+		return block.Ticket{}, errors.Errorf("can't sample ticket %d from %d tipsets", n, lastIdx+1)
+	}
+
+	return tipSetsDescending[n].MinTicket()
+}
+
 // SampleChainRandomness produces a slice of bytes (a ticket) sampled from the highest tipset with
 // height less than or equal to `sampleHeight`.
 // The tipset slice must be sorted by descending block height.

--- a/internal/pkg/sampling/chain_randomness_test.go
+++ b/internal/pkg/sampling/chain_randomness_test.go
@@ -85,6 +85,36 @@ func TestSamplingChainRandomness(t *testing.T) {
 	})
 }
 
+func TestSampleNthTicket(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		_, ch := makeChain(t, 10)
+		r, err := sampling.SampleNthTicket(3, ch)
+		assert.NoError(t, err)
+		// 9 - 3 = 6
+		assert.Equal(t, block.VRFPi(strconv.Itoa(6)), r.VRFProof)
+	})
+
+	t.Run("falls back to genesis", func(t *testing.T) {
+		_, ch := makeChain(t, 4)
+		r, err := sampling.SampleNthTicket(5, ch)
+		assert.NoError(t, err)
+		assert.Equal(t, block.VRFPi(strconv.Itoa(0)), r.VRFProof)
+	})
+
+	t.Run("not enough tickets", func(t *testing.T) {
+		_, ch := makeChain(t, 10)
+		ch = ch[:5]
+		_, err := sampling.SampleNthTicket(5, ch)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty ancestors array", func(t *testing.T) {
+		_, err := sampling.SampleNthTicket(5, nil)
+		assert.Error(t, err)
+	})
+
+}
+
 // Builds a chain of single-block tips, returned in descending height order.
 // Each block's ticket is its stringified height (as bytes).
 func makeChain(t *testing.T, length int) (*chain.Builder, []block.TipSet) {

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -8,6 +8,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin"
 	cid "github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
@@ -17,9 +18,9 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
 )
 
-// NewValidTestBlockFromTipSet creates a block for when proofs & power table don't need
-// to be correct
-func NewValidTestBlockFromTipSet(baseTipSet block.TipSet, stateRootCid cid.Cid, height uint64, minerAddr address.Address, minerWorker address.Address, signer types.Signer) (*block.Block, error) {
+// RequireSignedTestBlockFromTipSet creates a block with a valid signature by
+// the passed in miner work and a Miner field set to the minerAddr.
+func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, stateRootCid cid.Cid, height uint64, minerAddr address.Address, minerWorker address.Address, signer types.Signer) *block.Block {
 	electionProof := consensus.MakeFakeElectionProofForTest()
 	ticket := consensus.MakeFakeTicketForTest()
 	emptyBLSSig := (*bls.Aggregate([]bls.Signature{}))[:]
@@ -35,12 +36,10 @@ func NewValidTestBlockFromTipSet(baseTipSet block.TipSet, stateRootCid cid.Cid, 
 		BLSAggregateSig: emptyBLSSig,
 	}
 	sig, err := signer.SignBytes(b.SignatureData(), minerWorker)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 	b.BlockSig = sig
 
-	return b, nil
+	return b
 }
 
 // MakeRandomPoStProofForTest creates a random proof.


### PR DESCRIPTION
### Motivation
We need our consensus election to look back into chain history so that our elections can prevent grinding per the spec.

### Proposed changes
Add lookback parameter to consensus election to get us up to spec.  Hardcoding to 5.  This PR involves 0 cleanup and sticks to old ugly patterns.  On the plus side it is very simple and doesn't make anything worse.

Closes issue #2223 

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

