### PR TITLE
Block state root and receipt cid now reference result of parent tip set message processing

### DIFF
--- a/cmd/go-filecoin/show.go
+++ b/cmd/go-filecoin/show.go
@@ -37,7 +37,6 @@ all other block properties will be included as well.`,
 	},
 	Options: []cmdkit.Option{
 		cmdkit.BoolOption("messages", "m", "show messages in block"),
-		cmdkit.BoolOption("receipts", "r", "show receipts in block"),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		cid, err := cid.Decode(req.Arguments[0])
@@ -65,14 +64,12 @@ Miner:  %s
 Weight: %s
 Height: %s
 Messages:  %s
-Receipts:  %s
 Timestamp:  %s
 `,
 				block.Header.Miner,
 				wStr,
 				strconv.FormatUint(uint64(block.Header.Height), 10),
 				block.Header.Messages.String(),
-				block.Header.MessageReceipts.String(),
 				strconv.FormatUint(uint64(block.Header.Timestamp), 10),
 			)
 			if err != nil {
@@ -82,13 +79,6 @@ Timestamp:  %s
 			showMessages, _ := req.Options["messages"].(bool)
 			if showMessages == true {
 				_, err = fmt.Fprintf(w, `Messages:  %s`+"\n", block.Messages)
-			}
-			if err != nil {
-				return err
-			}
-			showReceipts, _ := req.Options["receipts"].(bool)
-			if showReceipts == true {
-				_, err = fmt.Fprintf(w, `Receipts: %s`+"\n", block.Receipts)
 			}
 			return err
 		}),

--- a/cmd/go-filecoin/show_test.go
+++ b/cmd/go-filecoin/show_test.go
@@ -124,7 +124,7 @@ func TestBlockDaemon(t *testing.T) {
 		assert.Equal(t, 0, len(receipts))
 	})
 
