### PR TITLE
Added command line option for creating bls addresses.

### DIFF
--- a/cmd/go-filecoin/address.go
+++ b/cmd/go-filecoin/address.go
@@ -49,11 +49,15 @@ type AddressLsResult struct {
 
 var addrsNewCmd = &cmds.Command{
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
-		addr, err := GetPorcelainAPI(env).WalletNewAddress()
+		addressType := req.Options["type"].(string)
+		addr, err := GetPorcelainAPI(env).WalletNewAddress(addressType)
 		if err != nil {
 			return err
 		}
 		return re.Emit(&addressResult{addr.String()})
+	},
+	Options: []cmdkit.Option{
+		cmdkit.StringOption("type", "The type of address to create: bls or secp256k1 (default)").WithDefault(types.SECP256K1),
 	},
 	Type: &addressResult{},
 	Encoders: cmds.EncoderMap{

--- a/internal/app/go-filecoin/plumbing/api.go
+++ b/internal/app/go-filecoin/plumbing/api.go
@@ -2,7 +2,9 @@ package plumbing
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
@@ -355,8 +357,15 @@ func (api *API) WalletGetPubKeyForAddress(addr address.Address) ([]byte, error) 
 }
 
 // WalletNewAddress generates a new wallet address
-func (api *API) WalletNewAddress() (address.Address, error) {
-	return wallet.NewAddress(api.wallet, address.SECP256K1)
+func (api *API) WalletNewAddress(addressType string) (address.Address, error) {
+	switch strings.ToLower(addressType) { //this assumes that any additions to types/helpers.go will be lowercase
+	case types.BLS:
+		return wallet.NewAddress(api.wallet, address.BLS)
+	case types.SECP256K1:
+		return wallet.NewAddress(api.wallet, address.SECP256K1)
+	default:
+		return address.Undef, fmt.Errorf("invalid address type: %s", addressType)
+	}
 }
 
 // WalletImport adds a given set of KeyInfos to the wallet


### PR DESCRIPTION
### Motivation
Allow creation of BLS addresses through command line.

### Proposed changes
New option for `go-filecoin address new --type=[bls|secp256k1]` with default value `secp256k11`.

Closes issue #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

