### PR TITLE
feat: new vm runtime

### DIFF
--- a/internal/pkg/vm/actor/builtin/initactor/init.go
+++ b/internal/pkg/vm/actor/builtin/initactor/init.go
@@ -86,7 +86,7 @@ func (*Actor) InitializeState(storage runtime.Storage, networkInterface interfac
 type Impl Actor
 
 // GetNetwork returns the network name for this network
-func (*Impl) GetNetwork(ctx runtime.Runtime) (string, uint8, error) {
+func (*Impl) GetNetwork(ctx runtime.InvocationContext) (string, uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return "", internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}

--- a/internal/pkg/vm/actor/builtin/miner/miner.go
+++ b/internal/pkg/vm/actor/builtin/miner/miner.go
@@ -445,7 +445,6 @@ type invocationContext interface {
 	Message() *types.UnsignedMessage
 }
 
-
 // AddAsk adds an ask to this miners ask list
 func (*Impl) AddAsk(ctx invocationContext, price types.AttoFIL, expiry *big.Int) (*big.Int, uint8,
 	error) {

--- a/internal/pkg/vm/actor/builtin/miner/miner.go
+++ b/internal/pkg/vm/actor/builtin/miner/miner.go
@@ -438,8 +438,16 @@ const (
 	PoStStateUnrecoverable
 )
 
+// minerInvocationContext has some special sauce for the miner.
+type invocationContext interface {
+	runtime.InvocationContext
+	Verifier() verification.Verifier
+	Message() *types.UnsignedMessage
+}
+
+
 // AddAsk adds an ask to this miners ask list
-func (*Impl) AddAsk(ctx runtime.Runtime, price types.AttoFIL, expiry *big.Int) (*big.Int, uint8,
+func (*Impl) AddAsk(ctx invocationContext, price types.AttoFIL, expiry *big.Int) (*big.Int, uint8,
 	error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return nil, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
@@ -454,11 +462,13 @@ func (*Impl) AddAsk(ctx runtime.Runtime, price types.AttoFIL, expiry *big.Int) (
 		id := big.NewInt(0).Set(state.NextAskID)
 		state.NextAskID = state.NextAskID.Add(state.NextAskID, big.NewInt(1))
 
+		epoch := ctx.Runtime().CurrentEpoch()
+
 		// filter out expired asks
 		asks := state.Asks
 		state.Asks = state.Asks[:0]
 		for _, a := range asks {
-			if ctx.BlockHeight().LessThan(a.Expiry) {
+			if epoch.LessThan(a.Expiry) {
 				state.Asks = append(state.Asks, a)
 			}
 		}
@@ -470,7 +480,7 @@ func (*Impl) AddAsk(ctx runtime.Runtime, price types.AttoFIL, expiry *big.Int) (
 
 		state.Asks = append(state.Asks, &Ask{
 			Price:  price,
-			Expiry: ctx.BlockHeight().Add(expiryBH),
+			Expiry: epoch.Add(expiryBH),
 			ID:     id,
 		})
 
@@ -489,7 +499,7 @@ func (*Impl) AddAsk(ctx runtime.Runtime, price types.AttoFIL, expiry *big.Int) (
 }
 
 // GetAsks returns all the asks for this miner.
-func (*Impl) GetAsks(ctx runtime.Runtime) ([]types.Uint64, uint8, error) {
+func (*Impl) GetAsks(ctx invocationContext) ([]types.Uint64, uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return nil, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -518,7 +528,7 @@ func (*Impl) GetAsks(ctx runtime.Runtime) ([]types.Uint64, uint8, error) {
 }
 
 // GetAsk returns an ask by ID
-func (*Impl) GetAsk(ctx runtime.Runtime, askid *big.Int) ([]byte, uint8, error) {
+func (*Impl) GetAsk(ctx invocationContext, askid *big.Int) ([]byte, uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return nil, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -557,7 +567,7 @@ func (*Impl) GetAsk(ctx runtime.Runtime, askid *big.Int) ([]byte, uint8, error) 
 }
 
 // GetOwner returns the miners owner.
-func (*Impl) GetOwner(ctx runtime.Runtime) (address.Address, uint8, error) {
+func (*Impl) GetOwner(ctx invocationContext) (address.Address, uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return address.Undef, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -579,7 +589,7 @@ func (*Impl) GetOwner(ctx runtime.Runtime) (address.Address, uint8, error) {
 }
 
 // GetLastUsedSectorID returns the last used sector id.
-func (*Impl) GetLastUsedSectorID(ctx runtime.Runtime) (uint64, uint8, error) {
+func (*Impl) GetLastUsedSectorID(ctx invocationContext) (uint64, uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return 0, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -601,20 +611,21 @@ func (*Impl) GetLastUsedSectorID(ctx runtime.Runtime) (uint64, uint8, error) {
 
 // IsBootstrapMiner indicates whether the receiving miner was created in the
 // genesis block, i.e. used to bootstrap the network
-func (a *Impl) IsBootstrapMiner(ctx runtime.Runtime) (bool, uint8, error) {
+func (a *Impl) IsBootstrapMiner(ctx invocationContext) (bool, uint8, error) {
 	return a.Bootstrap, 0, nil
 }
 
 // GetPoStState returns whether the miner's last submitPoSt is within the proving period,
 // late or after the generation attack threshold.
-func (*Impl) GetPoStState(ctx runtime.Runtime) (*big.Int, uint8, error) {
+func (*Impl) GetPoStState(ctx invocationContext) (*big.Int, uint8, error) {
 	var state State
 	out, err := actor.WithState(ctx, &state, func() (interface{}, error) {
 		// Don't check lateness unless there is storage to prove
 		if state.ProvingSet.Size() == 0 {
 			return int64(PoStStateNoStorage), nil
 		}
-		lateState, _ := lateState(state.ProvingPeriodEnd, ctx.BlockHeight(), LatePoStGracePeriod(state.SectorSize))
+		epoch := ctx.Runtime().CurrentEpoch()
+		lateState, _ := lateState(state.ProvingPeriodEnd, &epoch, LatePoStGracePeriod(state.SectorSize))
 		return lateState, nil
 	})
 
@@ -631,7 +642,7 @@ func (*Impl) GetPoStState(ctx runtime.Runtime) (*big.Int, uint8, error) {
 }
 
 // GetProvingSetCommitments returns all sector commitments posted by this miner.
-func (*Impl) GetProvingSetCommitments(ctx runtime.Runtime) (map[string]types.Commitments, uint8, error) {
+func (*Impl) GetProvingSetCommitments(ctx invocationContext) (map[string]types.Commitments, uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return nil, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -655,7 +666,7 @@ func (*Impl) GetProvingSetCommitments(ctx runtime.Runtime) (map[string]types.Com
 
 // GetSectorSize returns the size of the sectors committed to the network by
 // this miner.
-func (*Impl) GetSectorSize(ctx runtime.Runtime) (*types.BytesAmount, uint8, error) {
+func (*Impl) GetSectorSize(ctx invocationContext) (*types.BytesAmount, uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return nil, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -678,7 +689,7 @@ func (*Impl) GetSectorSize(ctx runtime.Runtime) (*types.BytesAmount, uint8, erro
 
 // CommitSector adds a commitment to the specified sector. The sector must not
 // already be committed.
-func (a *Impl) CommitSector(ctx runtime.Runtime, sectorID uint64, commD, commR, commRStar []byte, proof types.PoRepProof) (uint8, error) {
+func (a *Impl) CommitSector(ctx invocationContext, sectorID uint64, commD, commR, commRStar []byte, proof types.PoRepProof) (uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -728,7 +739,7 @@ func (a *Impl) CommitSector(ctx runtime.Runtime, sectorID uint64, commD, commR, 
 
 		// make sure the miner has enough collateral to add more storage
 		collateral := CollateralForSector(state.SectorSize)
-		if collateral.GreaterThan(ctx.MyBalance().Sub(state.ActiveCollateral)) {
+		if collateral.GreaterThan(ctx.Balance().Sub(state.ActiveCollateral)) {
 			return nil, Errors[ErrInsufficientCollateral]
 		}
 
@@ -742,9 +753,10 @@ func (a *Impl) CommitSector(ctx runtime.Runtime, sectorID uint64, commD, commR, 
 		// proving set.  This  allows us to add power immediately in
 		// genesis with commitSector and submitPoSt calls without
 		// adding special casing for bootstrappers.
-		if state.ProvingSet.Size() == 0 || ctx.BlockHeight().Equal(types.NewBlockHeight(0)) {
+		epoch := ctx.Runtime().CurrentEpoch()
+		if state.ProvingSet.Size() == 0 || epoch.Equal(types.NewBlockHeight(0)) {
 			state.ProvingSet = state.ProvingSet.Add(sectorID)
-			state.ProvingPeriodEnd = ctx.BlockHeight().Add(types.NewBlockHeight(ProvingPeriodDuration(state.SectorSize)))
+			state.ProvingPeriodEnd = epoch.Add(types.NewBlockHeight(ProvingPeriodDuration(state.SectorSize)))
 		}
 		comms := types.Commitments{
 			CommD:     types.CommD{},
@@ -769,12 +781,12 @@ func (a *Impl) CommitSector(ctx runtime.Runtime, sectorID uint64, commD, commR, 
 // VerifyPieceInclusion verifies that proof proves that the data represented by commP is included in the sector, and
 // verifies that this miner is not slashable
 // This method returns nothing if the verification succeeds and returns a revert error if verification fails.
-func (*Impl) VerifyPieceInclusion(ctx runtime.Runtime, commP []byte, pieceSize *types.BytesAmount, sectorID uint64, proof []byte) (uint8, error) {
+func (*Impl) VerifyPieceInclusion(ctx invocationContext, commP []byte, pieceSize *types.BytesAmount, sectorID uint64, proof []byte) (uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
 
-	chainHeight := ctx.BlockHeight()
+	chainHeight := ctx.Runtime().CurrentEpoch()
 
 	var state State
 	_, err := actor.WithState(ctx, &state, func() (interface{}, error) {
@@ -820,7 +832,7 @@ func (*Impl) VerifyPieceInclusion(ctx runtime.Runtime, commP []byte, pieceSize *
 }
 
 // ChangeWorker alters the worker address in state
-func (*Impl) ChangeWorker(ctx runtime.Runtime, worker address.Address) (uint8, error) {
+func (*Impl) ChangeWorker(ctx invocationContext, worker address.Address) (uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -843,7 +855,7 @@ func (*Impl) ChangeWorker(ctx runtime.Runtime, worker address.Address) (uint8, e
 }
 
 // GetWorker returns the worker address for this miner.
-func (*Impl) GetWorker(ctx runtime.Runtime) (address.Address, uint8, error) {
+func (*Impl) GetWorker(ctx invocationContext) (address.Address, uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return address.Address{}, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -865,7 +877,7 @@ func (*Impl) GetWorker(ctx runtime.Runtime) (address.Address, uint8, error) {
 }
 
 // GetPeerID returns the libp2p peer ID that this miner can be reached at.
-func (*Impl) GetPeerID(ctx runtime.Runtime) (peer.ID, uint8, error) {
+func (*Impl) GetPeerID(ctx invocationContext) (peer.ID, uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return peer.ID(""), internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -881,7 +893,7 @@ func (*Impl) GetPeerID(ctx runtime.Runtime) (peer.ID, uint8, error) {
 }
 
 // UpdatePeerID is used to update the peerID this miner is operating under.
-func (*Impl) UpdatePeerID(ctx runtime.Runtime, pid peer.ID) (uint8, error) {
+func (*Impl) UpdatePeerID(ctx invocationContext, pid peer.ID) (uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -905,7 +917,7 @@ func (*Impl) UpdatePeerID(ctx runtime.Runtime, pid peer.ID) (uint8, error) {
 }
 
 // GetPower returns the amount of proven sectors for this miner.
-func (*Impl) GetPower(ctx runtime.Runtime) (*types.BytesAmount, uint8, error) {
+func (*Impl) GetPower(ctx invocationContext) (*types.BytesAmount, uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return nil, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -928,7 +940,7 @@ func (*Impl) GetPower(ctx runtime.Runtime) (*types.BytesAmount, uint8, error) {
 
 // GetActiveCollateral returns the active collateral a miner is holding to
 // protect storage.
-func (*Impl) GetActiveCollateral(ctx runtime.Runtime) (types.AttoFIL, uint8, error) {
+func (*Impl) GetActiveCollateral(ctx invocationContext) (types.AttoFIL, uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return types.ZeroAttoFIL, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -948,7 +960,7 @@ func (*Impl) GetActiveCollateral(ctx runtime.Runtime) (types.AttoFIL, uint8, err
 	return collateral, 0, nil
 }
 
-func (*Impl) AddFaults(ctx runtime.Runtime, faults types.FaultSet) (uint8, error) {
+func (*Impl) AddFaults(ctx invocationContext, faults types.FaultSet) (uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -957,7 +969,8 @@ func (*Impl) AddFaults(ctx runtime.Runtime, faults types.FaultSet) (uint8, error
 	_, err := actor.WithState(ctx, &state, func() (interface{}, error) {
 		challengeBlockHeight := provingWindowStart(state)
 
-		if ctx.BlockHeight().LessThan(challengeBlockHeight) {
+		epoch := ctx.Runtime().CurrentEpoch()
+		if epoch.LessThan(challengeBlockHeight) {
 			// Up to the challenge time new faults can be added.
 			state.CurrentFaultSet = state.CurrentFaultSet.Union(faults.SectorIds)
 		} else {
@@ -977,12 +990,12 @@ func (*Impl) AddFaults(ctx runtime.Runtime, faults types.FaultSet) (uint8, error
 
 // SubmitPoSt is used to submit a coalesced PoST to the chain to convince the chain
 // that you have been actually storing the files you claim to be.
-func (a *Impl) SubmitPoSt(ctx runtime.Runtime, poStProof types.PoStProof, faults types.FaultSet, done types.IntSet) (uint8, error) {
+func (a *Impl) SubmitPoSt(ctx invocationContext, poStProof types.PoStProof, faults types.FaultSet, done types.IntSet) (uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
 
-	chainHeight := ctx.BlockHeight()
+	chainHeight := ctx.Runtime().CurrentEpoch()
 	sender := ctx.Message().From
 	var state State
 	_, err := actor.WithState(ctx, &state, func() (interface{}, error) {
@@ -1004,7 +1017,7 @@ func (a *Impl) SubmitPoSt(ctx runtime.Runtime, poStProof types.PoStProof, faults
 				ProvingPeriodDuration(state.SectorSize))
 		}
 
-		feeRequired := latePoStFee(a.getPledgeCollateralRequirement(state, chainHeight), state.ProvingPeriodEnd, chainHeight, provingPeriodDuration)
+		feeRequired := latePoStFee(a.getPledgeCollateralRequirement(state, &chainHeight), state.ProvingPeriodEnd, &chainHeight, provingPeriodDuration)
 
 		// The message value has been added to the actor's balance.
 		// Ensure this value fully covers the fee which will be charged to this balance so that the resulting
@@ -1024,7 +1037,7 @@ func (a *Impl) SubmitPoSt(ctx runtime.Runtime, poStProof types.PoStProof, faults
 		// Refund any overpayment of fees to the owner.
 		if messageValue.GreaterThan(feeRequired) {
 			overpayment := messageValue.Sub(feeRequired)
-			_, _, err := ctx.Send(sender, types.SendMethodID, overpayment, []interface{}{})
+			_, _, err := ctx.Runtime().Send(sender, types.SendMethodID, overpayment, []interface{}{})
 			if err != nil {
 				return nil, errors.NewRevertErrorf("Failed to refund overpayment of %s to %s", overpayment, sender)
 			}
@@ -1107,7 +1120,7 @@ func (a *Impl) SubmitPoSt(ctx runtime.Runtime, poStProof types.PoStProof, faults
 		delta := newPower.Sub(oldPower)
 
 		if !delta.IsZero() {
-			_, ret, err := ctx.Send(address.StorageMarketAddress, Storagemarket_UpdateStorage, types.ZeroAttoFIL, []interface{}{delta})
+			_, ret, err := ctx.Runtime().Send(address.StorageMarketAddress, Storagemarket_UpdateStorage, types.ZeroAttoFIL, []interface{}{delta})
 			if err != nil {
 				return nil, err
 			}
@@ -1144,12 +1157,12 @@ func (a *Impl) SubmitPoSt(ctx runtime.Runtime, poStProof types.PoStProof, faults
 // SlashStorageFault is called by an independent actor to remove power and
 // take collateral from this miner when the miner has failed to submit a
 // PoSt on time.
-func (*Impl) SlashStorageFault(ctx runtime.Runtime) (uint8, error) {
+func (*Impl) SlashStorageFault(ctx invocationContext) (uint8, error) {
 	if err := ctx.Charge(actor.DefaultGasCost); err != nil {
 		return internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
 
-	chainHeight := ctx.BlockHeight()
+	chainHeight := ctx.Runtime().CurrentEpoch()
 	var state State
 	_, err := actor.WithState(ctx, &state, func() (interface{}, error) {
 		// You can only be slashed once for missing your PoSt.
@@ -1170,7 +1183,7 @@ func (*Impl) SlashStorageFault(ctx runtime.Runtime) (uint8, error) {
 
 		// Strip the miner of their power.
 		powerDelta := types.ZeroBytes.Sub(state.Power) // negate bytes amount
-		_, ret, err := ctx.Send(address.StorageMarketAddress, Storagemarket_UpdateStorage, types.ZeroAttoFIL, []interface{}{powerDelta})
+		_, ret, err := ctx.Runtime().Send(address.StorageMarketAddress, Storagemarket_UpdateStorage, types.ZeroAttoFIL, []interface{}{powerDelta})
 		if err != nil {
 			return nil, err
 		}
@@ -1193,7 +1206,7 @@ func (*Impl) SlashStorageFault(ctx runtime.Runtime) (uint8, error) {
 		state.ProvingSet = types.NewIntSet()
 
 		// save chain height, so we know when this miner was slashed
-		state.SlashedAt = chainHeight
+		state.SlashedAt = &chainHeight
 
 		return nil, nil
 	})
@@ -1206,7 +1219,7 @@ func (*Impl) SlashStorageFault(ctx runtime.Runtime) (uint8, error) {
 }
 
 // GetProvingWindow returns the proving period start and proving period end
-func (*Impl) GetProvingWindow(ctx runtime.Runtime) ([]types.Uint64, uint8, error) {
+func (*Impl) GetProvingWindow(ctx invocationContext) ([]types.Uint64, uint8, error) {
 	var state State
 	err := actor.ReadState(ctx, &state)
 	if err != nil {
@@ -1221,14 +1234,15 @@ func (*Impl) GetProvingWindow(ctx runtime.Runtime) ([]types.Uint64, uint8, error
 
 // CalculateLateFee calculates the late fee due for a PoSt arriving at `height` for the actor's current
 // power and proving period.
-func (a *Impl) CalculateLateFee(ctx runtime.Runtime, height *types.BlockHeight) (types.AttoFIL, uint8, error) {
+func (a *Impl) CalculateLateFee(ctx invocationContext, height *types.BlockHeight) (types.AttoFIL, uint8, error) {
 	var state State
 	err := actor.ReadState(ctx, &state)
 	if err != nil {
 		return types.ZeroAttoFIL, errors.CodeError(err), err
 	}
 
-	collateral := a.getPledgeCollateralRequirement(state, ctx.BlockHeight())
+	epoch := ctx.Runtime().CurrentEpoch()
+	collateral := a.getPledgeCollateralRequirement(state, &epoch)
 	gracePeriod := types.NewBlockHeight(ProvingPeriodDuration(state.SectorSize))
 	fee := latePoStFee(collateral, state.ProvingPeriodEnd, height, gracePeriod)
 	return fee, 0, nil
@@ -1240,8 +1254,8 @@ func (a *Impl) CalculateLateFee(ctx runtime.Runtime, height *types.BlockHeight) 
 // expectation of this being important for future protocol upgrade mechanisms.
 //
 
-func (*Impl) burnFunds(ctx runtime.Runtime, amount types.AttoFIL) error {
-	_, _, err := ctx.Send(address.BurntFundsAddress, types.SendMethodID, amount, []interface{}{})
+func (*Impl) burnFunds(ctx invocationContext, amount types.AttoFIL) error {
+	_, _, err := ctx.Runtime().Send(address.BurntFundsAddress, types.SendMethodID, amount, []interface{}{})
 	return err
 }
 
@@ -1252,11 +1266,8 @@ func (*Impl) getPledgeCollateralRequirement(state State, height *types.BlockHeig
 }
 
 // getPoStChallengeSeed returns some chain randomness
-func getPoStChallengeSeed(ctx runtime.Runtime, state State, sampleAt *types.BlockHeight) (types.PoStChallengeSeed, error) {
-	randomness, err := ctx.SampleChainRandomness(sampleAt)
-	if err != nil {
-		return types.PoStChallengeSeed{}, err
-	}
+func getPoStChallengeSeed(ctx invocationContext, state State, sampleAt *types.BlockHeight) (types.PoStChallengeSeed, error) {
+	randomness := ctx.Runtime().Randomness(*sampleAt, 0)
 
 	seed := types.PoStChallengeSeed{}
 	copy(seed[:], randomness)
@@ -1269,9 +1280,9 @@ func getPoStChallengeSeed(ctx runtime.Runtime, state State, sampleAt *types.Bloc
 //
 
 // GetProofsMode returns the genesis block-configured proofs mode.
-func GetProofsMode(ctx runtime.Runtime) (types.ProofsMode, error) {
+func GetProofsMode(ctx invocationContext) (types.ProofsMode, error) {
 	var proofsMode types.ProofsMode
-	msgResult, _, err := ctx.Send(address.StorageMarketAddress, Storagemarket_GetProofsMode, types.ZeroAttoFIL, nil)
+	msgResult, _, err := ctx.Runtime().Send(address.StorageMarketAddress, Storagemarket_GetProofsMode, types.ZeroAttoFIL, nil)
 	if err != nil {
 		return types.TestProofsMode, xerrors.Wrap(err, "'GetProofsMode' message failed")
 	}

--- a/internal/pkg/vm/actor/builtin/miner/miner_test.go
+++ b/internal/pkg/vm/actor/builtin/miner/miner_test.go
@@ -31,7 +31,6 @@ import (
 	vmerrors "github.com/filecoin-project/go-filecoin/internal/pkg/vm/errors"
 	internal "github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/errors"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/gastracker"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/runtime"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/storagemap"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/vmcontext"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
@@ -1707,7 +1706,7 @@ type minerEnvBuilder struct {
 	verifier         *verification.FakeVerifier
 }
 
-func (b *minerEnvBuilder) build() (runtime.Runtime, *verification.FakeVerifier, *Impl) {
+func (b *minerEnvBuilder) build() (*vm.FakeVMContext, *verification.FakeVerifier, *Impl) {
 	minerState := NewState(address.TestAddress, address.TestAddress, peer.ID(""), b.sectorSize)
 	minerState.SectorCommitments = b.sectorSet
 	minerState.ProvingPeriodEnd = b.provingPeriodEnd

--- a/internal/pkg/vm/actor/builtin/miner/miner_test.go
+++ b/internal/pkg/vm/actor/builtin/miner/miner_test.go
@@ -401,7 +401,6 @@ func TestMinerGetProvingPeriod(t *testing.T) {
 		start := window.Val.([]types.Uint64)[0]
 		end := window.Val.([]types.Uint64)[1]
 
-
 		// end of proving period is now plus proving period size
 		expectedEnd := blockHeight + uint64(LargestSectorSizeProvingPeriodBlocks)
 		// start of proving period is end minus the PoSt challenge time

--- a/internal/pkg/vm/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/internal/pkg/vm/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -1309,7 +1309,7 @@ func (ma *PBTestActor) InitializeState(storage runtime.Storage, initializerData 
 	return nil
 }
 
-func (ma *PBTestActor) ParamsNotZero(ctx runtime.Runtime, addr address.Address, sector uint64, bh *types.BlockHeight) (uint8, error) {
+func (ma *PBTestActor) ParamsNotZero(ctx runtime.InvocationContext, addr address.Address, sector uint64, bh *types.BlockHeight) (uint8, error) {
 	if addr == address.Undef {
 		return 1, errors.NewRevertError("got undefined address")
 	}

--- a/internal/pkg/vm/actor/builtin/power/power.go
+++ b/internal/pkg/vm/actor/builtin/power/power.go
@@ -183,7 +183,7 @@ func (*impl) createStorageMiner(vmctx invocationContext, ownerAddr, workerAddr a
 
 		// Update power table.
 		ctx := context.Background()
-		newPowerTable, err := actor.WithLookup(ctx,  vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
+		newPowerTable, err := actor.WithLookup(ctx, vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
 			// Do not overwrite table entry if it already exists
 			err := lookup.Find(ctx, addr.String(), nil)
 			if err != hamt.ErrNotFound { // we expect to not find the power table entry
@@ -229,7 +229,7 @@ func (*impl) removeStorageMiner(vmctx invocationContext, delAddr address.Address
 	var state State
 	_, err := actor.WithState(vmctx, &state, func() (interface{}, error) {
 		ctx := context.Background()
-		newPowerTable, err := actor.WithLookup(ctx,  vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
+		newPowerTable, err := actor.WithLookup(ctx, vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
 			// Find entry to delete.
 			var delEntry TableEntry
 			err := lookup.Find(ctx, delAddr.String(), &delEntry)
@@ -272,7 +272,7 @@ func (*impl) getTotalPower(vmctx invocationContext) (*types.BytesAmount, uint8, 
 	ret, err := actor.WithState(vmctx, &state, func() (interface{}, error) {
 		ctx := context.Background()
 		total := types.NewBytesAmount(0)
-		err := actor.WithLookupForReading(ctx,  vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
+		err := actor.WithLookupForReading(ctx, vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
 			// TODO https://github.com/filecoin-project/specs/issues/634 this is inefficient
 			return lookup.ForEachValue(ctx, TableEntry{}, func(k string, value interface{}) error {
 				entry, ok := value.(TableEntry)
@@ -301,7 +301,7 @@ func (*impl) getPowerReport(vmctx invocationContext, addr address.Address) (type
 	ret, err := actor.WithState(vmctx, &state, func() (interface{}, error) {
 		ctx := context.Background()
 		var report types.PowerReport
-		err := actor.WithLookupForReading(ctx,  vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
+		err := actor.WithLookupForReading(ctx, vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
 			err := lookup.Find(ctx, addr.String(), &report)
 			if err != nil {
 				if err == hamt.ErrNotFound {
@@ -328,7 +328,7 @@ func (*impl) processPowerReport(vmctx invocationContext, report types.PowerRepor
 	var state State
 	_, err := actor.WithState(vmctx, &state, func() (interface{}, error) {
 		ctx := context.Background()
-		newPowerTable, err := actor.WithLookup(ctx,  vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
+		newPowerTable, err := actor.WithLookup(ctx, vmctx.Storage(), state.PowerTable, func(lookup storage.Lookup) error {
 			// Find entry to update.
 			var updateEntry TableEntry
 			err := lookup.Find(ctx, updateAddr.String(), &updateEntry)

--- a/internal/pkg/vm/actor/builtin/storagemarket/storagemarket.go
+++ b/internal/pkg/vm/actor/builtin/storagemarket/storagemarket.go
@@ -102,7 +102,7 @@ func (a *Actor) Method(id types.MethodID) (dispatch.Method, *dispatch.FunctionSi
 		return reflect.ValueOf((*impl)(a).getLateMiners), signatures[GetLateMiners], true
 	default:
 		return nil, nil, false
-	}
+}
 }
 
 // InitializeState stores the actor's initial data structure.
@@ -145,9 +145,16 @@ var Errors = map[uint8]error{
 	ErrUnsupportedSectorSize: errors.NewCodedRevertErrorf(ErrUnsupportedSectorSize, "sector size is not supported"),
 }
 
+type invocationContext interface {
+	runtime.InvocationContext
+	Message() *types.UnsignedMessage
+	CreateNewActor(addr address.Address, code cid.Cid, initalizationParams interface{}) error
+	AddressForNewActor() (address.Address, error)
+}
+
 // CreateStorageMiner creates a new miner which will commit sectors of the
 // given size. The miners collateral is set by the value in the message.
-func (*impl) createStorageMiner(vmctx runtime.Runtime, sectorSize *types.BytesAmount, pid peer.ID) (address.Address, uint8, error) {
+func (*impl) createStorageMiner(vmctx invocationContext, sectorSize *types.BytesAmount, pid peer.ID) (address.Address, uint8, error) {
 	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
 		return address.Undef, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -166,7 +173,8 @@ func (*impl) createStorageMiner(vmctx runtime.Runtime, sectorSize *types.BytesAm
 		minerInitializationParams := miner.NewState(vmctx.Message().From, vmctx.Message().From, pid, sectorSize)
 
 		actorCodeCid := types.MinerActorCodeCid
-		if vmctx.BlockHeight().Equal(types.NewBlockHeight(0)) {
+		epoch := vmctx.Runtime().CurrentEpoch()
+		if epoch.Equal(types.NewBlockHeight(0)) {
 			actorCodeCid = types.BootstrapMinerActorCodeCid
 		}
 
@@ -174,7 +182,7 @@ func (*impl) createStorageMiner(vmctx runtime.Runtime, sectorSize *types.BytesAm
 			return nil, err
 		}
 
-		_, _, err = vmctx.Send(addr, types.SendMethodID, vmctx.Message().Value, nil)
+		_, _, err = vmctx.Runtime().Send(addr, types.SendMethodID, vmctx.Message().Value, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -198,7 +206,7 @@ func (*impl) createStorageMiner(vmctx runtime.Runtime, sectorSize *types.BytesAm
 // UpdateStorage is called to reflect a change in the overall power of the network.
 // This occurs either when a miner adds a new commitment, or when one is removed
 // (via slashing, faults or willful removal). The delta is in number of bytes.
-func (*impl) updateStorage(vmctx runtime.Runtime, delta *types.BytesAmount) (uint8, error) {
+func (*impl) updateStorage(vmctx invocationContext, delta *types.BytesAmount) (uint8, error) {
 	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
 		return internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -232,7 +240,7 @@ func (*impl) updateStorage(vmctx runtime.Runtime, delta *types.BytesAmount) (uin
 	return 0, nil
 }
 
-func (a *impl) getLateMiners(vmctx runtime.Runtime) (*map[string]uint64, uint8, error) {
+func (a *impl) getLateMiners(vmctx invocationContext) (*map[string]uint64, uint8, error) {
 	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
 		return nil, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -279,7 +287,7 @@ func (a *impl) getLateMiners(vmctx runtime.Runtime) (*map[string]uint64, uint8, 
 }
 
 // GetTotalStorage returns the total amount of proven storage in the system.
-func (*impl) getTotalStorage(vmctx runtime.Runtime) (*types.BytesAmount, uint8, error) {
+func (*impl) getTotalStorage(vmctx invocationContext) (*types.BytesAmount, uint8, error) {
 	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
 		return nil, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -301,7 +309,7 @@ func (*impl) getTotalStorage(vmctx runtime.Runtime) (*types.BytesAmount, uint8, 
 }
 
 // GetSectorSize returns the sector size of the block chain
-func (*impl) getProofsMode(vmctx runtime.Runtime) (types.ProofsMode, uint8, error) {
+func (*impl) getProofsMode(vmctx invocationContext) (types.ProofsMode, uint8, error) {
 	if err := vmctx.Charge(actor.DefaultGasCost); err != nil {
 		return 0, internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
@@ -322,8 +330,8 @@ func (*impl) getProofsMode(vmctx runtime.Runtime) (types.ProofsMode, uint8, erro
 	return size, 0, nil
 }
 
-func (*impl) getMinerPoStState(vmctx runtime.Runtime, minerAddr address.Address) (uint64, error) {
-	msgResult, _, err := vmctx.Send(minerAddr, miner.GetPoStState, types.ZeroAttoFIL, nil)
+func (*impl) getMinerPoStState(vmctx invocationContext, minerAddr address.Address) (uint64, error) {
+	msgResult, _, err := vmctx.Runtime().Send(minerAddr, miner.GetPoStState, types.ZeroAttoFIL, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/pkg/vm/actor/builtin/storagemarket/storagemarket.go
+++ b/internal/pkg/vm/actor/builtin/storagemarket/storagemarket.go
@@ -102,7 +102,7 @@ func (a *Actor) Method(id types.MethodID) (dispatch.Method, *dispatch.FunctionSi
 		return reflect.ValueOf((*impl)(a).getLateMiners), signatures[GetLateMiners], true
 	default:
 		return nil, nil, false
-}
+	}
 }
 
 // InitializeState stores the actor's initial data structure.

--- a/internal/pkg/vm/actor/storage.go
+++ b/internal/pkg/vm/actor/storage.go
@@ -44,7 +44,7 @@ func UnmarshalStorage(raw []byte, to interface{}) error {
 //
 // Note that if 'f' returns an error, modifications to the storage are not
 // saved.
-func WithState(ctx runtime.Runtime, st interface{}, f func() (interface{}, error)) (interface{}, error) {
+func WithState(ctx runtime.InvocationContext, st interface{}, f func() (interface{}, error)) (interface{}, error) {
 	if err := ReadState(ctx, st); err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func WithState(ctx runtime.Runtime, st interface{}, f func() (interface{}, error
 }
 
 // ReadState is a helper method to read the cbor node at the actor's Head into the given struct
-func ReadState(ctx runtime.Runtime, st interface{}) error {
+func ReadState(ctx runtime.InvocationContext, st interface{}) error {
 	storage := ctx.Storage()
 
 	memory, err := storage.Get(storage.Head())

--- a/internal/pkg/vm/internal/dispatch/dispatch.go
+++ b/internal/pkg/vm/internal/dispatch/dispatch.go
@@ -23,9 +23,6 @@ type ExecutableActor interface {
 // Exports describe the public methods of an actor.
 type Exports map[types.MethodID]*FunctionSignature
 
-// ExportedFunc is the signature an exported method of an actor is expected to have.
-type ExportedFunc func(ctx runtime.Runtime) ([]byte, uint8, error)
-
 // FunctionSignature describes the signature of a single function.
 type FunctionSignature struct {
 	// Params is a list of the types of the parameters the function expects.

--- a/internal/pkg/vm/internal/exitcode/exitcode.go
+++ b/internal/pkg/vm/internal/exitcode/exitcode.go
@@ -1,0 +1,65 @@
+package exitcode
+
+import "github.com/filecoin-project/go-filecoin/internal/pkg/types"
+
+// ExitCode is the exit code of a method executing inside the VM.
+type ExitCode types.Uint64
+
+// Exit codes.
+// Review: for @spec, the spec should reserve a lot more ErrorCodes (have users start at 1024 or more).
+const (
+	// OK is the success return value, similar to unix exit code 0.
+	Ok ExitCode = ExitCode(0)
+
+	// ActorNotFound represents a failure to find an actor.
+	ActorNotFound = ExitCode(1)
+
+	// ActorCodeNotFound represents a failure to find the code for a
+	// particular actor in the VM registry.
+	ActorCodeNotFound = ExitCode(2)
+
+	// InvalidMethod represents a failure to find a method in an actor
+	InvalidMethod = ExitCode(3)
+
+	// InsufficientFunds represents a failure to apply a message, as
+	// it did not carry sufficient funds for its application.
+	InsufficientFunds = ExitCode(4)
+
+	// InvalidCallSeqNum represents a message invocation out of sequence.
+	// This happens when message.CallSeqNum is not exactly actor.CallSeqNum + 1
+	InvalidCallSeqNum = ExitCode(5)
+
+	// OutOfGasError is returned when the execution of an actor method
+	// (including its subcalls) uses more gas than initially allocated.
+	OutOfGas = ExitCode(6)
+
+	// RuntimeAPIError is returned when an actor method invocation makes a call
+	// to the runtime that does not satisfy its preconditions.
+	RuntimeAPIError = ExitCode(7)
+
+	// MethodPanic is returned when an actor method invocation calls rt.Abort.
+	MethodAbort = ExitCode(8)
+
+	// MethodPanic is returned when the runtime intercepts a panic within
+	// an actor method invocation (not via rt.Abort).
+	MethodPanic = ExitCode(9)
+
+	// MethodSubcallError is returned when an actor method's Send call has
+	// returned with a failure error code (and the Send call did not specify
+	// to ignore errors).
+	MethodSubcallError = ExitCode(10)
+
+	// Runtime failed to encode the object.
+	// Review: for @spec, @go-filecoin, added this error
+	EncodingError = ExitCode(11)
+)
+
+// IsSuccess returns `True` if the exit code represents success.
+func (code ExitCode) IsSuccess() bool {
+	return code == Ok
+}
+
+// IsError returns `True` if the exit code is an error.
+func (code ExitCode) IsError() bool {
+	return code != Ok
+}

--- a/internal/pkg/vm/internal/pattern/pattern.go
+++ b/internal/pkg/vm/internal/pattern/pattern.go
@@ -6,7 +6,7 @@ import (
 )
 
 // IsAccountActor pattern checks if the caller is an account actor.
-type IsAccountActor struct {}
+type IsAccountActor struct{}
 
 // IsMatch returns "True" if the patterns matches
 func (IsAccountActor) IsMatch(ctx runtime.PatternContext) bool {

--- a/internal/pkg/vm/internal/pattern/pattern.go
+++ b/internal/pkg/vm/internal/pattern/pattern.go
@@ -1,0 +1,9 @@
+package pattern
+
+// IsAccountActor pattern checks if the caller is an account actor.
+type IsAccountActor struct {}
+
+// IsMatch returns "True" if the patterns matches
+func (IsAccountActor) IsMatch() bool {
+	panic("byteme")
+}

--- a/internal/pkg/vm/internal/pattern/pattern.go
+++ b/internal/pkg/vm/internal/pattern/pattern.go
@@ -1,9 +1,14 @@
 package pattern
 
+import (
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/runtime"
+)
+
 // IsAccountActor pattern checks if the caller is an account actor.
 type IsAccountActor struct {}
 
 // IsMatch returns "True" if the patterns matches
-func (IsAccountActor) IsMatch() bool {
-	panic("byteme")
+func (IsAccountActor) IsMatch(ctx runtime.PatternContext) bool {
+	return types.AccountActorCodeCid.Equals(ctx.Code())
 }

--- a/internal/pkg/vm/internal/result/result.go
+++ b/internal/pkg/vm/internal/result/result.go
@@ -1,0 +1,38 @@
+package result
+
+import (
+	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/exitcode"
+)
+
+// InvocOutput is what is returned by an actor executing a method.
+type InvocOutput struct {
+	ExitCode    exitcode.ExitCode
+	ReturnValue []byte
+}
+
+// Success returns an empty succesfull result.
+func Success() InvocOutput {
+	return InvocOutput{ExitCode: 0}
+}
+
+// Value returns a successfull code with the value encoded.
+//
+// Callers do NOT need to encode the value before calling this method.
+// Review: for @spec, @go-filecoin, changed this to an interface so the caller doesnt have to do the serialization himself
+func Value(obj interface{}) InvocOutput {
+	aux, err := encoding.Encode(obj)
+	if err != nil {
+		return InvocOutput{ExitCode: exitcode.EncodingError}
+	}
+
+	return InvocOutput{
+		ExitCode:    0,
+		ReturnValue: aux,
+	}
+}
+
+// Error returns an error output.
+func Error(exitCode exitcode.ExitCode) InvocOutput {
+	return InvocOutput{ExitCode: exitCode}
+}

--- a/internal/pkg/vm/internal/result/result.go
+++ b/internal/pkg/vm/internal/result/result.go
@@ -16,7 +16,7 @@ func Success() InvocOutput {
 	return InvocOutput{ExitCode: 0}
 }
 
-// Value returns a successfull code with the value encoded.
+// Value returns a successful code with the value encoded.
 //
 // Callers do NOT need to encode the value before calling this method.
 // Review: for @spec, @go-filecoin, changed this to an interface so the caller doesnt have to do the serialization himself

--- a/internal/pkg/vm/internal/runtime/runtime.go
+++ b/internal/pkg/vm/internal/runtime/runtime.go
@@ -46,13 +46,6 @@ type InvocationContext interface {
 	Charge(cost types.GasUnits) error
 }
 
-// initInvocationContext is a more powerfull context for the "init" actor.
-type initInvocationContext interface {
-	InvocationContext
-	// CreateActor allows the creation of a new actor.
-	CreateActor(state interface{}, addr address.Address, constructorParams MethodParams) error
-}
-
 // ActorStateHandle handles the actor state, allowing actors to lock on the state.
 type ActorStateHandle interface {
 	// Take loads the state and locks it.
@@ -131,6 +124,6 @@ type Storage interface {
 	Get(cid.Cid) ([]byte, error)
 	// Review: why is this needed on the actor API? Actor commit is implicit upon a succesfull termination.
 	// Review: an explicit Commit() on actor code leads to bugs
-	// Review: what situation requires state to change, succesfully execute the method, but not to be commited?
+	// Review: what situation requires state to change, successfully execute the method, but not to be commited?
 	Commit(cid.Cid, cid.Cid) error
 }

--- a/internal/pkg/vm/internal/runtime/runtime.go
+++ b/internal/pkg/vm/internal/runtime/runtime.go
@@ -3,32 +3,131 @@ package runtime
 import (
 	"github.com/ipfs/go-cid"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/proofs/verification"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 )
 
-// Runtime defines the ABI interface exposed to actors.
+// Runtime has operations in the VM that are exposed to all actors.
 type Runtime interface {
-	Message() *types.UnsignedMessage
-	Storage() Storage
+	// CurrentEpoch is the current chain epoch.
+	CurrentEpoch() types.BlockHeight
+	// Randomness gives the actors access to sampling peudo-randomess from the chain.
+	Randomness(epoch types.BlockHeight, offset uint64) Randomness
+	// Send allows actors to invoke methods on other actors
+	// Send(input InvocInput) result.InvocOutput
+	// Dragons: match signature for this PR, change to struct on next PR
 	Send(to address.Address, method types.MethodID, value types.AttoFIL, params []interface{}) ([][]byte, uint8, error)
-	AddressForNewActor() (address.Address, error)
-	BlockHeight() *types.BlockHeight
-	MyBalance() types.AttoFIL
-	IsFromAccountActor() bool
+	// Review: should be add `Abort` and `Assert` here?
+}
+
+// InvocationContext is passed to the actors on each method call.
+type InvocationContext interface {
+	// Runtime exposes some methods on the runtime to the actor.
+	Runtime() Runtime
+	// ValidateCaller validates the caller against a patter.
+	//
+	// All actor methods MUST call this method before returning.
+	ValidateCaller(CallerPattern)
+	// Caller is the immediate caller to the current executing method.
+	Caller() address.Address
+	// StateHandle handles access to the actor state.
+	StateHandle() ActorStateHandle
+	// ValueReceived is the amount of FIL received by this actor during this method call.
+	//
+	// Note: the value is already been deposited on the actors account and is reflected on the balance.
+	ValueReceived() types.AttoFIL
+	// Balance is the current balance on the current actors account.
+	//
+	// Note: the value received for this invocation is already reflected on the balance.
+	Balance() types.AttoFIL
+	// Review: we seem to require this
+	Storage() Storage
+	// Dragons: here just to avoid deleting a lot of lines while we wait for the new Gas Accounting to land
 	Charge(cost types.GasUnits) error
-	SampleChainRandomness(sampleHeight *types.BlockHeight) ([]byte, error)
+}
 
-	CreateNewActor(addr address.Address, code cid.Cid, initalizationParams interface{}) error
 
-	Verifier() verification.Verifier
+// initInvocationContext is a more powerfull context for the "init" actor.
+type initInvocationContext interface {
+	InvocationContext
+	// CreateActor allows the creation of a new actor.
+	CreateActor(state interface{}, addr address.Address, constructorParams MethodParams) error
+}
+
+
+
+// ActorStateHandle handles the actor state, allowing actors to lock on the state.
+type ActorStateHandle interface {
+	// Take loads the state and locks it.
+	//
+	// Any futre calls to `Take` on this actors state will `abort` the execution.
+	// Review: for @spec, the impl of `Take` is panic'ing on the second call on the SAME object instance (this objects are not kept around, so it is always a new instance..).
+	Take(interface{})
+	// UpdateRelease updates the actor state and releases the lock on it.
+	//
+	// No future calls to `Take` are allowed on this object.
+	// Review: for @spec, this method can currently be called without having called `Take` first.
+	UpdateRelease(interface{})
+	// Release asserts that the state has not changed and releases the lock on it.
+	//
+	// No future calls to `Take` are allowed on this object.
+	// Review: for @spec, this method can currently be called without having called `Take` first.
+	// Review: for @spec, why is this method required?
+	Release(interface{})
+}
+
+// Randomness is a string of random bytes
+type Randomness []byte
+
+// InvocInput are the params to invoke a method in an Actor.
+type InvocInput struct {
+    To      address.Address
+    Method  types.MethodID
+    Params  MethodParams
+    Value   types.AttoFIL
+}
+
+// MethodParam is the parameter to an actor method.
+type MethodParam []byte
+// MethodParams is a list of `MethodParam` to be passed into an Actor method.
+type MethodParams []MethodParam
+
+// CallerPattern checks if the caller matches the pattern.
+type CallerPattern interface {
+	// IsMatch returns "True" if the patterns matches
+	IsMatch() bool
+}
+
+// AbortPanicError is used on panic when `Abort` is called by actors.
+type AbortPanicError struct{
+	msg string
+}
+
+func (x AbortPanicError) Error() string {
+	return x.msg
+}
+
+// Abort will stop the VM execution and return an abort error to the caller.
+func Abort(msg string) {
+	panic(AbortPanicError{msg: msg})
+}
+
+// Assert will abort if the condition is `False` and return an abort error to the caller.
+func Assert(cond bool) {
+	if !cond {
+		Abort("assertion failure in actor code.")
+	}
 }
 
 // Storage defines the storage module exposed to actors.
 type Storage interface {
-	Put(interface{}) (cid.Cid, error)
-	Get(cid.Cid) ([]byte, error)
-	Commit(cid.Cid, cid.Cid) error
 	Head() cid.Cid
+	Put(interface{}) (cid.Cid, error)
+	// Dragons: this interface is wrong, the caller does not know how the object got serialized (Put/1 takes an interface{} not bytes)
+	// TODO: change to `Get(cid, interface{}) error`
+	Get(cid.Cid) ([]byte, error)
+	// Review: why is this needed on the actor API? Actor commit is implicit upon a succesfull termination.
+	// Review: an explicit Commit() on actor code leads to bugs
+	// Review: what situation requires state to change, succesfully execute the method, but not to be commited?
+	Commit(cid.Cid, cid.Cid) error
 }

--- a/internal/pkg/vm/internal/runtime/runtime.go
+++ b/internal/pkg/vm/internal/runtime/runtime.go
@@ -92,10 +92,15 @@ type MethodParam []byte
 // MethodParams is a list of `MethodParam` to be passed into an Actor method.
 type MethodParams []MethodParam
 
+// PatternContext is the context a pattern gets access to in order to determine if the caller matches.
+type PatternContext interface {
+	Code() cid.Cid
+}
+
 // CallerPattern checks if the caller matches the pattern.
 type CallerPattern interface {
 	// IsMatch returns "True" if the patterns matches
-	IsMatch() bool
+	IsMatch(ctx PatternContext) bool
 }
 
 // AbortPanicError is used on panic when `Abort` is called by actors.

--- a/internal/pkg/vm/internal/runtime/runtime.go
+++ b/internal/pkg/vm/internal/runtime/runtime.go
@@ -124,6 +124,6 @@ type Storage interface {
 	Get(cid.Cid) ([]byte, error)
 	// Review: why is this needed on the actor API? Actor commit is implicit upon a succesfull termination.
 	// Review: an explicit Commit() on actor code leads to bugs
-	// Review: what situation requires state to change, successfully execute the method, but not to be commited?
+	// Review: what situation requires state to change, successfully execute the method, but not to be committed?
 	Commit(cid.Cid, cid.Cid) error
 }

--- a/internal/pkg/vm/internal/runtime/runtime.go
+++ b/internal/pkg/vm/internal/runtime/runtime.go
@@ -46,15 +46,12 @@ type InvocationContext interface {
 	Charge(cost types.GasUnits) error
 }
 
-
 // initInvocationContext is a more powerfull context for the "init" actor.
 type initInvocationContext interface {
 	InvocationContext
 	// CreateActor allows the creation of a new actor.
 	CreateActor(state interface{}, addr address.Address, constructorParams MethodParams) error
 }
-
-
 
 // ActorStateHandle handles the actor state, allowing actors to lock on the state.
 type ActorStateHandle interface {
@@ -81,14 +78,15 @@ type Randomness []byte
 
 // InvocInput are the params to invoke a method in an Actor.
 type InvocInput struct {
-    To      address.Address
-    Method  types.MethodID
-    Params  MethodParams
-    Value   types.AttoFIL
+	To     address.Address
+	Method types.MethodID
+	Params MethodParams
+	Value  types.AttoFIL
 }
 
 // MethodParam is the parameter to an actor method.
 type MethodParam []byte
+
 // MethodParams is a list of `MethodParam` to be passed into an Actor method.
 type MethodParams []MethodParam
 
@@ -104,7 +102,7 @@ type CallerPattern interface {
 }
 
 // AbortPanicError is used on panic when `Abort` is called by actors.
-type AbortPanicError struct{
+type AbortPanicError struct {
 	msg string
 }
 

--- a/internal/pkg/vm/internal/vmcontext/actor_state_handle.go
+++ b/internal/pkg/vm/internal/vmcontext/actor_state_handle.go
@@ -1,0 +1,111 @@
+package vmcontext
+
+import (
+	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/runtime"
+	"github.com/ipfs/go-cid"
+)
+
+type actorStateHandle struct {
+	ctx  actorStateHandleContext
+	head *cid.Cid
+}
+
+type actorStateHandleContext interface {
+	Storage() runtime.Storage
+}
+
+// NewActorStateHandle returns a new `actorStateHandle`
+func NewActorStateHandle(ctx actorStateHandleContext, head cid.Cid) runtime.ActorStateHandle {
+	return &actorStateHandle{
+		ctx:  ctx,
+		head: &head,
+	}
+}
+
+var _ runtime.ActorStateHandle = (*actorStateHandle)(nil)
+
+// Take loads the state and locks it.
+//
+// Any futre calls to `Take` on this actors state will `abort` the execution.
+func (h *actorStateHandle) Take(obj interface{}) {
+	// check if the state has already been taken
+	if h.head == nil {
+		runtime.Abort("Must call Take() only once on actor substate object")
+	}
+
+	// load state from storage
+	storage := h.ctx.Storage()
+	rawstate, err := storage.Get(*h.head)
+	if err != nil {
+		runtime.Abort("Storage get error")
+	}
+
+	// Dragons: cleanup after changing `Get` to `Get(cid, interface{})`
+	if err := encoding.Decode(rawstate, obj); err != nil {
+		runtime.Abort("Could not deserialize state")
+	}
+
+	// clear head value so that it cannot be taken again
+	h.head = nil
+}
+
+// UpdateRelease updates the actor state and releases the lock on it.
+//
+// No future calls to `Take` are allowed on this object.
+func (h *actorStateHandle) UpdateRelease(obj interface{}) {
+	// Review: for @spec why are all this checks here?
+	// rt._checkRunning()
+	// rt._checkActorStateAcquired()
+	if h.head != nil {
+		runtime.Abort("Must call Take() before calling UpdateRelease()")
+	}
+
+	storage := h.ctx.Storage()
+	oldcid := storage.Head()
+
+	// store the new state
+	newcid, err := storage.Put(obj)
+	if err != nil {
+		runtime.Abort("Storage put error")
+	}
+
+	// commit the new state
+	// Note: this is more of a commit into pending, not a real commit
+	err = storage.Commit(newcid, oldcid)
+	if err != nil {
+		runtime.Abort("Storage commit error")
+	}
+
+	// make new head available to take
+	h.head = &newcid
+}
+
+// Release asserts that the state has not changed and releases the lock on it.
+//
+// No future calls to `Take` are allowed on this object.
+func (h *actorStateHandle) Release(obj interface{}) {
+	// Review: for @spec why are all this checks here?
+	// rt._checkRunning()
+	// rt._checkActorStateAcquired()
+	if h.head != nil {
+		runtime.Abort("Must call Take() before calling Release()")
+	}
+
+	storage := h.ctx.Storage()
+	oldcid := storage.Head()
+
+	// store the new state
+	// Dragons: we need a `CidOf(interface{})` on the storage that doesnt actually store anything
+	newcid, err := storage.Put(obj)
+	if err != nil {
+		runtime.Abort("Storage put error")
+	}
+
+	if newcid != oldcid {
+		runtime.Abort("State CID differs upon release call")
+	}
+
+	// make new head available to take
+	h.head = &newcid
+}

--- a/internal/pkg/vm/internal/vmcontext/actor_state_handle_test.go
+++ b/internal/pkg/vm/internal/vmcontext/actor_state_handle_test.go
@@ -1,0 +1,134 @@
+package vmcontext_test
+
+import (
+	"testing"
+
+	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/runtime"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/vmcontext"
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/assert"
+)
+
+func setup() testSetup {
+	initialstate := "fakestate"
+
+	ctx := fakeActorStateHandleContext{
+		storage: vm.NewTestStorage(initialstate),
+	}
+	initialhead := ctx.storage.Head()
+	h := vmcontext.NewActorStateHandle(&ctx, initialhead)
+
+	return testSetup{
+		initialstate: initialstate,
+		ctx:          ctx,
+		initialhead:  initialhead,
+		h:            h,
+	}
+}
+
+func TestActorStateHandle(t *testing.T) {
+	tf.UnitTest(t)
+
+	t.Run("take", func(t *testing.T) {
+		ts := setup()
+
+		var out string
+		ts.h.Take(&out)
+
+		assert.Equal(t, out, ts.initialstate)
+	})
+
+	t.Run("abort on take twice", func(t *testing.T) {
+		defer mustPanic(t)
+
+		ts := setup()
+
+		var out string
+		ts.h.Take(&out)
+		ts.h.Take(&out)
+	})
+
+	t.Run("release", func(t *testing.T) {
+		var out string
+
+		ts := setup()
+
+		ts.h.Take(&out)
+		ts.h.Release(&out)
+	})
+
+	t.Run("abort on releasing new state", func(t *testing.T) {
+		defer mustPanic(t)
+
+		ts := setup()
+
+		var out string
+		ts.h.Take(&out)
+		ts.h.Release("some new state")
+	})
+
+	t.Run("release and take", func(t *testing.T) {
+		ts := setup()
+
+		var out string
+		ts.h.Take(&out)
+		ts.h.Release(out)
+		ts.h.Take(&out)
+		assert.Equal(t, out, ts.initialstate)
+	})
+
+	t.Run("abort when calling release without taking", func(t *testing.T) {
+		defer mustPanic(t)
+
+		ts := setup()
+
+		ts.h.Release("fake")
+	})
+
+	t.Run("update release", func(t *testing.T) {
+		var out string
+
+		ts := setup()
+
+		ts.h.Take(&out)
+		// check state is not what we are going to use
+		expected := "new state"
+		assert.NotEqual(t, out, expected)
+		// update the state
+		ts.h.UpdateRelease(expected)
+		// take it out and check that we have what we put in
+		ts.h.Take(&out)
+		assert.Equal(t, out, expected)
+	})
+
+	t.Run("abort when calling update release without taking", func(t *testing.T) {
+		defer mustPanic(t)
+
+		ts := setup()
+
+		ts.h.UpdateRelease("fake")
+	})
+}
+
+type fakeActorStateHandleContext struct {
+	storage runtime.Storage
+}
+
+func (ctx *fakeActorStateHandleContext) Storage() runtime.Storage {
+	return ctx.storage
+}
+
+type testSetup struct {
+	initialstate string
+	ctx          fakeActorStateHandleContext
+	initialhead  cid.Cid
+	h            runtime.ActorStateHandle
+}
+
+func mustPanic(t *testing.T) {
+	if r := recover(); r == nil {
+		t.Fail()
+	}
+}

--- a/internal/pkg/vm/internal/vmcontext/export_test.go
+++ b/internal/pkg/vm/internal/vmcontext/export_test.go
@@ -253,7 +253,7 @@ func (*impl) six(ctx runtime.Runtime) (uint8, error) {
 	return 0, fmt.Errorf("NOT A REVERT OR FAULT -- PROGRAMMER ERROR")
 }
 
-func makeCtx(method types.MethodID) runtime.Runtime {
+func makeCtx(method types.MethodID) *VMContext {
 	addrGetter := address.NewForTestGetter()
 
 	vmCtxParams := NewContextParams{

--- a/internal/pkg/vm/internal/vmcontext/vmcontext.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext.go
@@ -179,7 +179,7 @@ func (ctx *VMContext) Caller() address.Address {
 
 // StateHandle handles access to the actor state.
 func (ctx *VMContext) StateHandle() runtime.ActorStateHandle {
-	// Review: this is how the spec does it, although I think this handles need to be mantained in memory for the current high level dispatch
+	// Review: this is how the spec does it, although I think this handles need to be maintained in memory for the current high level dispatch
 	return NewActorStateHandle(ctx, ctx.to.Head)
 }
 
@@ -202,8 +202,8 @@ func (ctx *VMContext) Storage() runtime.Storage {
 	return ctx.storageMap.NewStorage(ctx.message.To, ctx.to)
 }
 
-// Dragons: here just to avoid deleting a lot of lines while we wait for the new Gas Accounting to land
 // Charge attempts to add the given cost to the accrued gas cost of this transaction
+// Dragons: here just to avoid deleting a lot of lines while we wait for the new Gas Accounting to land
 func (ctx *VMContext) Charge(cost types.GasUnits) error {
 	return ctx.gasTracker.Charge(cost)
 }

--- a/internal/pkg/vm/internal/vmcontext/vmcontext_test.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext_test.go
@@ -271,29 +271,6 @@ func TestVMContextSendFailures(t *testing.T) {
 
 }
 
-func TestVMContextIsAccountActor(t *testing.T) {
-	tf.UnitTest(t)
-
-	bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
-	vms := storagemap.NewStorageMap(bs)
-
-	accountActor, err := account.NewActor(types.NewAttoFILFromFIL(1000))
-	require.NoError(t, err)
-	vmCtxParams := NewContextParams{
-		From:       accountActor,
-		StorageMap: vms,
-		GasTracker: gastracker.NewGasTracker(),
-	}
-
-	ctx := NewVMContext(vmCtxParams)
-	assert.True(t, ctx.IsFromAccountActor())
-
-	nonAccountActor := actor.NewActor(types.NewCidForTestGetter()(), types.NewAttoFILFromFIL(1000))
-	vmCtxParams.From = nonAccountActor
-	ctx = NewVMContext(vmCtxParams)
-	assert.False(t, ctx.IsFromAccountActor())
-}
-
 func TestSendErrorHandling(t *testing.T) {
 	tf.UnitTest(t)
 	actor1 := actor.NewActor(types.CidFromString(t, "somecid"), types.NewAttoFILFromFIL(100))

--- a/internal/pkg/vm/testing.go
+++ b/internal/pkg/vm/testing.go
@@ -68,12 +68,12 @@ func NewFakeVMContextWithVerifier(message *types.UnsignedMessage, state interfac
 
 var _ runtime.Runtime = &FakeVMContext{}
 
-// BlockHeight is the current chain height
+// CurrentEpoch is the current chain height
 func (tc *FakeVMContext) CurrentEpoch() types.BlockHeight {
 	return *tc.BlockHeightValue
 }
 
-// SampleChainRandomness provides random bytes used in verification challenges
+// Randomness provides random bytes used in verification challenges
 func (tc *FakeVMContext) Randomness(epoch types.BlockHeight, offset uint64) runtime.Randomness {
 	rnd, _ := tc.Sampler(&epoch)
 	return rnd


### PR DESCRIPTION
### Motivation

Spec changed. We need to make several changes to get closer to the spec.
We have an opportunity to make some refactors.

(see https://github.com/filecoin-project/go-filecoin/pull/3636 for conv with the spec team)

### Proposed changes

- split the existing Runtime into two abstractions a `Runtime` which represents the VM and an `InvocationContext` that is tied to the current executing method.
- New `ActorStateHandle`, still in conv with spec on some details. 

### Not changed
- actors are not using new `ActorStateHandle` to retrieve state, followup PR 
- VMContext implementation is still one monolith, followup PR 
- `Storage` visibility is not clear until new actors pseudocode lands.  
- Left gas, message, and address calls in place until we delete the actors using them. 