### PR TITLE
Implement ChainEpochClock similar to spec definition 

### DIFF
--- a/cmd/go-filecoin/daemon.go
+++ b/cmd/go-filecoin/daemon.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/paths"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/config"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/journal"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
 )
@@ -36,7 +36,7 @@ var daemonCmd = &cmds.Command{
 		cmdkit.BoolOption(OfflineMode, "start the node without networking"),
 		cmdkit.BoolOption(ELStdout),
 		cmdkit.BoolOption(IsRelay, "advertise and allow filecoin network traffic to be relayed through this node"),
-		cmdkit.StringOption(BlockTime, "time a node waits before trying to mine the next block").WithDefault(consensus.DefaultBlockTime.String()),
+		cmdkit.StringOption(BlockTime, "time a node waits before trying to mine the next block").WithDefault(clock.EpochDuration.String()),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		return daemonRun(req, re)

--- a/cmd/go-filecoin/daemon.go
+++ b/cmd/go-filecoin/daemon.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/paths"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/config"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/journal"
@@ -95,7 +94,6 @@ func daemonRun(req *cmds.Request, re cmds.ResponseEmitter) error {
 		return errors.Wrap(err, "Bad block time passed")
 	}
 	opts = append(opts, node.BlockTime(blockTime))
-	opts = append(opts, node.ClockConfigOption(clock.NewSystemClock()))
 
 	journal, err := journal.NewZapJournal(rep.JournalPath())
 	if err != nil {

--- a/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
@@ -35,7 +35,7 @@ type SyncerSubmodule struct {
 type syncerConfig interface {
 	GenesisCid() cid.Cid
 	BlockTime() time.Duration
-	Clock() clock.Clock
+	ChainClock() clock.ChainEpochClock
 }
 
 type nodeChainSelector interface {
@@ -47,7 +47,7 @@ type nodeChainSelector interface {
 func NewSyncerSubmodule(ctx context.Context, config syncerConfig, repo chainRepo, blockstore *BlockstoreSubmodule, network *NetworkSubmodule, discovery *DiscoverySubmodule, chn *ChainSubmodule) (SyncerSubmodule, error) {
 	// setup block validation
 	// TODO when #2961 is resolved do the needful here.
-	blkValid := consensus.NewDefaultBlockValidator(config.BlockTime(), config.Clock())
+	blkValid := consensus.NewDefaultBlockValidator(config.BlockTime(), config.ChainClock())
 
 	// register block validation on floodsub
 	btv := net.NewBlockTopicValidator(blkValid)
@@ -71,9 +71,9 @@ func NewSyncerSubmodule(ctx context.Context, config syncerConfig, repo chainRepo
 	loader := gsstoreutil.LoaderForBlockstore(blockstore.Blockstore)
 	storer := gsstoreutil.StorerForBlockstore(blockstore.Blockstore)
 	gsync := graphsync.New(ctx, graphsyncNetwork, bridge, loader, storer)
-	fetcher := fetcher.NewGraphSyncFetcher(ctx, gsync, blockstore.Blockstore, blkValid, config.Clock(), discovery.PeerTracker)
+	fetcher := fetcher.NewGraphSyncFetcher(ctx, gsync, blockstore.Blockstore, blkValid, config.ChainClock(), discovery.PeerTracker)
 
-	chainSyncManager, err := chainsync.NewManager(nodeConsensus, blkValid, nodeChainSelector, chn.ChainReader, chn.MessageStore, fetcher, config.Clock())
+	chainSyncManager, err := chainsync.NewManager(nodeConsensus, blkValid, nodeChainSelector, chn.ChainReader, chn.MessageStore, fetcher, config.ChainClock())
 	if err != nil {
 		return SyncerSubmodule{}, err
 	}

--- a/internal/app/go-filecoin/node/block_propagate_test.go
+++ b/internal/app/go-filecoin/node/block_propagate_test.go
@@ -135,7 +135,7 @@ func TestChainSync(t *testing.T) {
 // makeNodes makes at least two nodes, a miner and a client; numNodes is the total wanted
 func makeNodesBlockPropTests(t *testing.T, numNodes int) (address.Address, []*Node) {
 	seed := MakeChainSeed(t, TestGenCfg)
-	builderOpts := []BuilderOpt{ClockConfigOption(th.NewFakeClock(time.Unix(1234567890, 0)))}
+	builderOpts := []BuilderOpt{ChainClockConfigOption(th.NewFakeChainClock(0, time.Unix(1234567890, 0)))}
 	minerNode := MakeNodeWithChainSeed(t, seed, builderOpts,
 		PeerKeyOpt(PeerKeys[0]),
 	)

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -52,7 +52,7 @@ type Node struct {
 	// OfflineMode, when true, disables libp2p.
 	OfflineMode bool
 
-	// ChainClock is a chainClock used byt the node for chain epoch.
+	// ChainClock is a chainClock used by the node for chain epoch.
 	ChainClock clock.ChainEpochClock
 
 	// Repo is the repo this node was created with.

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -52,8 +52,8 @@ type Node struct {
 	// OfflineMode, when true, disables libp2p.
 	OfflineMode bool
 
-	// Clock is a clock used by the node for time.
-	Clock clock.Clock
+	// ChainClock is a chainClock used byt the node for chain epoch.
+	ChainClock clock.ChainEpochClock
 
 	// Repo is the repo this node was created with.
 	//
@@ -715,7 +715,7 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (mining.Worker, error)
 		MessageStore:  node.chain.MessageStore,
 		Processor:     processor,
 		Blockstore:    node.Blockstore.Blockstore,
-		Clock:         node.Clock,
+		Clock:         node.ChainClock,
 	}), nil
 }
 

--- a/internal/pkg/chain/store.go
+++ b/internal/pkg/chain/store.go
@@ -280,6 +280,11 @@ func (store *Store) GetGenesisState(ctx context.Context) (state.Tree, error) {
 	return store.stateTreeLoader.LoadStateTree(ctx, store.stateAndBlockSource.cborStore, genesis.StateRoot)
 }
 
+// GetGenesisBlock returns the genesis block held by the chain store.
+func (store *Store) GetGenesisBlock(ctx context.Context) (*block.Block, error) {
+	return store.stateAndBlockSource.GetBlock(ctx, store.GenesisCid())
+}
+
 // GetTipSetStateRoot returns the aggregate state root CID of the tipset identified by `key`.
 func (store *Store) GetTipSetStateRoot(key block.TipSetKey) (cid.Cid, error) {
 	return store.tipIndex.GetTipSetStateRoot(key)

--- a/internal/pkg/clock/chainclock.go
+++ b/internal/pkg/clock/chainclock.go
@@ -8,7 +8,13 @@ import (
 
 // EpochDuration is a constant that represents the UTC time duration
 // of a blockchain epoch.
-var EpochDuration = time.Second * 15
+const EpochDuration = EpochUnits * time.Duration(EpochCount)
+
+// EpochCount is the number of instances in an Epoch.
+const EpochCount = int64(15)
+
+// EpochUnits is the units an Epoch is measured in.
+const EpochUnits = time.Second
 
 // ChainEpochClock is an interface for a clock that represents epochs of the protocol.
 type ChainEpochClock interface {
@@ -35,7 +41,11 @@ func NewChainClock(genesisTime uint64) ChainEpochClock {
 // It first subtracts GenesisTime, then divides by EpochDuration
 // and returns the resulting number of epochs.
 func (cc *chainClock) EpochAtTime(t time.Time) *types.BlockHeight {
+	// anything before the genesis is epoch 0.
+	if t.Unix() <= cc.GenesisTime.Unix() {
+		return types.NewBlockHeight(uint64(0))
+	}
 	difference := t.Sub(cc.GenesisTime)
 	epochs := difference / EpochDuration
-	return types.NewBlockHeight(uint64(epochs.Seconds()))
+	return types.NewBlockHeight(uint64(epochs))
 }

--- a/internal/pkg/clock/chainclock.go
+++ b/internal/pkg/clock/chainclock.go
@@ -2,18 +2,17 @@ package clock
 
 import (
 	"time"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
 // EpochDuration is a constant that represents the UTC time duration
 // of a blockchain epoch.
 var EpochDuration = time.Second * 15
 
-// ChainEpoch represents a round of a blockchain protocol.
-type ChainEpoch uint64
-
 // ChainEpochClock is an interface for a clock that represents epochs of the protocol.
 type ChainEpochClock interface {
-	EpochAtTime(t time.Time) ChainEpoch
+	EpochAtTime(t time.Time) *types.BlockHeight
 	Clock
 }
 
@@ -35,8 +34,8 @@ func NewChainClock(genesisTime uint64) ChainEpochClock {
 // EpochAtTime returns the ChainEpoch corresponding to t.
 // It first subtracts GenesisTime, then divides by EpochDuration
 // and returns the resulting number of epochs.
-func (cc *chainClock) EpochAtTime(t time.Time) ChainEpoch {
+func (cc *chainClock) EpochAtTime(t time.Time) *types.BlockHeight {
 	difference := t.Sub(cc.GenesisTime)
 	epochs := difference / EpochDuration
-	return ChainEpoch(epochs)
+	return types.NewBlockHeight(uint64(epochs.Seconds()))
 }

--- a/internal/pkg/clock/chainclock.go
+++ b/internal/pkg/clock/chainclock.go
@@ -2,8 +2,6 @@ package clock
 
 import (
 	"time"
-
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
 // EpochDuration is a constant that represents the UTC time duration
@@ -18,7 +16,7 @@ const EpochUnits = time.Second
 
 // ChainEpochClock is an interface for a clock that represents epochs of the protocol.
 type ChainEpochClock interface {
-	EpochAtTime(t time.Time) *types.BlockHeight
+	EpochAtTime(t time.Time) int64
 	Clock
 }
 
@@ -40,12 +38,8 @@ func NewChainClock(genesisTime uint64) ChainEpochClock {
 // EpochAtTime returns the ChainEpoch corresponding to t.
 // It first subtracts GenesisTime, then divides by EpochDuration
 // and returns the resulting number of epochs.
-func (cc *chainClock) EpochAtTime(t time.Time) *types.BlockHeight {
-	// anything before the genesis is epoch 0.
-	if t.Unix() <= cc.GenesisTime.Unix() {
-		return types.NewBlockHeight(uint64(0))
-	}
+func (cc *chainClock) EpochAtTime(t time.Time) int64 {
 	difference := t.Sub(cc.GenesisTime)
 	epochs := difference / EpochDuration
-	return types.NewBlockHeight(uint64(epochs))
+	return int64(epochs)
 }

--- a/internal/pkg/clock/chainclock.go
+++ b/internal/pkg/clock/chainclock.go
@@ -1,0 +1,42 @@
+package clock
+
+import (
+	"time"
+)
+
+// EpochDuration is a constant that represents the UTC time duration
+// of a blockchain epoch.
+var EpochDuration = time.Second * 15
+
+// ChainEpoch represents a round of a blockchain protocol.
+type ChainEpoch uint64
+
+// ChainEpochClock is an interface for a clock that represents epochs of the protocol.
+type ChainEpochClock interface {
+	EpochAtTime(t time.Time) ChainEpoch
+	Clock
+}
+
+// chainClock is a clock that represents epochs of the protocol.
+type chainClock struct {
+	// GenesisTime is the time of the first block. EpochClock counts
+	// up from there.
+	GenesisTime time.Time
+
+	Clock
+}
+
+// NewChainClock returns a ChainEpochClock.
+func NewChainClock(genesisTime uint64) ChainEpochClock {
+	gt := time.Unix(int64(genesisTime), 0)
+	return &chainClock{GenesisTime: gt, Clock: NewSystemClock()}
+}
+
+// EpochAtTime returns the ChainEpoch corresponding to t.
+// It first subtracts GenesisTime, then divides by EpochDuration
+// and returns the resulting number of epochs.
+func (cc *chainClock) EpochAtTime(t time.Time) ChainEpoch {
+	difference := t.Sub(cc.GenesisTime)
+	epochs := difference / EpochDuration
+	return ChainEpoch(epochs)
+}

--- a/internal/pkg/clock/chainclock_test.go
+++ b/internal/pkg/clock/chainclock_test.go
@@ -1,7 +1,6 @@
 package clock_test
 
 import (
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"testing"
 	"time"
 
@@ -20,17 +19,19 @@ func TestChainEpochClock(t *testing.T) {
 
 	epoch0 := time.Unix(now, 0)
 	epoch1 := time.Unix(now+clock.EpochCount, 0)
-	assert.Equal(t, types.NewBlockHeight(0), cec.EpochAtTime(epoch0))
-	assert.Equal(t, types.NewBlockHeight(1), cec.EpochAtTime(epoch1))
+	assert.Equal(t, int64(0), cec.EpochAtTime(epoch0))
+	assert.Equal(t, int64(1), cec.EpochAtTime(epoch1))
 
 	epoch2 := time.Unix(now+clock.EpochCount*2, 0)
 	epoch2again := time.Unix((now+clock.EpochCount*3)-1, 0)
-	assert.Equal(t, types.NewBlockHeight(2), cec.EpochAtTime(epoch2))
-	assert.Equal(t, types.NewBlockHeight(2), cec.EpochAtTime(epoch2again))
+	assert.Equal(t, int64(2), cec.EpochAtTime(epoch2))
+	assert.Equal(t, int64(2), cec.EpochAtTime(epoch2again))
 
 	epoch200 := time.Unix(now+clock.EpochCount*200, 0)
-	assert.Equal(t, types.NewBlockHeight(200), cec.EpochAtTime(epoch200))
+	assert.Equal(t, int64(200), cec.EpochAtTime(epoch200))
 
-	epochBeforeGenesis := time.Unix(0, 0)
-	assert.Equal(t, types.NewBlockHeight(0), cec.EpochAtTime(epochBeforeGenesis))
+	epochBeforeGenesis := time.Unix(now-clock.EpochCount, 0)
+	epochWayBeforeGenesis := time.Unix(now-clock.EpochCount*30, 0)
+	assert.Equal(t, int64(-1), cec.EpochAtTime(epochBeforeGenesis))
+	assert.Equal(t, int64(-30), cec.EpochAtTime(epochWayBeforeGenesis))
 }

--- a/internal/pkg/clock/chainclock_test.go
+++ b/internal/pkg/clock/chainclock_test.go
@@ -1,0 +1,36 @@
+package clock_test
+
+import (
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
+	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
+)
+
+func TestChainEpochClock(t *testing.T) {
+	tf.UnitTest(t)
+
+	now := int64(123456789)
+
+	cec := clock.NewChainClock(uint64(now))
+
+	epoch0 := time.Unix(now, 0)
+	epoch1 := time.Unix(now+clock.EpochCount, 0)
+	assert.Equal(t, types.NewBlockHeight(0), cec.EpochAtTime(epoch0))
+	assert.Equal(t, types.NewBlockHeight(1), cec.EpochAtTime(epoch1))
+
+	epoch2 := time.Unix(now+clock.EpochCount*2, 0)
+	epoch2again := time.Unix((now+clock.EpochCount*3)-1, 0)
+	assert.Equal(t, types.NewBlockHeight(2), cec.EpochAtTime(epoch2))
+	assert.Equal(t, types.NewBlockHeight(2), cec.EpochAtTime(epoch2again))
+
+	epoch200 := time.Unix(now+clock.EpochCount*200, 0)
+	assert.Equal(t, types.NewBlockHeight(200), cec.EpochAtTime(epoch200))
+
+	epochBeforeGenesis := time.Unix(0, 0)
+	assert.Equal(t, types.NewBlockHeight(0), cec.EpochAtTime(epochBeforeGenesis))
+}

--- a/internal/pkg/consensus/block_validation_test.go
+++ b/internal/pkg/consensus/block_validation_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
@@ -20,7 +21,7 @@ import (
 func TestBlockValidSemantic(t *testing.T) {
 	tf.UnitTest(t)
 
-	blockTime := consensus.DefaultBlockTime
+	blockTime := clock.EpochDuration
 	ts := time.Unix(1234567890, 0)
 	mclock := th.NewFakeClock(ts)
 	ctx := context.Background()
@@ -85,7 +86,7 @@ func TestBlockValidSemantic(t *testing.T) {
 func TestBlockValidSyntax(t *testing.T) {
 	tf.UnitTest(t)
 
-	blockTime := consensus.DefaultBlockTime
+	blockTime := clock.EpochDuration
 	ts := time.Unix(1234567890, 0)
 	mclock := th.NewFakeClock(ts)
 	ctx := context.Background()

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -50,11 +50,6 @@ var (
 	ErrReceiptRootMismatch = errors.New("blocks receipt root does not match parent tip set")
 )
 
-// DefaultBlockTime is the estimated proving period time.
-// We define this so that we can fake mining in the current incomplete system.
-// We also use this to enforce a soft block validation.
-const DefaultBlockTime = 30 * time.Second
-
 // ElectionLookback is the number of tipsets past the head (inclusive)) that
 // must be traversed to sample the election ticket.
 const ElectionLookback = 5

--- a/internal/pkg/testhelpers/chainclock.go
+++ b/internal/pkg/testhelpers/chainclock.go
@@ -1,7 +1,6 @@
 package testhelpers
 
 import (
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"time"
 )
 
@@ -9,17 +8,17 @@ import (
 type FakeChainClock interface {
 	FakeClock
 
-	EpochAtTime(t time.Time) *types.BlockHeight
+	EpochAtTime(t time.Time) int64
 }
 
 type fakeChainClock struct {
-	epoch uint64
+	epoch int64
 
 	FakeClock
 }
 
 // NewFakeChainClock returns a FakeChainClock.
-func NewFakeChainClock(chainEpoch uint64, wallTime time.Time) FakeChainClock {
+func NewFakeChainClock(chainEpoch int64, wallTime time.Time) FakeChainClock {
 	return &fakeChainClock{
 		epoch:     chainEpoch,
 		FakeClock: NewFakeClock(wallTime),
@@ -27,11 +26,11 @@ func NewFakeChainClock(chainEpoch uint64, wallTime time.Time) FakeChainClock {
 }
 
 // EpochAtTime returns the ChainEpoch held by the fakeChainClock.
-func (fcc *fakeChainClock) EpochAtTime(t time.Time) *types.BlockHeight {
-	return types.NewBlockHeight(fcc.epoch)
+func (fcc *fakeChainClock) EpochAtTime(t time.Time) int64 {
+	return fcc.epoch
 }
 
 // SetChainEpoch sets the FakeChainClock's ChainEpoch to `epoch`.
-func (fcc *fakeChainClock) SetChainEpoch(epoch uint64) {
+func (fcc *fakeChainClock) SetChainEpoch(epoch int64) {
 	fcc.epoch = epoch
 }

--- a/internal/pkg/testhelpers/chainclock.go
+++ b/internal/pkg/testhelpers/chainclock.go
@@ -1,16 +1,15 @@
 package testhelpers
 
 import (
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"time"
-
-	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
 )
 
 // FakeChainClock is an interface for a clock that represents epochs of the protocol.
 type FakeChainClock interface {
 	FakeClock
 
-	EpochAtTime(t time.Time) clock.ChainEpoch
+	EpochAtTime(t time.Time) *types.BlockHeight
 }
 
 type fakeChainClock struct {
@@ -28,8 +27,8 @@ func NewFakeChainClock(chainEpoch uint64, wallTime time.Time) FakeChainClock {
 }
 
 // EpochAtTime returns the ChainEpoch held by the fakeChainClock.
-func (fcc *fakeChainClock) EpochAtTime(t time.Time) clock.ChainEpoch {
-	return clock.ChainEpoch(fcc.epoch)
+func (fcc *fakeChainClock) EpochAtTime(t time.Time) *types.BlockHeight {
+	return types.NewBlockHeight(fcc.epoch)
 }
 
 // SetChainEpoch sets the FakeChainClock's ChainEpoch to `epoch`.

--- a/internal/pkg/testhelpers/chainclock.go
+++ b/internal/pkg/testhelpers/chainclock.go
@@ -1,0 +1,44 @@
+package testhelpers
+
+import (
+	"sync"
+	"time"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
+)
+
+// FakeChainClock is an interface for a clock that represents epochs of the protocol.
+type FakeChainClock interface {
+	FakeClock
+
+	EpochAtTime(t time.Time) clock.ChainEpoch
+}
+
+type fakeChainClock struct {
+	epochMu sync.Mutex
+	epoch   uint64
+
+	FakeClock
+}
+
+// NewFakeChainClock returns a FakeChainClock.
+func NewFakeChainClock(chainEpoch uint64, wallTime time.Time) FakeChainClock {
+	return &fakeChainClock{
+		epoch:     chainEpoch,
+		FakeClock: NewFakeClock(wallTime),
+	}
+}
+
+// EpochAtTime returns the ChainEpoch held by the fakeChainClock.
+func (fcc *fakeChainClock) EpochAtTime(t time.Time) clock.ChainEpoch {
+	fcc.epochMu.Lock()
+	defer fcc.epochMu.Unlock()
+	return clock.ChainEpoch(fcc.epoch)
+}
+
+// SetChainEpoch sets the FakeChainClock's ChainEpoch to `epoch`.
+func (fcc *fakeChainClock) SetChainEpoch(epoch uint64) {
+	fcc.epochMu.Lock()
+	defer fcc.epochMu.Unlock()
+	fcc.epoch = epoch
+}

--- a/internal/pkg/testhelpers/chainclock.go
+++ b/internal/pkg/testhelpers/chainclock.go
@@ -1,7 +1,6 @@
 package testhelpers
 
 import (
-	"sync"
 	"time"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
@@ -15,8 +14,7 @@ type FakeChainClock interface {
 }
 
 type fakeChainClock struct {
-	epochMu sync.Mutex
-	epoch   uint64
+	epoch uint64
 
 	FakeClock
 }
@@ -31,14 +29,10 @@ func NewFakeChainClock(chainEpoch uint64, wallTime time.Time) FakeChainClock {
 
 // EpochAtTime returns the ChainEpoch held by the fakeChainClock.
 func (fcc *fakeChainClock) EpochAtTime(t time.Time) clock.ChainEpoch {
-	fcc.epochMu.Lock()
-	defer fcc.epochMu.Unlock()
 	return clock.ChainEpoch(fcc.epoch)
 }
 
 // SetChainEpoch sets the FakeChainClock's ChainEpoch to `epoch`.
 func (fcc *fakeChainClock) SetChainEpoch(epoch uint64) {
-	fcc.epochMu.Lock()
-	defer fcc.epochMu.Unlock()
 	fcc.epoch = epoch
 }

--- a/tools/fast/series/ctx_sleep_delay.go
+++ b/tools/fast/series/ctx_sleep_delay.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
 )
 
 type ctxSleepDelayKey struct{}
@@ -14,7 +14,7 @@ var (
 	sleepDelayKey = ctxSleepDelayKey{}
 
 	// Default delay
-	defaultSleepDelay = consensus.DefaultBlockTime
+	defaultSleepDelay = clock.EpochDuration
 )
 
 // SetCtxSleepDelay returns a context with `d` set in the context. To sleep with
@@ -25,7 +25,7 @@ func SetCtxSleepDelay(ctx context.Context, d time.Duration) context.Context {
 
 // CtxSleepDelay is a helper method to make sure people don't call `time.Sleep`
 // or `time.After` themselves in series. It will use the time.Duration in the
-// context, or default to `mining.DefaultBlockTime` from the go-filecoin/mining package.
+// context, or default to `clock.EpochDuration` from the go-filecoin/mining package.
 // A channel is return which will receive a time.Time value after the delay.
 func CtxSleepDelay(ctx context.Context) <-chan time.Time {
 	d, ok := ctx.Value(sleepDelayKey).(time.Duration)


### PR DESCRIPTION
### Motivation
[Spec Clock](https://filecoin-project.github.io/specs/#systems__filecoin_nodes__clock)


### Proposed changes
- Implement the ChainEpoch clock on the Node as described in the spec exposing it as an interface wrapping the existing System Clock.
- Pass the ChainEpoch clock to the syncer module as it will be used during block validation later.

### Whats Left?
- [x] Unit Tests ChainEpochClock
- [x]  Get clarification on  filecoin-project/specs#653

Closes issue #3652 

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