-	t.Run("show messages and show receipts", func(t *testing.T) {
+	t.Run("show messages", func(t *testing.T) {
 		d := th.NewDaemon(
 			t,
 			th.DefaultAddress(fixtures.TestAddresses[0]),
@@ -170,23 +170,15 @@ func TestBlockDaemon(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(blockGetLine), &blockGetBlock))
 
 		assert.Equal(t, 3, len(blockGetBlock.Messages))
-		assert.Equal(t, 3, len(blockGetBlock.Receipts))
 
 		fromAddr, err := address.NewFromString(from)
 		require.NoError(t, err)
 		assert.Equal(t, fromAddr, blockGetBlock.Messages[0].Message.From)
-		assert.Equal(t, uint8(0), blockGetBlock.Receipts[0].ExitCode)
 
 		// Full block matches show messages
 		messagesGetLine := th.RunSuccessFirstLine(d, "show", "messages", blockGetBlock.Header.Messages.SecpRoot.String(), "--enc", "json")
 		var messages []*types.SignedMessage
 		require.NoError(t, json.Unmarshal([]byte(messagesGetLine), &messages))
 		assert.Equal(t, blockGetBlock.Messages, messages)
-
-		// Full block matches show receipts
-		receiptsGetLine := th.RunSuccessFirstLine(d, "show", "receipts", blockGetBlock.Header.MessageReceipts.String(), "--enc", "json")
-		var receipts []*types.MessageReceipt
-		require.NoError(t, json.Unmarshal([]byte(receiptsGetLine), &receipts))
-		assert.Equal(t, blockGetBlock.Receipts, receipts)
 	})
 }

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -704,11 +704,12 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (mining.Worker, error)
 		MinerOwnerAddr: minerOwnerAddr,
 		WorkerSigner:   node.Wallet.Wallet,
 
-		GetStateTree: node.getStateTree,
-		GetWeight:    node.getWeight,
-		GetAncestors: node.getAncestors,
-		Election:     consensus.ElectionMachine{},
-		TicketGen:    consensus.TicketMachine{},
+		GetStateTree:   node.getStateTree,
+		GetWeight:      node.getWeight,
+		GetAncestors:   node.getAncestors,
+		Election:       consensus.ElectionMachine{},
+		TicketGen:      consensus.TicketMachine{},
+		TipSetMetadata: node.chain.ChainReader,
 
 		MessageSource: node.Messaging.Inbox.Pool(),
 		MessageStore:  node.chain.MessageStore,

--- a/internal/app/go-filecoin/porcelain/chain.go
+++ b/internal/app/go-filecoin/porcelain/chain.go
@@ -22,7 +22,6 @@ func ChainHead(plumbing chainHeadPlumbing) (block.TipSet, error) {
 type fullBlockPlumbing interface {
 	ChainGetBlock(context.Context, cid.Cid) (*block.Block, error)
 	ChainGetMessages(context.Context, types.TxMeta) ([]*types.SignedMessage, error)
-	ChainGetReceipts(context.Context, cid.Cid) ([]*types.MessageReceipt, error)
 }
 
 // GetFullBlock returns a full block: header, messages, receipts.
@@ -36,11 +35,6 @@ func GetFullBlock(ctx context.Context, plumbing fullBlockPlumbing, id cid.Cid) (
 	}
 
 	out.Messages, err = plumbing.ChainGetMessages(ctx, out.Header.Messages)
-	if err != nil {
-		return nil, err
-	}
-
-	out.Receipts, err = plumbing.ChainGetReceipts(ctx, out.Header.MessageReceipts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/block/full_block.go
+++ b/internal/pkg/block/full_block.go
@@ -7,14 +7,12 @@ import "github.com/filecoin-project/go-filecoin/internal/pkg/types"
 type FullBlock struct {
 	Header   *Block
 	Messages []*types.SignedMessage
-	Receipts []*types.MessageReceipt
 }
 
 // NewFullBlock constructs a new full block.
-func NewFullBlock(header *Block, msgs []*types.SignedMessage, rcpts []*types.MessageReceipt) *FullBlock {
+func NewFullBlock(header *Block, msgs []*types.SignedMessage) *FullBlock {
 	return &FullBlock{
 		Header:   header,
 		Messages: msgs,
-		Receipts: rcpts,
 	}
 }

--- a/internal/pkg/chain/testing.go
+++ b/internal/pkg/chain/testing.go
@@ -399,7 +399,7 @@ type FakeStateEvaluator struct {
 }
 
 // RunStateTransition delegates to StateBuilder.ComputeState.
-func (e *FakeStateEvaluator) RunStateTransition(ctx context.Context, tip block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error) {
+func (e *FakeStateEvaluator) RunStateTransition(ctx context.Context, tip block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid, receiptCid cid.Cid) (cid.Cid, []*types.MessageReceipt, error) {
 	return e.ComputeState(stateID, blsMessages, secpMessages)
 }
 

--- a/internal/pkg/chainsync/internal/syncer/syncer.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer.go
@@ -263,9 +263,6 @@ func (syncer *Syncer) syncOne(ctx context.Context, grandParent, parent, next blo
 		return err
 	}
 
-	for _, r := range receipts {
-		logSyncer.Infof("Storing receipt %v", r)
-	}
 	receiptCid, err := syncer.messageProvider.StoreReceipts(ctx, receipts)
 	if err != nil {
 		return errors.Wrapf(err, "could not store message rerceipts for tip set %s", next.String())

--- a/internal/pkg/chainsync/internal/syncer/syncer.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer.go
@@ -117,7 +117,7 @@ type HeaderValidator interface {
 type FullBlockValidator interface {
 	// RunStateTransition returns the state root CID resulting from applying the input ts to the
 	// prior `stateRoot`.  It returns an error if the transition is invalid.
-	RunStateTransition(ctx context.Context, ts block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error)
+	RunStateTransition(ctx context.Context, ts block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid, receiptRoot cid.Cid) (cid.Cid, []*types.MessageReceipt, error)
 }
 
 var reorgCnt *metrics.Int64Counter

--- a/internal/pkg/chainsync/internal/syncer/syncer_integration_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_integration_test.go
@@ -236,7 +236,7 @@ type integrationStateEvaluator struct {
 	c512 cid.Cid
 }
 
-func (n *integrationStateEvaluator) RunStateTransition(_ context.Context, ts block.TipSet, _ [][]*types.UnsignedMessage, _ [][]*types.SignedMessage, _ []block.TipSet, _ uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error) {
+func (n *integrationStateEvaluator) RunStateTransition(_ context.Context, ts block.TipSet, _ [][]*types.UnsignedMessage, _ [][]*types.SignedMessage, _ []block.TipSet, _ uint64, stateID cid.Cid, rCid cid.Cid) (cid.Cid, []*types.MessageReceipt, error) {
 	for i := 0; i < ts.Len(); i++ {
 		if ts.At(i).StateRoot.Equals(n.c512) {
 			return n.c512, []*types.MessageReceipt{}, nil

--- a/internal/pkg/chainsync/internal/syncer/syncer_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_test.go
@@ -380,7 +380,7 @@ func newPoisonValidator(t *testing.T, headerFailure, fullFailure uint64) *poison
 	return &poisonValidator{headerFailureTS: headerFailure, fullFailureTS: fullFailure}
 }
 
-func (pv *poisonValidator) RunStateTransition(_ context.Context, ts block.TipSet, _ [][]*types.UnsignedMessage, _ [][]*types.SignedMessage, _ []block.TipSet, _ uint64, _ cid.Cid) (cid.Cid, []*types.MessageReceipt, error) {
+func (pv *poisonValidator) RunStateTransition(_ context.Context, ts block.TipSet, _ [][]*types.UnsignedMessage, _ [][]*types.SignedMessage, _ []block.TipSet, _ uint64, _ cid.Cid, _ cid.Cid) (cid.Cid, []*types.MessageReceipt, error) {
 	stamp, err := ts.MinTimestamp()
 	require.NoError(pv.t, err)
 

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -42,8 +42,12 @@ func init() {
 var (
 	// ErrStateRootMismatch is returned when the computed state root doesn't match the expected result.
 	ErrStateRootMismatch = errors.New("blocks state root does not match computed result")
+	// ErrInvalidBase is returned when the chain doesn't connect back to a known good block.
+	ErrInvalidBase = errors.New("block does not connect to a known good chain")
 	// ErrUnorderedTipSets is returned when weight and minticket are the same between two tipsets.
 	ErrUnorderedTipSets = errors.New("trying to order two identical tipsets")
+	// ErrReceiptRootMismatch is returned when the block's receipt root doesn't match the receipt root computed for the parent tipset.
+	ErrReceiptRootMismatch = errors.New("blocks receipt root does not match parent tip set")
 )
 
 // DefaultBlockTime is the estimated proving period time.
@@ -137,12 +141,12 @@ func (c *Expected) BlockTime() time.Duration {
 // RunStateTransition applies the messages in a tipset to a state, and persists that new state.
 // It errors if the tipset was not mined according to the EC rules, or if any of the messages
 // in the tipset results in an error.
-func (c *Expected) RunStateTransition(ctx context.Context, ts block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, ancestors []block.TipSet, parentWeight uint64, priorStateID cid.Cid) (root cid.Cid, receipts []*types.MessageReceipt, err error) {
+func (c *Expected) RunStateTransition(ctx context.Context, ts block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, ancestors []block.TipSet, parentWeight uint64, parentStateRoot cid.Cid, parentReceiptRoot cid.Cid) (root cid.Cid, receipts []*types.MessageReceipt, err error) {
 	ctx, span := trace.StartSpan(ctx, "Expected.RunStateTransition")
 	span.AddAttributes(trace.StringAttribute("tipset", ts.String()))
 	defer tracing.AddErrorEndSpan(ctx, span, &err)
 
-	priorState, err := c.loadStateTree(ctx, priorStateID)
+	priorState, err := c.loadStateTree(ctx, parentStateRoot)
 	if err != nil {
 		return cid.Undef, []*types.MessageReceipt{}, err
 	}
@@ -153,7 +157,7 @@ func (c *Expected) RunStateTransition(ctx context.Context, ts block.TipSet, blsM
 
 	vms := vm.NewStorageMap(c.bstore)
 	var st state.Tree
-	st, receipts, err = c.runMessages(ctx, priorState, vms, ts, blsMessages, unwrap(secpMessages), ancestors)
+	st, receipts, err = c.runMessages(ctx, priorState, vms, ts, blsMessages, unwrap(secpMessages), parentReceiptRoot, ancestors)
 	if err != nil {
 		return cid.Undef, []*types.MessageReceipt{}, err
 	}
@@ -248,46 +252,24 @@ func (c *Expected) validateMining(ctx context.Context, st state.Tree, ts block.T
 // An error is returned if individual blocks contain messages that do not
 // lead to successful state transitions.  An error is also returned if the node
 // faults while running aggregate state computation.
-func (c *Expected) runMessages(ctx context.Context, st state.Tree, vms vm.StorageMap, ts block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.UnsignedMessage, ancestors []block.TipSet) (state.Tree, []*types.MessageReceipt, error) {
-	var cpySt state.Tree
-	var results []*ApplicationResult
-
-	// TODO: don't process messages twice
-	for i := 0; i < ts.Len(); i++ {
-		blk := ts.At(i)
-		cpyCid, err := st.Flush(ctx)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "error validating block state")
-		}
-		// state copied so changes don't propagate between block validations
-		cpySt, err = c.loadStateTree(ctx, cpyCid)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "error validating block state")
-		}
-
-		// Combine messages to process BLS first.
-		msgs := append(blsMessages[i], secpMessages[i]...)
-		results, err = c.processor.ProcessBlock(ctx, cpySt, vms, blk, msgs, ancestors)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "error validating block state")
-		}
-
-		outCid, err := cpySt.Flush(ctx)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "error validating block state")
-		}
-
-		if !outCid.Equals(blk.StateRoot) {
-			return nil, nil, ErrStateRootMismatch
-		}
+func (c *Expected) runMessages(ctx context.Context, st state.Tree, vms vm.StorageMap, ts block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.UnsignedMessage, parentReceipts cid.Cid, ancestors []block.TipSet) (state.Tree, []*types.MessageReceipt, error) {
+	parentStateRoot, err := st.Flush(ctx)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error getting parent state root")
 	}
 
-	if ts.Len() <= 1 { // block validation state == aggregate parent state
-		receipts := make([]*types.MessageReceipt, len(results))
-		for i, res := range results {
-			receipts[i] = res.Receipt
+	for i := 0; i < ts.Len(); i++ {
+		blk := ts.At(i)
+
+		// confirm block state root matches parent state root
+		if !parentStateRoot.Equals(blk.StateRoot) {
+			return nil, nil, ErrStateRootMismatch
 		}
-		return cpySt, receipts, nil
+
+		// confirm block receipts match parent receipts
+		if !parentReceipts.Equals(blk.MessageReceipts) {
+			return nil, nil, ErrReceiptRootMismatch
+		}
 	}
 
 	// multiblock tipsets require reapplying messages to get aggregate state
@@ -301,7 +283,7 @@ func (c *Expected) runMessages(ctx context.Context, st state.Tree, vms vm.Storag
 	}
 
 	receipts := make([]*types.MessageReceipt, len(resp.Results))
-	for i, res := range results {
+	for i, res := range resp.Results {
 		receipts[i] = res.Receipt
 	}
 

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -70,9 +70,6 @@ var AncestorRoundsNeeded = max(miner.LargestSectorSizeProvingPeriodBlocks+miner.
 
 // A Processor processes all the messages in a block or tip set.
 type Processor interface {
-	// ProcessBlock processes all messages in a block.
-	ProcessBlock(context.Context, state.Tree, vm.StorageMap, *block.Block, []*types.UnsignedMessage, []block.TipSet) ([]*ApplicationResult, error)
-
 	// ProcessTipSet processes all messages in a tip set.
 	ProcessTipSet(context.Context, state.Tree, vm.StorageMap, block.TipSet, [][]*types.UnsignedMessage, []block.TipSet) (*ProcessTipSetResponse, error)
 }

--- a/internal/pkg/consensus/expected_test.go
+++ b/internal/pkg/consensus/expected_test.go
@@ -62,7 +62,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		tipSet := th.RequireNewTipSet(t, nextBlocks...)
 
 		emptyBLSMessages, emptyMessages := emptyMessages(len(nextBlocks))
-		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(nextBlocks[0].ParentWeight), nextBlocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(nextBlocks[0].ParentWeight), nextBlocks[0].StateRoot, nextBlocks[0].MessageReceipts)
 		assert.NoError(t, err)
 	})
 
@@ -77,7 +77,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		emptyBLSMessages, emptyMessages := emptyMessages(len(nextBlocks))
 
-		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(nextBlocks[0].ParentWeight), genesisBlock.StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(nextBlocks[0].ParentWeight), genesisBlock.StateRoot, genesisBlock.MessageReceipts)
 		assert.EqualError(t, err, "block author did not win election")
 	})
 
@@ -113,7 +113,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		tipSet := th.RequireNewTipSet(t, nextBlocks...)
 
 		emptyBLSMessages, emptyMessages := emptyMessages(len(nextBlocks))
-		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, ancestors, uint64(nextBlocks[0].ParentWeight), nextRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, ancestors, uint64(nextBlocks[0].ParentWeight), nextRoot, nextBlocks[0].MessageReceipts)
 		assert.NoError(t, err)
 	})
 
@@ -136,7 +136,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		msg := types.NewUnsignedMessage(blsAddr, address.TestAddress2, 0, types.NewAttoFILFromFIL(0), types.InvalidMethodID, []byte{})
 		blsMessages[0] = append(blsMessages[0], msg)
 
-		_, _, err = exp.RunStateTransition(ctx, tipSet, blsMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(nextBlocks[0].ParentWeight), nextBlocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, blsMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(nextBlocks[0].ParentWeight), nextBlocks[0].StateRoot, nextBlocks[0].MessageReceipts)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "block BLS signature does not validate")
 	})
@@ -164,7 +164,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		}
 		secpMessages[0] = append(secpMessages[0], smsg)
 
-		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, secpMessages, []block.TipSet{pTipSet}, uint64(nextBlocks[0].ParentWeight), nextBlocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, secpMessages, []block.TipSet{pTipSet}, uint64(nextBlocks[0].ParentWeight), nextBlocks[0].StateRoot, nextBlocks[0].MessageReceipts)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "secp message signature invalid")
 	})
