### PR TITLE
Remove a bunch of unnecessary block services wrapping blockstores.

### DIFF
--- a/internal/app/go-filecoin/internal/submodule/blockstore_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/blockstore_submodule.go
@@ -3,11 +3,9 @@ package submodule
 import (
 	"context"
 
-	bserv "github.com/ipfs/go-blockservice"
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-hamt-ipld"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
-	offline "github.com/ipfs/go-ipfs-exchange-offline"
 )
 
 // BlockstoreSubmodule enhances the `Node` with local key/value storing capabilities.
@@ -33,10 +31,10 @@ func NewBlockstoreSubmodule(ctx context.Context, repo blockstoreRepo) (Blockstor
 	// set up block store
 	bs := bstore.NewBlockstore(repo.Datastore())
 	// setup a ipldCbor on top of the local store
-	ipldCborStore := hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
+	ipldCborStore := hamt.CSTFromBstore(bs)
 
 	return BlockstoreSubmodule{
 		Blockstore: bs,
-		CborStore:  &ipldCborStore,
+		CborStore:  ipldCborStore,
 	}, nil
 }

--- a/internal/app/go-filecoin/internal/submodule/network_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/network_submodule.go
@@ -4,18 +4,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/config"
 	"github.com/ipfs/go-bitswap"
-	ds "github.com/ipfs/go-datastore"
-
 	bsnet "github.com/ipfs/go-bitswap/network"
-	bserv "github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
+	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-hamt-ipld"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
 	exchange "github.com/ipfs/go-ipfs-exchange-interface"
-	offline "github.com/ipfs/go-ipfs-exchange-offline"
 	offroute "github.com/ipfs/go-ipfs-routing/offline"
 	cbornode "github.com/ipfs/go-ipld-cbor"
 	"github.com/libp2p/go-libp2p"
