### PR TITLE
Change StorageMinerActor.GetProvingWindow to return UIntArray instead of multiple returns.

### DIFF
--- a/internal/app/go-filecoin/porcelain/client.go
+++ b/internal/app/go-filecoin/porcelain/client.go
@@ -79,13 +79,13 @@ func listAsksFromActorResult(ctx context.Context, plumbing claPlubming, actorRes
 		return err
 	}
 
-	var asksIds []uint64
+	var asksIds []types.Uint64
 	if err := encoding.Decode(ret[0], &asksIds); err != nil {
 		return err
 	}
 
 	for _, id := range asksIds {
-		ask, err := getAskByID(ctx, plumbing, addr, id)
+		ask, err := getAskByID(ctx, plumbing, addr, uint64(id))
 		if err != nil {
 			return err
 		}

--- a/internal/app/go-filecoin/porcelain/client_test.go
+++ b/internal/app/go-filecoin/porcelain/client_test.go
@@ -65,7 +65,7 @@ func (cla *claPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Ad
 	}
 
 	if method == miner.GetAsks {
-		askIDs, _ := encoding.Encode([]uint64{0})
+		askIDs, _ := encoding.Encode([]types.Uint64{0})
 		return [][]byte{askIDs}, nil
 	}
 

--- a/internal/app/go-filecoin/porcelain/miner.go
+++ b/internal/app/go-filecoin/porcelain/miner.go
@@ -409,7 +409,12 @@ func MinerGetProvingWindow(ctx context.Context, plumbing minerQueryAndDeserializ
 	if err != nil {
 		return MinerProvingWindow{}, errors.Wrap(err, "query ProvingPeriod method failed")
 	}
-	start, end := types.NewBlockHeightFromBytes(res[0]), types.NewBlockHeightFromBytes(res[1])
+
+	window, err := abi.Deserialize(res[0], abi.UintArray)
+	if err != nil {
+		return MinerProvingWindow{}, err
+	}
+	windowVal := window.Val.([]types.Uint64)
 
 	res, err = plumbing.MessageQuery(
 		ctx,
@@ -437,8 +442,8 @@ func MinerGetProvingWindow(ctx context.Context, plumbing minerQueryAndDeserializ
 	}
 
 	return MinerProvingWindow{
-		Start:      *start,
-		End:        *end,
+		Start:      *types.NewBlockHeight(uint64(windowVal[0])),
+		End:        *types.NewBlockHeight(uint64(windowVal[1])),
 		ProvingSet: commitments,
 	}, nil
 }

--- a/internal/app/go-filecoin/porcelain/miner_test.go
+++ b/internal/app/go-filecoin/porcelain/miner_test.go
@@ -481,7 +481,11 @@ func (mpp *minerGetProvingPeriodPlumbing) ChainHeadKey() block.TipSetKey {
 
 func (mpp *minerGetProvingPeriodPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, _ block.TipSetKey, params ...interface{}) ([][]byte, error) {
 	if method == miner.GetProvingWindow {
-		return [][]byte{types.NewBlockHeight(10).Bytes(), types.NewBlockHeight(20).Bytes()}, nil
+		ret, err := (&abi.Value{Type: abi.UintArray, Val: []types.Uint64{10, 20}}).Serialize()
+		if err != nil {
+			return nil, err
+		}
+		return [][]byte{ret}, nil
 	}
 	if method == miner.GetProvingSetCommitments {
 		commitments := make(map[string]types.Commitments)
@@ -490,7 +494,10 @@ func (mpp *minerGetProvingPeriodPlumbing) MessageQuery(ctx context.Context, optF
 			CommR:     [32]byte{1},
 			CommRStar: [32]byte{1},
 		}
-		thing, _ := encoding.Encode(commitments)
+		thing, err := encoding.Encode(commitments)
+		if err != nil {
+			return nil, err
+		}
 		return [][]byte{thing}, nil
 	}
 	return nil, fmt.Errorf("unsupported method: %s", method)

--- a/internal/pkg/protocol/storage/miner.go
+++ b/internal/pkg/protocol/storage/miner.go
@@ -838,7 +838,12 @@ func (sm *Miner) getProvingWindow() (*types.BlockHeight, *types.BlockHeight, err
 		return nil, nil, err
 	}
 
-	return types.NewBlockHeightFromBytes(res[0]), types.NewBlockHeightFromBytes(res[1]), nil
+	window, err := abi.Deserialize(res[0], abi.UintArray)
+	if err != nil {
+		return nil, nil, err
+	}
+	windowVal := window.Val.([]types.Uint64)
+	return types.NewBlockHeight(uint64(windowVal[0])), types.NewBlockHeight(uint64(windowVal[1])), nil
 }
 
 func (sm *Miner) submitPoSt(ctx context.Context, start, end *types.BlockHeight, inputs []PoStInputs) {

--- a/internal/pkg/protocol/storage/miner_test.go
+++ b/internal/pkg/protocol/storage/miner_test.go
@@ -8,19 +8,19 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/plumbing/cfg"
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/porcelain"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/sectorbuilder"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/abi"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin"
@@ -449,7 +449,7 @@ func TestOnNewHeaviestTipSet(t *testing.T) {
 
 		handlers := successMessageHandlers(t)
 		handlers[minerActor.GetProvingWindow] = func(a address.Address, v types.AttoFIL, p ...interface{}) ([][]byte, error) {
-			return mustEncodeResults(t, types.NewBlockHeight(200), types.NewBlockHeight(400)), nil
+			return mustEncodeResults(t, []types.Uint64{200, 400}), nil
 		}
 		handlers[minerActor.SubmitPoSt] = func(a address.Address, v types.AttoFIL, p ...interface{}) ([][]byte, error) {
 			postParams = p
@@ -491,7 +491,7 @@ func TestOnNewHeaviestTipSet(t *testing.T) {
 
 		handlers := successMessageHandlers(t)
 		handlers[minerActor.GetProvingWindow] = func(a address.Address, v types.AttoFIL, p ...interface{}) ([][]byte, error) {
-			return mustEncodeResults(t, types.NewBlockHeight(200), types.NewBlockHeight(400)), nil
+			return mustEncodeResults(t, []types.Uint64{200, 400}), nil
 		}
 		handlers[minerActor.SubmitPoSt] = func(a address.Address, v types.AttoFIL, p ...interface{}) ([][]byte, error) {
 			t.Error("Should not have called submit post")
@@ -520,7 +520,7 @@ func TestOnNewHeaviestTipSet(t *testing.T) {
 
 		handlers := successMessageHandlers(t)
 		handlers[minerActor.GetProvingWindow] = func(a address.Address, v types.AttoFIL, p ...interface{}) ([][]byte, error) {
-			return mustEncodeResults(t, types.NewBlockHeight(200), types.NewBlockHeight(400)), nil
+			return mustEncodeResults(t, []types.Uint64{200, 400}), nil
 		}
 		handlers[minerActor.SubmitPoSt] = func(a address.Address, v types.AttoFIL, p ...interface{}) ([][]byte, error) {
 			t.Error("Should not have called submit post")
@@ -555,7 +555,7 @@ func successMessageHandlers(t *testing.T) messageHandlerMap {
 		return mustEncodeResults(t, commitments), nil
 	}
 	handlers[minerActor.GetProvingWindow] = func(a address.Address, v types.AttoFIL, p ...interface{}) ([][]byte, error) {
-		return mustEncodeResults(t, types.NewBlockHeight(20003), types.NewBlockHeight(40003)), nil
+		return mustEncodeResults(t, []types.Uint64{20003, 40003}), nil
 	}
 	handlers[minerActor.SubmitPoSt] = func(a address.Address, v types.AttoFIL, p ...interface{}) ([][]byte, error) {
 		return [][]byte{}, nil

--- a/internal/pkg/vm/abi/abi.go
+++ b/internal/pkg/vm/abi/abi.go
@@ -38,7 +38,7 @@ const (
 	Bytes
 	// String is a string
 	String
-	// UintArray is an array of uint64
+	// UintArray is an array of types.Uint64
 	UintArray
 	// PeerID is a libp2p peer ID
 	PeerID
@@ -88,7 +88,7 @@ func (t Type) String() string {
 	case String:
 		return "string"
 	case UintArray:
-		return "[]uint64"
+		return "[]types.Uint64"
 	case PeerID:
 		return "peer.ID"
 	case SectorID:
@@ -145,7 +145,7 @@ func (av *Value) String() string {
 	case String:
 		return av.Val.(string)
 	case UintArray:
-		return fmt.Sprint(av.Val.([]uint64))
+		return fmt.Sprint(av.Val.([]types.Uint64))
 	case PeerID:
 		return av.Val.(peer.ID).String()
 	case SectorID:
@@ -242,9 +242,9 @@ func (av *Value) Serialize() ([]byte, error) {
 
 		return []byte(s), nil
 	case UintArray:
-		arr, ok := av.Val.([]uint64)
+		arr, ok := av.Val.([]types.Uint64)
 		if !ok {
-			return nil, &typeError{[]uint64{}, av.Val}
+			return nil, &typeError{[]types.Uint64{}, av.Val}
 		}
 
 		return encoding.Encode(arr)
@@ -363,7 +363,7 @@ func ToValues(i []interface{}) ([]*Value, error) {
 			out = append(out, &Value{Type: Bytes, Val: v})
 		case string:
 			out = append(out, &Value{Type: String, Val: v})
-		case []uint64:
+		case []types.Uint64:
 			out = append(out, &Value{Type: UintArray, Val: v})
 		case peer.ID:
 			out = append(out, &Value{Type: PeerID, Val: v})
@@ -459,7 +459,7 @@ func Deserialize(data []byte, t Type) (*Value, error) {
 			Val:  string(data),
 		}, nil
 	case UintArray:
-		var arr []uint64
+		var arr []types.Uint64
 		if err := encoding.Decode(data, &arr); err != nil {
 			return nil, err
 		}
@@ -576,7 +576,7 @@ var typeTable = map[Type]reflect.Type{
 	BlockHeight:     reflect.TypeOf(&types.BlockHeight{}),
 	Integer:         reflect.TypeOf(&big.Int{}),
 	String:          reflect.TypeOf(string("")),
-	UintArray:       reflect.TypeOf([]uint64{}),
+	UintArray:       reflect.TypeOf([]types.Uint64{}),
 	PeerID:          reflect.TypeOf(peer.ID("")),
 	SectorID:        reflect.TypeOf(uint64(0)),
 	CommitmentsMap:  reflect.TypeOf(map[string]types.Commitments{}),


### PR DESCRIPTION
### Motivation
This is the only method utilizing multiple returns. Changing this will let us change the
`dispatch.FunctionSignature` to return a single value instead of array, and then propagate
this to the MessageReceipt. See #3568.

I avoided creating a custom return type for the tuple just to save on noise, but can do so if requested. This also uses uint64 instead of `types.BlockHeight` because I expect the spec to define epoch numbers to be uint64 anyway (and we can ditch the type wrapper). Retaining the `BlockHeight` would require a custom ABI type.

### Proposed changes
Return a `UIntArray` (always of 2 elements) instead of multiple values.