@@ -179,7 +179,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		emptyBLSMessages, emptyMessages := emptyMessages(len(nextBlocks))
 
-		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(nextBlocks[0].ParentWeight), genesisBlock.StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(nextBlocks[0].ParentWeight), genesisBlock.StateRoot, genesisBlock.MessageReceipts)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "invalid ticket")
 	})
@@ -197,7 +197,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		tipSet := th.RequireNewTipSet(t, nextBlocks...)
 		emptyBLSMessages, emptyMessages := emptyMessages(len(nextBlocks))
 
-		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(nextBlocks[0].ParentWeight), nextBlocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, uint64(nextBlocks[0].ParentWeight), nextBlocks[0].StateRoot, nextBlocks[0].MessageReceipts)
 		assert.EqualError(t, err, "block signature invalid")
 	})
 
@@ -213,7 +213,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		emptyBLSMessages, emptyMessages := emptyMessages(len(nextBlocks))
 
-		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, invalidParentWeight, nextBlocks[0].StateRoot)
+		_, _, err = exp.RunStateTransition(ctx, tipSet, emptyBLSMessages, emptyMessages, []block.TipSet{pTipSet}, invalidParentWeight, nextBlocks[0].StateRoot, nextBlocks[0].MessageReceipts)
 		assert.Contains(t, err.Error(), "invalid parent weight")
 	})
 }