@@ -32,6 +27,8 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/config"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/discovery"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/net"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
@@ -147,7 +144,7 @@ func NewNetworkSubmodule(ctx context.Context, config networkConfig, repo network
 }
 
 func retrieveNetworkName(ctx context.Context, genCid cid.Cid, bs bstore.Blockstore) (string, error) {
-	cborStore := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
+	cborStore := hamt.CSTFromBstore(bs)
 	var genesis block.Block
 
 	err := cborStore.Get(ctx, genCid, &genesis)

--- a/internal/app/go-filecoin/node/init.go
+++ b/internal/app/go-filecoin/node/init.go
@@ -3,10 +3,8 @@ package node
 import (
 	"context"
 
-	bserv "github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-hamt-ipld"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
-	offline "github.com/ipfs/go-ipfs-exchange-offline"
 	keystore "github.com/ipfs/go-ipfs-keystore"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/pkg/errors"
@@ -56,7 +54,7 @@ func Init(ctx context.Context, r repo.Repo, gen consensus.GenesisInitFunc, opts 
 	}
 
 	bs := bstore.NewBlockstore(r.Datastore())
-	cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
+	cst := hamt.CSTFromBstore(bs)
 	if _, err := chain.Init(ctx, r, bs, cst, gen); err != nil {
 		return errors.Wrap(err, "Could not Init Node")
 	}

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -558,7 +558,6 @@ func initSectorBuilderForNode(ctx context.Context, node *Node) (sectorbuilder.Se
 		return nil, err
 	}
 	cfg := sectorbuilder.RustSectorBuilderConfig{
-		BlockService:     node.Blockservice.Blockservice,
 		LastUsedSectorID: lastUsedSectorID,
 		MetadataDir:      stagingDir,
 		MinerAddr:        minerAddr,

--- a/internal/app/go-filecoin/node/testing.go
+++ b/internal/app/go-filecoin/node/testing.go
@@ -6,16 +6,14 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	bserv "github.com/ipfs/go-blockservice"
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-hamt-ipld"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
-	offline "github.com/ipfs/go-ipfs-exchange-offline"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/proofs/verification"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
@@ -49,9 +47,7 @@ func MakeChainSeed(t *testing.T, cfg *gengen.GenesisCfg) *ChainSeed {
 
 	mds := ds.NewMapDatastore()
 	bstore := blockstore.NewBlockstore(mds)
-	offl := offline.Exchange(bstore)
-	blkserv := bserv.New(bstore, offl)
-	cst := &hamt.CborIpldStore{Blocks: blkserv}
+	cst := hamt.CSTFromBstore(bstore)
 
 	info, err := gengen.GenGen(context.TODO(), cfg, cst, bstore, 0)
 	require.NoError(t, err)

--- a/internal/app/go-filecoin/plumbing/msg/testing.go
+++ b/internal/app/go-filecoin/plumbing/msg/testing.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"testing"
 
-	bserv "github.com/ipfs/go-blockservice"
-	hamt "github.com/ipfs/go-hamt-ipld"
+	"github.com/ipfs/go-hamt-ipld"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
-	offline "github.com/ipfs/go-ipfs-exchange-offline"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
@@ -35,7 +33,7 @@ func requiredCommonDeps(t *testing.T, gif consensus.GenesisInitFunc) *commonDeps
 // need to set some actor state up ahead of time (actor state is ultimately found in the
 // block store).
 func requireCommonDepsWithGifAndBlockstore(t *testing.T, gif consensus.GenesisInitFunc, r repo.Repo, bs bstore.Blockstore) *commonDeps {
-	cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
+	cst := hamt.CSTFromBstore(bs)
 	chainStore, err := chain.Init(context.Background(), r, bs, cst, gif)
 	require.NoError(t, err)
 	messageStore := chain.NewMessageStore(bs)

--- a/internal/pkg/consensus/actor_state_test.go
+++ b/internal/pkg/consensus/actor_state_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
-	bserv "github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-hamt-ipld"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
-	"github.com/ipfs/go-ipfs-exchange-offline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
 	. "github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
@@ -20,8 +20,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestQuery(t *testing.T) {
@@ -51,7 +49,7 @@ func TestQuery(t *testing.T) {
 			// Actor we will send the query from. The method we will call returns an Address.
 			ActorAccount(fromAddr, types.NewAttoFILFromFIL(0)),
 		)
-		cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
+		cst := hamt.CSTFromBstore(bs)
 		chainStore, err := chain.Init(context.Background(), r, bs, cst, testGen)
 		require.NoError(t, err)
 
@@ -94,7 +92,7 @@ func TestQuery(t *testing.T) {
 			// Actor we will send the query from. The method we will call returns an Address.
 			ActorAccount(fromAddr, types.NewAttoFILFromFIL(0)),
 		)
-		cst := &hamt.CborIpldStore{Blocks: bserv.New(bs, offline.Exchange(bs))}
+		cst := hamt.CSTFromBstore(bs)
 		chainStore, err := chain.Init(context.Background(), r, bs, cst, testGen)
 		require.NoError(t, err)
 

--- a/internal/pkg/consensus/expected_test.go
+++ b/internal/pkg/consensus/expected_test.go
@@ -5,17 +5,15 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/filecoin-project/go-bls-sigs"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-hamt-ipld"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
-	offline "github.com/ipfs/go-ipfs-exchange-offline"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-bls-sigs"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
@@ -229,11 +227,8 @@ func emptyMessages(numBlocks int) ([][]*types.UnsignedMessage, [][]*types.Signed
 }
 
 func setupCborBlockstore() (*hamt.CborIpldStore, blockstore.Blockstore) {
-	mds := datastore.NewMapDatastore()
-	bs := blockstore.NewBlockstore(mds)
-	offl := offline.Exchange(bs)
-	blkserv := blockservice.New(bs, offl)
-	cis := &hamt.CborIpldStore{Blocks: blkserv}
+	bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
+	cis := hamt.CSTFromBstore(bs)
 
 	return cis, bs
 }

--- a/internal/pkg/sectorbuilder/rustsectorbuilder.go
+++ b/internal/pkg/sectorbuilder/rustsectorbuilder.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"unsafe"
 
-	bserv "github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
 	"github.com/pkg/errors"
@@ -25,8 +24,7 @@ const MaxNumStagedSectors = 1
 
 // RustSectorBuilder is a struct which serves as a proxy for a SectorBuilder in Rust.
 type RustSectorBuilder struct {
-	blockService bserv.BlockService
-	ptr          unsafe.Pointer
+	ptr unsafe.Pointer
 
 	// sectorSealResults is sent a value whenever seal completes for a sector,
 	// either successfully or with a failure.
@@ -46,7 +44,6 @@ var _ SectorBuilder = &RustSectorBuilder{}
 // RustSectorBuilderConfig is a configuration object used when instantiating a
 // Rust-backed SectorBuilder through the FFI. All fields are required.
 type RustSectorBuilderConfig struct {
-	BlockService     bserv.BlockService
 	LastUsedSectorID uint64
 	MetadataDir      string
 	MinerAddr        address.Address
@@ -63,7 +60,6 @@ func NewRustSectorBuilder(cfg RustSectorBuilderConfig) (*RustSectorBuilder, erro
 	}
 
 	sb := &RustSectorBuilder{
-		blockService:      cfg.BlockService,
 		ptr:               ptr,
 		sectorSealResults: make(chan SectorSealResult),
 		SectorClass:       cfg.SectorClass,

--- a/internal/pkg/sectorbuilder/testing/builder.go
+++ b/internal/pkg/sectorbuilder/testing/builder.go
@@ -78,7 +78,6 @@ func (b *Builder) Build() Harness {
 	class := types.NewSectorClass(types.OneKiBSectorSize)
 
 	sb, err := sectorbuilder.NewRustSectorBuilder(sectorbuilder.RustSectorBuilderConfig{
-		BlockService:     blockService,
 		LastUsedSectorID: 0,
 		MetadataDir:      b.stagingDir,
 		MinerAddr:        minerAddr,

--- a/tools/gengen/util/gengen.go
+++ b/tools/gengen/util/gengen.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/filecoin-project/go-amt-ipld"
+
 	"github.com/filecoin-project/go-bls-sigs"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
@@ -320,15 +321,11 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 
 // GenGenesisCar generates a car for the given genesis configuration
 func GenGenesisCar(cfg *GenesisCfg, out io.Writer, seed int64) (*RenderedGenInfo, error) {
-	// TODO: these six lines are ugly. We can do better...
-	mds := ds.NewMapDatastore()
-	bstore := blockstore.NewBlockstore(mds)
-	offl := offline.Exchange(bstore)
-	blkserv := bserv.New(bstore, offl)
-	cst := &hamt.CborIpldStore{Blocks: blkserv}
-	dserv := dag.NewDAGService(blkserv)
-
 	ctx := context.Background()
+
+	bstore := blockstore.NewBlockstore(ds.NewMapDatastore())
+	cst := hamt.CSTFromBstore(bstore)
+	dserv := dag.NewDAGService(bserv.New(bstore, offline.Exchange(bstore)))
 
 	info, err := GenGen(ctx, cfg, cst, bstore, seed)
 	if err != nil {

--- a/tools/gengen/util/gengen_test.go
+++ b/tools/gengen/util/gengen_test.go
@@ -5,11 +5,9 @@ import (
 	"io/ioutil"
 	"testing"
 
-	bserv "github.com/ipfs/go-blockservice"
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-hamt-ipld"
 	"github.com/ipfs/go-ipfs-blockstore"
-	"github.com/ipfs/go-ipfs-exchange-offline"
 
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
@@ -62,16 +60,11 @@ func TestGenGenLoading(t *testing.T) {
 func TestGenGenDeterministicBetweenBuilds(t *testing.T) {
 	tf.UnitTest(t)
 
+	ctx := context.Background()
 	var info *RenderedGenInfo
 	for i := 0; i < 50; i++ {
-		mds := ds.NewMapDatastore()
-		bstore := blockstore.NewBlockstore(mds)
-		offl := offline.Exchange(bstore)
-		blkserv := bserv.New(bstore, offl)
-		cst := &hamt.CborIpldStore{Blocks: blkserv}
-
-		ctx := context.Background()
-
+		bstore := blockstore.NewBlockstore(ds.NewMapDatastore())
+		cst := hamt.CSTFromBstore(bstore)
 		inf, err := GenGen(ctx, testConfig, cst, bstore, 0)
 		assert.NoError(t, err)
 		if info == nil {


### PR DESCRIPTION
### Motivation
Most places we instantiate a blockservice, it's "offline" and adds no value. The hamt package provides a wrapper to adapt to the required interface.

### Proposed changes
Call `hamt.CSTFromBstore` where possible.
Also remove unnecessary blockservice from sector builder.
