### PR TITLE
Catchup Follow transitions

### DIFF
--- a/internal/pkg/chainsync/chainsync.go
+++ b/internal/pkg/chainsync/chainsync.go
@@ -30,7 +30,8 @@ func NewManager(fv syncer.FullBlockValidator, hv syncer.HeaderValidator, cs sync
 	if err != nil {
 		return Manager{}, err
 	}
-	dispatcher := dispatcher.NewDispatcher(syncer)
+	gapTransitioner := dispatcher.NewGapTransitioner(s, syncer)
+	dispatcher := dispatcher.NewDispatcher(syncer, gapTransitioner)
 	return Manager{
 		syncer:     syncer,
 		dispatcher: dispatcher,
@@ -40,7 +41,7 @@ func NewManager(fv syncer.FullBlockValidator, hv syncer.HeaderValidator, cs sync
 // Start starts the chain sync manager.
 func (m *Manager) Start(ctx context.Context) error {
 	m.dispatcher.Start(ctx)
-	return m.syncer.StageHead()
+	return m.syncer.InitStaged()
 }
 
 // BlockProposer returns the block proposer.

--- a/internal/pkg/chainsync/internal/dispatcher/dispatcher_test.go
+++ b/internal/pkg/chainsync/internal/dispatcher/dispatcher_test.go
@@ -19,7 +19,8 @@ type mockSyncer struct {
 	headsCalled []block.TipSetKey
 }
 
-type noopTransitioner struct {}
+type noopTransitioner struct{}
+
 func (nt *noopTransitioner) MaybeTransitionToCatchup(inCatchup bool, _ []dispatcher.Target) (bool, error) {
 	return inCatchup, nil
 }

--- a/internal/pkg/chainsync/internal/syncer/syncer.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer.go
@@ -2,7 +2,7 @@ package syncer
 
 import (
 	"context"
-	
+
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chainsync/status"
@@ -433,7 +433,7 @@ func (syncer *Syncer) HandleNewTipSet(ctx context.Context, ci *block.ChainInfo, 
 }
 
 func (syncer *Syncer) handleNewTipSet(ctx context.Context, ci *block.ChainInfo) (err error) {
-	// handleNewTipSet extends the Syncer's chain store with the given tipset if 
+	// handleNewTipSet extends the Syncer's chain store with the given tipset if
 	// the chain is a valid extension.  It stages new heaviest tipsets for later
 	// setting the chain head
 	logSyncer.Debugf("Begin fetch and sync of chain with head %v", ci.Head)


### PR DESCRIPTION
### Motivation
The syncer needs to be able to transition between catchup and follow states based on gaps in tipset epochs and only set chain heads during the follow state.

### Proposed changes
* Introduce a transitioner type and new dispatcher data and logic calling it to manage chain sync transitions 
* Reintroduce the boolean into HandleNewTipSet so that the caller can differentiate modes to control head setting
* Expose a method on the syncer for directly setting the staged head to call during transitions 
* Cleanup syncer by removing unused lock (all calls to syncer are serialized through the dispatcher's event loop)

Closes issue #3666

### Testing
Testing this is going to be quite challenging.  I'm working on something I'd like to include in this PR but wanted to surface this work first.  In the interest of moving faster I might defer the tests until a later PR.

Advice on how to test is appreciated.  Right now I'm planning to build out calls on the node to allow for in process integration tests.  Likely this is going to require evaluating and doing useful but non-trivial testing-specific development such as
* improve node mining interface / tools so that it is simple to setup the chains on a set of nodes exercising the catchup to follow transition
* remove race in mine once by providing a blocking call back to the dispatcher
* add blocking sync call directly to the node interface 
* add state dump to dispatcher's event loop

There is also some basic unit testing I should do in the syncer and new transitioner.
<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