--- a/internal/pkg/consensus/expected_test.go
+++ b/internal/pkg/consensus/expected_test.go
@@ -58,7 +58,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		pTipSet := th.RequireNewTipSet(t, genesisBlock)
 		nextRoot := setTree(ctx, t, kis, cistore, bstore, genesisBlock.StateRoot)
-		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, nextRoot, kis, mockSigner)
+		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, nextRoot, types.EmptyReceiptsCID, kis, mockSigner)
 		tipSet := th.RequireNewTipSet(t, nextBlocks...)
 
 		emptyBLSMessages, emptyMessages := emptyMessages(len(nextBlocks))
@@ -72,7 +72,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		as := testActorState(t, kis)
 		exp := consensus.NewExpected(cistore, bstore, consensus.NewDefaultProcessor(), as, th.BlockTimeTest, &consensus.FailingElectionValidator{}, &consensus.FakeTicketMachine{})
 
-		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, genesisBlock.StateRoot, kis, mockSigner)
+		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, genesisBlock.StateRoot, types.EmptyReceiptsCID, kis, mockSigner)
 		tipSet := th.RequireNewTipSet(t, nextBlocks...)
 
 		emptyBLSMessages, emptyMessages := emptyMessages(len(nextBlocks))
@@ -88,7 +88,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		nextRoot := setTree(ctx, t, kis, cistore, bstore, genesisBlock.StateRoot)
 		ancestors := make([]block.TipSet, 5)
 		for i := 0; i < consensus.ElectionLookback; i++ {
-			ancestorBlk := requireMakeNBlocks(t, 1, pTipSet, nextRoot, kis, mockSigner)
+			ancestorBlk := requireMakeNBlocks(t, 1, pTipSet, nextRoot, types.EmptyReceiptsCID, kis, mockSigner)
 			ancestors[i] = th.RequireNewTipSet(t, ancestorBlk...)
 			pTipSet = ancestors[i]
 		}
