### PR TITLE
Basic Insecure Power Actor

### DIFF
--- a/cmd/go-filecoin/actor.go
+++ b/cmd/go-filecoin/actor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/initactor"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/paymentbroker"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/power"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/storagemarket"
 
 	"github.com/ipfs/go-cid"
@@ -63,6 +64,8 @@ var actorLsCmd = &cmds.Command{
 				output = makeActorView(result.Actor, result.Address, &storagemarket.Actor{})
 			case result.Actor.Code.Equals(types.PaymentBrokerActorCodeCid):
 				output = makeActorView(result.Actor, result.Address, &paymentbroker.Actor{})
+			case result.Actor.Code.Equals(types.PowerActorCodeCid):
+				output = makeActorView(result.Actor, result.Address, &power.Actor{})
 			case result.Actor.Code.Equals(types.MinerActorCodeCid):
 				output = makeActorView(result.Actor, result.Address, &miner.Actor{})
 			case result.Actor.Code.Equals(types.BootstrapMinerActorCodeCid):

--- a/cmd/go-filecoin/actor_daemon_test.go
+++ b/cmd/go-filecoin/actor_daemon_test.go
@@ -37,7 +37,7 @@ func TestActorDaemon(t *testing.T) {
 		// The order of actors is consistent, but only within builds of genesis.car.
 		// We just want to make sure the views have something valid in them.
 		for _, av := range avs {
-			assert.Contains(t, []string{"StoragemarketActor", "AccountActor", "PaymentbrokerActor", "MinerActor", "BootstrapMinerActor", "InitActor"}, av.ActorType)
+			assert.Contains(t, []string{"StoragemarketActor", "AccountActor", "PaymentbrokerActor", "PowerActor", "MinerActor", "BootstrapMinerActor", "InitActor"}, av.ActorType)
 		}
 	})
 }

--- a/internal/pkg/consensus/genesis.go
+++ b/internal/pkg/consensus/genesis.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/initactor"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/paymentbroker"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/power"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/storagemarket"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
@@ -256,6 +257,16 @@ func SetupDefaultActors(ctx context.Context, st state.Tree, storageMap vm.Storag
 		return err
 	}
 	if err = st.SetActor(ctx, address.PaymentBrokerAddress, pbAct); err != nil {
+		return err
+	}
+
+	powAct := power.NewActor()
+	err = (&power.Actor{}).InitializeState(storageMap.NewStorage(address.PowerAddress, powAct), nil)
+	if err != nil {
+		return err
+	}
+	err = st.SetActor(ctx, address.PowerAddress, powAct)
+	if err != nil {
 		return err
 	}
 

--- a/internal/pkg/types/constants.go
+++ b/internal/pkg/types/constants.go
@@ -22,6 +22,12 @@ var StorageMarketActorCodeObj ipld.Node
 // StorageMarketActorCodeCid is the cid of the above object
 var StorageMarketActorCodeCid cid.Cid
 
+// PowerActorCodeObj is the code representation of the builtin power actor
+var PowerActorCodeObj ipld.Node
+
+// PowerActorCodeCid is the cid of the above object
+var PowerActorCodeCid cid.Cid
+
 // PaymentBrokerActorCodeObj is the code representation of the builtin payment broker actor.
 var PaymentBrokerActorCodeObj ipld.Node
 
