### PR TITLE
Init actor Exec, GetAdressByActorID, GetActorIDByAddress

### DIFF
--- a/cmd/go-filecoin/util_test.go
+++ b/cmd/go-filecoin/util_test.go
@@ -18,7 +18,7 @@ func TestOptionalAddr(t *testing.T) {
 
 		opts := make(cmdkit.OptMap)
 
-		specifiedAddr, err := address.NewActorAddress([]byte("a new test address"))
+		specifiedAddr, err := address.NewSecp256k1Address([]byte("a new test address"))
 		require.NoError(t, err)
 		opts["from"] = specifiedAddr.String()
 

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -370,7 +370,7 @@ func (node *Node) SetupMining(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get mining address")
 	}
-	_, err = node.PorcelainAPI.ActorGet(ctx, minerAddr)
+	_, err = node.PorcelainAPI.ActorGetStable(ctx, minerAddr)
 	if err != nil {
 		return errors.Wrap(err, "failed to get miner actor")
 	}
@@ -410,7 +410,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 
 	err := node.SetupMining(ctx)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to setup mining")
 	}
 
 	minerAddr, err := node.MiningAddress()

--- a/internal/app/go-filecoin/node/node_test.go
+++ b/internal/app/go-filecoin/node/node_test.go
@@ -141,7 +141,7 @@ func TestNodeStartMining(t *testing.T) {
 	seed.GiveKey(t, minerNode, 0)
 	mineraddr, ownerAddr := seed.GiveMiner(t, minerNode, 0)
 	// Start mining give error for fail to get miner actor from the heaviest tipset stateroot
-	assert.Contains(t, minerNode.StartMining(ctx).Error(), "failed to get miner actor")
+	assert.Contains(t, minerNode.StartMining(ctx).Error(), "failed to setup mining")
 	_, err := storage.NewMiner(mineraddr, ownerAddr, &storage.FakeProver{}, types.OneKiBSectorSize, minerNode, minerNode.Repo.DealsDatastore(), nil)
 	assert.NoError(t, err)
 

--- a/internal/app/go-filecoin/porcelain/api.go
+++ b/internal/app/go-filecoin/porcelain/api.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	go_sectorbuilder "github.com/filecoin-project/go-sectorbuilder"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -45,6 +47,16 @@ type API struct {
 // New returns a new porcelain.API.
 func New(plumbing *plumbing.API) *API {
 	return &API{plumbing}
+}
+
+// ActorGetStable gets an actor by address, converting the address to an id address if necessary
+func (a *API) ActorGetStable(ctx context.Context, addr address.Address) (*actor.Actor, error) {
+	return GetStableActor(ctx, a, addr)
+}
+
+// ActorGetStableSignature gets an actor signature by address, converting the address to an id address if necessary
+func (a *API) ActorGetStableSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (_ *vm.FunctionSignature, err error) {
+	return GetStableActorSignature(ctx, a, actorAddr, method)
 }
 
 // ChainHead returns the current head tipset

--- a/internal/app/go-filecoin/porcelain/chain.go
+++ b/internal/app/go-filecoin/porcelain/chain.go
@@ -2,8 +2,14 @@ package porcelain
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/abi"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/initactor"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
@@ -40,4 +46,53 @@ func GetFullBlock(ctx context.Context, plumbing fullBlockPlumbing, id cid.Cid) (
 	}
 
 	return &out, nil
+}
+
+type getStableActorPlumbing interface {
+	ActorGet(ctx context.Context, addr address.Address) (*actor.Actor, error)
+	ChainHeadKey() block.TipSetKey
+	MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, baseKey block.TipSetKey, params ...interface{}) ([][]byte, error)
+	ActorGetSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (_ *vm.FunctionSignature, err error)
+}
+
+// GetStableActor looks up an actor by address. If the address is an actor address it will first convert it to an id address.
+func GetStableActor(ctx context.Context, plumbing getStableActorPlumbing, addr address.Address) (*actor.Actor, error) {
+	stateAddr, err := retrieveActorIDForActorAddress(ctx, plumbing, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	// get actor
+	return plumbing.ActorGet(ctx, stateAddr)
+}
+
+// GetStableActorSignature looks up and actor method signature by address. If the addresss is an actor address it will first convert it to an id address.
+func GetStableActorSignature(ctx context.Context, plumbing getStableActorPlumbing, actorAddr address.Address, method types.MethodID) (_ *vm.FunctionSignature, err error) {
+	stateAddr, err := retrieveActorIDForActorAddress(ctx, plumbing, actorAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	// get actor
+	return plumbing.ActorGetSignature(ctx, stateAddr, method)
+}
+
+func retrieveActorIDForActorAddress(ctx context.Context, plumbing getStableActorPlumbing, addr address.Address) (address.Address, error) {
+	if addr.Protocol() != address.Actor {
+		return addr, nil
+	}
+
+	head := plumbing.ChainHeadKey()
+	ret, err := plumbing.MessageQuery(ctx, address.Undef, address.InitAddress, initactor.GetActorIDForAddress, head, addr)
+	if err != nil {
+		return address.Undef, err
+	}
+
+	idVal, err := abi.Deserialize(ret[0], abi.Integer)
+	if err != nil {
+		return address.Undef, err
+	}
+
+	return address.NewIDAddress(idVal.Val.(*big.Int).Uint64())
+
 }

--- a/internal/app/go-filecoin/porcelain/miner.go
+++ b/internal/app/go-filecoin/porcelain/miner.go
@@ -258,7 +258,7 @@ func MinerPreviewSetPrice(ctx context.Context, plumbing mpspAPI, from address.Ad
 type minerQueryAndDeserialize interface {
 	ChainHeadKey() block.TipSetKey
 	MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, baseKey block.TipSetKey, params ...interface{}) ([][]byte, error)
-	ActorGetSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (*vm.FunctionSignature, error)
+	ActorGetStableSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (*vm.FunctionSignature, error)
 }
 
 // MinerGetOwnerAddress queries for the owner address of the given miner
@@ -290,7 +290,7 @@ func queryAndDeserialize(ctx context.Context, plumbing minerQueryAndDeserialize,
 		return nil, errors.Wrapf(err, "'%s' query message failed", method)
 	}
 
-	methodSignature, err := plumbing.ActorGetSignature(ctx, minerAddr, method)
+	methodSignature, err := plumbing.ActorGetStableSignature(ctx, minerAddr, method)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to acquire '%s' signature", method)
 	}
@@ -428,7 +428,7 @@ func MinerGetProvingWindow(ctx context.Context, plumbing minerQueryAndDeserializ
 		return MinerProvingWindow{}, errors.Wrap(err, "query SetCommitments method failed")
 	}
 
-	sig, err := plumbing.ActorGetSignature(ctx, minerAddr, minerActor.GetProvingSetCommitments)
+	sig, err := plumbing.ActorGetStableSignature(ctx, minerAddr, minerActor.GetProvingSetCommitments)
 	if err != nil {
 		return MinerProvingWindow{}, errors.Wrap(err, "query method failed")
 	}

--- a/internal/app/go-filecoin/porcelain/miner_test.go
+++ b/internal/app/go-filecoin/porcelain/miner_test.go
@@ -443,7 +443,7 @@ func (mgop *minerQueryAndDeserializePlumbing) MessageQuery(ctx context.Context, 
 	}
 }
 