@@ -109,7 +109,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), as, th.BlockTimeTest, mockElection, mockTicketGen)
 
-		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, nextRoot, kis, mockSigner)
+		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, nextRoot, types.EmptyReceiptsCID, kis, mockSigner)
 		tipSet := th.RequireNewTipSet(t, nextBlocks...)
 
 		emptyBLSMessages, emptyMessages := emptyMessages(len(nextBlocks))
@@ -122,7 +122,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), as, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
 
 		pTipSet := th.RequireNewTipSet(t, genesisBlock)
-		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, genesisBlock.StateRoot, kis, mockSigner)
+		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, genesisBlock.StateRoot, types.EmptyReceiptsCID, kis, mockSigner)
 		tipSet := th.RequireNewTipSet(t, nextBlocks...)
 
 		_, emptyMessages := emptyMessages(len(nextBlocks))
@@ -146,7 +146,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), as, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
 
 		pTipSet := th.RequireNewTipSet(t, genesisBlock)
-		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, genesisBlock.StateRoot, kis, mockSigner)
+		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, genesisBlock.StateRoot, types.EmptyReceiptsCID, kis, mockSigner)
 		tipSet := th.RequireNewTipSet(t, nextBlocks...)
 
 		emptyBLSMessages, _ := emptyMessages(len(nextBlocks))
@@ -174,7 +174,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), as, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FailingTicketValidator{})
 
 		pTipSet := th.RequireNewTipSet(t, genesisBlock)
-		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, genesisBlock.StateRoot, kis, mockSigner)
+		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, genesisBlock.StateRoot, types.EmptyReceiptsCID, kis, mockSigner)
 		tipSet := th.RequireNewTipSet(t, nextBlocks...)
 
 		emptyBLSMessages, emptyMessages := emptyMessages(len(nextBlocks))
@@ -189,7 +189,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), as, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
 
 		pTipSet := th.RequireNewTipSet(t, genesisBlock)
-		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, genesisBlock.StateRoot, kis, mockSigner)
+		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, genesisBlock.StateRoot, types.EmptyReceiptsCID, kis, mockSigner)
 
 		// Give block 0 an invalid signature
 		nextBlocks[0].BlockSig = nextBlocks[1].BlockSig
@@ -206,7 +206,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), as, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{})
 
 		pTipSet := th.RequireNewTipSet(t, genesisBlock)
-		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, genesisBlock.StateRoot, kis, mockSigner)
+		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, genesisBlock.StateRoot, types.EmptyReceiptsCID, kis, mockSigner)
 		tipSet := th.RequireNewTipSet(t, nextBlocks...)
 
 		invalidParentWeight := uint64(6)
