### PR TITLE
Add timestamp to genesis block

### DIFF
--- a/cmd/go-filecoin/miner_daemon_test.go
+++ b/cmd/go-filecoin/miner_daemon_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/filecoin-project/go-filecoin/tools/gengen/util"
 )
 
+var genesisTime = time.Unix(123456789, 0)
+
 func TestMinerHelp(t *testing.T) {
 	t.Skip("Long term solution: #3642")
 	tf.IntegrationTest(t)
@@ -104,7 +106,7 @@ func runHelpSuccess(t *testing.T, args ...string) string {
 		t.Fatal(err)
 	}
 
-	if _, err = gengen.GenGenesisCar(testConfig, fi, 0); err != nil {
+	if _, err = gengen.GenGenesisCar(testConfig, fi, 0, genesisTime); err != nil {
 		t.Fatal(err)
 	}
 
@@ -321,7 +323,7 @@ func TestMinerOwner(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err = gengen.GenGenesisCar(testConfig, fi, 0); err != nil {
+	if _, err = gengen.GenGenesisCar(testConfig, fi, 0, genesisTime); err != nil {
 		t.Fatal(err)
 	}
 
@@ -360,7 +362,7 @@ func TestMinerPower(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err = gengen.GenGenesisCar(testConfig, fi, 0); err != nil {
+	if _, err = gengen.GenGenesisCar(testConfig, fi, 0, genesisTime); err != nil {
 		t.Fatal(err)
 	}
 
@@ -400,7 +402,7 @@ func TestMinerActiveCollateral(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err = gengen.GenGenesisCar(testConfig, fi, 0); err != nil {
+	if _, err = gengen.GenGenesisCar(testConfig, fi, 0, genesisTime); err != nil {
 		t.Fatal(err)
 	}
 

--- a/functional-tests/faucet_test.go
+++ b/functional-tests/faucet_test.go
@@ -41,7 +41,8 @@ func TestFaucetSendFunds(t *testing.T) {
 	blockTime := time.Second * 5
 
 	// Setup first node, note: Testbed.Name() is the directory
-	genesis := iptbtester.MustGenerateGenesis(t, 10000, node0.Testbed.Name())
+	genesisTime := time.Unix(123456789, 0)
+	genesis := iptbtester.MustGenerateGenesis(t, 10000, node0.Testbed.Name(), genesisTime)
 
 	node0.MustInitWithGenesis(ctx, genesis)
 	node0.MustStart(ctx, "--block-time="+blockTime.String())

--- a/functional-tests/faucet_test.go
+++ b/functional-tests/faucet_test.go
@@ -42,7 +42,7 @@ func TestFaucetSendFunds(t *testing.T) {
 
 	// Setup first node, note: Testbed.Name() is the directory
 	genesisTime := time.Unix(123456789, 0)
-	genesis := iptbtester.MustGenerateGenesis(t, 10000, node0.Testbed.Name(), genesisTime)
+	genesis := iptbtester.RequireGenerateGenesis(t, 10000, node0.Testbed.Name(), genesisTime)
 
 	node0.MustInitWithGenesis(ctx, genesis)
 	node0.MustStart(ctx, "--block-time="+blockTime.String())

--- a/internal/app/go-filecoin/node/testing.go
+++ b/internal/app/go-filecoin/node/testing.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"testing"
+	"time"
 
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-hamt-ipld"
@@ -48,8 +49,9 @@ func MakeChainSeed(t *testing.T, cfg *gengen.GenesisCfg) *ChainSeed {
 	mds := ds.NewMapDatastore()
 	bstore := blockstore.NewBlockstore(mds)
 	cst := hamt.CSTFromBstore(bstore)
+	genesisTime := time.Unix(123456789, 0)
 
-	info, err := gengen.GenGen(context.TODO(), cfg, cst, bstore, 0)
+	info, err := gengen.GenGen(context.TODO(), cfg, cst, bstore, 0, genesisTime)
 	require.NoError(t, err)
 
 	return &ChainSeed{

--- a/internal/pkg/consensus/genesis.go
+++ b/internal/pkg/consensus/genesis.go
@@ -227,6 +227,7 @@ func MakeGenesisFunc(opts ...GenOption) GenesisInitFunc {
 			MessageReceipts: emptyAMTCid,
 			BLSAggregateSig: emptyBLSSignature[:],
 			Ticket:          block.Ticket{VRFProof: []byte{0xec}},
+			Timestamp:       types.Uint64(genCfg.genesisTimestamp.Unix()),
 		}
 
 		if _, err := cst.Put(ctx, genesis); err != nil {

--- a/internal/pkg/consensus/genesis.go
+++ b/internal/pkg/consensus/genesis.go
@@ -121,7 +121,8 @@ func ProofsMode(proofsMode types.ProofsMode) GenOption {
 	}
 }
 
-func GenesisTimeFunc(genesisTimestamp time.Time) GenOption {
+// GenesisTime sets the timestamp in the genesis block.
+func GenesisTime(genesisTimestamp time.Time) GenOption {
 	return func(gc *Config) error {
 		gc.genesisTimestamp = genesisTimestamp
 		return nil

--- a/internal/pkg/consensus/genesis.go
+++ b/internal/pkg/consensus/genesis.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"context"
+	"time"
 
 	"github.com/filecoin-project/go-amt-ipld"
 	"github.com/filecoin-project/go-bls-sigs"
@@ -47,12 +48,13 @@ type minerActorConfig struct {
 
 // Config is used to configure values in the GenesisInitFunction.
 type Config struct {
-	accounts   map[address.Address]types.AttoFIL
-	nonces     map[address.Address]uint64
-	actors     map[address.Address]*actor.Actor
-	miners     map[address.Address]*minerActorConfig
-	network    string
-	proofsMode types.ProofsMode
+	accounts         map[address.Address]types.AttoFIL
+	nonces           map[address.Address]uint64
+	actors           map[address.Address]*actor.Actor
+	miners           map[address.Address]*minerActorConfig
+	network          string
+	proofsMode       types.ProofsMode
+	genesisTimestamp time.Time
 }
 
 // GenOption is a configuration option for the GenesisInitFunction.
@@ -119,15 +121,25 @@ func ProofsMode(proofsMode types.ProofsMode) GenOption {
 	}
 }
 
+func GenesisTimeFunc(genesisTimestamp time.Time) GenOption {
+	return func(gc *Config) error {
+		gc.genesisTimestamp = genesisTimestamp
+		return nil
+	}
+}
+
+var defaultGenesisTimestamp = time.Unix(123456789, 0)
+
 // NewEmptyConfig inits and returns an empty config
 func NewEmptyConfig() *Config {
 	return &Config{
-		accounts:   make(map[address.Address]types.AttoFIL),
-		nonces:     make(map[address.Address]uint64),
-		actors:     make(map[address.Address]*actor.Actor),
-		miners:     make(map[address.Address]*minerActorConfig),
-		network:    "localnet",
-		proofsMode: types.TestProofsMode,
+		accounts:         make(map[address.Address]types.AttoFIL),
+		nonces:           make(map[address.Address]uint64),
+		actors:           make(map[address.Address]*actor.Actor),
+		miners:           make(map[address.Address]*minerActorConfig),
+		network:          "localnet",
+		proofsMode:       types.TestProofsMode,
+		genesisTimestamp: defaultGenesisTimestamp,
 	}
 }
 

--- a/internal/pkg/consensus/power_table_view_test.go
+++ b/internal/pkg/consensus/power_table_view_test.go
@@ -3,6 +3,7 @@ package consensus_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/ipfs/go-hamt-ipld"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
@@ -75,7 +76,7 @@ func requireMinerWithNumCommittedSectors(ctx context.Context, t *testing.T, numC
 		Network: "ptvtest",
 	}
 
-	info, err := gengen.GenGen(ctx, genCfg, cst, bs, 0)
+	info, err := gengen.GenGen(ctx, genCfg, cst, bs, 0, time.Unix(123456789, 0))
 	require.NoError(t, err)
 
 	var calcGenBlk block.Block

--- a/internal/pkg/testhelpers/iptbtester/genesis.go
+++ b/internal/pkg/testhelpers/iptbtester/genesis.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/filecoin-project/go-filecoin/cmd/go-filecoin"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
@@ -27,7 +28,7 @@ type idResult struct {
 
 // MustGenerateGenesis constructs the requires information and files to build a single
 // filecoin node with the provided funds. The GenesisInfo can be used with MustImportGenesisMiner
-func MustGenerateGenesis(t *testing.T, funds int64, dir string) *GenesisInfo {
+func MustGenerateGenesis(t *testing.T, funds int64, dir string, genesisTime time.Time) *GenesisInfo {
 	// Setup, generate a genesis and key file
 	cfg := &gengen.GenesisCfg{
 		ProofsMode: types.TestProofsMode,
@@ -55,7 +56,7 @@ func MustGenerateGenesis(t *testing.T, funds int64, dir string) *GenesisInfo {
 		t.Fatal(err)
 	}
 
-	info, err := gengen.GenGenesisCar(cfg, genfile, 0)
+	info, err := gengen.GenGenesisCar(cfg, genfile, 0, genesisTime)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/testhelpers/iptbtester/genesis.go
+++ b/internal/pkg/testhelpers/iptbtester/genesis.go
@@ -26,9 +26,9 @@ type idResult struct {
 	ID string
 }
 
-// MustGenerateGenesis constructs the requires information and files to build a single
+// RequireGenerateGenesis constructs the required information and files to build a single
 // filecoin node with the provided funds. The GenesisInfo can be used with MustImportGenesisMiner
-func MustGenerateGenesis(t *testing.T, funds int64, dir string, genesisTime time.Time) *GenesisInfo {
+func RequireGenerateGenesis(t *testing.T, funds int64, dir string, genesisTime time.Time) *GenesisInfo {
 	// Setup, generate a genesis and key file
 	cfg := &gengen.GenesisCfg{
 		ProofsMode: types.TestProofsMode,

--- a/tools/fast/environment/environment_memory_genesis.go
+++ b/tools/fast/environment/environment_memory_genesis.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"sync"
+	"time"
 
 	logging "github.com/ipfs/go-log"
 
@@ -250,7 +251,7 @@ func (e *MemoryGenesis) buildGenesis(funds *big.Int) error {
 
 	var genbuffer bytes.Buffer
 
-	info, err := gengen.GenGenesisCar(cfg, &genbuffer, 0)
+	info, err := gengen.GenGenesisCar(cfg, &genbuffer, 0, time.Unix(123456789, 0))
 	if err != nil {
 		return err
 	}

--- a/tools/gengen/main.go
+++ b/tools/gengen/main.go
@@ -98,7 +98,8 @@ func main() {
 		outfile = f
 	}
 
-	info, err := gengen.GenGenesisCar(cfg, outfile, *seed)
+	genesisTime := time.Now()
+	info, err := gengen.GenGenesisCar(cfg, outfile, *seed, genesisTime)
 	if err != nil {
 		fmt.Println("ERROR", err)
 		panic(err)

--- a/tools/gengen/main.go
+++ b/tools/gengen/main.go
@@ -76,6 +76,7 @@ func main() {
 	outCar := flag.String("out-car", "", "writes the generated car file to the give path, instead of stdout")
 	configFilePath := flag.String("config", "", "reads configuration from this json file, instead of stdin")
 	seed := flag.Int64("seed", defaultSeed, "provides the seed for randomization, defaults to current unix epoch")
+	genesisTimeFlag := flag.Int64("genesisTimestamp", 123456789, "provide the timestamp value for the genesis block")
 
 	// ExitOnError is set
 	flag.Parse(os.Args[1:]) // nolint: errcheck
@@ -98,7 +99,7 @@ func main() {
 		outfile = f
 	}
 
-	genesisTime := time.Now()
+	genesisTime := time.Unix(*genesisTimeFlag, 0)
 	info, err := gengen.GenGenesisCar(cfg, outfile, *seed, genesisTime)
 	if err != nil {
 		fmt.Println("ERROR", err)

--- a/tools/gengen/util/gengen_test.go
+++ b/tools/gengen/util/gengen_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var defaultGenesisTime = time.Unix(123456789, 0)
+
 var testConfig = &GenesisCfg{
 	ProofsMode: types.TestProofsMode,
 	Keys:       4,
@@ -43,7 +45,7 @@ func TestGenGenLoading(t *testing.T) {
 	fi, err := ioutil.TempFile("", "gengentest")
 	assert.NoError(t, err)
 
-	_, err = GenGenesisCar(testConfig, fi, 0, time.Unix(123456789, 0))
+	_, err = GenGenesisCar(testConfig, fi, 0, defaultGenesisTime)
 	assert.NoError(t, err)
 	assert.NoError(t, fi.Close())
 
@@ -61,14 +63,12 @@ func TestGenGenLoading(t *testing.T) {
 func TestGenGenDeterministicBetweenBuilds(t *testing.T) {
 	tf.UnitTest(t)
 
-	genesisTime := time.Unix(123456789, 0)
-
 	ctx := context.Background()
 	var info *RenderedGenInfo
 	for i := 0; i < 50; i++ {
 		bstore := blockstore.NewBlockstore(ds.NewMapDatastore())
 		cst := hamt.CSTFromBstore(bstore)
-		inf, err := GenGen(ctx, testConfig, cst, bstore, 0, genesisTime)
+		inf, err := GenGen(ctx, testConfig, cst, bstore, 0, defaultGenesisTime)
 		assert.NoError(t, err)
 		if info == nil {
 			info = inf

--- a/tools/gengen/util/gengen_test.go
+++ b/tools/gengen/util/gengen_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"testing"
+	"time"
 
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-hamt-ipld"
@@ -42,7 +43,7 @@ func TestGenGenLoading(t *testing.T) {
 	fi, err := ioutil.TempFile("", "gengentest")
 	assert.NoError(t, err)
 
-	_, err = GenGenesisCar(testConfig, fi, 0)
+	_, err = GenGenesisCar(testConfig, fi, 0, time.Unix(123456789, 0))
 	assert.NoError(t, err)
 	assert.NoError(t, fi.Close())
 
@@ -60,12 +61,14 @@ func TestGenGenLoading(t *testing.T) {
 func TestGenGenDeterministicBetweenBuilds(t *testing.T) {
 	tf.UnitTest(t)
 
+	genesisTime := time.Unix(123456789, 0)
+
 	ctx := context.Background()
 	var info *RenderedGenInfo
 	for i := 0; i < 50; i++ {
 		bstore := blockstore.NewBlockstore(ds.NewMapDatastore())
 		cst := hamt.CSTFromBstore(bstore)
-		inf, err := GenGen(ctx, testConfig, cst, bstore, 0)
+		inf, err := GenGen(ctx, testConfig, cst, bstore, 0, genesisTime)
 		assert.NoError(t, err)
 		if info == nil {
 			info = inf


### PR DESCRIPTION
### Motivation
Genesis block requires a timestamp field so that a GenesisTime value may be derived as defined in the [clock section of the spec](https://filecoin-project.github.io/specs/#systems__filecoin_nodes__clock). Further motivation may also be found here: https://github.com/filecoin-project/go-filecoin/issues/3653


### Proposed changes
Modify `GenGenesisCar`, `GenGen`, `MustGenerateGenesis`, and genesis Config to accept a timestamp for the genesis block.

When a genesis block is required for a tests its timestamp is set to `time.Unix(123456789, 0)` for consistency

When calling the gengen binary, time is accepted as a command line argument (`date +%s`) defaulting to 123456789 if no value is given for the flag.

### Alternatives
Instead of modifying the aforementioned methods to accept a timestamp as an argument the `GenesisCfg` structure could be modified to contain the value. I decided against this since the `GenesisCfg` values have file based configuration and requiring a configuration file change in order to change the timestamp in the genesis block looked ugly.

Closes issue #3653 