-func (mgop *minerQueryAndDeserializePlumbing) ActorGetSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (*vm.FunctionSignature, error) {
+func (mgop *minerQueryAndDeserializePlumbing) ActorGetStableSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (*vm.FunctionSignature, error) {
 	if method == miner.GetSectorSize {
 		return &vm.FunctionSignature{
 			Params: nil,
@@ -509,7 +509,7 @@ func (mpp *minerGetProvingPeriodPlumbing) MessageQuery(ctx context.Context, optF
 	return nil, fmt.Errorf("unsupported method: %s", method)
 }
 
-func (mpp *minerGetProvingPeriodPlumbing) ActorGetSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (*vm.FunctionSignature, error) {
+func (mpp *minerGetProvingPeriodPlumbing) ActorGetStableSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (*vm.FunctionSignature, error) {
 	if method == miner.GetProvingSetCommitments {
 		return &vm.FunctionSignature{
 			Params: nil,
@@ -599,7 +599,7 @@ func (minerGetSectorSizePlumbing) ChainHeadKey() block.TipSetKey {
 func (minerGetSectorSizePlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, _ block.TipSetKey, params ...interface{}) ([][]byte, error) {
 	return [][]byte{types.NewBytesAmount(1234).Bytes()}, nil
 }
-func (minerGetSectorSizePlumbing) ActorGetSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (*vm.FunctionSignature, error) {
+func (minerGetSectorSizePlumbing) ActorGetStableSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (*vm.FunctionSignature, error) {
 	return &vm.FunctionSignature{
 		Params: nil,
 		Return: []abi.Type{abi.BytesAmount},
@@ -624,7 +624,7 @@ func (minerGetLastCommittedSectorIDPlumbing) ChainHeadKey() block.TipSetKey {
 func (minerGetLastCommittedSectorIDPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, _ block.TipSetKey, params ...interface{}) ([][]byte, error) {
 	return [][]byte{leb128.FromUInt64(5432)}, nil
 }
-func (minerGetLastCommittedSectorIDPlumbing) ActorGetSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (*vm.FunctionSignature, error) {
+func (minerGetLastCommittedSectorIDPlumbing) ActorGetStableSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (*vm.FunctionSignature, error) {
 	return &vm.FunctionSignature{
 		Params: nil,
 		Return: []abi.Type{abi.SectorID},

--- a/internal/app/go-filecoin/porcelain/protocol_test.go
+++ b/internal/app/go-filecoin/porcelain/protocol_test.go
@@ -35,9 +35,9 @@ func (tppp *testProtocolParamsPlumbing) ChainHeadKey() block.TipSetKey {
 }
 
 func (tppp *testProtocolParamsPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, _ block.TipSetKey, params ...interface{}) ([][]byte, error) {
-	if method == storagemarket.GetProofsMode {
+	if to == address.StorageMarketAddress && method == storagemarket.GetProofsMode {
 		return [][]byte{{byte(types.TestProofsMode)}}, nil
-	} else if method == initactor.GetNetwork {
+	} else if to == address.InitAddress && method == initactor.GetNetwork {
 		return [][]byte{[]byte("protocolTest")}, nil
 	}
 	return [][]byte{}, errors.Errorf("call to unknown method %s", method)

--- a/internal/pkg/chain/testing.go
+++ b/internal/pkg/chain/testing.go
@@ -60,7 +60,7 @@ func NewBuilder(t *testing.T, miner address.Address) *Builder {
 func NewBuilderWithState(t *testing.T, miner address.Address, sb StateBuilder) *Builder {
 	if miner.Empty() {
 		var err error
-		miner, err = address.NewActorAddress([]byte("miner"))
+		miner, err = address.NewSecp256k1Address([]byte("miner"))
 		require.NoError(t, err)
 	}
 

--- a/internal/pkg/chain/traversal_test.go
+++ b/internal/pkg/chain/traversal_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestIterAncestors(t *testing.T) {
 	tf.UnitTest(t)
-	miner, err := address.NewActorAddress([]byte(fmt.Sprintf("address")))
+	miner, err := address.NewSecp256k1Address([]byte(fmt.Sprintf("address")))
 	require.NoError(t, err)
 
 	t.Run("iterates", func(t *testing.T) {

--- a/internal/pkg/consensus/expected_test.go
+++ b/internal/pkg/consensus/expected_test.go
@@ -250,7 +250,7 @@ func minerAddrsFromKis(t *testing.T, kis []types.KeyInfo) []address.Address {
 	minerAddrs := make([]address.Address, len(kis))
 	var err error
 	for i := 0; i < len(kis); i++ {
-		minerAddrs[i], err = address.NewActorAddress([]byte(fmt.Sprintf("%s%s", kis[i], "Miner")))
+		minerAddrs[i], err = address.NewSecp256k1Address([]byte(fmt.Sprintf("%s%s", kis[i], "Miner")))
 
 		require.NoError(t, err)
 	}

--- a/internal/pkg/consensus/processor_test.go
+++ b/internal/pkg/consensus/processor_test.go
@@ -66,7 +66,7 @@ func TestProcessTipSetSuccess(t *testing.T) {
 	})
 
 	vms := th.VMStorage()
-	minerOwner, err := address.NewActorAddress([]byte("mo"))
+	minerOwner, err := address.NewSecp256k1Address([]byte("mo"))
 	require.NoError(t, err)
 	stCid, miner := mustCreateStorageMiner(ctx, t, st, vms, minerAddr, minerOwner)
 
@@ -139,7 +139,7 @@ func TestProcessTipsConflicts(t *testing.T) {
 		fromAddr:               act1,
 	})
 
-	minerOwner, err := address.NewActorAddress([]byte("mo"))
+	minerOwner, err := address.NewSecp256k1Address([]byte("mo"))
 	require.NoError(t, err)
 	stCid, miner := mustCreateStorageMiner(ctx, t, st, vms, minerAddr, minerOwner)
 

--- a/internal/pkg/metrics/heartbeat_test.go
+++ b/internal/pkg/metrics/heartbeat_test.go
@@ -141,7 +141,7 @@ func TestHeartbeatRunSuccess(t *testing.T) {
 	expHeight := types.Uint64(444)
 	expTs := mustMakeTipset(t, expHeight)
 
-	addr, err := address.NewActorAddress([]byte("miner address"))
+	addr, err := address.NewSecp256k1Address([]byte("miner address"))
 	require.NoError(t, err)
 
 	// The handle method will run the assertions for the test

--- a/internal/pkg/protocol/storage/miner.go
+++ b/internal/pkg/protocol/storage/miner.go
@@ -82,7 +82,7 @@ type Miner struct {
 
 // minerPorcelain is the subset of the porcelain API that storage.Miner needs.
 type minerPorcelain interface {
-	ActorGetSignature(context.Context, address.Address, types.MethodID) (*vm.FunctionSignature, error)
+	ActorGetStableSignature(context.Context, address.Address, types.MethodID) (*vm.FunctionSignature, error)
 
 	ChainHeadKey() block.TipSetKey
 	ChainTipSet(block.TipSetKey) (block.TipSet, error)
@@ -656,9 +656,9 @@ func (sm *Miner) isBootstrapMinerActor(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, errors.Wrap(err, "query method failed")
 	}
-	sig, err := sm.porcelainAPI.ActorGetSignature(ctx, sm.minerAddr, miner.IsBootstrapMiner)
+	sig, err := sm.porcelainAPI.ActorGetStableSignature(ctx, sm.minerAddr, miner.IsBootstrapMiner)
 	if err != nil {
-		return false, errors.Wrap(err, "query method failed")
+		return false, errors.Wrap(err, "method signature retrieval failed")
 	}
 
 	deserialized, err := abi.Deserialize(returnValues[0], sig.Return[0])
@@ -687,7 +687,7 @@ func (sm *Miner) getActorSectorCommitments(ctx context.Context) (map[string]type
 	if err != nil {
 		return nil, errors.Wrap(err, "query method failed")
 	}
-	sig, err := sm.porcelainAPI.ActorGetSignature(ctx, sm.minerAddr, miner.GetProvingSetCommitments)
+	sig, err := sm.porcelainAPI.ActorGetStableSignature(ctx, sm.minerAddr, miner.GetProvingSetCommitments)
 	if err != nil {
 		return nil, errors.Wrap(err, "query method failed")
 	}

--- a/internal/pkg/protocol/storage/miner_test.go
+++ b/internal/pkg/protocol/storage/miner_test.go
@@ -635,7 +635,7 @@ func newMinerTestPorcelain(t *testing.T, minerPriceString string) *minerTestPorc
 	}
 }
 
-func (mtp *minerTestPorcelain) ActorGetSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (_ *vm.FunctionSignature, err error) {
+func (mtp *minerTestPorcelain) ActorGetStableSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (_ *vm.FunctionSignature, err error) {
 	ea, error := builtin.DefaultActors.GetActorCode(types.MinerActorCodeCid, 0)
 	if error != nil {
 		return nil, err

--- a/internal/pkg/sectorbuilder/testing/builder.go
+++ b/internal/pkg/sectorbuilder/testing/builder.go
@@ -70,7 +70,7 @@ func (b *Builder) Build() Harness {
 	memRepo := repo.NewInMemoryRepo()
 	blockStore := bstore.NewBlockstore(memRepo.Datastore())
 	blockService := bserv.New(blockStore, offline.Exchange(blockStore))
-	minerAddr, err := address.NewActorAddress([]byte("wombat"))
+	minerAddr, err := address.NewSecp256k1Address([]byte("wombat"))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/pkg/sectorbuilder/utils.go
+++ b/internal/pkg/sectorbuilder/utils.go
@@ -8,21 +8,19 @@ import (
 
 // AddressToProverID creates a prover id by padding an address hash to 31 bytes
 func AddressToProverID(addr address.Address) [31]byte {
-	// this code will no longer WAE when ID's or BLS pub keys are added
-	// as they will break the assumption of addresses all being the same length
-	if addr.Protocol() != address.Actor && addr.Protocol() != address.SECP256K1 {
-		panic("cannot create prover hash from new address protocol")
+	payload := addr.Payload()
+	if len(payload) > 31 {
+		panic("cannot create prover id from address because address is too long")
 	}
-	hash := addr.Payload()
 
-	dlen := 31          // desired length
-	hlen := len(hash)   // hash length
-	padl := dlen - hlen // padding length
+	dlen := 31           // desired length
+	hlen := len(payload) // hash length
+	padl := dlen - hlen  // padding length
 
 	var prid [31]byte
 
 	// will copy dlen bytes from hash
-	copy(prid[:], hash)
+	copy(prid[:], payload)
 
 	if padl > 0 {
 		copy(prid[hlen:], bytes.Repeat([]byte{0}, padl))

--- a/internal/pkg/sectorbuilder/utils_test.go
+++ b/internal/pkg/sectorbuilder/utils_test.go
@@ -13,7 +13,7 @@ func TestSectorBuilderUtils(t *testing.T) {
 	tf.UnitTest(t)
 
 	t.Run("prover id creation", func(t *testing.T) {
-		addr, err := address.NewActorAddress([]byte("satoshi"))
+		addr, err := address.NewSecp256k1Address([]byte("satoshi"))
 		require.NoError(t, err)
 
 		id := AddressToProverID(addr)

--- a/internal/pkg/types/message.go
+++ b/internal/pkg/types/message.go
@@ -29,6 +29,8 @@ const (
 	InvalidMethodID = MethodID(0xFFFFFFFFFFFFFFFF)
 	// SendMethodID is the method ID for sending money to an actor.
 	SendMethodID = MethodID(0)
+	// ConstructorMethodID is the method ID used to initialize an actor's state.
+	ConstructorMethodID = MethodID(1)
 )
 
 // GasUnits represents number of units of gas consumed

--- a/internal/pkg/types/signed_message_test.go
+++ b/internal/pkg/types/signed_message_test.go
@@ -74,7 +74,7 @@ func TestSignedMessageCidToNode(t *testing.T) {
 }
 
 func makeMessage(t *testing.T, signer MockSigner, nonce uint64) *SignedMessage {
-	newAddr, err := address.NewActorAddress([]byte("receiver"))
+	newAddr, err := address.NewSecp256k1Address([]byte("receiver"))
 	require.NoError(t, err)
 
 	msg := NewMeteredMessage(

--- a/internal/pkg/types/testing.go
+++ b/internal/pkg/types/testing.go
@@ -161,7 +161,7 @@ func NewSignedMessageForTestGetter(ms MockSigner) func() *SignedMessage {
 	return func() *SignedMessage {
 		s := fmt.Sprintf("smsg%d", i)
 		i++
-		newAddr, err := address.NewActorAddress([]byte(s + "-to"))
+		newAddr, err := address.NewSecp256k1Address([]byte(s + "-to"))
 		if err != nil {
 			panic(err)
 		}
@@ -217,11 +217,11 @@ func NewMessageForTestGetter() func() *UnsignedMessage {
 	return func() *UnsignedMessage {
 		s := fmt.Sprintf("msg%d", i)
 		i++
-		from, err := address.NewActorAddress([]byte(s + "-from"))
+		from, err := address.NewSecp256k1Address([]byte(s + "-from"))
 		if err != nil {
 			panic(err)
 		}
-		to, err := address.NewActorAddress([]byte(s + "-to"))
+		to, err := address.NewSecp256k1Address([]byte(s + "-to"))
 		if err != nil {
 			panic(err)
 		}

--- a/internal/pkg/types/testing_messages.go
+++ b/internal/pkg/types/testing_messages.go
@@ -46,7 +46,7 @@ func (mm *MessageMaker) Signer() *MockSigner {
 func (mm *MessageMaker) NewUnsignedMessage(from address.Address, nonce uint64) *UnsignedMessage {
 	seq := mm.seq
 	mm.seq++
-	to, err := address.NewActorAddress([]byte("destination"))
+	to, err := address.NewSecp256k1Address([]byte("destination"))
 	require.NoError(mm.t, err)
 	return NewMeteredMessage(
 		from,

--- a/internal/pkg/version/protocol_version_table_test.go
+++ b/internal/pkg/version/protocol_version_table_test.go
@@ -3,7 +3,7 @@ package version
 import (
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"testing"
@@ -54,7 +54,7 @@ func TestUpgradeTable(t *testing.T) {
 	t.Run("constructing a table with no versions is an error", func(t *testing.T) {
 		_, err := NewProtocolVersionTableBuilder(network).Build()
 		require.Error(t, err)
-		assert.Matches(t, err.Error(), "no protocol versions specified for network testnetwork")
+		assert.Contains(t, err.Error(), "no protocol versions specified for network testnetwork")
 	})
 
 	t.Run("constructing a table with no version at genesis is an error", func(t *testing.T) {
@@ -62,7 +62,7 @@ func TestUpgradeTable(t *testing.T) {
 			Add(network, 2, types.NewBlockHeight(20)).
 			Build()
 		require.Error(t, err)
-		assert.Matches(t, err.Error(), "no protocol version at genesis for network testnetwork")
+		assert.Contains(t, err.Error(), "no protocol version at genesis for network testnetwork")
 	})
 
 	t.Run("ignores versions from wrong network", func(t *testing.T) {
@@ -98,7 +98,7 @@ func TestUpgradeTable(t *testing.T) {
 			Add(network, 4, types.NewBlockHeight(40)).
 			Build()
 		require.Error(t, err)
-		assert.Matches(t, err.Error(), "protocol version 2 effective at 30 is not greater than previous version, 2")
+		assert.Contains(t, err.Error(), "protocol version 2 effective at 30 is not greater than previous version, 2")
 	})
 
 	t.Run("does not permit version numbers to decline", func(t *testing.T) {
@@ -110,6 +110,6 @@ func TestUpgradeTable(t *testing.T) {
 			Add(network, 0, types.NewBlockHeight(40)).
 			Build()
 		require.Error(t, err)
-		assert.Matches(t, err.Error(), "protocol version 3 effective at 10 is not greater than previous version, 4")
+		assert.Contains(t, err.Error(), "protocol version 3 effective at 10 is not greater than previous version, 4")
 	})
 }

--- a/internal/pkg/vm/actor/builtin/initactor/init.go
+++ b/internal/pkg/vm/actor/builtin/initactor/init.go
@@ -1,18 +1,21 @@
 package initactor
 
 import (
+	"context"
+	"math/big"
 	"reflect"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/dispatch"
-	internal "github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/errors"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/runtime"
-	"github.com/ipfs/go-cid"
-
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/abi"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/errors"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/dispatch"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/errors"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/runtime"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-hamt-ipld"
 )
 
 // Actor is the builtin actor responsible for network initialization.
@@ -21,12 +24,26 @@ type Actor struct{}
 
 // State is the init actor's storage.
 type State struct {
-	Network string
+	Network    string
+	AddressMap cid.Cid `refmt:",omitempty"`
+	IdMap      cid.Cid `refmt:",omitempty"`
+	NextID     types.Uint64
+}
+
+// assignNewID returns the nextID and increments the counter
+func (s *State) assignNewID() types.Uint64 {
+	id := s.NextID
+	s.NextID++
+	return id
 }
 
 // Actor methods
 const (
-	GetNetwork types.MethodID = iota + 32
+	Exec                 types.MethodID = 3
+	GetActorIDForAddress types.MethodID = 4
+	// currently unspecified
+	GetAddressForActorID types.MethodID = iota + 32
+	GetNetwork
 )
 
 // NewActor returns a init actor.
@@ -46,11 +63,29 @@ var signatures = dispatch.Exports{
 		Params: []abi.Type{},
 		Return: []abi.Type{abi.String},
 	},
+	Exec: &dispatch.FunctionSignature{
+		Params: []abi.Type{abi.Cid, abi.Parameters},
+		Return: []abi.Type{abi.Address},
+	},
+	GetActorIDForAddress: &dispatch.FunctionSignature{
+		Params: []abi.Type{abi.Address},
+		Return: []abi.Type{abi.Integer},
+	},
+	GetAddressForActorID: &dispatch.FunctionSignature{
+		Params: []abi.Type{abi.Address},
+		Return: []abi.Type{abi.Integer},
+	},
 }
 
 // Method returns method definition for a given method id.
 func (a *Actor) Method(id types.MethodID) (dispatch.Method, *dispatch.FunctionSignature, bool) {
 	switch id {
+	case Exec:
+		return reflect.ValueOf((*Impl)(a).Exec), signatures[Exec], true
+	case GetActorIDForAddress:
+		return reflect.ValueOf((*Impl)(a).GetActorIDForAddress), signatures[GetActorIDForAddress], true
+	case GetAddressForActorID:
+		return reflect.ValueOf((*Impl)(a).GetAddressForActorID), signatures[GetAddressForActorID], true
 	case GetNetwork:
 		return reflect.ValueOf((*Impl)(a).GetNetwork), signatures[GetNetwork], true
 	default:
@@ -59,11 +94,15 @@ func (a *Actor) Method(id types.MethodID) (dispatch.Method, *dispatch.FunctionSi
 }
 
 // InitializeState for init actor.
-func (*Actor) InitializeState(storage runtime.Storage, networkInterface interface{}) error {
-	network := networkInterface.(string)
+func (*Actor) InitializeState(storage runtime.Storage, params interface{}) error {
+	network, ok := params.(string)
+	if !ok {
+		return errors.NewRevertError("init actor network parameter is not a string")
+	}
 
 	initStorage := &State{
 		Network: network,
+		NextID:  100,
 	}
 	stateBytes, err := encoding.Encode(initStorage)
 	if err != nil {
@@ -82,6 +121,14 @@ func (*Actor) InitializeState(storage runtime.Storage, networkInterface interfac
 // vm methods for actor
 //
 
+// minerInvocationContext has some special sauce for the miner.
+type invocationContext interface {
+	runtime.InvocationContext
+	AddressForNewActor() (address.Address, error)
+	CreateNewActor(addr address.Address, code cid.Cid) error
+	Message() *types.UnsignedMessage
+}
+
 // Impl is the VM implementation of the actor.
 type Impl Actor
 
@@ -98,4 +145,191 @@ func (*Impl) GetNetwork(ctx runtime.InvocationContext) (string, uint8, error) {
 	}
 
 	return state.Network, 0, nil
+}
+
+// GetActorIDForAddress looks up the actor id for a filecoin address.
+func (a *Impl) GetActorIDForAddress(rt runtime.InvocationContext, addr address.Address) (*big.Int, uint8, error) {
+	if err := rt.Charge(actor.DefaultGasCost); err != nil {
+		return big.NewInt(0), internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
+	var state State
+	err := actor.ReadState(rt, &state)
+	if err != nil {
+		return big.NewInt(0), errors.CodeError(err), err
+	}
+
+	ctx := context.TODO()
+	lookup, err := actor.LoadLookup(ctx, rt.Storage(), state.AddressMap)
+	if err != nil {
+		return big.NewInt(0), errors.CodeError(err), errors.RevertErrorWrapf(err, "could not load lookup for cid: %s", state.IdMap)
+	}
+
+	var id types.Uint64
+	err = lookup.Find(ctx, addr.String(), &id)
+	if err != nil {
+		if err == hamt.ErrNotFound {
+			return big.NewInt(0), errors.CodeError(err), errors.RevertErrorWrapf(err, "actor id not found for address: %s", addr.String())
+		}
+		return big.NewInt(0), errors.CodeError(err), errors.FaultErrorWrap(err, "could not lookup actor id")
+	}
+
+	return big.NewInt(int64(id)), 0, nil
+}
+
+// GetAddressForActorID looks up the address for an actor id.
+func (a *Impl) GetAddressForActorID(rt runtime.InvocationContext, actorID types.Uint64) (address.Address, uint8, error) {
+	if err := rt.Charge(actor.DefaultGasCost); err != nil {
+		return address.Undef, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
+	var state State
+	err := actor.ReadState(rt, &state)
+	if err != nil {
+		return address.Undef, errors.CodeError(err), err
+	}
+
+	ctx := context.TODO()
+	lookup, err := actor.LoadLookup(ctx, rt.Storage(), state.IdMap)
+	if err != nil {
+		return address.Undef, errors.CodeError(err), errors.RevertErrorWrapf(err, "could not load lookup for cid: %s", state.IdMap)
+	}
+
+	key, err := a.keyForActorID(actorID)
+	if err != nil {
+		return address.Undef, errors.CodeError(err), errors.FaultErrorWrapf(err, "could not encode actor id: %d", actorID)
+	}
+
+	var addr address.Address
+	err = lookup.Find(ctx, key, &addr)
+	if err != nil {
+		if err == hamt.ErrNotFound {
+			return address.Undef, errors.CodeError(err), errors.RevertErrorWrapf(err, "actor address not found for id: %d", actorID)
+		}
+		return address.Undef, errors.CodeError(err), errors.FaultErrorWrap(err, "could not lookup actor address")
+	}
+
+	return addr, 0, nil
+}
+
+// Exec creates a new builtin actor.
+func (a *Impl) Exec(rt invocationContext, codeCID cid.Cid, params []interface{}) (address.Address, uint8, error) {
+	if err := rt.Charge(actor.DefaultGasCost); err != nil {
+		return address.Undef, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
+	if !a.isBuiltinActor(codeCID) {
+		return address.Undef, 1, errors.NewRevertError("cannot launch actor instance that is not a builtin actor")
+	}
+
+	if a.isSingletonActor(codeCID) {
+		return address.Undef, 1, errors.NewRevertError("cannot launch another actor of this type")
+	}
+
+	var state State
+	err := actor.ReadState(rt, &state)
+	if err != nil {
+		return address.Undef, errors.CodeError(err), err
+	}
+
+	// create more stable address
+	actorAddr, err := rt.AddressForNewActor()
+	if err != nil {
+		return address.Undef, errors.CodeError(err), errors.FaultErrorWrapf(err, "could not create address for actor")
+	}
+
+	// create id address
+	actorID := state.assignNewID()
+	idAddr, err := address.NewIDAddress(uint64(actorID))
+	if err != nil {
+		return address.Undef, errors.CodeError(err), errors.FaultErrorWrapf(err, "could not create id address with id %d", actorID)
+	}
+
+	// map id to address and vice versa
+	ctx := context.TODO()
+	state.AddressMap, err = a.setId(ctx, rt.Storage(), state.AddressMap, actorAddr, actorID)
+	if err != nil {
+		return address.Undef, errors.CodeError(err), errors.FaultErrorWrap(err, "could not save id by address")
+	}
+
+	state.IdMap, err = a.setAddress(ctx, rt.Storage(), state.IdMap, actorID, actorAddr)
+	if err != nil {
+		return address.Undef, errors.CodeError(err), errors.FaultErrorWrap(err, "could not save addres by id")
+	}
+
+	// write the state
+	err = actor.WriteState(rt, state)
+	if err != nil {
+		return address.Undef, errors.CodeError(err), errors.FaultErrorWrap(err, "could not write actor state")
+	}
+
+	// create new actor keyed by id address
+	err = rt.CreateNewActor(idAddr, codeCID)
+	if err != nil {
+		return address.Undef, errors.CodeError(err), errors.FaultErrorWrapf(err, "could not create actor with address %s", idAddr.String())
+	}
+
+	// send message containing actor's initial balance to construct it with the given params
+	_, _, err = rt.Runtime().Send(idAddr, types.ConstructorMethodID, rt.Message().Value, params)
+	if err != nil {
+		return address.Undef, errors.CodeError(err), err
+	}
+
+	return actorAddr, 0, nil
+}
+
+func (a *Impl) setAddress(ctx context.Context, storage runtime.Storage, idMap cid.Cid, actorID types.Uint64, addr address.Address) (cid.Cid, error) {
+	lookup, err := actor.LoadLookup(ctx, storage, idMap)
+	if err != nil {
+		return cid.Undef, errors.RevertErrorWrapf(err, "could not load lookup for cid: %s", idMap)
+	}
+
+	key, err := a.keyForActorID(actorID)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	err = lookup.Set(ctx, key, addr)
+	if err != nil {
+		return cid.Undef, errors.FaultErrorWrapf(err, "could not set address")
+	}
+
+	return lookup.Commit(ctx)
+}
+
+func (a *Impl) setId(ctx context.Context, storage runtime.Storage, addressMap cid.Cid, addr address.Address, actorID types.Uint64) (cid.Cid, error) {
+	lookup, err := actor.LoadLookup(ctx, storage, addressMap)
+	if err != nil {
+		return cid.Undef, errors.RevertErrorWrapf(err, "could not load lookup for cid: %s", addressMap)
+	}
+
+	err = lookup.Set(ctx, addr.String(), actorID)
+	if err != nil {
+		return cid.Undef, errors.FaultErrorWrapf(err, "could not set id")
+	}
+
+	return lookup.Commit(ctx)
+}
+
+func (a *Impl) keyForActorID(actorID types.Uint64) (string, error) {
+	key, err := encoding.Encode(actorID)
+	if err != nil {
+		return "", errors.FaultErrorWrapf(err, "could not encode actor id: %d", actorID)
+	}
+
+	return string(key), nil
+}
+
+func (a *Impl) isBuiltinActor(code cid.Cid) bool {
+	return code.Equals(types.StorageMarketActorCodeCid) ||
+		code.Equals(types.InitActorCodeCid) ||
+		code.Equals(types.MinerActorCodeCid) ||
+		code.Equals(types.BootstrapMinerActorCodeCid) ||
+		code.Equals(types.PaymentBrokerActorCodeCid)
+}
+
+func (a *Impl) isSingletonActor(code cid.Cid) bool {
+	return code.Equals(types.StorageMarketActorCodeCid) ||
+		code.Equals(types.InitActorCodeCid) ||
+		code.Equals(types.PaymentBrokerActorCodeCid)
 }

--- a/internal/pkg/vm/actor/builtin/initactor/init_test.go
+++ b/internal/pkg/vm/actor/builtin/initactor/init_test.go
@@ -11,7 +11,11 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	. "github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/initactor"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
-	"github.com/magiconair/properties/assert"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-ipfs-blockstore"
+	dag "github.com/ipfs/go-merkledag"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,7 +50,7 @@ func TestInitActorGetNetwork(t *testing.T) {
 		Network: "bar",
 	}
 
-	msg := types.NewUnsignedMessage(address.TestAddress, address.InitAddress, 0, types.ZeroAttoFIL, GetNetwork, []byte{})
+	msg := types.NewUnsignedMessage(address.TestAddress, address.InitAddress, 0, types.NewAttoFILFromFIL(53), GetNetwork, []byte{})
 	vmctx := vm.NewFakeVMContext(msg, state)
 
 	actor := &Impl{}
@@ -55,4 +59,115 @@ func TestInitActorGetNetwork(t *testing.T) {
 	require.Equal(t, uint8(0), code)
 
 	assert.Equal(t, "bar", network)
+}
+
+func TestInitActorExec(t *testing.T) {
+	tf.UnitTest(t)
+
+	msg := types.NewUnsignedMessage(address.TestAddress, address.InitAddress, 0, types.ZeroAttoFIL, Exec, []byte{})
+
+	newState := func() *State {
+		return &State{
+			Network: "bar",
+			NextID:  42,
+		}
+	}
+	initParams := []interface{}{[]byte("one"), []byte("two")}
+	act := &Impl{}
+
+	t.Run("exec charges gas", func(t *testing.T) {
+		var charge types.GasUnits
+		vmctx := vm.NewFakeVMContext(msg, newState())
+		vmctx.Charger = func(cost types.GasUnits) error { charge = cost; return nil }
+
+		_, _, err := act.Exec(vmctx, types.MinerActorCodeCid, initParams)
+		require.NoError(t, err)
+
+		assert.Equal(t, types.NewGasUnits(actor.DefaultGasCost), charge)
+	})
+
+	t.Run("exec refuses to construct a non builtin actor", func(t *testing.T) {
+		code := dag.NewRawNode([]byte("nonesuch")).Cid()
+		_, _, err := act.Exec(vm.NewFakeVMContext(msg, newState()), code, initParams)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a builtin actor")
+	})
+
+	t.Run("exec refuses to construct singleton actor", func(t *testing.T) {
+		code := types.StorageMarketActorCodeCid // storage market is a singleton actor
+		_, _, err := act.Exec(vm.NewFakeVMContext(msg, newState()), code, initParams)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot launch another actor of this type")
+	})
+
+	t.Run("exec constructs a permanent address and creates a mapping to the id", func(t *testing.T) {
+		vmctx := vm.NewFakeVMContext(msg, newState())
+
+		// set up enough storage so that it actually uses the hamts
+		sm := vm.NewStorageMap(blockstore.NewBlockstore(datastore.NewMapDatastore()))
+		actorModel := actor.NewActor(types.InitActorCodeCid, types.ZeroAttoFIL)
+		vmctx.StorageValue = sm.NewStorage(address.InitAddress, actorModel)
+		err := (*Actor)(act).InitializeState(vmctx.Storage(), "network")
+		require.NoError(t, err)
+
+		addr, _, err := act.Exec(vmctx, types.MinerActorCodeCid, initParams)
+		require.NoError(t, err)
+
+		_, _, err = act.GetActorIDForAddress(vmctx, addr)
+		require.NoError(t, err)
+	})
+
+	t.Run("exec creates a new actor at the id address", func(t *testing.T) {
+		var actualAddr address.Address
+		var actualCode cid.Cid
+		vmctx := vm.NewFakeVMContext(msg, newState())
+		vmctx.ActorCreator = func(addr address.Address, code cid.Cid) error {
+			actualAddr = addr
+			actualCode = code
+			return nil
+		}
+		_, _, err := act.Exec(vmctx, types.MinerActorCodeCid, initParams)
+		require.NoError(t, err)
+
+		assert.Equal(t, address.ID, actualAddr.Protocol())
+		assert.Equal(t, types.MinerActorCodeCid, actualCode)
+	})
+
+	t.Run("exec calls constructor and sends funds", func(t *testing.T) {
+		var constructedAddr address.Address
+		var actualTo address.Address
+		var actualMethod types.MethodID
+		var actualValue types.AttoFIL
+		var actualParams []interface{}
+		vmctx := vm.NewFakeVMContext(msg, newState())
+		vmctx.ActorCreator = func(addr address.Address, code cid.Cid) error {
+			constructedAddr = addr
+			return nil
+		}
+		vmctx.Sender = func(to address.Address, method types.MethodID, value types.AttoFIL, params []interface{}) ([][]byte, uint8, error) {
+			actualTo = to
+			actualMethod = method
+			actualValue = value
+			actualParams = params
+			return [][]byte{}, 0, nil
+		}
+		_, _, err := act.Exec(vmctx, types.MinerActorCodeCid, initParams)
+		require.NoError(t, err)
+
+		// sends to actor it just created
+		assert.Equal(t, constructedAddr, actualTo)
+
+		// sends to constructor method
+		assert.Equal(t, types.ConstructorMethodID, actualMethod)
+
+		// sends value given it on to actor
+		assert.Equal(t, msg.Value, actualValue)
+
+		// sends given parameters on to constructor
+		require.Equal(t, 2, len(actualParams))
+		assert.Equal(t, initParams[0], actualParams[0])
+		assert.Equal(t, initParams[1], actualParams[1])
+	})
 }

--- a/internal/pkg/vm/actor/builtin/power/power_test.go
+++ b/internal/pkg/vm/actor/builtin/power/power_test.go
@@ -39,7 +39,8 @@ func TestPowerCreateStorageMiner(t *testing.T) {
 	outAddr, err := address.NewFromBytes(result.Receipt.Return[0])
 	require.NoError(t, err)
 
-	minerActor, err := st.GetActor(ctx, outAddr)
+	idAddr := th.RequireActorIDAddress(ctx, t, st, vms, outAddr)
+	minerActor, err := st.GetActor(ctx, idAddr)
 	require.NoError(t, err)
 
 	powerAct, err := st.GetActor(ctx, address.PowerAddress)
@@ -49,7 +50,7 @@ func TestPowerCreateStorageMiner(t *testing.T) {
 	assert.Equal(t, types.NewAttoFILFromFIL(100), minerActor.Balance)
 
 	var mstor miner.State
-	builtin.RequireReadState(t, vms, outAddr, minerActor, &mstor)
+	builtin.RequireReadState(t, vms, idAddr, minerActor, &mstor)
 
 	assert.Equal(t, mstor.ActiveCollateral, types.NewAttoFILFromFIL(0))
 	assert.Equal(t, mstor.PeerID, pid)
@@ -66,8 +67,9 @@ func TestProcessPowerReport(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		st, vms := th.RequireCreateStorages(ctx, t)
 		pid := th.RequireRandomPeerID(t)
-		minerAddr := requireCreateMiner(hundredAttoFIL, t, st, vms, address.TestAddress, pid, 0)
+		outAddr := requireCreateMiner(hundredAttoFIL, t, st, vms, address.TestAddress, pid, 0)
 
+		minerAddr := th.RequireActorIDAddress(ctx, t, st, vms, outAddr)
 		reportInit := requireGetPowerReport(t, st, vms, minerAddr)
 		assert.Equal(t, types.NewBytesAmount(0), reportInit.ActivePower)
 		assert.Equal(t, types.NewBytesAmount(0), reportInit.InactivePower)
@@ -118,7 +120,9 @@ func TestGetTotalPower(t *testing.T) {
 
 	st, vms := th.RequireCreateStorages(ctx, t)
 	pid := th.RequireRandomPeerID(t)
-	minerAddr := requireCreateMiner(hundredAttoFIL, t, st, vms, address.TestAddress, pid, 0)
+	outAddr := requireCreateMiner(hundredAttoFIL, t, st, vms, address.TestAddress, pid, 0)
+
+	minerAddr := th.RequireActorIDAddress(ctx, t, st, vms, outAddr)
 
 	// set power
 	report1 := types.NewPowerReport(600, 400)
@@ -149,8 +153,9 @@ func TestRemoveStorageMiner(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		st, vms := th.RequireCreateStorages(ctx, t)
 		pid := th.RequireRandomPeerID(t)
-		minerAddr := requireCreateMiner(hundredAttoFIL, t, st, vms, address.TestAddress, pid, 0)
+		outAddr := requireCreateMiner(hundredAttoFIL, t, st, vms, address.TestAddress, pid, 0)
 
+		minerAddr := th.RequireActorIDAddress(ctx, t, st, vms, outAddr)
 		pdata := actor.MustConvertParams(minerAddr)
 		msg := types.NewUnsignedMessage(address.TestAddress, address.PowerAddress, 0, hundredAttoFIL, power.RemoveStorageMiner, pdata)
 		result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
@@ -164,7 +169,9 @@ func TestRemoveStorageMiner(t *testing.T) {
 	t.Run("remove nonempty fails", func(t *testing.T) {
 		st, vms := th.RequireCreateStorages(ctx, t)
 		pid := th.RequireRandomPeerID(t)
-		minerAddr := requireCreateMiner(hundredAttoFIL, t, st, vms, address.TestAddress, pid, 0)
+		outAddr := requireCreateMiner(hundredAttoFIL, t, st, vms, address.TestAddress, pid, 0)
+
+		minerAddr := th.RequireActorIDAddress(ctx, t, st, vms, outAddr)
 
 		// set power
 		report1 := types.NewPowerReport(600, 400)

--- a/internal/pkg/vm/actor/builtin/storagemarket/storagemarket_test.go
+++ b/internal/pkg/vm/actor/builtin/storagemarket/storagemarket_test.go
@@ -42,7 +42,9 @@ func TestStorageMarketCreateStorageMiner(t *testing.T) {
 	outAddr, err := address.NewFromBytes(result.Receipt.Return[0])
 	require.NoError(t, err)
 
-	minerActor, err := st.GetActor(ctx, outAddr)
+	minerAddr := th.RequireActorIDAddress(ctx, t, st, vms, outAddr)
+
+	minerActor, err := st.GetActor(ctx, minerAddr)
 	require.NoError(t, err)
 
 	storageMkt, err := st.GetActor(ctx, address.StorageMarketAddress)
@@ -52,7 +54,7 @@ func TestStorageMarketCreateStorageMiner(t *testing.T) {
 	assert.Equal(t, types.NewAttoFILFromFIL(100), minerActor.Balance)
 
 	var mstor miner.State
-	builtin.RequireReadState(t, vms, outAddr, minerActor, &mstor)
+	builtin.RequireReadState(t, vms, minerAddr, minerActor, &mstor)
 
 	assert.Equal(t, mstor.ActiveCollateral, types.NewAttoFILFromFIL(0))
 	assert.Equal(t, mstor.PeerID, pid)
@@ -67,7 +69,7 @@ func TestStorageMarketCreateStorageMinerDoesNotOverwriteActorBalance(t *testing.
 	st, vms := th.RequireCreateStorages(ctx, t)
 
 	// create account of future miner actor by sending FIL to the predicted address
-	minerAddr, err := deriveMinerAddress(address.TestAddress, 0)
+	minerAddr, err := address.NewIDAddress(100) // 100 is the first address of a constructed actor
 	require.NoError(t, err)
 
 	msg := types.NewUnsignedMessage(address.TestAddress2, minerAddr, 0, types.NewAttoFILFromFIL(100), types.SendMethodID, []byte{})
@@ -83,9 +85,10 @@ func TestStorageMarketCreateStorageMinerDoesNotOverwriteActorBalance(t *testing.
 	require.NoError(t, result.ExecutionError)
 
 	// ensure our derived address is the address storage market creates
+	derivedAddr, err := deriveMinerAddress(address.TestAddress, 0)
 	createdAddress, err := address.NewFromBytes(result.Receipt.Return[0])
 	require.NoError(t, err)
-	assert.Equal(t, minerAddr, createdAddress)
+	assert.Equal(t, derivedAddr, createdAddress)
 	miner, err := st.GetActor(ctx, minerAddr)
 	require.NoError(t, err)
 
@@ -167,8 +170,10 @@ func TestStorageMarketGetLateMiners(t *testing.T) {
 
 		// create 3 bootstrap miners by passing in 0 block height, so that VerifyProof is skipped
 		// Otherwise this test will fail
-		addr1 := th.CreateTestMiner(t, st, vms, address.TestAddress, th.RequireRandomPeerID(t))
-		addr2 := th.CreateTestMiner(t, st, vms, address.TestAddress, th.RequireRandomPeerID(t))
+		outAddr1 := th.CreateTestMiner(t, st, vms, address.TestAddress, th.RequireRandomPeerID(t))
+		addr1 := th.RequireActorIDAddress(ctx, t, st, vms, outAddr1)
+		outAddr2 := th.CreateTestMiner(t, st, vms, address.TestAddress, th.RequireRandomPeerID(t))
+		addr2 := th.RequireActorIDAddress(ctx, t, st, vms, outAddr2)
 		_ = th.CreateTestMiner(t, st, vms, address.TestAddress, th.RequireRandomPeerID(t))
 
 		// 2 of the 3 miners make a commitment
@@ -226,7 +231,8 @@ func TestUpdateStorage(t *testing.T) {
 		st, vms := th.RequireCreateStorages(ctx, t)
 		// Create miner so that update can pass checks
 		pid := th.RequireRandomPeerID(t)
-		minerAddr := th.CreateTestMiner(t, st, vms, address.TestAddress, pid)
+		outAddr := th.CreateTestMiner(t, st, vms, address.TestAddress, pid)
+		minerAddr := th.RequireActorIDAddress(ctx, t, st, vms, outAddr)
 
 		// Add update to total storage
 		update := types.NewBytesAmount(uint64(3000000))
@@ -269,7 +275,8 @@ func TestUpdateStorage(t *testing.T) {
 		st, vms := th.RequireCreateStorages(ctx, t)
 		// Create miner so that update can pass checks
 		pid := th.RequireRandomPeerID(t)
-		minerAddr := th.CreateTestMiner(t, st, vms, address.TestAddress, pid)
+		outAddr := th.CreateTestMiner(t, st, vms, address.TestAddress, pid)
+		minerAddr := th.RequireActorIDAddress(ctx, t, st, vms, outAddr)
 
 		// Add plus (positive number) and minus (negative number) to total storage
 		plus := types.NewBytesAmount(uint64(3000000))

--- a/internal/pkg/vm/actor/storage.go
+++ b/internal/pkg/vm/actor/storage.go
@@ -85,6 +85,23 @@ func ReadState(ctx runtime.InvocationContext, st interface{}) error {
 	return nil
 }
 
+// WriteState stores state and commits it as the actor's head
+func WriteState(ctx runtime.InvocationContext, state interface{}) error {
+	stage := ctx.Storage()
+
+	cid, err := stage.Put(state)
+	if err != nil {
+		return vmerrors.RevertErrorWrap(err, "Could not stage memory chunk")
+	}
+
+	err = stage.Commit(cid, stage.Head())
+	if err != nil {
+		return vmerrors.RevertErrorWrap(err, "Could not commit actor memory")
+	}
+
+	return nil
+}
+
 // SetKeyValue convenience method to load a lookup, set one key value pair and commit.
 // This function is inefficient when multiple values need to be set into the lookup.
 func SetKeyValue(ctx context.Context, storage runtime.Storage, id cid.Cid, key string, value interface{}) (cid.Cid, error) {

--- a/internal/pkg/vm/address/constants.go
+++ b/internal/pkg/vm/address/constants.go
@@ -11,12 +11,12 @@ func init() {
 
 	var err error
 
-	TestAddress, err = NewActorAddress([]byte("satoshi"))
+	TestAddress, err = NewSecp256k1Address([]byte("satoshi"))
 	if err != nil {
 		panic(err)
 	}
 
-	TestAddress2, err = NewActorAddress([]byte("nakamoto"))
+	TestAddress2, err = NewSecp256k1Address([]byte("nakamoto"))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/pkg/vm/address/testing.go
+++ b/internal/pkg/vm/address/testing.go
@@ -11,7 +11,7 @@ func NewForTestGetter() func() Address {
 	return func() Address {
 		s := fmt.Sprintf("address%d", i)
 		i++
-		newAddr, err := NewActorAddress([]byte(s))
+		newAddr, err := NewSecp256k1Address([]byte(s))
 		if err != nil {
 			panic(err)
 		}

--- a/internal/pkg/vm/state/testing.go
+++ b/internal/pkg/vm/state/testing.go
@@ -125,7 +125,7 @@ func (m *MockStateTree) GetActorCode(c cid.Cid, protocol uint64) (dispatch.Execu
 // states.
 func TreeFromString(t *testing.T, s string, cst *hamt.CborIpldStore) Tree {
 	tree := NewTree(cst)
-	strAddr, err := address.NewActorAddress([]byte(s))
+	strAddr, err := address.NewSecp256k1Address([]byte(s))
 	require.NoError(t, err)
 	err = tree.SetActor(context.Background(), strAddr, &actor.Actor{})
 	require.NoError(t, err)


### PR DESCRIPTION
### Motivation

We need to move actor creation into the init actor so we get ID addresses.

### Proposed changes

This PR sets the following goals:

1. `StorageMinerActor`s are instantiated in the InitActor's `Exec` method.
2. `StorageMinerActor`s get ID addresses instead of actor addresses.

The [InitActor spec](https://filecoin-project.github.io/specs/#InitActor) and the VM methods on which it relies are very rough. This PR attempts to implement the Spec faithfully where doing so will lead to a working implementation. It attempts to make reasonable guesses where the spec has gaps. And it sticks to the existing implementation where those options aren't available. Decisions are documented in the code.