@@ -240,13 +240,13 @@ func setupCborBlockstore() (*hamt.CborIpldStore, blockstore.Blockstore) {
 
 // requireMakeNBlocks sets up 3 blocks with 3 owner actors and 3 miner actors and puts them in the state tree.
 // the owner actors have associated mockSigners for signing blocks and tickets.
-func requireMakeNBlocks(t *testing.T, n int, pTipSet block.TipSet, root cid.Cid, kis []types.KeyInfo, signer types.Signer) []*block.Block {
+func requireMakeNBlocks(t *testing.T, n int, pTipSet block.TipSet, root cid.Cid, receiptRoot cid.Cid, kis []types.KeyInfo, signer types.Signer) []*block.Block {
 	require.True(t, n <= len(kis))
 	minerAddrs := minerAddrsFromKis(t, kis)
 	m2w := minerToWorkerFromKis(t, kis)
 	blocks := make([]*block.Block, n)
 	for i := 0; i < n; i++ {
-		blocks[i] = th.RequireSignedTestBlockFromTipSet(t, pTipSet, root, 1, minerAddrs[i], m2w[minerAddrs[i]], signer)
+		blocks[i] = th.RequireSignedTestBlockFromTipSet(t, pTipSet, root, receiptRoot, 1, minerAddrs[i], m2w[minerAddrs[i]], signer)
 	}
 	return blocks
 }

--- a/internal/pkg/consensus/processor.go
+++ b/internal/pkg/consensus/processor.go
@@ -116,10 +116,6 @@ func (p *DefaultProcessor) ProcessTipSet(ctx context.Context, st state.Tree, vms
 	}
 	bh := types.NewBlockHeight(h)
 
-	var res ProcessTipSetResponse
-	res.Failures = make(map[cid.Cid]struct{})
-	res.Successes = make(map[cid.Cid]struct{})
-
 	dedupedMessages, err := DeduppedMessages(tsMessages)
 
 	for blkIdx := 0; blkIdx < ts.Len(); blkIdx++ {

--- a/internal/pkg/consensus/processor.go
+++ b/internal/pkg/consensus/processor.go
@@ -29,7 +29,6 @@ var (
 
 	// Timers
 	amTimer = metrics.NewTimerMs("consensus/apply_message", "Duration of message application in milliseconds", msgMethodKey)
-	pbTimer = metrics.NewTimerMs("consensus/process_block", "Duration of block processing in milliseconds")
 )
 
 // MessageValidator validates the syntax and semantics of a message before it is applied.

--- a/internal/pkg/consensus/processor.go
+++ b/internal/pkg/consensus/processor.go
@@ -173,6 +173,10 @@ func (p *DefaultProcessor) ProcessTipSet(ctx context.Context, st state.Tree, vms
 	}
 	bh := types.NewBlockHeight(h)
 
+	var res ProcessTipSetResponse
+	res.Failures = make(map[cid.Cid]struct{})
+	res.Successes = make(map[cid.Cid]struct{})
+
 	dedupedMessages, err := DeduppedMessages(tsMessages)
 
 	for blkIdx := 0; blkIdx < ts.Len(); blkIdx++ {
@@ -226,12 +230,6 @@ func DeduppedMessages(tsMessages [][]*types.UnsignedMessage) ([][]*types.Unsigne
 		}
 	}
 	return allMessages, nil
-}
-
-// DeduppedUnwrappedMessages unwraps and removes all messages that have the same cid
-func DeduppedUnwrappedMessages(msgs [][]*types.SignedMessage) ([][]*types.UnsignedMessage, error) {
-	unwrapped := unwrap(msgs)
-	return DeduppedMessages(unwrapped)
 }
 
 // ApplyMessage attempts to apply a message to a state tree. It is the

--- a/internal/pkg/consensus/processor_test.go
+++ b/internal/pkg/consensus/processor_test.go
@@ -181,8 +181,8 @@ func TestProcessTipsConflicts(t *testing.T) {
 	assert.True(t, expStCid.Equals(gotStCid))
 }
 
-// ProcessBlock should not fail with an unsigned block reward message.
-func TestProcessBlockReward(t *testing.T) {
+// ProcessTipset should not fail with an unsigned block reward message.
+func TestProcessTipsetReward(t *testing.T) {
 	tf.UnitTest(t)
 
 	newAddress := address.NewForTestGetter()
@@ -221,7 +221,7 @@ func TestProcessBlockReward(t *testing.T) {
 	assert.Equal(t, minerBalance.Add(blockRewardAmount), minerOwnerActor.Balance)
 }
 
-func TestProcessBlockVMErrors(t *testing.T) {
+func TestProcessTipsetVMErrors(t *testing.T) {
 	tf.BadUnitTestWithSideEffects(t)
 
 	ctx := context.Background()
@@ -290,7 +290,7 @@ func TestProcessBlockVMErrors(t *testing.T) {
 	assert.True(t, expectedStCid.Equals(gotStCid))
 }
 
-func TestProcessBlockParamsLengthError(t *testing.T) {
+func TestProcessTipsetParamsLengthError(t *testing.T) {
 	tf.UnitTest(t)
 
 	newAddress := address.NewForTestGetter()
@@ -317,7 +317,7 @@ func TestProcessBlockParamsLengthError(t *testing.T) {
 	assert.Contains(t, rct.ExecutionError.Error(), "invalid params: expected 0 parameters, but got 1")
 }
 
-func TestProcessBlockParamsError(t *testing.T) {
+func TestProcessTipsetParamsError(t *testing.T) {
 	tf.UnitTest(t)
 
 	newAddress := address.NewForTestGetter()

--- a/internal/pkg/consensus/protocol.go
+++ b/internal/pkg/consensus/protocol.go
@@ -27,7 +27,7 @@ import (
 type Protocol interface {
 	// RunStateTransition returns the state root CID resulting from applying the input ts to the
 	// prior `stateID`.  It returns an error if the transition is invalid.
-	RunStateTransition(ctx context.Context, ts block.TipSet, blsMsgs [][]*types.UnsignedMessage, secpMsgs [][]*types.SignedMessage, ancestors []block.TipSet, parentWeight uint64, stateID cid.Cid) (cid.Cid, []*types.MessageReceipt, error)
+	RunStateTransition(ctx context.Context, ts block.TipSet, blsMsgs [][]*types.UnsignedMessage, secpMsgs [][]*types.SignedMessage, ancestors []block.TipSet, parentWeight uint64, parentStateRoot cid.Cid, parentReceiptRoot cid.Cid) (cid.Cid, []*types.MessageReceipt, error)
 
 	// BlockTime returns the block time used by the consensus protocol.
 	BlockTime() time.Duration

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -65,20 +65,13 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 	pending := w.messageSource.Pending()
 	mq := NewMessageQueue(pending)
 	candidateMsgs := orderMessageCandidates(mq.Drain())
+
+	// run state transition to learn which messages are valid
 	vms := vm.NewStorageMap(w.blockstore)
 	results, err := w.processor.ApplyMessagesAndPayRewards(ctx, stateTree, vms, types.UnwrapSigned(candidateMsgs),
 		w.minerOwnerAddr, types.NewBlockHeight(blockHeight), ancestors)
 	if err != nil {
 		return nil, errors.Wrap(err, "generate apply messages")
-	}
-
-	newStateTreeCid, err := stateTree.Flush(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "generate flush state tree")
-	}
-
-	if err = vms.Flush(); err != nil {
-		return nil, errors.Wrap(err, "generate flush vm storage map")
 	}
 
 	var receipts []*types.MessageReceipt
@@ -124,20 +117,27 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 	if err != nil {
 		return nil, errors.Wrap(err, "error persisting messages")
 	}
-	rcptsCid, err := w.messageStore.StoreReceipts(ctx, receipts)
+
+	// get tipset state root and receipt root
+	baseStateRoot, err := w.tsMetadata.GetTipSetStateRoot(baseTipSet.Key())
 	if err != nil {
-		return nil, errors.Wrap(err, "error persisting receipts")
+		return nil, errors.Wrapf(err, "error retrieving state root for tipset %s", baseTipSet.Key().String())
+	}
+
+	baseReceiptRoot, err := w.tsMetadata.GetTipSetReceiptsRoot(baseTipSet.Key())
+	if err != nil {
+		return nil, errors.Wrapf(err, "error retrieving receipt root for tipset %s", baseTipSet.Key().String())
 	}
 
 	next := &block.Block{
 		Miner:           w.minerAddr,
 		Height:          types.Uint64(blockHeight),
 		Messages:        txMeta,
-		MessageReceipts: rcptsCid,
+		MessageReceipts: baseReceiptRoot,
 		Parents:         baseTipSet.Key(),
 		ParentWeight:    types.Uint64(weight),
 		ElectionProof:   electionProof,
-		StateRoot:       newStateTreeCid,
+		StateRoot:       baseStateRoot,
 		Ticket:          ticket,
 		Timestamp:       types.Uint64(w.clock.Now().Unix()),
 		BLSAggregateSig: blsAggregateSig,

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -74,7 +74,6 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 		return nil, errors.Wrap(err, "generate apply messages")
 	}
 
-	var receipts []*types.MessageReceipt
 	var blsAccepted []*types.SignedMessage
 	var secpAccepted []*types.SignedMessage
 
@@ -83,7 +82,6 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 	for i, r := range results {
 		msg := candidateMsgs[i]
 		if r.Failure == nil {
-			receipts = append(receipts, r.Receipt)
 			if msg.Message.From.Protocol() == address.BLS {
 				blsAccepted = append(blsAccepted, msg)
 			} else {

--- a/internal/pkg/mining/scheduler_test.go
+++ b/internal/pkg/mining/scheduler_test.go
@@ -81,11 +81,12 @@ func TestMineOnce10Null(t *testing.T) {
 		MinerOwnerAddr: addr,
 		WorkerSigner:   mockSigner,
 
-		GetStateTree: getStateTree,
-		GetWeight:    getWeightTest,
-		GetAncestors: getAncestors,
-		Election:     &consensus.ElectionMachine{},
-		TicketGen:    &consensus.TicketMachine{},
+		TipSetMetadata: fakeTSMetadata{},
+		GetStateTree:   getStateTree,
+		GetWeight:      getWeightTest,
+		GetAncestors:   getAncestors,
+		Election:       &consensus.ElectionMachine{},
+		TicketGen:      &consensus.TicketMachine{},
 
 		MessageSource: pool,
 		Processor:     th.NewFakeProcessor(),

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -87,6 +87,11 @@ type ticketGenerator interface {
 	NextTicket(block.Ticket, address.Address, types.Signer) (block.Ticket, error)
 }
 
+type tipSetMetadata interface {
+	GetTipSetStateRoot(key block.TipSetKey) (cid.Cid, error)
+	GetTipSetReceiptsRoot(key block.TipSetKey) (cid.Cid, error)
+}
+
 // DefaultWorker runs a mining job.
 type DefaultWorker struct {
 	api workerPorcelainAPI
@@ -96,6 +101,7 @@ type DefaultWorker struct {
 	workerSigner   types.Signer
 
 	// consensus things
+	tsMetadata   tipSetMetadata
 	getStateTree GetStateTree
 	getWeight    GetWeight
 	getAncestors GetAncestors
@@ -119,11 +125,12 @@ type WorkerParameters struct {
 	WorkerSigner   types.Signer
 
 	// consensus things
-	GetStateTree GetStateTree
-	GetWeight    GetWeight
-	GetAncestors GetAncestors
-	Election     electionUtil
-	TicketGen    ticketGenerator
+	TipSetMetadata tipSetMetadata
+	GetStateTree   GetStateTree
+	GetWeight      GetWeight
+	GetAncestors   GetAncestors
+	Election       electionUtil
+	TicketGen      ticketGenerator
 
 	// core filecoin things
 	MessageSource MessageSource
@@ -149,6 +156,7 @@ func NewDefaultWorker(parameters WorkerParameters) *DefaultWorker {
 		workerSigner:   parameters.WorkerSigner,
 		election:       parameters.Election,
 		ticketGen:      parameters.TicketGen,
+		tsMetadata:     parameters.TipSetMetadata,
 		clock:          parameters.Clock,
 	}
 }

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -826,23 +826,6 @@ func TestGenerateError(t *testing.T) {
 	assert.Len(t, pool.Pending(), 1) // No messages are removed from the pool.
 }
 
-type stateTreeForTest struct {
-	state.Tree
-	TestFlush func(ctx context.Context) (cid.Cid, error)
-}
-
-func wrapStateTreeForTest(st state.Tree) *stateTreeForTest {
-	stt := stateTreeForTest{
-		st,
-		st.Flush,
-	}
-	return &stt
-}
-
-func (st *stateTreeForTest) Flush(ctx context.Context) (cid.Cid, error) {
-	return st.TestFlush(ctx)
-}
-
 func getWeightTest(_ context.Context, ts block.TipSet) (uint64, error) {
 	w, err := ts.ParentWeight()
 	if err != nil {

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -72,11 +72,12 @@ func TestLookbackElection(t *testing.T) {
 			MinerOwnerAddr: minerOwnerAddr,
 			WorkerSigner:   mockSigner,
 
-			GetStateTree: getStateTree,
-			GetWeight:    getWeightTest,
-			GetAncestors: getAncestors,
-			Election:     mem,
-			TicketGen:    &consensus.FakeTicketMachine{},
+			TipSetMetadata: fakeTSMetadata{},
+			GetStateTree:   getStateTree,
+			GetWeight:      getWeightTest,
+			GetAncestors:   getAncestors,
+			Election:       mem,
+			TicketGen:      &consensus.FakeTicketMachine{},
 
 			MessageSource: pool,
 			Processor:     th.NewFakeProcessor(),
@@ -107,11 +108,12 @@ func TestLookbackElection(t *testing.T) {
 			MinerOwnerAddr: minerOwnerAddr,
 			WorkerSigner:   mockSigner,
 
-			GetStateTree: getStateTree,
-			GetWeight:    getWeightTest,
-			GetAncestors: getAncestors,
-			Election:     &consensus.FakeElectionMachine{},
-			TicketGen:    mtm,
+			TipSetMetadata: fakeTSMetadata{},
+			GetStateTree:   getStateTree,
+			GetWeight:      getWeightTest,
+			GetAncestors:   getAncestors,
+			Election:       &consensus.FakeElectionMachine{},
+			TicketGen:      mtm,
 
 			MessageSource: pool,
 			Processor:     th.NewFakeProcessor(),
@@ -220,7 +222,8 @@ func Test_Mine(t *testing.T) {
 
 		go worker.Mine(ctx, tipSet, 0, outCh)
 		r := <-outCh
-		assert.EqualError(t, r.Err, "generate flush state tree: boom no flush")
+		require.Error(t, r.Err)
+		assert.Contains(t, r.Err.Error(), "test error retrieving state root")
 		assert.True(t, ticketGen)
 	})
 

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -20,7 +20,7 @@ import (
 
 // RequireSignedTestBlockFromTipSet creates a block with a valid signature by
 // the passed in miner work and a Miner field set to the minerAddr.
-func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, stateRootCid cid.Cid, height uint64, minerAddr address.Address, minerWorker address.Address, signer types.Signer) *block.Block {
+func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, stateRootCid cid.Cid, receiptRootCid cid.Cid, height uint64, minerAddr address.Address, minerWorker address.Address, signer types.Signer) *block.Block {
 	electionProof := consensus.MakeFakeElectionProofForTest()
 	ticket := consensus.MakeFakeTicketForTest()
 	emptyBLSSig := (*bls.Aggregate([]bls.Signature{}))[:]
@@ -32,6 +32,7 @@ func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, sta
 		ParentWeight:    types.Uint64(10000 * height),
 		Height:          types.Uint64(height),
 		StateRoot:       stateRootCid,
+		MessageReceipts: receiptRootCid,
 		ElectionProof:   electionProof,
 		BLSAggregateSig: emptyBLSSig,
 	}


### PR DESCRIPTION
### Motivation

The spec dictates (or will dictate) that state root and receipt root in the block header reflect the result of messages processed in the parent tipset, not messages processed in the currrent  block as currently implemented.

### Proposed changes

1. Set state root and receipt root to the values saved with the parent tipset when generating a block. The block generator must still run a state transition in order to determine which messages are valid to include.
2. When validating a block, only validate that the block miner has included the correct state root and message receipts for the parent tipset. Here we stop running state transitions on individual blocks.
3. Modify the message waiter to pull receipts for an entire tipset. This involves some slightly involved logic around determining the index of a receipt given multiple message sets associated with its blocks.
4. Since receipts are now associated with a tipset rather than a block, we remove them from our block analysis UI, including `show block`.

Closes issue #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