@@ -54,6 +60,8 @@ func init() {
 	AccountActorCodeCid = AccountActorCodeObj.Cid()
 	StorageMarketActorCodeObj = dag.NewRawNode([]byte("storagemarket"))
 	StorageMarketActorCodeCid = StorageMarketActorCodeObj.Cid()
+	PowerActorCodeObj = dag.NewRawNode([]byte("power"))
+	PowerActorCodeCid = PowerActorCodeObj.Cid()
 	PaymentBrokerActorCodeObj = dag.NewRawNode([]byte("paymentbroker"))
 	PaymentBrokerActorCodeCid = PaymentBrokerActorCodeObj.Cid()
 	MinerActorCodeObj = dag.NewRawNode([]byte("mineractor"))
@@ -68,6 +76,7 @@ func init() {
 	// This is good enough for now.
 	ActorCodeCidTypeNames[AccountActorCodeCid] = "AccountActor"
 	ActorCodeCidTypeNames[StorageMarketActorCodeCid] = "StorageMarketActor"
+	ActorCodeCidTypeNames[PowerActorCodeCid] = "PowerActor"
 	ActorCodeCidTypeNames[PaymentBrokerActorCodeCid] = "PaymentBrokerActor"
 	ActorCodeCidTypeNames[MinerActorCodeCid] = "MinerActor"
 	ActorCodeCidTypeNames[BootstrapMinerActorCodeCid] = "MinerActor"

--- a/internal/pkg/types/power_report.go
+++ b/internal/pkg/types/power_report.go
@@ -1,9 +1,23 @@
 package types
 
+import "github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
+
+func init() {
+	encoding.RegisterIpldCborType(PowerReport{})
+}
+
 // PowerReport reports new miner power values
 type PowerReport struct {
 	ActivePower   *BytesAmount
 	InactivePower *BytesAmount
+}
+
+// NewPowerReport returns a new power report.
+func NewPowerReport(active, inactive uint64) PowerReport {
+	return PowerReport{
+		ActivePower:   NewBytesAmount(active),
+		InactivePower: NewBytesAmount(inactive),
+	}
 }
 
 // FaultReport reports new miner storage faults

--- a/internal/pkg/types/power_report.go
+++ b/internal/pkg/types/power_report.go
@@ -1,0 +1,14 @@
+package types
+
+// PowerReport reports new miner power values
+type PowerReport struct {
+	ActivePower   *BytesAmount
+	InactivePower *BytesAmount
+}
+
+// FaultReport reports new miner storage faults
+type FaultReport struct {
+	NewDeclaredFaults   uint
+	NewDetectedFaults   uint
+	NewTerminatedFaults uint
+}

--- a/internal/pkg/vm/abi/abi.go
+++ b/internal/pkg/vm/abi/abi.go
@@ -65,6 +65,10 @@ const (
 	MinerPoStStates
 	// FaultSet is the faults generated during PoSt generation
 	FaultSet
+	// PowerReport is a tuple of *types.ByteAmount
+	PowerReport
+	// FaultReport is a triple of integers
+	FaultReport
 )
 
 func (t Type) String() string {
@@ -113,6 +117,10 @@ func (t Type) String() string {
 		return "*map[string]uint64"
 	case FaultSet:
 		return "types.FaultSet"
+	case PowerReport:
+		return "types.PowerReport"
+	case FaultReport:
+		return "types.FaultReport"
 	default:
 		return "<unknown type>"
 	}
@@ -170,6 +178,10 @@ func (av *Value) String() string {
 		return fmt.Sprint(av.Val.(*map[address.Address]uint8))
 	case FaultSet:
 		return av.Val.(types.FaultSet).String()
+	case PowerReport:
+		return fmt.Sprint(av.Val.(types.PowerReport))
+	case FaultReport:
+		return fmt.Sprint(av.Val.(types.FaultReport))
 	default:
 		return "<unknown type>"
 	}
@@ -332,6 +344,18 @@ func (av *Value) Serialize() ([]byte, error) {
 			return nil, &typeError{types.FaultSet{}, av.Val}
 		}
 		return encoding.Encode(fs)
+	case PowerReport:
+		pr, ok := av.Val.(types.PowerReport)
+		if !ok {
+			return nil, &typeError{types.PowerReport{}, av.Val}
+		}
+		return encoding.Encode(pr)
+	case FaultReport:
+		fr, ok := av.Val.(types.FaultReport)
+		if !ok {
+			return nil, &typeError{types.FaultReport{}, av.Val}
+		}
+		return encoding.Encode(fr)
 	default:
 		return nil, fmt.Errorf("unrecognized Type: %d", av.Type)
 	}
@@ -389,6 +413,10 @@ func ToValues(i []interface{}) ([]*Value, error) {
 			out = append(out, &Value{Type: MinerPoStStates, Val: v})
 		case types.FaultSet:
 			out = append(out, &Value{Type: FaultSet, Val: v})
+		case types.PowerReport:
+			out = append(out, &Value{Type: PowerReport, Val: v})
+		case types.FaultReport:
+			out = append(out, &Value{Type: FaultReport, Val: v})
 		default:
 			return nil, fmt.Errorf("unsupported type: %T", v)
 		}
@@ -560,6 +588,26 @@ func Deserialize(data []byte, t Type) (*Value, error) {
 			Type: t,
 			Val:  fs,
 		}, nil
+	case PowerReport:
+		var pr types.PowerReport
+		err := encoding.Decode(data, &pr)
+		if err != nil {
+			return nil, err
+		}
+		return &Value{
+			Type: t,
+			Val:  pr,
+		}, nil
+	case FaultReport:
+		var fr types.FaultReport
+		err := encoding.Decode(data, &fr)
+		if err != nil {
+			return nil, err
+		}
+		return &Value{
+			Type: t,
+			Val:  fr,
+		}, nil
 	case Invalid:
 		return nil, ErrInvalidType
 	default:
@@ -589,6 +637,8 @@ var typeTable = map[Type]reflect.Type{
 	IntSet:          reflect.TypeOf(types.IntSet{}),
 	MinerPoStStates: reflect.TypeOf(&map[string]uint64{}),
 	FaultSet:        reflect.TypeOf(types.FaultSet{}),
+	PowerReport:     reflect.TypeOf(types.PowerReport{}),
+	FaultReport:     reflect.TypeOf(types.FaultReport{}),
 }
 
 // TypeMatches returns whether or not 'val' is the go type expected for the given ABI type

--- a/internal/pkg/vm/actor/actor.go
+++ b/internal/pkg/vm/actor/actor.go
@@ -124,6 +124,10 @@ func InitBuiltinActorCodeObjs(cst *hamt.CborIpldStore) error {
 	if err := cst.Blocks.AddBlock(types.PaymentBrokerActorCodeObj); err != nil {
 		return err
 	}
+	if err := cst.Blocks.AddBlock(types.PowerActorCodeObj); err != nil {
+		return err
+	}
+
 	return cst.Blocks.AddBlock(types.InitActorCodeObj)
 
 }

--- a/internal/pkg/vm/actor/builtin/builtin.go
+++ b/internal/pkg/vm/actor/builtin/builtin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/initactor"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/paymentbroker"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/power"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/storagemarket"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/dispatch"
 	cid "github.com/ipfs/go-cid"
@@ -66,6 +67,7 @@ func (bab *BuiltinActorsBuilder) Build() Actors {
 var DefaultActors = NewBuilder().
 	Add(types.AccountActorCodeCid, 0, &account.Actor{}).
 	Add(types.StorageMarketActorCodeCid, 0, &storagemarket.Actor{}).
+	Add(types.PowerActorCodeCid, 0, &power.Actor{}).
 	Add(types.PaymentBrokerActorCodeCid, 0, &paymentbroker.Actor{}).
 	Add(types.MinerActorCodeCid, 0, &miner.Actor{}).
 	Add(types.BootstrapMinerActorCodeCid, 0, &miner.Actor{Bootstrap: true}).

--- a/internal/pkg/vm/actor/builtin/power/power.go
+++ b/internal/pkg/vm/actor/builtin/power/power.go
@@ -21,6 +21,11 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/storage"
 )
 
+func init() {
+	encoding.RegisterIpldCborType(State{})
+	encoding.RegisterIpldCborType(TableEntry{})
+}
+
 // Actor provides bookkeeping for the storage power of registered mienrs.
 // It updates power based on faults and storage proofs.
 // It also tracks pledge collateral conditions.
@@ -174,7 +179,7 @@ func (*impl) createStorageMiner(vmctx runtime.Runtime, ownerAddr, workerAddr add
 			}
 
 			// Create fresh entry
-			err = lookup.Set(ctx, addr.String(), &TableEntry{
+			err = lookup.Set(ctx, addr.String(), TableEntry{
 				ActivePower:            types.NewBytesAmount(0),
 				InactivePower:          types.NewBytesAmount(0),
 				AvailableBalance:       types.ZeroAttoFIL,
@@ -251,7 +256,7 @@ func (*impl) getTotalPower(vmctx runtime.Runtime) (*types.BytesAmount, uint8, er
 		total := types.NewBytesAmount(0)
 		err := actor.WithLookupForReading(ctx, vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
 			return lookup.ForEachValue(ctx, TableEntry{}, func(k string, value interface{}) error {
-				entry, ok := value.(*TableEntry)
+				entry, ok := value.(TableEntry)
 				if !ok {
 					return errors.NewFaultError("Expected TableEntry from power table lookup")
 				}

--- a/internal/pkg/vm/actor/builtin/power/power.go
+++ b/internal/pkg/vm/actor/builtin/power/power.go
@@ -1,0 +1,303 @@
+package power
+
+import (
+	"context"
+	"reflect"
+
+	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-hamt-ipld"
+	"github.com/libp2p/go-libp2p-core/peer"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/abi"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/miner"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/errors"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/dispatch"
+	internal "github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/errors"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/runtime"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/storage"
+)
+
+// Actor provides bookkeeping for the storage power of registered mienrs.
+// It updates power based on faults and storage proofs.
+// It also tracks pledge collateral conditions.
+type Actor struct{}
+
+// State keeps track of power and collateral of registered miner actors
+type State struct {
+	// PowerTable is a lookup mapping actorAddr -> PowerTableEntry
+	PowerTable cid.Cid `refmt:",omitempty"`
+}
+
+// TableEntry tracks a single miner actor's power and collateral
+type TableEntry struct {
+	ActivePower            *types.BytesAmount
+	InactivePower          *types.BytesAmount
+	AvailableBalance       types.AttoFIL
+	LockedPledgeCollateral types.AttoFIL
+}
+
+// Actor Methods
+const (
+	CreateStorageMiner types.MethodID = iota + 32
+	RemoveStorageMiner
+	GetTotalPower
+	EnsurePledgeCollateralSatisfied
+	ProcessPowerReport
+	ProcessFaultReport
+	// ReportConsensusFault
+	// Surprise
+	// AddBalance ? (review: is this a runtime builtin?)
+	// WithdrawBalance ? (review: is this a runtime builtin?)
+)
+
+// NewActor returns a new power actor
+func NewActor() *actor.Actor {
+	return actor.NewActor(types.PowerActorCodeCid, types.ZeroAttoFIL)
+}
+
+//
+// ExecutableActor impl for Actor
+//
+
+var _ dispatch.ExecutableActor = (*Actor)(nil)
+
+var signatures = dispatch.Exports{
+	CreateStorageMiner: &dispatch.FunctionSignature{
+		Params: []abi.Type{abi.Address, abi.Address, abi.PeerID, abi.BytesAmount},
+		Return: []abi.Type{abi.Address},
+	},
+	RemoveStorageMiner: &dispatch.FunctionSignature{
+		Params: []abi.Type{abi.Address},
+		Return: nil,
+	},
+	GetTotalPower: &dispatch.FunctionSignature{
+		Params: nil,
+		Return: []abi.Type{abi.BytesAmount},
+	},
+	ProcessPowerReport: &dispatch.FunctionSignature{
+		Params: []abi.Type{abi.PowerReport, abi.Address},
+		Return: nil,
+	},
+}
+
+// Method returns method definition for a given method id.
+func (a *Actor) Method(id types.MethodID) (dispatch.Method, *dispatch.FunctionSignature, bool) {
+	switch id {
+	case CreateStorageMiner:
+		return reflect.ValueOf((*impl)(a).createStorageMiner), signatures[CreateStorageMiner], true
+	case RemoveStorageMiner:
+		return reflect.ValueOf((*impl)(a).removeStorageMiner), signatures[RemoveStorageMiner], true
+	case GetTotalPower:
+		return reflect.ValueOf((*impl)(a).getTotalPower), signatures[GetTotalPower], true
+	case ProcessPowerReport:
+		return reflect.ValueOf((*impl)(a).processPowerReport), signatures[ProcessPowerReport], true
+	default:
+		return nil, nil, false
+	}
+}
+
+// InitializeState stores the actor's initial data structure.
+func (*Actor) InitializeState(storage runtime.Storage, _ interface{}) error {
+	initStorage := &State{}
+	stateBytes, err := encoding.Encode(initStorage)
+	if err != nil {
+		return err
+	}
+
+	id, err := storage.Put(stateBytes)
+	if err != nil {
+		return err
+	}
+
+	return storage.Commit(id, cid.Undef)
+}
+
+//
+// vm methods for actor
+//
+
+type impl Actor
+
+const (
+	// ErrDeleteMinerWithPower signals that RemoveStorageMiner was called on an actor with nonzero power
+	ErrDeleteMinerWithPower = 100
+	// ErrUnknownEntry entry is returned when the actor attempts to access a power table entry at an address not in the power table
+	ErrUnknownEntry = 101
+	// ErrDuplicateEntry is returned when there is an attempt to create a new power table entry at an existing addrErr
+	ErrDuplicateEntry = 102
+)
+
+// Errors map error codes to revert errors this actor may return.
+var Errors = map[uint8]error{
+	ErrDeleteMinerWithPower: errors.NewCodedRevertError(ErrDeleteMinerWithPower, "cannot delete miner with power from power table"),
+	ErrUnknownEntry:         errors.NewCodedRevertError(ErrUnknownEntry, "cannot find address in power table"),
+	ErrDuplicateEntry:       errors.NewCodedRevertError(ErrDuplicateEntry, "duplicate create power table entry attempt"),
+}
+
+// CreateStorageMiner creates a new record of a miner in the power table.
+func (*impl) createStorageMiner(vmctx runtime.Runtime, ownerAddr, workerAddr address.Address, pid peer.ID, sectorSize *types.BytesAmount) (address.Address, uint8, error) {
+	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
+		return address.Undef, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
+	var state State
+	ret, err := actor.WithState(vmctx, &state, func() (interface{}, error) {
+		addr, err := vmctx.AddressForNewActor()
+		if err != nil {
+			return nil, errors.FaultErrorWrap(err, "could not get address for new actor")
+		}
+
+		minerInitializationParams := miner.NewState(ownerAddr, workerAddr, pid, sectorSize)
+		if err := vmctx.CreateNewActor(addr, types.MinerActorCodeCid, minerInitializationParams); err != nil {
+			return nil, err
+		}
+
+		_, _, err = vmctx.Send(addr, types.SendMethodID, vmctx.Message().Value, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		// Update power table.
+		ctx := context.Background()
+		newPowerTable, err := actor.WithLookup(ctx, vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
+			// Do not overwrite table entry if it already exists
+			err := lookup.Find(ctx, addr.String(), nil)
+			if err != hamt.ErrNotFound { // we expect to not find the power table entry
+				if err == nil {
+					return Errors[ErrDuplicateEntry]
+				}
+				return errors.FaultErrorWrapf(err, "Error looking for new entry in power table at addres %s", addr.String())
+			}
+
+			// Create fresh entry
+			err = lookup.Set(ctx, addr.String(), &TableEntry{
+				ActivePower:            types.NewBytesAmount(0),
+				InactivePower:          types.NewBytesAmount(0),
+				AvailableBalance:       types.ZeroAttoFIL,
+				LockedPledgeCollateral: types.ZeroAttoFIL,
+			})
+			if err != nil {
+				return errors.FaultErrorWrapf(err, "Could not set power table at address: %s", addr.String())
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		state.PowerTable = newPowerTable
+		return addr, nil
+	})
+	if err != nil {
+		return address.Undef, errors.CodeError(err), err
+	}
+
+	return ret.(address.Address), 0, nil
+}
+
+// RemoveStorageMiner removes the given miner address from the power table.  This call will fail if
+// the miner has any power remaining in the table or if the actor does not already exit in the table.
+func (*impl) removeStorageMiner(vmctx runtime.Runtime, delAddr address.Address) (uint8, error) {
+	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
+		return internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
+	var state State
+	_, err := actor.WithState(vmctx, &state, func() (interface{}, error) {
+		ctx := context.Background()
+		newPowerTable, err := actor.WithLookup(ctx, vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
+			// Find entry to delete.
+			var delEntry TableEntry
+			err := lookup.Find(ctx, delAddr.String(), &delEntry)
+			if err != nil {
+				if err == hamt.ErrNotFound {
+					return Errors[ErrUnknownEntry]
+				}
+				return errors.FaultErrorWrapf(err, "Could not retrieve power table entry with ID: %s", delAddr.String())
+			}
+
+			// Never delete an entry that still has power
+			if delEntry.ActivePower.IsPositive() || delEntry.InactivePower.IsPositive() {
+				return Errors[ErrDeleteMinerWithPower]
+			}
+
+			// All clear to delete
+			return lookup.Delete(ctx, delAddr.String())
+		})
+		if err != nil {
+			return nil, err
+		}
+		state.PowerTable = newPowerTable
+		return nil, nil
+	})
+	if err != nil {
+		return errors.CodeError(err), err
+	}
+	return 0, nil
+}
+
+// GetTotalPower returns the total power (in bytes) held by all miners registered in the system
+func (*impl) getTotalPower(vmctx runtime.Runtime) (*types.BytesAmount, uint8, error) {
+	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
+		return nil, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
+	var state State
+	ret, err := actor.WithState(vmctx, &state, func() (interface{}, error) {
+		ctx := context.Background()
+		total := types.NewBytesAmount(0)
+		err := actor.WithLookupForReading(ctx, vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
+			return lookup.ForEachValue(ctx, TableEntry{}, func(k string, value interface{}) error {
+				entry, ok := value.(*TableEntry)
+				if !ok {
+					return errors.NewFaultError("Expected TableEntry from power table lookup")
+				}
+				total = total.Add(entry.ActivePower)
+				total = total.Add(entry.InactivePower)
+				return nil
+			})
+		})
+		return total, err
+	})
+	if err != nil {
+		return nil, errors.CodeError(err), err
+	}
+	return ret.(*types.BytesAmount), 0, nil
+}
+
+// ProcessPowerReport updates a registered miner's power table entry according to the power report.
+func (*impl) processPowerReport(vmctx runtime.Runtime, report types.PowerReport, updateAddr address.Address) (uint8, error) {
+	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
+		return internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
+	var state State
+	_, err := actor.WithState(vmctx, &state, func() (interface{}, error) {
+		ctx := context.Background()
+		newPowerTable, err := actor.WithLookup(ctx, vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
+			// Find entry to update.
+			var updateEntry TableEntry
+			err := lookup.Find(ctx, updateAddr.String(), &updateEntry)
+			if err != nil {
+				if err == hamt.ErrNotFound {
+					return Errors[ErrUnknownEntry]
+				}
+				return errors.FaultErrorWrapf(err, "Could not retrieve power table entry with ID: %s", updateAddr.String())
+			}
+			// All clear to update
+			return lookup.Set(ctx, updateAddr.String(), report)
+		})
+		if err != nil {
+			return nil, err
+		}
+		state.PowerTable = newPowerTable
+		return nil, nil
+	})
+	if err != nil {
+		return errors.CodeError(err), err
+	}
+	return 0, nil
+}

--- a/internal/pkg/vm/actor/builtin/power/power_test.go
+++ b/internal/pkg/vm/actor/builtin/power/power_test.go
@@ -1,0 +1,190 @@
+package power_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
+	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/abi"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/miner"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/power"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
+)
+
+func TestPowerCreateStorageMiner(t *testing.T) {
+	tf.UnitTest(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	st, vms := th.RequireCreateStorages(ctx, t)
+
+	pid := th.RequireRandomPeerID(t)
+	pdata := actor.MustConvertParams(address.TestAddress, address.TestAddress, pid, types.OneKiBSectorSize)
+	msg := types.NewUnsignedMessage(address.TestAddress, address.PowerAddress, 0, types.NewAttoFILFromFIL(100), power.CreateStorageMiner, pdata)
+	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
+	require.NoError(t, err)
+	require.Nil(t, result.ExecutionError)
+
+	outAddr, err := address.NewFromBytes(result.Receipt.Return[0])
+	require.NoError(t, err)
+
+	minerActor, err := st.GetActor(ctx, outAddr)
+	require.NoError(t, err)
+
+	powerAct, err := st.GetActor(ctx, address.PowerAddress)
+	require.NoError(t, err)
+
+	assert.Equal(t, types.NewAttoFILFromFIL(0), powerAct.Balance)
+	assert.Equal(t, types.NewAttoFILFromFIL(100), minerActor.Balance)
+
+	var mstor miner.State
+	builtin.RequireReadState(t, vms, outAddr, minerActor, &mstor)
+
+	assert.Equal(t, mstor.ActiveCollateral, types.NewAttoFILFromFIL(0))
+	assert.Equal(t, mstor.PeerID, pid)
+
+}
+
+func TestProcessPowerReport(t *testing.T) {
+	tf.UnitTest(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hundredAttoFIL := types.NewAttoFILFromFIL(100)
+
+	t.Run("happy path", func(t *testing.T) {
+		st, vms := th.RequireCreateStorages(ctx, t)
+		pid := th.RequireRandomPeerID(t)
+		minerAddr := requireCreateMiner(hundredAttoFIL, t, st, vms, address.TestAddress, pid, 0)
+
+		// set power
+		report1 := types.NewPowerReport(600, 5555)
+		pdata1 := actor.MustConvertParams(report1, minerAddr)
+		msg1 := types.NewUnsignedMessage(address.TestAddress, address.PowerAddress, 0, hundredAttoFIL, power.ProcessPowerReport, pdata1)
+		result1, err := th.ApplyTestMessage(st, vms, msg1, types.NewBlockHeight(0))
+		require.NoError(t, err)
+		require.Nil(t, result1.ExecutionError)
+
+		// set power again
+		report2 := types.NewPowerReport(77, 990)
+		pdata2 := actor.MustConvertParams(report2, minerAddr)
+		msg2 := types.NewUnsignedMessage(address.TestAddress, address.PowerAddress, 0, hundredAttoFIL, power.ProcessPowerReport, pdata2)
+		result2, err := th.ApplyTestMessage(st, vms, msg2, types.NewBlockHeight(0))
+		require.NoError(t, err)
+		require.Nil(t, result2.ExecutionError)
+
+	})
+
+	t.Run("process nonexistent account", func(t *testing.T) {
+		st, vms := th.RequireCreateStorages(ctx, t)
+		report := types.NewPowerReport(1, 2)
+		pdata := actor.MustConvertParams(report, address.TestAddress)
+		msg := types.NewUnsignedMessage(address.TestAddress, address.PowerAddress, 0, hundredAttoFIL, power.ProcessPowerReport, pdata)
+		result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
+		assert.NoError(t, err)
+		assert.Equal(t, power.Errors[power.ErrUnknownEntry], result.ExecutionError)
+	})
+}
+
+func TestGetTotalPower(t *testing.T) {
+	tf.UnitTest(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hundredAttoFIL := types.NewAttoFILFromFIL(100)
+
+	st, vms := th.RequireCreateStorages(ctx, t)
+	pid := th.RequireRandomPeerID(t)
+	minerAddr := requireCreateMiner(hundredAttoFIL, t, st, vms, address.TestAddress, pid, 0)
+
+	// set power
+	report1 := types.NewPowerReport(600, 400)
+	pdata1 := actor.MustConvertParams(report1, minerAddr)
+	msg1 := types.NewUnsignedMessage(address.TestAddress, address.PowerAddress, 0, hundredAttoFIL, power.ProcessPowerReport, pdata1)
+	result1, err := th.ApplyTestMessage(st, vms, msg1, types.NewBlockHeight(0))
+	require.NoError(t, err)
+	require.Nil(t, result1.ExecutionError)
+
+	// get power
+	msg2 := types.NewUnsignedMessage(address.TestAddress, address.PowerAddress, 0, hundredAttoFIL, power.GetTotalPower, nil)
+	result2, err := th.ApplyTestMessage(st, vms, msg2, types.NewBlockHeight(1))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(result2.Receipt.Return))
+	totalPowerIface, err := abi.Deserialize(result2.Receipt.Return[0], abi.BytesAmount)
+	require.NoError(t, err)
+	totalPower, ok := totalPowerIface.Val.(*types.BytesAmount)
+	require.True(t, ok)
+	assert.Equal(t, types.NewBytesAmount(1000), totalPower)
+}
+
+func TestRemoveStorageMiner(t *testing.T) {
+	tf.UnitTest(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hundredAttoFIL := types.NewAttoFILFromFIL(100)
+	t.Run("happy path", func(t *testing.T) {
+		st, vms := th.RequireCreateStorages(ctx, t)
+		pid := th.RequireRandomPeerID(t)
+		minerAddr := requireCreateMiner(hundredAttoFIL, t, st, vms, address.TestAddress, pid, 0)
+
+		pdata := actor.MustConvertParams(minerAddr)
+		msg := types.NewUnsignedMessage(address.TestAddress, address.PowerAddress, 0, hundredAttoFIL, power.RemoveStorageMiner, pdata)
+		result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
+		assert.NoError(t, err)
+		assert.Nil(t, result.ExecutionError)
+	})
+
+	t.Run("remove nonempty fails", func(t *testing.T) {
+		st, vms := th.RequireCreateStorages(ctx, t)
+		pid := th.RequireRandomPeerID(t)
+		minerAddr := requireCreateMiner(hundredAttoFIL, t, st, vms, address.TestAddress, pid, 0)
+
+		// set power
+		report1 := types.NewPowerReport(600, 400)
+		pdata1 := actor.MustConvertParams(report1, minerAddr)
+		msg1 := types.NewUnsignedMessage(address.TestAddress, address.PowerAddress, 0, hundredAttoFIL, power.ProcessPowerReport, pdata1)
+		result1, err := th.ApplyTestMessage(st, vms, msg1, types.NewBlockHeight(0))
+		require.NoError(t, err)
+		require.Nil(t, result1.ExecutionError)
+
+		pdata2 := actor.MustConvertParams(minerAddr)
+		msg2 := types.NewUnsignedMessage(address.TestAddress, address.PowerAddress, 0, hundredAttoFIL, power.RemoveStorageMiner, pdata2)
+		result2, err := th.ApplyTestMessage(st, vms, msg2, types.NewBlockHeight(0))
+		require.NoError(t, err)
+		assert.Equal(t, power.Errors[power.ErrDeleteMinerWithPower], result2.ExecutionError)
+	})
+
+	t.Run("remove nonexistent fails", func(t *testing.T) {
+		st, vms := th.RequireCreateStorages(ctx, t)
+		pdata := actor.MustConvertParams(address.TestAddress)
+		msg := types.NewUnsignedMessage(address.TestAddress, address.PowerAddress, 0, hundredAttoFIL, power.RemoveStorageMiner, pdata)
+		result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
+		require.NoError(t, err)
+		assert.Equal(t, power.Errors[power.ErrUnknownEntry], result.ExecutionError)
+	})
+}
+
+// helpers
+func requireCreateMiner(collateral types.AttoFIL, t *testing.T, st state.Tree, vms vm.StorageMap, minerOwnerAddr address.Address, pid peer.ID, height uint64) address.Address {
+	pdata := actor.MustConvertParams(minerOwnerAddr, minerOwnerAddr, pid, types.OneKiBSectorSize)
+	msg := types.NewUnsignedMessage(address.TestAddress, address.PowerAddress, 0, collateral, power.CreateStorageMiner, pdata)
+	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
+	require.NoError(t, err)
+	require.Nil(t, result.ExecutionError)
+
+	minerAddr, err := address.NewFromBytes(result.Receipt.Return[0])
+	require.NoError(t, err)
+	return minerAddr
+}

--- a/internal/pkg/vm/address/constants.go
+++ b/internal/pkg/vm/address/constants.go
@@ -41,6 +41,11 @@ func init() {
 		panic(err)
 	}
 
+	PowerAddress, err = NewIDAddress(4)
+	if err != nil {
+		panic(err)
+	}
+
 	BurntFundsAddress, err = NewIDAddress(99)
 	if err != nil {
 		panic(err)
@@ -61,6 +66,8 @@ var (
 	StorageMarketAddress Address
 	// PaymentBrokerAddress is the hard-coded address of the filecoin payment broker actor.
 	PaymentBrokerAddress Address
+	// PowerAddress is the hard-coded address of the filecoin power actor.
+	PowerAddress Address
 	// BurntFundsAddress is the hard-coded address of the burnt funds account actor.
 	BurntFundsAddress Address
 )

--- a/internal/pkg/vm/internal/vmcontext/vmcontext.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext.go
@@ -131,7 +131,7 @@ func (ctx *VMContext) Send(to address.Address, method types.MethodID, value type
 
 	msg := types.NewUnsignedMessage(from, to, 0, value, method, paramData)
 	if msg.From == msg.To {
-		// TODO: handle this
+		// TODO 3647: handle this
 		return nil, 1, errors.NewFaultErrorf("unhandled: sending to self (%s)", msg.From)
 	}
 


### PR DESCRIPTION
### Motivation

We need a power actor distinct from both miner actor and storage market actor per the new 
[spec](https://filecoin-project.github.io/specs/#storagepoweractor-implementation)

This PR introduces it

#### Caveats

-Power updates can be called by anyone so totally insecure (but useful for mocking out power for tests before we have a correct miner in the state machine)
- Missing all power actor calls unrelated to table updates
- Uses old vm infrastructure and patterns, it might need to change a lot with upcoming changes

### Proposed changes
New Power Actor in state machine
Rest of system does not interact with it, that comes next

Closes issue #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

