### PR TITLE
Feat/gossip sub

### DIFF
--- a/cmd/go-filecoin/chain_daemon_test.go
+++ b/cmd/go-filecoin/chain_daemon_test.go
@@ -42,7 +42,6 @@ func TestChainLs(t *testing.T) {
 	t.Run("chain ls with json encoding returns the whole chain as json", func(t *testing.T) {
 		d := makeTestDaemonWithMinerAndStart(t)
 		defer d.ShutdownSuccess()
-
 		op1 := d.RunSuccess("mining", "once", "--enc", "text")
 		result1 := op1.ReadStdoutTrimNewlines()
 		c, err := cid.Parse(result1)

--- a/cmd/go-filecoin/message.go
+++ b/cmd/go-filecoin/message.go
@@ -106,7 +106,7 @@ var msgSendCmd = &cmds.Command{
 			})
 		}
 
-		c, err := GetPorcelainAPI(env).MessageSend(
+		c, _, err := GetPorcelainAPI(env).MessageSend(
 			req.Context,
 			fromAddr,
 			target,
@@ -159,7 +159,7 @@ var signedMsgSendCmd = &cmds.Command{
 		}
 		signed := &m
 
-		c, err := GetPorcelainAPI(env).SignedMessageSend(
+		c, _, err := GetPorcelainAPI(env).SignedMessageSend(
 			req.Context,
 			signed,
 		)

--- a/cmd/go-filecoin/miner.go
+++ b/cmd/go-filecoin/miner.go
@@ -336,7 +336,7 @@ var minerUpdatePeerIDCmd = &cmds.Command{
 				Preview: true,
 			})
 		}
-		
+
 		c, _, err := GetPorcelainAPI(env).MessageSend(
 			req.Context,
 			fromAddr,

--- a/cmd/go-filecoin/miner.go
+++ b/cmd/go-filecoin/miner.go
@@ -336,8 +336,8 @@ var minerUpdatePeerIDCmd = &cmds.Command{
 				Preview: true,
 			})
 		}
-
-		c, err := GetPorcelainAPI(env).MessageSend(
+		
+		c, _, err := GetPorcelainAPI(env).MessageSend(
 			req.Context,
 			fromAddr,
 			minerAddr,

--- a/cmd/go-filecoin/payment_channel.go
+++ b/cmd/go-filecoin/payment_channel.go
@@ -97,7 +97,7 @@ message to be mined to get the channelID.`,
 			})
 		}
 
-		c, err := GetPorcelainAPI(env).MessageSend(
+		c, _, err := GetPorcelainAPI(env).MessageSend(
 			req.Context,
 			fromAddr,
 			address.PaymentBrokerAddress,
@@ -289,7 +289,7 @@ var redeemCmd = &cmds.Command{
 				params...,
 			)
 		} else {
-			result.Cid, err = GetPorcelainAPI(env).MessageSend(
+			result.Cid, _, err = GetPorcelainAPI(env).MessageSend(
 				req.Context,
 				fromAddr,
 				address.PaymentBrokerAddress,
@@ -374,7 +374,7 @@ var reclaimCmd = &cmds.Command{
 			})
 		}
 
-		c, err := GetPorcelainAPI(env).MessageSend(
+		c, _, err := GetPorcelainAPI(env).MessageSend(
 			req.Context,
 			fromAddr,
 			address.PaymentBrokerAddress,
@@ -464,7 +464,7 @@ var closeCmd = &cmds.Command{
 				params...,
 			)
 		} else {
-			result.Cid, err = GetPorcelainAPI(env).MessageSend(
+			result.Cid, _, err = GetPorcelainAPI(env).MessageSend(
 				req.Context,
 				fromAddr,
 				address.PaymentBrokerAddress,
@@ -561,7 +561,7 @@ var extendCmd = &cmds.Command{
 			})
 		}
 
-		c, err := GetPorcelainAPI(env).MessageSend(
+		c, _, err := GetPorcelainAPI(env).MessageSend(
 			req.Context,
 			fromAddr,
 			address.PaymentBrokerAddress,
@@ -648,7 +648,7 @@ var cancelCmd = &cmds.Command{
 			})
 		}
 
-		c, err := GetPorcelainAPI(env).MessageSend(
+		c, _, err := GetPorcelainAPI(env).MessageSend(
 			req.Context,
 			fromAddr,
 			address.PaymentBrokerAddress,

--- a/internal/app/go-filecoin/internal/submodule/messaging_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/messaging_submodule.go
@@ -39,7 +39,7 @@ func NewMessagingSubmodule(ctx context.Context, config messagingConfig, repo mes
 	msgPool := message.NewPool(repo.Config().Mpool, consensus.NewIngestionValidator(chain.State, repo.Config().Mpool))
 	inbox := message.NewInbox(msgPool, message.InboxMaxAgeTipsets, chain.ChainReader, chain.MessageStore)
 
-	// setup messaging topic. 
+	// setup messaging topic.
 	topic, err := network.gsub.Join(net.MessageTopic(network.NetworkName))
 	if err != nil {
 		return MessagingSubmodule{}, err

--- a/internal/app/go-filecoin/internal/submodule/messaging_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/messaging_submodule.go
@@ -40,7 +40,7 @@ func NewMessagingSubmodule(ctx context.Context, config messagingConfig, repo mes
 	inbox := message.NewInbox(msgPool, message.InboxMaxAgeTipsets, chain.ChainReader, chain.MessageStore)
 
 	// setup messaging topic.
-	topic, err := network.gsub.Join(net.MessageTopic(network.NetworkName))
+	topic, err := network.pubsub.Join(net.MessageTopic(network.NetworkName))
 	if err != nil {
 		return MessagingSubmodule{}, err
 	}

--- a/internal/app/go-filecoin/internal/submodule/messaging_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/messaging_submodule.go
@@ -39,8 +39,8 @@ func NewMessagingSubmodule(ctx context.Context, config messagingConfig, repo mes
 	msgPool := message.NewPool(repo.Config().Mpool, consensus.NewIngestionValidator(chain.State, repo.Config().Mpool))
 	inbox := message.NewInbox(msgPool, message.InboxMaxAgeTipsets, chain.ChainReader, chain.MessageStore)
 
-	// setup messaging topic. TODO #3631 fix this to avoid construction side effects
-	topic, err := network.Fsub.Join(net.MessageTopic(network.NetworkName))
+	// setup messaging topic. 
+	topic, err := network.gsub.Join(net.MessageTopic(network.NetworkName))
 	if err != nil {
 		return MessagingSubmodule{}, err
 	}

--- a/internal/app/go-filecoin/internal/submodule/network_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/network_submodule.go
@@ -45,7 +45,7 @@ type NetworkSubmodule struct {
 	// Router is a router from IPFS
 	Router routing.Routing
 
-	Fsub *libp2pps.PubSub
+	gsub *libp2pps.PubSub
 
 	// TODO: split chain bitswap from storage bitswap (issue: ???)
 	Bitswap exchange.Interface
@@ -113,7 +113,7 @@ func NewNetworkSubmodule(ctx context.Context, config networkConfig, repo network
 	// Set up libp2p network
 	// TODO: PubSub requires strict message signing, disabled for now
 	// reference issue: #3124
-	fsub, err := libp2pps.NewFloodSub(ctx, peerHost, libp2pps.WithMessageSigning(false))
+	gsub, err := libp2pps.NewGossipSub(ctx, peerHost, libp2pps.WithMessageSigning(false))
 	if err != nil {
 		return NetworkSubmodule{}, errors.Wrap(err, "failed to set up network")
 	}
@@ -134,7 +134,7 @@ func NewNetworkSubmodule(ctx context.Context, config networkConfig, repo network
 		NetworkName: networkName,
 		Host:        peerHost,
 		Router:      router,
-		Fsub:        fsub,
+		gsub:        gsub,
 		Bitswap:     bswap,
 		Network:     network,
 	}, nil

--- a/internal/app/go-filecoin/internal/submodule/network_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/network_submodule.go
@@ -47,7 +47,7 @@ type NetworkSubmodule struct {
 	// Router is a router from IPFS
 	Router routing.Routing
 
-	gsub *libp2pps.PubSub
+	pubsub *libp2pps.PubSub
 
 	// TODO: split chain bitswap from storage bitswap (issue: ???)
 	Bitswap exchange.Interface
@@ -140,7 +140,7 @@ func NewNetworkSubmodule(ctx context.Context, config networkConfig, repo network
 		NetworkName: networkName,
 		Host:        peerHost,
 		Router:      router,
-		gsub:        gsub,
+		pubsub:      gsub,
 		Bitswap:     bswap,
 		Network:     network,
 	}, nil

--- a/internal/app/go-filecoin/internal/submodule/network_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/network_submodule.go
@@ -33,7 +33,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/discovery"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/net"	
+	"github.com/filecoin-project/go-filecoin/internal/pkg/net"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
 )

--- a/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
@@ -51,12 +51,12 @@ func NewSyncerSubmodule(ctx context.Context, config syncerConfig, repo chainRepo
 
 	// register block validation on floodsub
 	btv := net.NewBlockTopicValidator(blkValid)
-	if err := network.Fsub.RegisterTopicValidator(btv.Topic(network.NetworkName), btv.Validator(), btv.Opts()...); err != nil {
+	if err := network.gsub.RegisterTopicValidator(btv.Topic(network.NetworkName), btv.Validator(), btv.Opts()...); err != nil {
 		return SyncerSubmodule{}, errors.Wrap(err, "failed to register block validator")
 	}
 
-	// setup topic.  TODO #3631 fix this to avoid side effects during construction.
-	topic, err := network.Fsub.Join(net.BlockTopic(network.NetworkName))
+	// setup topic.
+	topic, err := network.gsub.Join(net.BlockTopic(network.NetworkName))
 	if err != nil {
 		return SyncerSubmodule{}, err
 	}

--- a/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
@@ -51,12 +51,12 @@ func NewSyncerSubmodule(ctx context.Context, config syncerConfig, repo chainRepo
 
 	// register block validation on floodsub
 	btv := net.NewBlockTopicValidator(blkValid)
-	if err := network.gsub.RegisterTopicValidator(btv.Topic(network.NetworkName), btv.Validator(), btv.Opts()...); err != nil {
+	if err := network.pubsub.RegisterTopicValidator(btv.Topic(network.NetworkName), btv.Validator(), btv.Opts()...); err != nil {
 		return SyncerSubmodule{}, errors.Wrap(err, "failed to register block validator")
 	}
 
 	// setup topic.
-	topic, err := network.gsub.Join(net.BlockTopic(network.NetworkName))
+	topic, err := network.pubsub.Join(net.BlockTopic(network.NetworkName))
 	if err != nil {
 		return SyncerSubmodule{}, err
 	}

--- a/internal/app/go-filecoin/node/block.go
+++ b/internal/app/go-filecoin/node/block.go
@@ -32,8 +32,8 @@ func (node *Node) AddNewBlock(ctx context.Context, b *block.Block) (err error) {
 			log.Errorf("error publishing new block on block topic %s", err)
 		}
 	}()
-
-	return node.syncer.ChainSyncManager.BlockProposer().SendOwnBlock(block.NewChainInfo(node.Host().ID(), node.Host().ID(), block.NewTipSetKey(blkCid), uint64(b.Height)))
+	ci := block.NewChainInfo(node.Host().ID(), node.Host().ID(), block.NewTipSetKey(blkCid), uint64(b.Height))
+	return node.syncer.ChainSyncManager.BlockProposer().SendOwnBlock(ci)
 }
 
 func (node *Node) processBlock(ctx context.Context, msg pubsub.Message) (err error) {

--- a/internal/app/go-filecoin/node/message_propagate_test.go
+++ b/internal/app/go-filecoin/node/message_propagate_test.go
@@ -65,7 +65,7 @@ func TestMessagePropagation(t *testing.T) {
 	fooMethod := types.MethodID(7232)
 
 	t.Run("message propagates", func(t *testing.T) {
-		_, err := sender.PorcelainAPI.MessageSend(
+		_, _, err := sender.PorcelainAPI.MessageSend(
 			ctx,
 			senderAddress,
 			address.NetworkAddress,

--- a/internal/app/go-filecoin/node/message_propagate_test.go
+++ b/internal/app/go-filecoin/node/message_propagate_test.go
@@ -56,7 +56,7 @@ func TestMessagePropagation(t *testing.T) {
 	connect(t, nodes[0], nodes[1])
 	connect(t, nodes[1], nodes[2])
 	// Wait for network connection notifications to propagate
-	time.Sleep(time.Millisecond * 50)
+	time.Sleep(time.Millisecond * 200)
 
 	require.Equal(t, 0, len(nodes[1].Messaging.Inbox.Pool().Pending()))
 	require.Equal(t, 0, len(nodes[2].Messaging.Inbox.Pool().Pending()))

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -325,7 +325,7 @@ func (node *Node) Stop(ctx context.Context) {
 		fmt.Printf("error closing host: %s\n", err)
 	}
 
-	if err := node.Repo.Close(); err != nil {
+ 	if err := node.Repo.Close(); err != nil {
 		fmt.Printf("error closing repo: %s\n", err)
 	}
 
@@ -467,7 +467,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 
 					// This call can fail due to, e.g. nonce collisions. Our miners existence depends on this.
 					// We should deal with this, but MessageSendWithRetry is problematic.
-					msgCid, err := node.PorcelainAPI.MessageSend(
+					msgCid, _, err := node.PorcelainAPI.MessageSend(
 						miningCtx,
 						workerAddr,
 						minerAddr,

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -325,7 +325,7 @@ func (node *Node) Stop(ctx context.Context) {
 		fmt.Printf("error closing host: %s\n", err)
 	}
 
- 	if err := node.Repo.Close(); err != nil {
+	if err := node.Repo.Close(); err != nil {
 		fmt.Printf("error closing repo: %s\n", err)
 	}
 

--- a/internal/app/go-filecoin/plumbing/api.go
+++ b/internal/app/go-filecoin/plumbing/api.go
@@ -269,7 +269,9 @@ func (api *API) Snapshot(ctx context.Context, baseKey block.TipSetKey) (consensu
 // MessageSend sends a message. It uses the default from address if none is given and signs the
 // message using the wallet. This call "sends" in the sense that it enqueues the
 // message in the msg pool and broadcasts it to the network; it does not wait for the
-// message to go on chain. Note that no default from address is provided.
+// message to go on chain. Note that no default from address is provided.  The error
+// channel returned receives either nil or an error and is immediately closed after
+// the message is published to the network to signal that the publish is complete.
 func (api *API) MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, chan error, error) {
 	return api.outbox.Send(ctx, from, to, value, gasPrice, gasLimit, true, method, params...)
 }

--- a/internal/app/go-filecoin/plumbing/api.go
+++ b/internal/app/go-filecoin/plumbing/api.go
@@ -270,12 +270,12 @@ func (api *API) Snapshot(ctx context.Context, baseKey block.TipSetKey) (consensu
 // message using the wallet. This call "sends" in the sense that it enqueues the
 // message in the msg pool and broadcasts it to the network; it does not wait for the
 // message to go on chain. Note that no default from address is provided.
-func (api *API) MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, error) {
+func (api *API) MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, chan error, error) {
 	return api.outbox.Send(ctx, from, to, value, gasPrice, gasLimit, true, method, params...)
 }
 
 //SignedMessageSend sends a siged message.
-func (api *API) SignedMessageSend(ctx context.Context, smsg *types.SignedMessage) (cid.Cid, error) {
+func (api *API) SignedMessageSend(ctx context.Context, smsg *types.SignedMessage) (cid.Cid, chan error, error) {
 	return api.outbox.SignedSend(ctx, smsg, true)
 }
 

--- a/internal/app/go-filecoin/porcelain/miner.go
+++ b/internal/app/go-filecoin/porcelain/miner.go
@@ -527,7 +527,7 @@ func MinerSetWorkerAddress(
 		return cid.Undef, errors.Wrap(err, "could not get miner owner address")
 	}
 
-	c, _, err :=  plumbing.MessageSend(
+	c, _, err := plumbing.MessageSend(
 		ctx,
 		minerOwnerAddr,
 		minerAddr,

--- a/internal/app/go-filecoin/porcelain/miner.go
+++ b/internal/app/go-filecoin/porcelain/miner.go
@@ -25,7 +25,7 @@ import (
 type mcAPI interface {
 	ConfigGet(dottedPath string) (interface{}, error)
 	ConfigSet(dottedPath string, paramJSON string) error
-	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, error)
+	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, chan error, error)
 	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*block.Block, *types.SignedMessage, *types.MessageReceipt) error) error
 	WalletDefaultAddress() (address.Address, error)
 }
@@ -59,7 +59,7 @@ func MinerCreate(
 		return nil, fmt.Errorf("can only have one miner per node")
 	}
 
-	smsgCid, err := plumbing.MessageSend(
+	smsgCid, _, err := plumbing.MessageSend(
 		ctx,
 		minerOwnerAddr,
 		address.StorageMarketAddress,
@@ -143,7 +143,7 @@ func MinerPreviewCreate(
 type mspAPI interface {
 	ConfigGet(dottedPath string) (interface{}, error)
 	ConfigSet(dottedKey string, jsonString string) error
-	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, error)
+	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, chan error, error)
 	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*block.Block, *types.SignedMessage, *types.MessageReceipt) error) error
 }
 
@@ -187,7 +187,7 @@ func MinerSetPrice(ctx context.Context, plumbing mspAPI, from address.Address, m
 	}
 
 	// create ask
-	res.AddAskCid, err = plumbing.MessageSend(ctx, from, res.MinerAddr, types.ZeroAttoFIL, gasPrice, gasLimit, minerActor.AddAsk, price, expiry)
+	res.AddAskCid, _, err = plumbing.MessageSend(ctx, from, res.MinerAddr, types.ZeroAttoFIL, gasPrice, gasLimit, minerActor.AddAsk, price, expiry)
 	if err != nil {
 		return res, errors.Wrap(err, "couldn't send message")
 	}
@@ -499,7 +499,7 @@ func MinerGetCollateral(ctx context.Context, plumbing mgaAPI, minerAddr address.
 // mwapi is the subset of the plumbing.API that MinerSetWorkerAddress use.
 type mwapi interface {
 	ConfigGet(dottedPath string) (interface{}, error)
-	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, error)
+	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, chan error, error)
 	MinerGetOwnerAddress(ctx context.Context, minerAddr address.Address) (address.Address, error)
 }
 
@@ -527,7 +527,7 @@ func MinerSetWorkerAddress(
 		return cid.Undef, errors.Wrap(err, "could not get miner owner address")
 	}
 
-	return plumbing.MessageSend(
+	c, _, err :=  plumbing.MessageSend(
 		ctx,
 		minerOwnerAddr,
 		minerAddr,
@@ -536,4 +536,5 @@ func MinerSetWorkerAddress(
 		gasLimit,
 		minerActor.ChangeWorker,
 		workerAddr)
+	return c, err
 }

--- a/internal/app/go-filecoin/porcelain/payments.go
+++ b/internal/app/go-filecoin/porcelain/payments.go
@@ -23,7 +23,7 @@ type cpPlumbing interface {
 	ChainHeadKey() block.TipSetKey
 	ChainTipSet(key block.TipSetKey) (block.TipSet, error)
 	MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, baseKey block.TipSetKey, params ...interface{}) ([][]byte, error)
-	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, error)
+	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, chan error, error)
 	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*block.Block, *types.SignedMessage, *types.MessageReceipt) error) error
 	SignBytes(data []byte, addr address.Address) (types.Signature, error)
 }
@@ -128,7 +128,7 @@ func CreatePayments(ctx context.Context, plumbing cpPlumbing, config CreatePayme
 	}
 
 	// Create channel
-	response.ChannelMsgCid, err = plumbing.MessageSend(ctx,
+	response.ChannelMsgCid, _, err = plumbing.MessageSend(ctx,
 		config.From,
 		address.PaymentBrokerAddress,
 		config.Value,

--- a/internal/app/go-filecoin/porcelain/storagedeals.go
+++ b/internal/app/go-filecoin/porcelain/storagedeals.go
@@ -93,7 +93,7 @@ type dealRedeemPlumbing interface {
 	ChainTipSet(key block.TipSetKey) (block.TipSet, error)
 	DealGet(context.Context, cid.Cid) (*storagedeal.Deal, error)
 	MessagePreview(context.Context, address.Address, address.Address, types.MethodID, ...interface{}) (types.GasUnits, error)
-	MessageSend(context.Context, address.Address, address.Address, types.AttoFIL, types.AttoFIL, types.GasUnits, types.MethodID, ...interface{}) (cid.Cid, error)
+	MessageSend(context.Context, address.Address, address.Address, types.AttoFIL, types.AttoFIL, types.GasUnits, types.MethodID, ...interface{}) (cid.Cid, chan error, error)
 }
 
 // DealRedeem redeems a voucher for the deal with the given cid and returns
@@ -104,7 +104,7 @@ func DealRedeem(ctx context.Context, plumbing dealRedeemPlumbing, fromAddr addre
 		return cid.Undef, err
 	}
 
-	return plumbing.MessageSend(
+	c, _, err := plumbing.MessageSend(
 		ctx,
 		fromAddr,
 		address.PaymentBrokerAddress,
@@ -114,6 +114,7 @@ func DealRedeem(ctx context.Context, plumbing dealRedeemPlumbing, fromAddr addre
 		paymentbroker.Redeem,
 		params...,
 	)
+	return c, err
 }
 
 // DealRedeemPreview previews the redeem method for a deal and returns the

--- a/internal/app/go-filecoin/porcelain/storagedeals_test.go
+++ b/internal/app/go-filecoin/porcelain/storagedeals_test.go
@@ -138,7 +138,7 @@ func (trp *testRedeemPlumbing) MessagePreview(_ context.Context, fromAddr addres
 	return trp.gasPrice, nil
 }
 
-func (trp *testRedeemPlumbing) MessageSend(_ context.Context, fromAddr address.Address, actorAddr address.Address, _ types.AttoFIL, _ types.AttoFIL, _ types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, error) {
+func (trp *testRedeemPlumbing) MessageSend(_ context.Context, fromAddr address.Address, actorAddr address.Address, _ types.AttoFIL, _ types.AttoFIL, _ types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, chan error, error) {
 	trp.ResultingFromAddr = fromAddr
 	trp.ResultingActorAddr = actorAddr
 	trp.ResultingMethod = method
@@ -146,7 +146,7 @@ func (trp *testRedeemPlumbing) MessageSend(_ context.Context, fromAddr address.A
 	trp.ResultingVoucherChannel = params[1].(*types.ChannelID)
 	trp.ResultingVoucherAmount = params[2].(types.AttoFIL)
 	trp.ResultingVoucherValidAt = params[3].(*types.BlockHeight)
-	return trp.messageCid, nil
+	return trp.messageCid, nil, nil
 }
 
 func TestDealRedeem(t *testing.T) {

--- a/internal/pkg/discovery/noop_discovery.go
+++ b/internal/pkg/discovery/noop_discovery.go
@@ -1,29 +1,29 @@
-package discovery                                                                                                                                 
-                                                                                                                                                         
-import (                                                                                                                                                
-        "context"
-        "time"
-	
-	pstore "github.com/libp2p/go-libp2p-peerstore"
-	libp2pdisc "github.com/libp2p/go-libp2p-core/discovery" 
-)                                                                                                                                                       
-                                                                                                                                                          
-// NoopDiscovery satisfies the discovery interface without doing anything                                                                           
-type NoopDiscovery struct {}                                                                                                                          
-                                                                                                                                                       
-// FindPeers returns a dead channel that is always closed                                                                                      
-func (sd *NoopDiscovery) FindPeers(ctx context.Context, ns string, opts ...libp2pdisc.Option) (<-chan pstore.PeerInfo, error) {                               
-        stupidCh := make(chan pstore.PeerInfo)                                                                                                             
-        // the output is immediately closed, discovery requests end immediately                                                                            
-        // Callstack:                                                                                                                                      
-        // https://github.com/libp2p/go-libp2p-pubsub/blob/55f4ad6eb98b9e617e46641e7078944781abb54c/discovery.go#L157                                    
-        // https://github.com/libp2p/go-libp2p-pubsub/blob/55f4ad6eb98b9e617e46641e7078944781abb54c/discovery.go#L287
-        // https://github.com/libp2p/go-libp2p-discovery/blob/master/backoffconnector.go#L52
-        close(stupidCh)
-        return stupidCh, nil
+package discovery
+
+import (
+	"context"
+	"time"
+
+	libp2pdisc "github.com/libp2p/go-libp2p-core/discovery"
+	pstore "github.com/libp2p/go-libp2p-peerstore" // nolint: staticcheck
+)
+
+// NoopDiscovery satisfies the discovery interface without doing anything
+type NoopDiscovery struct{}
+
+// FindPeers returns a dead channel that is always closed
+func (sd *NoopDiscovery) FindPeers(ctx context.Context, ns string, opts ...libp2pdisc.Option) (<-chan pstore.PeerInfo, error) { // nolint: staticcheck
+	stupidCh := make(chan pstore.PeerInfo) // nolint: staticcheck
+	// the output is immediately closed, discovery requests end immediately
+	// Callstack:
+	// https://github.com/libp2p/go-libp2p-pubsub/blob/55f4ad6eb98b9e617e46641e7078944781abb54c/discovery.go#L157
+	// https://github.com/libp2p/go-libp2p-pubsub/blob/55f4ad6eb98b9e617e46641e7078944781abb54c/discovery.go#L287
+	// https://github.com/libp2p/go-libp2p-discovery/blob/master/backoffconnector.go#L52
+	close(stupidCh)
+	return stupidCh, nil
 }
-                                                                                                                                                           
+
 // Advertise does nothing and returns 1 hour.
-func (sd *NoopDiscovery) Advertise(ctx context.Context, ns string, opts ...libp2pdisc.Option) (time.Duration, error) {
-        return time.Hour, nil
-}           
+func (sd *NoopDiscovery) Advertise(ctx context.Context, ns string, opts ...libp2pdisc.Option) (time.Duration, error) { // nolint: staticcheck
+	return time.Hour, nil
+}

--- a/internal/pkg/discovery/noop_discovery.go
+++ b/internal/pkg/discovery/noop_discovery.go
@@ -1,0 +1,29 @@
+package discovery                                                                                                                                 
+                                                                                                                                                         
+import (                                                                                                                                                
+        "context"
+        "time"
+	
+	pstore "github.com/libp2p/go-libp2p-peerstore"
+	libp2pdisc "github.com/libp2p/go-libp2p-core/discovery" 
+)                                                                                                                                                       
+                                                                                                                                                          
+// NoopDiscovery satisfies the discovery interface without doing anything                                                                           
+type NoopDiscovery struct {}                                                                                                                          
+                                                                                                                                                       
+// FindPeers returns a dead channel that is always closed                                                                                      
+func (sd *NoopDiscovery) FindPeers(ctx context.Context, ns string, opts ...libp2pdisc.Option) (<-chan pstore.PeerInfo, error) {                               
+        stupidCh := make(chan pstore.PeerInfo)                                                                                                             
+        // the output is immediately closed, discovery requests end immediately                                                                            
+        // Callstack:                                                                                                                                      
+        // https://github.com/libp2p/go-libp2p-pubsub/blob/55f4ad6eb98b9e617e46641e7078944781abb54c/discovery.go#L157                                    
+        // https://github.com/libp2p/go-libp2p-pubsub/blob/55f4ad6eb98b9e617e46641e7078944781abb54c/discovery.go#L287
+        // https://github.com/libp2p/go-libp2p-discovery/blob/master/backoffconnector.go#L52
+        close(stupidCh)
+        return stupidCh, nil
+}
+                                                                                                                                                           
+// Advertise does nothing and returns 1 hour.
+func (sd *NoopDiscovery) Advertise(ctx context.Context, ns string, opts ...libp2pdisc.Option) (time.Duration, error) {
+        return time.Hour, nil
+}           

--- a/internal/pkg/discovery/noop_discovery.go
+++ b/internal/pkg/discovery/noop_discovery.go
@@ -13,14 +13,14 @@ type NoopDiscovery struct{}
 
 // FindPeers returns a dead channel that is always closed
 func (sd *NoopDiscovery) FindPeers(ctx context.Context, ns string, opts ...libp2pdisc.Option) (<-chan pstore.PeerInfo, error) { // nolint: staticcheck
-	stupidCh := make(chan pstore.PeerInfo) // nolint: staticcheck
+	closedCh := make(chan pstore.PeerInfo) // nolint: staticcheck
 	// the output is immediately closed, discovery requests end immediately
 	// Callstack:
 	// https://github.com/libp2p/go-libp2p-pubsub/blob/55f4ad6eb98b9e617e46641e7078944781abb54c/discovery.go#L157
 	// https://github.com/libp2p/go-libp2p-pubsub/blob/55f4ad6eb98b9e617e46641e7078944781abb54c/discovery.go#L287
 	// https://github.com/libp2p/go-libp2p-discovery/blob/master/backoffconnector.go#L52
-	close(stupidCh)
-	return stupidCh, nil
+	close(closedCh)
+	return closedCh, nil
 }
 
 // Advertise does nothing and returns 1 hour.

--- a/internal/pkg/message/handler_integration_test.go
+++ b/internal/pkg/message/handler_integration_test.go
@@ -61,9 +61,9 @@ func TestNewHeadHandlerIntegration(t *testing.T) {
 		// First, send a message and expect to find it in the message queue and pool.
 		mid1, donePub1, err := outbox.Send(ctx, sender, dest, types.ZeroAttoFIL, gasPrice, gasUnits, true, types.MethodID(9000001))
 		require.NoError(t, err)
-		require.NotNil(t, donePub1)		
+		require.NotNil(t, donePub1)
 		require.Equal(t, 1, len(outbox.Queue().List(sender))) // Message is in the queue.
-		pub1Err := <- donePub1
+		pub1Err := <-donePub1
 		assert.NoError(t, pub1Err)
 		msg1, found := inbox.Pool().Get(mid1)
 		require.True(t, found) // Message is in the pool.
@@ -97,7 +97,7 @@ func TestNewHeadHandlerIntegration(t *testing.T) {
 		require.NotNil(t, donePub2)
 
 		// Both messages are in the pool.
-		pub2Err := <- donePub2
+		pub2Err := <-donePub2
 		assert.NoError(t, pub2Err)
 		_, found = inbox.Pool().Get(mid1)
 		require.True(t, found)

--- a/internal/pkg/message/handler_integration_test.go
+++ b/internal/pkg/message/handler_integration_test.go
@@ -59,9 +59,12 @@ func TestNewHeadHandlerIntegration(t *testing.T) {
 		inbox := handler.Inbox
 
 		// First, send a message and expect to find it in the message queue and pool.
-		mid1, err := outbox.Send(ctx, sender, dest, types.ZeroAttoFIL, gasPrice, gasUnits, true, types.MethodID(9000001))
+		mid1, donePub1, err := outbox.Send(ctx, sender, dest, types.ZeroAttoFIL, gasPrice, gasUnits, true, types.MethodID(9000001))
 		require.NoError(t, err)
+		require.NotNil(t, donePub1)		
 		require.Equal(t, 1, len(outbox.Queue().List(sender))) // Message is in the queue.
+		pub1Err := <- donePub1
+		assert.NoError(t, pub1Err)
 		msg1, found := inbox.Pool().Get(mid1)
 		require.True(t, found) // Message is in the pool.
 		assert.True(t, msg1.Equals(outbox.Queue().List(sender)[0].Msg))
@@ -86,13 +89,16 @@ func TestNewHeadHandlerIntegration(t *testing.T) {
 
 		// Send another message from the same account.
 		// First, send a message and expect to find it in the message queue and pool.
-		mid2, err := outbox.Send(ctx, sender, dest, types.ZeroAttoFIL, gasPrice, gasUnits, true, types.MethodID(9000002))
+		mid2, donePub2, err := outbox.Send(ctx, sender, dest, types.ZeroAttoFIL, gasPrice, gasUnits, true, types.MethodID(9000002))
 		// This case causes the nonce to be wrongly calculated, since the first, now-unmined message
 		// is not in the outbox, and actor state has not updated, but the message pool already has
 		// a message with the same nonce.
 		require.NoError(t, err)
+		require.NotNil(t, donePub2)
 
 		// Both messages are in the pool.
+		pub2Err := <- donePub2
+		assert.NoError(t, pub2Err)
 		_, found = inbox.Pool().Get(mid1)
 		require.True(t, found)
 		msg2, found := inbox.Pool().Get(mid2)

--- a/internal/pkg/message/outbox_test.go
+++ b/internal/pkg/message/outbox_test.go
@@ -74,7 +74,7 @@ func TestOutbox(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, uint64(test.height), queue.List(sender)[0].Stamp)
 			require.NotNil(t, pubDone)
-			pubErr := <- pubDone
+			pubErr := <-pubDone
 			assert.NoError(t, pubErr)
 			require.NotNil(t, publisher.Message)
 			assert.Equal(t, test.nonce, publisher.Message.Message.CallSeqNum)

--- a/internal/pkg/message/outbox_test.go
+++ b/internal/pkg/message/outbox_test.go
@@ -39,7 +39,7 @@ func TestOutbox(t *testing.T) {
 		ob := message.NewOutbox(w, message.FakeValidator{RejectMessages: true}, queue, publisher,
 			message.NullPolicy{}, provider, provider, newOutboxTestJournal(t))
 
-		cid, err := ob.Send(context.Background(), sender, sender, types.NewAttoFILFromFIL(2), types.NewGasPrice(0), types.NewGasUnits(0), bcast, types.InvalidMethodID)
+		cid, _, err := ob.Send(context.Background(), sender, sender, types.NewAttoFILFromFIL(2), types.NewGasPrice(0), types.NewGasUnits(0), bcast, types.InvalidMethodID)
 		assert.Errorf(t, err, "for testing")
 		assert.False(t, cid.Defined())
 	})
@@ -70,10 +70,13 @@ func TestOutbox(t *testing.T) {
 		}{{true, actr.Nonce, 1000}, {false, actr.Nonce + 1, 1000}}
 
 		for _, test := range testCases {
-			_, err := ob.Send(context.Background(), sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), types.NewGasUnits(0), test.bcast, types.InvalidMethodID)
+			_, pubDone, err := ob.Send(context.Background(), sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), types.NewGasUnits(0), test.bcast, types.InvalidMethodID)
 			require.NoError(t, err)
 			assert.Equal(t, uint64(test.height), queue.List(sender)[0].Stamp)
-			assert.NotNil(t, publisher.Message)
+			require.NotNil(t, pubDone)
+			pubErr := <- pubDone
+			assert.NoError(t, pubErr)
+			require.NotNil(t, publisher.Message)
 			assert.Equal(t, test.nonce, publisher.Message.Message.CallSeqNum)
 			assert.Equal(t, uint64(test.height), publisher.Height)
 			assert.Equal(t, test.bcast, publisher.Bcast)
@@ -107,7 +110,7 @@ func TestOutbox(t *testing.T) {
 			defer wg.Done()
 			for i := 0; i < msgCount; i++ {
 				method := types.MethodID(batch*10000 + i)
-				_, err := s.Send(ctx, sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), types.NewGasUnits(0), bcast, method, []byte{})
+				_, _, err := s.Send(ctx, sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), types.NewGasUnits(0), bcast, method, []byte{})
 				require.NoError(t, err)
 			}
 		}
@@ -151,7 +154,7 @@ func TestOutbox(t *testing.T) {
 
 		ob := message.NewOutbox(w, message.FakeValidator{}, queue, publisher, message.NullPolicy{}, provider, provider, newOutboxTestJournal(t))
 
-		_, err := ob.Send(context.Background(), sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), types.NewGasUnits(0), true, types.InvalidMethodID)
+		_, _, err := ob.Send(context.Background(), sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), types.NewGasUnits(0), true, types.InvalidMethodID)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "account or empty")
 	})

--- a/internal/pkg/net/pubsub/topic.go
+++ b/internal/pkg/net/pubsub/topic.go
@@ -46,9 +46,11 @@ func (t *Topic) Subscribe() (Subscription, error) {
 	return &subscriptionWrapper{sub}, err
 }
 
-// Publish publishes to a pubsub topic
+// Publish publishes to a pubsub topic. It blocks until there is at least one 
+// peer on the mesh that can receive the publish.
 func (t *Topic) Publish(ctx context.Context, data []byte) error {
-	return t.pubsubTopic.Publish(ctx, data)
+//	return t.pubsubTopic.Publish(ctx, data)
+	return t.pubsubTopic.Publish(ctx, data, libp2p.WithReadiness(libp2p.MinTopicSize(1)))
 }
 
 // subscriptionWrapper extends a pubsub.Subscription in order to wrap the Message type.

--- a/internal/pkg/net/pubsub/topic.go
+++ b/internal/pkg/net/pubsub/topic.go
@@ -46,10 +46,10 @@ func (t *Topic) Subscribe() (Subscription, error) {
 	return &subscriptionWrapper{sub}, err
 }
 
-// Publish publishes to a pubsub topic. It blocks until there is at least one 
+// Publish publishes to a pubsub topic. It blocks until there is at least one
 // peer on the mesh that can receive the publish.
 func (t *Topic) Publish(ctx context.Context, data []byte) error {
-//	return t.pubsubTopic.Publish(ctx, data)
+	//	return t.pubsubTopic.Publish(ctx, data)
 	return t.pubsubTopic.Publish(ctx, data, libp2p.WithReadiness(libp2p.MinTopicSize(1)))
 }
 

--- a/internal/pkg/protocol/mining/mining_api.go
+++ b/internal/pkg/protocol/mining/mining_api.go
@@ -3,6 +3,7 @@ package mining
 import (
 	"context"
 	"time"
+	"fmt"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/mining"
@@ -80,6 +81,7 @@ func (a *API) MiningOnce(ctx context.Context) (*block.Block, error) {
 		return nil, err
 	}
 
+	fmt.Printf("mining once\n")
 	res, err := mining.MineOnce(ctx, miningWorker, a.mineDelay, ts)
 	if err != nil {
 		return nil, err
@@ -88,6 +90,7 @@ func (a *API) MiningOnce(ctx context.Context) (*block.Block, error) {
 		return nil, res.Err
 	}
 
+	fmt.Printf("adding block\n")	
 	if err := a.addNewBlockFunc(ctx, res.NewBlock); err != nil {
 		return nil, err
 	}

--- a/internal/pkg/protocol/mining/mining_api.go
+++ b/internal/pkg/protocol/mining/mining_api.go
@@ -2,8 +2,8 @@ package mining
 
 import (
 	"context"
-	"time"
 	"fmt"
+	"time"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/mining"
@@ -90,7 +90,7 @@ func (a *API) MiningOnce(ctx context.Context) (*block.Block, error) {
 		return nil, res.Err
 	}
 
-	fmt.Printf("adding block\n")	
+	fmt.Printf("adding block\n")
 	if err := a.addNewBlockFunc(ctx, res.NewBlock); err != nil {
 		return nil, err
 	}

--- a/internal/pkg/protocol/storage/miner.go
+++ b/internal/pkg/protocol/storage/miner.go
@@ -93,7 +93,7 @@ type minerPorcelain interface {
 
 	ValidatePaymentVoucherCondition(ctx context.Context, condition *types.Predicate, minerAddr address.Address, commP types.CommP, pieceSize *types.BytesAmount) error
 
-	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, error)
+	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, chan error, error)
 	MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, baseKey block.TipSetKey, params ...interface{}) ([][]byte, error)
 	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*block.Block, *types.SignedMessage, *types.MessageReceipt) error) error
 	MinerGetWorkerAddress(ctx context.Context, minerAddr address.Address, baseKey block.TipSetKey) (address.Address, error)
@@ -857,7 +857,7 @@ func (sm *Miner) submitPoSt(ctx context.Context, start, end *types.BlockHeight, 
 		log.Errorf("failed to get worker address: %s", err)
 		return
 	}
-	_, err = sm.porcelainAPI.MessageSend(ctx, workerAddr, sm.minerAddr, submission.Fee, gasPrice, submission.GasLimit, miner.SubmitPoSt, submission.Proof, submission.Faults, done)
+	_, _, err = sm.porcelainAPI.MessageSend(ctx, workerAddr, sm.minerAddr, submission.Fee, gasPrice, submission.GasLimit, miner.SubmitPoSt, submission.Proof, submission.Faults, done)
 	if err != nil {
 		log.Errorf("failed to submit PoSt: %s", err)
 		return

--- a/internal/pkg/protocol/storage/miner_test.go
+++ b/internal/pkg/protocol/storage/miner_test.go
@@ -644,13 +644,13 @@ func (mtp *minerTestPorcelain) ActorGetSignature(ctx context.Context, actorAddr 
 	return signature, nil
 }
 
-func (mtp *minerTestPorcelain) MessageSend(ctx context.Context, from, to address.Address, val types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, error) {
+func (mtp *minerTestPorcelain) MessageSend(ctx context.Context, from, to address.Address, val types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, chan error, error) {
 	handler, ok := mtp.messageHandlers[method]
 	if ok {
 		_, err := handler(to, val, params...)
-		return cid.Cid{}, err
+		return cid.Cid{}, nil, err
 	}
-	return cid.Cid{}, nil
+	return cid.Cid{}, nil, nil
 }
 
 func (mtp *minerTestPorcelain) MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, _ block.TipSetKey, params ...interface{}) ([][]byte, error) {

--- a/tools/fast/fastesting/basic_test.go
+++ b/tools/fast/fastesting/basic_test.go
@@ -22,7 +22,6 @@ func TestSetFilecoinOpts(t *testing.T) {
 	}
 
 	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fastOpts)
-
 	clientNode := env.GenesisMiner
 	require.NoError(t, clientNode.MiningStart(ctx))
 	defer func() {

--- a/tools/fast/series/setup_genesis_node.go
+++ b/tools/fast/series/setup_genesis_node.go
@@ -27,7 +27,6 @@ func SetupGenesisNode(ctx context.Context, node *fast.Filecoin, minerAddress add
 		return err
 	}
 
-
 	wallet, err := node.WalletImport(ctx, minerOwner)
 	if err != nil {
 		return err

--- a/tools/fast/series/setup_genesis_node.go
+++ b/tools/fast/series/setup_genesis_node.go
@@ -27,16 +27,15 @@ func SetupGenesisNode(ctx context.Context, node *fast.Filecoin, minerAddress add
 		return err
 	}
 
+
 	wallet, err := node.WalletImport(ctx, minerOwner)
 	if err != nil {
 		return err
 	}
-
 	if err := node.ConfigSet(ctx, "wallet.defaultAddress", wallet[0].String()); err != nil {
 		return err
 	}
 
 	_, err = node.MinerUpdatePeerid(ctx, minerAddress, node.PeerID, fast.AOFromAddr(wallet[0]), fast.AOPrice(big.NewFloat(300)), fast.AOLimit(300))
-
 	return err
 }


### PR DESCRIPTION
### Motivation
We want to use gossipsub.  We also want to avoid races in the tests.  In the past attempts to integrate to gossipsub led to a race of the form
1) node A comes online
2) node A publishes a message node B needs to hear about
3) node B isn't around to hear it and the message silently drops
4) node B comes online and waits forever
5) node A waits forever on node B

This race has always been around, gossipsub just makes it worse by adding in extra steps to setup a topic mesh during subscription that caused tons of tests to hit the race.

### Proposed changes
We now have gossipsub without races by
1) updating to a new version of gossipsub
2) adding a noop discovery to our pubsub that allows publish to block until a peer exists for it
3) calling publish with an option that forces it to block until there is one other peer subscribing to the topic

This required a slight rethinking of the code that hit Publish: message send and add new block, in order to prevent daemon deadlock

4) add new block just introduces an extra goroutine wrapping publish and logs publish errors instead of propagating them
5) message send also wraps publish in a goroutine.  To help tests and for potentially useful handling down the road I've introduced a third argument from message send, an error channel that will output the result of publish.  All production code ignores the new error channel, maintaining the assumption that you can run `message send` without any peers and add the message to your pool.  The error channel seems like a step in the right direction if we keep the current architecture, though we might want to separate out the 3 different things happening with a send (queue push, pool put, pubsub publish) at a level closer to commands.

Closes issue #3630 #804 

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

