### PR TITLE
feat: new Send api to match spec

### DIFF
--- a/internal/pkg/consensus/genesis.go
+++ b/internal/pkg/consensus/genesis.go
@@ -178,7 +178,7 @@ func MakeGenesisFunc(opts ...GenOption) GenesisInitFunc {
 			if err != nil {
 				return nil, err
 			}
-			if err = s.Commit(scid, a.Head); err != nil {
+			if err = s.LegacyCommit(scid, a.Head); err != nil {
 				return nil, err
 			}
 			if err := st.SetActor(ctx, addr, a); err != nil {

--- a/internal/pkg/consensus/processor.go
+++ b/internal/pkg/consensus/processor.go
@@ -505,7 +505,7 @@ func (p *DefaultProcessor) resolveAddress(ctx context.Context, msg *types.Unsign
 		To:         to,
 	}
 	vmCtx := vm.NewVMContext(vmCtxParams)
-	ret, _, err := vmCtx.Send(address.InitAddress, initactor.GetActorIDForAddress, types.ZeroAttoFIL, []interface{}{msg.To})
+	ret, _, err := vmCtx.LegacySend(address.InitAddress, initactor.GetActorIDForAddress, types.ZeroAttoFIL, []interface{}{msg.To})
 	if err != nil {
 		return address.Undef, err
 	}

--- a/internal/pkg/vm/actor/builtin/initactor/init.go
+++ b/internal/pkg/vm/actor/builtin/initactor/init.go
@@ -114,7 +114,7 @@ func (*Actor) InitializeState(storage runtime.Storage, params interface{}) error
 		return err
 	}
 
-	return storage.Commit(id, cid.Undef)
+	return storage.LegacyCommit(id, cid.Undef)
 }
 
 //

--- a/internal/pkg/vm/actor/builtin/miner/miner.go
+++ b/internal/pkg/vm/actor/builtin/miner/miner.go
@@ -1052,7 +1052,7 @@ func (a *Impl) SubmitPoSt(ctx invocationContext, poStProof types.PoStProof, faul
 		// Refund any overpayment of fees to the owner.
 		if messageValue.GreaterThan(feeRequired) {
 			overpayment := messageValue.Sub(feeRequired)
-			_, _, err := ctx.Runtime().Send(sender, types.SendMethodID, overpayment, []interface{}{})
+			_, _, err := ctx.Runtime().LegacySend(sender, types.SendMethodID, overpayment, []interface{}{})
 			if err != nil {
 				return nil, errors.NewRevertErrorf("Failed to refund overpayment of %s to %s", overpayment, sender)
 			}
@@ -1135,7 +1135,7 @@ func (a *Impl) SubmitPoSt(ctx invocationContext, poStProof types.PoStProof, faul
 		delta := newPower.Sub(oldPower)
 
 		if !delta.IsZero() {
-			_, ret, err := ctx.Runtime().Send(address.StorageMarketAddress, Storagemarket_UpdateStorage, types.ZeroAttoFIL, []interface{}{delta})
+			_, ret, err := ctx.Runtime().LegacySend(address.StorageMarketAddress, Storagemarket_UpdateStorage, types.ZeroAttoFIL, []interface{}{delta})
 			if err != nil {
 				return nil, err
 			}
@@ -1198,7 +1198,7 @@ func (*Impl) SlashStorageFault(ctx invocationContext) (uint8, error) {
 
 		// Strip the miner of their power.
 		powerDelta := types.ZeroBytes.Sub(state.Power) // negate bytes amount
-		_, ret, err := ctx.Runtime().Send(address.StorageMarketAddress, Storagemarket_UpdateStorage, types.ZeroAttoFIL, []interface{}{powerDelta})
+		_, ret, err := ctx.Runtime().LegacySend(address.StorageMarketAddress, Storagemarket_UpdateStorage, types.ZeroAttoFIL, []interface{}{powerDelta})
 		if err != nil {
 			return nil, err
 		}
@@ -1270,7 +1270,7 @@ func (a *Impl) CalculateLateFee(ctx invocationContext, height *types.BlockHeight
 //
 
 func (*Impl) burnFunds(ctx invocationContext, amount types.AttoFIL) error {
-	_, _, err := ctx.Runtime().Send(address.BurntFundsAddress, types.SendMethodID, amount, []interface{}{})
+	_, _, err := ctx.Runtime().LegacySend(address.BurntFundsAddress, types.SendMethodID, amount, []interface{}{})
 	return err
 }
 
@@ -1297,7 +1297,7 @@ func getPoStChallengeSeed(ctx invocationContext, state State, sampleAt *types.Bl
 // GetProofsMode returns the genesis block-configured proofs mode.
 func GetProofsMode(ctx invocationContext) (types.ProofsMode, error) {
 	var proofsMode types.ProofsMode
-	msgResult, _, err := ctx.Runtime().Send(address.StorageMarketAddress, Storagemarket_GetProofsMode, types.ZeroAttoFIL, nil)
+	msgResult, _, err := ctx.Runtime().LegacySend(address.StorageMarketAddress, Storagemarket_GetProofsMode, types.ZeroAttoFIL, nil)
 	if err != nil {
 		return types.TestProofsMode, xerrors.Wrap(err, "'GetProofsMode' message failed")
 	}

--- a/internal/pkg/vm/actor/builtin/miner/miner.go
+++ b/internal/pkg/vm/actor/builtin/miner/miner.go
@@ -359,7 +359,7 @@ func (*Actor) InitializeState(storage runtime.Storage, initializerData interface
 		return err
 	}
 
-	return storage.Commit(id, cid.Undef)
+	return storage.LegacyCommit(id, cid.Undef)
 }
 
 //

--- a/internal/pkg/vm/actor/builtin/miner/miner_test.go
+++ b/internal/pkg/vm/actor/builtin/miner/miner_test.go
@@ -581,7 +581,7 @@ func (mal *minerActorLiason) requirePoSt(blockHeight uint64, done types.IntSet, 
 func (mal *minerActorLiason) requireReadState() State {
 	miner := state.MustGetActor(mal.st, mal.minerAddr)
 	storage := mal.vms.NewStorage(mal.minerAddr, miner)
-	stateBytes, err := storage.Get(storage.Head())
+	stateBytes, err := storage.Get(storage.LegacyHead())
 	require.NoError(mal.t, err)
 	var minerState State
 	err = actor.UnmarshalStorage(stateBytes, &minerState)

--- a/internal/pkg/vm/actor/builtin/paymentbroker/paymentbroker.go
+++ b/internal/pkg/vm/actor/builtin/paymentbroker/paymentbroker.go
@@ -748,7 +748,7 @@ func createVoucherSignatureData(channelID *types.ChannelID, amount types.AttoFIL
 }
 
 func withPayerChannels(ctx context.Context, st runtime.Storage, payer address.Address, f func(storage.Lookup) error) error {
-	stateCid, err := actor.WithLookup(ctx, st, st.Head(), func(byPayer storage.Lookup) error {
+	stateCid, err := actor.WithLookup(ctx, st, st.LegacyHead(), func(byPayer storage.Lookup) error {
 		byChannelLookup, err := findByChannelLookup(ctx, st, byPayer, payer)
 		if err != nil {
 			return err
@@ -778,11 +778,11 @@ func withPayerChannels(ctx context.Context, st runtime.Storage, payer address.Ad
 		return err
 	}
 
-	return st.Commit(stateCid, st.Head())
+	return st.LegacyCommit(stateCid, st.LegacyHead())
 }
 
 func withPayerChannelsForReading(ctx context.Context, st runtime.Storage, payer address.Address, f func(storage.Lookup) error) error {
-	return actor.WithLookupForReading(ctx, st, st.Head(), func(byPayer storage.Lookup) error {
+	return actor.WithLookupForReading(ctx, st, st.LegacyHead(), func(byPayer storage.Lookup) error {
 		byChannelLookup, err := findByChannelLookup(ctx, st, byPayer, payer)
 		if err != nil {
 			return err

--- a/internal/pkg/vm/actor/builtin/paymentbroker/paymentbroker.go
+++ b/internal/pkg/vm/actor/builtin/paymentbroker/paymentbroker.go
@@ -667,7 +667,7 @@ func validateAndUpdateChannel(ctx invocationContext, target address.Address, cha
 
 	// transfer funds to sender
 	updateAmount := amt.Sub(channel.AmountRedeemed)
-	_, _, err := ctx.Runtime().Send(ctx.Message().Caller(), types.SendMethodID, updateAmount, nil)
+	_, _, err := ctx.Runtime().LegacySend(ctx.Message().Caller(), types.SendMethodID, updateAmount, nil)
 	if err != nil {
 		return err
 	}
@@ -691,7 +691,7 @@ func reclaim(ctx context.Context, vmctx invocationContext, byChannelID storage.L
 	}
 
 	// send funds
-	_, _, err = vmctx.Runtime().Send(payer, types.SendMethodID, amt, nil)
+	_, _, err = vmctx.Runtime().LegacySend(payer, types.SendMethodID, amt, nil)
 	if err != nil {
 		return errors.RevertErrorWrap(err, "could not send update funds")
 	}
@@ -813,7 +813,7 @@ func checkCondition(vmctx invocationContext, channel *PaymentChannel) error {
 		return nil
 	}
 
-	_, _, err := vmctx.Runtime().Send(channel.Condition.To, channel.Condition.Method, types.ZeroAttoFIL, channel.Condition.Params)
+	_, _, err := vmctx.Runtime().LegacySend(channel.Condition.To, channel.Condition.Method, types.ZeroAttoFIL, channel.Condition.Params)
 	if err != nil {
 		if errors.IsFault(err) {
 			return err

--- a/internal/pkg/vm/actor/builtin/power/power.go
+++ b/internal/pkg/vm/actor/builtin/power/power.go
@@ -174,15 +174,9 @@ func (*impl) createStorageMiner(vmctx invocationContext, ownerAddr, workerAddr a
 		initParams := []interface{}{vmctx.Message().Caller(), vmctx.Message().Caller(), pid, sectorSize}
 
 		// create miner actor by messaging the init actor and sending it collateral
-		ret, _, err := vmctx.Runtime().LegacySend(address.InitAddress, initactor.Exec, vmctx.Message().ValueReceived(), []interface{}{actorCodeCid, initParams})
-		if err != nil {
-			return nil, err
-		}
+		ret := vmctx.Runtime().Send(address.InitAddress, initactor.Exec, vmctx.Message().ValueReceived(), []interface{}{actorCodeCid, initParams})
 
-		addr, err := address.NewFromBytes(ret[0])
-		if err != nil {
-			return nil, errors.FaultErrorWrap(err, "could not convert init.Exec return value to address")
-		}
+		addr := ret.(address.Address)
 
 		// retrieve id to key miner
 		actorIDAddr, err := retreiveActorID(vmctx.Runtime(), addr)
@@ -229,17 +223,11 @@ func (*impl) createStorageMiner(vmctx invocationContext, ownerAddr, workerAddr a
 
 // retriveActorId uses init actor to map an actorAddress to an id address
 func retreiveActorID(rt runtime.Runtime, actorAddr address.Address) (address.Address, error) {
-	ret, _, err := rt.LegacySend(address.InitAddress, initactor.GetActorIDForAddress, types.ZeroAttoFIL, []interface{}{actorAddr})
-	if err != nil {
-		return address.Undef, err
-	}
+	ret := rt.Send(address.InitAddress, initactor.GetActorIDForAddress, types.ZeroAttoFIL, []interface{}{actorAddr})
 
-	actorIDVal, err := abi.Deserialize(ret[0], abi.Integer)
-	if err != nil {
-		return address.Undef, errors.FaultErrorWrap(err, "could not convert actor id to big.Int")
-	}
+	actorIDVal := ret.(*big.Int)
 
-	return address.NewIDAddress(actorIDVal.Val.(*big.Int).Uint64())
+	return address.NewIDAddress(actorIDVal.Uint64())
 }
 
 // RemoveStorageMiner removes the given miner address from the power table.  This call will fail if

--- a/internal/pkg/vm/actor/builtin/power/power.go
+++ b/internal/pkg/vm/actor/builtin/power/power.go
@@ -174,7 +174,7 @@ func (*impl) createStorageMiner(vmctx invocationContext, ownerAddr, workerAddr a
 		initParams := []interface{}{vmctx.Message().Caller(), vmctx.Message().Caller(), pid, sectorSize}
 
 		// create miner actor by messaging the init actor and sending it collateral
-		ret, _, err := vmctx.Runtime().Send(address.InitAddress, initactor.Exec, vmctx.Message().ValueReceived(), []interface{}{actorCodeCid, initParams})
+		ret, _, err := vmctx.Runtime().LegacySend(address.InitAddress, initactor.Exec, vmctx.Message().ValueReceived(), []interface{}{actorCodeCid, initParams})
 		if err != nil {
 			return nil, err
 		}
@@ -228,8 +228,8 @@ func (*impl) createStorageMiner(vmctx invocationContext, ownerAddr, workerAddr a
 }
 
 // retriveActorId uses init actor to map an actorAddress to an id address
-func retreiveActorID(vmctx runtime.Runtime, actorAddr address.Address) (address.Address, error) {
-	ret, _, err := vmctx.Send(address.InitAddress, initactor.GetActorIDForAddress, types.ZeroAttoFIL, []interface{}{actorAddr})
+func retreiveActorID(rt runtime.Runtime, actorAddr address.Address) (address.Address, error) {
+	ret, _, err := rt.LegacySend(address.InitAddress, initactor.GetActorIDForAddress, types.ZeroAttoFIL, []interface{}{actorAddr})
 	if err != nil {
 		return address.Undef, err
 	}

--- a/internal/pkg/vm/actor/builtin/power/power.go
+++ b/internal/pkg/vm/actor/builtin/power/power.go
@@ -126,7 +126,7 @@ func (*Actor) InitializeState(storage runtime.Storage, _ interface{}) error {
 		return err
 	}
 
-	return storage.Commit(id, cid.Undef)
+	return storage.LegacyCommit(id, cid.Undef)
 }
 
 //

--- a/internal/pkg/vm/actor/builtin/storagemarket/storagemarket.go
+++ b/internal/pkg/vm/actor/builtin/storagemarket/storagemarket.go
@@ -171,7 +171,7 @@ func (*impl) createStorageMiner(vmctx runtime.InvocationContext, sectorSize *typ
 		initParams := []interface{}{vmctx.Message().Caller(), vmctx.Message().Caller(), pid, sectorSize}
 
 		// create miner actor by messaging the init actor and sending it collateral
-		ret, _, err := vmctx.Runtime().Send(address.InitAddress, initactor.Exec, vmctx.Message().ValueReceived(), []interface{}{actorCodeCid, initParams})
+		ret, _, err := vmctx.Runtime().LegacySend(address.InitAddress, initactor.Exec, vmctx.Message().ValueReceived(), []interface{}{actorCodeCid, initParams})
 		if err != nil {
 			return nil, err
 		}
@@ -204,8 +204,8 @@ func (*impl) createStorageMiner(vmctx runtime.InvocationContext, sectorSize *typ
 }
 
 // retriveActorId uses init actor to map an actorAddress to an id address
-func retreiveActorID(vmctx runtime.Runtime, actorAddr address.Address) (address.Address, error) {
-	ret, _, err := vmctx.Send(address.InitAddress, initactor.GetActorIDForAddress, types.ZeroAttoFIL, []interface{}{actorAddr})
+func retreiveActorID(rt runtime.Runtime, actorAddr address.Address) (address.Address, error) {
+	ret, _, err := rt.LegacySend(address.InitAddress, initactor.GetActorIDForAddress, types.ZeroAttoFIL, []interface{}{actorAddr})
 	if err != nil {
 		return address.Undef, err
 	}
@@ -346,7 +346,7 @@ func (*impl) getProofsMode(vmctx runtime.InvocationContext) (types.ProofsMode, u
 }
 
 func (*impl) getMinerPoStState(vmctx runtime.InvocationContext, minerAddr address.Address) (uint64, error) {
-	msgResult, _, err := vmctx.Runtime().Send(minerAddr, miner.GetPoStState, types.ZeroAttoFIL, nil)
+	msgResult, _, err := vmctx.Runtime().LegacySend(minerAddr, miner.GetPoStState, types.ZeroAttoFIL, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/pkg/vm/actor/builtin/storagemarket/storagemarket.go
+++ b/internal/pkg/vm/actor/builtin/storagemarket/storagemarket.go
@@ -127,7 +127,7 @@ func (*Actor) InitializeState(storage runtime.Storage, proofsModeInterface inter
 		return err
 	}
 
-	return storage.Commit(id, cid.Undef)
+	return storage.LegacyCommit(id, cid.Undef)
 }
 
 //

--- a/internal/pkg/vm/actor/storage.go
+++ b/internal/pkg/vm/actor/storage.go
@@ -61,7 +61,7 @@ func WithState(ctx runtime.InvocationContext, st interface{}, f func() (interfac
 		return nil, vmerrors.RevertErrorWrap(err, "Could not stage memory chunk")
 	}
 
-	err = stage.Commit(cid, stage.Head())
+	err = stage.LegacyCommit(cid, stage.LegacyHead())
 	if err != nil {
 		return nil, vmerrors.RevertErrorWrap(err, "Could not commit actor memory")
 	}
@@ -73,7 +73,7 @@ func WithState(ctx runtime.InvocationContext, st interface{}, f func() (interfac
 func ReadState(ctx runtime.InvocationContext, st interface{}) error {
 	storage := ctx.Runtime().Storage()
 
-	memory, err := storage.Get(storage.Head())
+	memory, err := storage.Get(storage.LegacyHead())
 	if err != nil {
 		return vmerrors.FaultErrorWrap(err, "Could not read actor storage")
 	}
@@ -94,7 +94,7 @@ func WriteState(ctx runtime.InvocationContext, state interface{}) error {
 		return vmerrors.RevertErrorWrap(err, "Could not stage memory chunk")
 	}
 
-	err = stage.Commit(cid, stage.Head())
+	err = stage.LegacyCommit(cid, stage.LegacyHead())
 	if err != nil {
 		return vmerrors.RevertErrorWrap(err, "Could not commit actor memory")
 	}

--- a/internal/pkg/vm/actor/storage_test.go
+++ b/internal/pkg/vm/actor/storage_test.go
@@ -64,7 +64,7 @@ func TestLoadLookup(t *testing.T) {
 
 	assert.True(t, c.Defined())
 
-	err = storage.Commit(c, cid.Undef)
+	err = storage.LegacyCommit(c, cid.Undef)
 	require.NoError(t, err)
 
 	err = vms.Flush()

--- a/internal/pkg/vm/actor/testing.go
+++ b/internal/pkg/vm/actor/testing.go
@@ -108,7 +108,7 @@ func (a *FakeActor) InitializeState(storage runtime.Storage, initializerData int
 		return err
 	}
 
-	return storage.Commit(id, cid.Undef)
+	return storage.LegacyCommit(id, cid.Undef)
 }
 
 // Method returns method definition for a given method id.

--- a/internal/pkg/vm/actor/testing.go
+++ b/internal/pkg/vm/actor/testing.go
@@ -196,32 +196,32 @@ func (*impl) NonZeroExitCode(ctx runtime.InvocationContext) (uint8, error) {
 
 // NestedBalance sends 100 to the given address.
 func (*impl) NestedBalance(ctx runtime.InvocationContext, target address.Address) (uint8, error) {
-	_, code, err := ctx.Runtime().Send(target, types.SendMethodID, types.NewAttoFILFromFIL(100), nil)
+	_, code, err := ctx.Runtime().LegacySend(target, types.SendMethodID, types.NewAttoFILFromFIL(100), nil)
 	return code, err
 }
 
 // SendTokens sends 100 to the given address.
 func (*impl) SendTokens(ctx runtime.InvocationContext, target address.Address) (uint8, error) {
-	_, code, err := ctx.Runtime().Send(target, types.SendMethodID, types.NewAttoFILFromFIL(100), nil)
+	_, code, err := ctx.Runtime().LegacySend(target, types.SendMethodID, types.NewAttoFILFromFIL(100), nil)
 	return code, err
 }
 
 // CallSendTokens tells the target to invoke SendTokens to send tokens to the
 // to address (that is, it calls target.SendTokens(to)).
 func (*impl) CallSendTokens(ctx runtime.InvocationContext, target address.Address, to address.Address) (uint8, error) {
-	_, code, err := ctx.Runtime().Send(target, sendTokensID, types.ZeroAttoFIL, []interface{}{to})
+	_, code, err := ctx.Runtime().LegacySend(target, sendTokensID, types.ZeroAttoFIL, []interface{}{to})
 	return code, err
 }
 
 // AttemptMultiSpend1 attempts to re-spend already spent tokens using a double reentrant call.
 func (*impl) AttemptMultiSpend1(ctx runtime.InvocationContext, self, target address.Address) (uint8, error) {
 	// This will transfer 100 tokens legitimately.
-	_, code, err := ctx.Runtime().Send(target, callSendTokensID, types.ZeroAttoFIL, []interface{}{self, target})
+	_, code, err := ctx.Runtime().LegacySend(target, callSendTokensID, types.ZeroAttoFIL, []interface{}{self, target})
 	if code != 0 || err != nil {
 		return code, errors.FaultErrorWrap(err, "failed first callSendTokens")
 	}
 	// Try to double spend
-	_, code, err = ctx.Runtime().Send(target, callSendTokensID, types.ZeroAttoFIL, []interface{}{self, target})
+	_, code, err = ctx.Runtime().LegacySend(target, callSendTokensID, types.ZeroAttoFIL, []interface{}{self, target})
 	if code != 0 || err != nil {
 		return code, errors.FaultErrorWrap(err, "failed second callSendTokens")
 	}
@@ -231,7 +231,7 @@ func (*impl) AttemptMultiSpend1(ctx runtime.InvocationContext, self, target addr
 // AttemptMultiSpend2 attempts to re-spend already spent tokens using a reentrant call followed by a direct spend call.
 func (a *impl) AttemptMultiSpend2(ctx runtime.InvocationContext, self, target address.Address) (uint8, error) {
 	// This will transfer 100 tokens legitimately.
-	_, code, err := ctx.Runtime().Send(target, callSendTokensID, types.ZeroAttoFIL, []interface{}{self, target})
+	_, code, err := ctx.Runtime().LegacySend(target, callSendTokensID, types.ZeroAttoFIL, []interface{}{self, target})
 	if code != 0 || err != nil {
 		return code, errors.FaultErrorWrap(err, "failed first callSendTokens")
 	}
@@ -248,7 +248,7 @@ func (*impl) RunsAnotherMessage(ctx runtime.InvocationContext, target address.Ad
 	if err := ctx.Charge(100); err != nil {
 		return internal.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
-	_, code, err := ctx.Runtime().Send(target, HasReturnValueID, types.ZeroAttoFIL, []interface{}{})
+	_, code, err := ctx.Runtime().LegacySend(target, HasReturnValueID, types.ZeroAttoFIL, []interface{}{})
 	return code, err
 }
 

--- a/internal/pkg/vm/internal/exitcode/exitcode.go
+++ b/internal/pkg/vm/internal/exitcode/exitcode.go
@@ -1,6 +1,10 @@
 package exitcode
 
-import "github.com/filecoin-project/go-filecoin/internal/pkg/types"
+import (
+	"fmt"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+)
 
 // ExitCode is the exit code of a method executing inside the VM.
 type ExitCode types.Uint64
@@ -60,4 +64,13 @@ func (code ExitCode) IsSuccess() bool {
 // IsError returns `True` if the exit code is an error.
 func (code ExitCode) IsError() bool {
 	return code != Ok
+}
+
+func (code ExitCode) String() string {
+	switch code {
+	case Ok:
+		return "Ok"
+	default:
+		return fmt.Sprintf("ExitCode(%d)", (uint64)(code))
+	}
 }

--- a/internal/pkg/vm/internal/runtime/runtime.go
+++ b/internal/pkg/vm/internal/runtime/runtime.go
@@ -165,7 +165,7 @@ func Abort(msg string) {
 }
 
 // Abortf will stop the VM execution and return an abort error to the caller.
-func Abortf(msg string, args ...interface{}) error {
+func Abortf(msg string, args ...interface{}) {
 	panic(AbortPanicError{msg: fmt.Sprintf(msg, args...)})
 }
 

--- a/internal/pkg/vm/internal/runtime/runtime.go
+++ b/internal/pkg/vm/internal/runtime/runtime.go
@@ -179,7 +179,7 @@ func Assert(cond bool) {
 // Storage defines the storage module exposed to actors.
 type Storage interface {
 	// Dragons: move out after cleaning up the actor state construction
-	Head() cid.Cid
+	LegacyHead() cid.Cid
 	Put(interface{}) (cid.Cid, error)
 	// Dragons: move out after cleaning up the actor state construction
 	CidOf(interface{}) (cid.Cid, error)
@@ -187,5 +187,5 @@ type Storage interface {
 	// TODO: change to `Get(cid, interface{}) error`
 	Get(cid.Cid) ([]byte, error)
 	// Dragons: move out after cleaning up the actor state construction
-	Commit(cid.Cid, cid.Cid) error
+	LegacyCommit(cid.Cid, cid.Cid) error
 }

--- a/internal/pkg/vm/internal/runtime/runtime.go
+++ b/internal/pkg/vm/internal/runtime/runtime.go
@@ -14,9 +14,9 @@ type Runtime interface {
 	CurrentEpoch() types.BlockHeight
 	// Randomness gives the actors access to sampling peudo-randomess from the chain.
 	Randomness(epoch types.BlockHeight, offset uint64) Randomness
-	// Send allows actors to invoke methods on other actors
-	// Dragons: cleanup to match new vm expectations
-	Send(to address.Address, method types.MethodID, value types.AttoFIL, params []interface{}) ([][]byte, uint8, error)
+	// LegacySend allows actors to invoke methods on other actors
+	// TODO: remove after all legacy actor code is gone (issue #???)
+	LegacySend(to address.Address, method types.MethodID, value types.AttoFIL, params []interface{}) ([][]byte, uint8, error)
 	// Storage is the raw store for IPLD objects.
 	//
 	// Note: this is required for custom data structures.

--- a/internal/pkg/vm/internal/storagemap/storagemap.go
+++ b/internal/pkg/vm/internal/storagemap/storagemap.go
@@ -141,10 +141,10 @@ func (s storage) Get(cid cid.Cid) ([]byte, error) {
 	return blk.RawData(), nil
 }
 
-// Commit updates the head of the current actor to the given cid.
+// LegacyCommit updates the head of the current actor to the given cid.
 // The new cid must be the content id of a chunk put in storage.
 // The given oldCid must match the cid of the current actor.
-func (s storage) Commit(newCid cid.Cid, oldCid cid.Cid) error {
+func (s storage) LegacyCommit(newCid cid.Cid, oldCid cid.Cid) error {
 	// commit to initialize actor only permitted if Head and expected id are nil
 	if oldCid.Defined() && s.actor.Head.Defined() && !oldCid.Equals(s.actor.Head) {
 		return internal.Errors[internal.ErrStaleHead]
@@ -162,8 +162,8 @@ func (s storage) Commit(newCid cid.Cid, oldCid cid.Cid) error {
 	return nil
 }
 
-// Head return the current head of the actor's memory
-func (s storage) Head() cid.Cid {
+// LegacyHead return the current head of the actor's memory
+func (s storage) LegacyHead() cid.Cid {
 	return s.actor.Head
 }
 

--- a/internal/pkg/vm/internal/storagemap/storagemap_test.go
+++ b/internal/pkg/vm/internal/storagemap/storagemap_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/errors"
+	internal "github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -158,12 +158,12 @@ func TestStorageHeadAndCommit(t *testing.T) {
 		newCid, err := stage.Put(newMemory.RawData())
 		require.NoError(t, err)
 
-		assert.NotEqual(t, newCid, stage.Head())
+		assert.NotEqual(t, newCid, stage.LegacyHead())
 
-		err = stage.Commit(newCid, stage.Head())
+		err = stage.LegacyCommit(newCid, stage.LegacyHead())
 		assert.NoError(t, err)
 
-		assert.Equal(t, newCid, stage.Head())
+		assert.Equal(t, newCid, stage.LegacyHead())
 	})
 
 	t.Run("Committing a non existent chunk is an error", func(t *testing.T) {
@@ -174,7 +174,7 @@ func TestStorageHeadAndCommit(t *testing.T) {
 		newMemory, err := cbor.WrapObject([]byte("New memory"), types.DefaultHashFunction, -1)
 		require.NoError(t, err)
 
-		ec := stage.Commit(newMemory.Cid(), stage.Head())
+		ec := stage.LegacyCommit(newMemory.Cid(), stage.LegacyHead())
 		assert.Equal(t, internal.Errors[internal.ErrDanglingPointer], ec)
 	})
 
@@ -195,7 +195,7 @@ func TestStorageHeadAndCommit(t *testing.T) {
 		_, err = stage.Put(newMemory2.RawData())
 		require.NoError(t, err)
 
-		err = stage.Commit(newMemory2.Cid(), newMemory1.Cid())
+		err = stage.LegacyCommit(newMemory2.Cid(), newMemory1.Cid())
 		assert.Equal(t, internal.Errors[internal.ErrStaleHead], err)
 	})
 }
@@ -235,7 +235,7 @@ func TestDatastoreBacking(t *testing.T) {
 		require.NoError(t, err)
 
 		// commit the change
-		assert.NoError(t, stage.Commit(cid, stage.Head()))
+		assert.NoError(t, stage.LegacyCommit(cid, stage.LegacyHead()))
 
 		// flush the change
 		err = storage.Flush()
@@ -262,7 +262,7 @@ func TestDatastoreBacking(t *testing.T) {
 		require.NoError(t, err)
 
 		// only commit the second change
-		assert.NoError(t, stage.Commit(cid2, stage.Head()))
+		assert.NoError(t, stage.LegacyCommit(cid2, stage.LegacyHead()))
 
 		// flush the change
 		err = storage.Flush()
@@ -296,7 +296,7 @@ func TestDatastoreBacking(t *testing.T) {
 		require.NoError(t, err)
 
 		// only commit the second change
-		assert.NoError(t, stage.Commit(cid2, stage.Head()))
+		assert.NoError(t, stage.LegacyCommit(cid2, stage.LegacyHead()))
 
 		// flush the change
 		err = storage.Flush()
@@ -331,7 +331,7 @@ func TestValidationAndPruning(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Attempt to commit before adding linked memory
-		err = stage.Commit(cid, stage.Head())
+		err = stage.LegacyCommit(cid, stage.LegacyHead())
 		assert.Equal(t, internal.Errors[internal.ErrDanglingPointer], err)
 	})
 }

--- a/internal/pkg/vm/internal/vmcontext/actor_state_handle.go
+++ b/internal/pkg/vm/internal/vmcontext/actor_state_handle.go
@@ -55,7 +55,7 @@ func (h *actorStateHandle) Readonly(obj interface{}) {
 	}
 
 	// Dragons: needed while we can get actor state modified directly by actor code
-	h.head = h.ctx.Storage().Head()
+	h.head = h.ctx.Storage().LegacyHead()
 
 	// load state from storage
 	// Note: we copy the head over to `readonlyHead` in case it gets modified afterwards via `Transaction()`.
@@ -84,7 +84,7 @@ func (h *actorStateHandle) Transaction(obj interface{}, f transactionFn) (interf
 	}
 
 	// Dragons: needed while we can get actor state modified directly by actor code
-	h.head = h.ctx.Storage().Head()
+	h.head = h.ctx.Storage().LegacyHead()
 
 	// load state from storage
 	oldcid := h.head
@@ -113,7 +113,7 @@ func (h *actorStateHandle) Transaction(obj interface{}, f transactionFn) (interf
 
 	// commit the new state
 	// Note: this is more of a commit into pending, not a real commit
-	err = storage.Commit(newcid, oldcid)
+	err = storage.LegacyCommit(newcid, oldcid)
 	if err != nil {
 		runtime.Abort("Storage commit error")
 	}

--- a/internal/pkg/vm/internal/vmcontext/actor_state_handle_test.go
+++ b/internal/pkg/vm/internal/vmcontext/actor_state_handle_test.go
@@ -28,7 +28,7 @@ func setup() testSetup {
 		storage:          vm.NewTestStorage(initialstate),
 		allowSideEffects: true,
 	}
-	initialhead := ctx.storage.Head()
+	initialhead := ctx.storage.LegacyHead()
 	h := vmcontext.NewActorStateHandle(&ctx, initialhead)
 
 	cleanup := func() {
@@ -222,7 +222,7 @@ func TestActorStateHandleNilState(t *testing.T) {
 			storage:          vm.NewTestStorage(nil),
 			allowSideEffects: true,
 		}
-		initialhead := ctx.storage.Head()
+		initialhead := ctx.storage.LegacyHead()
 		h := vmcontext.NewActorStateHandle(&ctx, initialhead)
 
 		cleanup := func() {

--- a/internal/pkg/vm/internal/vmcontext/export.go
+++ b/internal/pkg/vm/internal/vmcontext/export.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ExportedFunc is the signature an exported method of an actor is expected to have.
-type ExportedFunc func(ctx ExtendedRuntime) ([]byte, uint8, error)
+type ExportedFunc func(ctx ExtendedRuntime) ([]interface{}, uint8, error)
 
 // makeTypedExport finds the correct method on the given actor and returns it.
 // The returned function is wrapped such that it takes care of serialization and type checks.
@@ -72,7 +72,7 @@ func makeTypedExport(actor dispatch.ExecutableActor, method types.MethodID) (Exp
 		badImpl()
 	}
 
-	return func(ctx ExtendedRuntime) ([]byte, uint8, error) {
+	return func(ctx ExtendedRuntime) ([]interface{}, uint8, error) {
 		params, err := abi.DecodeValues(ctx.LegacyMessage().Params, signature.Params)
 		if err != nil {
 			return nil, 1, errors.RevertErrorWrap(err, "invalid params")
@@ -107,11 +107,6 @@ func makeTypedExport(actor dispatch.ExecutableActor, method types.MethodID) (Exp
 		for _, vv := range out[:len(out)-2] {
 			vals = append(vals, vv.Interface())
 		}
-		retVal, err := abi.ToEncodedValues(vals...)
-		if err != nil {
-			return nil, 1, errors.FaultErrorWrap(err, "failed to marshal output value")
-		}
-
-		return retVal, exitCode, nil
+		return vals, exitCode, nil
 	}, true
 }

--- a/internal/pkg/vm/internal/vmcontext/export_test.go
+++ b/internal/pkg/vm/internal/vmcontext/export_test.go
@@ -36,7 +36,7 @@ func TestMakeTypedExportSuccess(t *testing.T) {
 		ret, exitCode, err := fn(makeCtx(Two))
 		assert.NoError(t, err)
 		assert.Equal(t, exitCode, uint8(0))
-		assert.Nil(t, ret)
+		assert.Equal(t, len(ret), 0)
 	})
 
 	t.Run("with return", func(t *testing.T) {
@@ -53,11 +53,11 @@ func TestMakeTypedExportSuccess(t *testing.T) {
 		ret, exitCode, err := fn(makeCtx(Four))
 		assert.NoError(t, err)
 		assert.Equal(t, exitCode, uint8(0))
+		assert.Equal(t, len(ret), 1)
 
-		vv, err := abi.DecodeValues(ret, a.signatures[Four].Return)
-		assert.NoError(t, err)
-		assert.Equal(t, 1, len(vv))
-		assert.Equal(t, vv[0].Val, []byte("hello"))
+		v, ok := ret[0].([]byte)
+		assert.True(t, ok)
+		assert.Equal(t, v, []byte("hello"))
 	})
 
 	t.Run("with error return", func(t *testing.T) {

--- a/internal/pkg/vm/internal/vmcontext/vmcontext.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext.go
@@ -116,8 +116,8 @@ func (ctx *VMContext) Randomness(epoch types.BlockHeight, offset uint64) runtime
 	return rnd
 }
 
-// Send allows actors to invoke methods on other actors
-func (ctx *VMContext) Send(to address.Address, method types.MethodID, value types.AttoFIL, params []interface{}) ([][]byte, uint8, error) {
+// LegacySend allows actors to invoke methods on other actors
+func (ctx *VMContext) LegacySend(to address.Address, method types.MethodID, value types.AttoFIL, params []interface{}) ([][]byte, uint8, error) {
 	// check if side-effects are allowed
 	if !ctx.allowSideEffects {
 		runtime.Abort("Calling Send() is not allowed during side-effet lock")
@@ -306,7 +306,7 @@ func (ctx *VMContext) CreateActor(actorID types.Uint64, code cid.Cid, params []i
 	newActor.Code = code
 
 	// send message containing actor's initial balance to construct it with the given params
-	_, _, err = ctx.Runtime().Send(idAddr, types.ConstructorMethodID, ctx.Message().ValueReceived(), params)
+	_, _, err = ctx.Runtime().LegacySend(idAddr, types.ConstructorMethodID, ctx.Message().ValueReceived(), params)
 	if err != nil {
 		runtime.Abort("Constructor failed on actor")
 	}
@@ -490,7 +490,7 @@ func (ctx *VMContext) resolveActorAddress(addr address.Address) (address.Address
 		return addr, nil
 	}
 
-	ret, _, err := ctx.Send(address.InitAddress, initactor.GetActorIDForAddress, types.ZeroAttoFIL, []interface{}{addr})
+	ret, _, err := ctx.LegacySend(address.InitAddress, initactor.GetActorIDForAddress, types.ZeroAttoFIL, []interface{}{addr})
 	if err != nil {
 		return address.Undef, err
 	}

--- a/internal/pkg/vm/internal/vmcontext/vmcontext.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext.go
@@ -22,6 +22,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/errors"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/dispatch"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/exitcode"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/gastracker"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/runtime"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/storagemap"
@@ -173,7 +174,7 @@ func (ctx *VMContext) LegacySend(to address.Address, method types.MethodID, valu
 	}
 	innerCtx := NewVMContext(innerParams)
 
-	out, ret, err := deps.Send(context.Background(), innerCtx)
+	out, ret, err := deps.LegacySend(context.Background(), innerCtx)
 	if err != nil {
 		return nil, ret, err
 	}
@@ -182,6 +183,122 @@ func (ctx *VMContext) LegacySend(to address.Address, method types.MethodID, valu
 	ctx.stateHandle.Validate()
 
 	return out, ret, nil
+}
+
+// Send allows actors to invoke methods on other actors
+func (ctx *VMContext) Send(to address.Address, method types.MethodID, value types.AttoFIL, params []interface{}) interface{} {
+	// check if side-effects are allowed
+	if !ctx.allowSideEffects {
+		runtime.Abort("Calling Send() is not allowed during side-effet lock")
+	}
+
+	deps := ctx.deps
+
+	// the message sender is the `to` actor, so this is what we set as `from` in the new message
+	from := ctx.toAddr
+	fromActor := ctx.to
+
+	vals, err := deps.ToValues(params)
+	if err != nil {
+		runtime.Abort("failed to convert inputs to abi values")
+	}
+
+	paramData, err := deps.EncodeValues(vals)
+	if err != nil {
+		runtime.Abort("encoding params failed")
+	}
+
+	msg := types.NewUnsignedMessage(from, to, 0, value, method, paramData)
+	if msg.From == msg.To {
+		// TODO 3647: handle this
+		runtime.Abortf("unhandled: sending to self (%s)", msg.From)
+	}
+
+	// fetch id address from init actor if necessary
+	toAddr, err := ctx.resolveActorAddress(msg.To)
+	if err != nil {
+		panic(exitcode.ActorNotFound)
+	}
+
+	toActor, err := deps.GetOrCreateActor(context.TODO(), toAddr, func() (*actor.Actor, error) {
+		return &actor.Actor{}, nil
+	})
+	if err != nil {
+		runtime.Abortf("failed to get or create To actor %s", msg.To)
+	}
+	// TODO(fritz) de-dup some of the logic between here and core.Send
+	innerParams := NewContextParams{
+		From:        fromActor,
+		To:          toActor,
+		ToAddr:      toAddr,
+		Message:     msg,
+		OriginMsg:   ctx.originMsg,
+		State:       ctx.state,
+		StorageMap:  ctx.storageMap,
+		GasTracker:  ctx.gasTracker,
+		BlockHeight: ctx.blockHeight,
+		Ancestors:   ctx.ancestors,
+		Actors:      ctx.actors,
+	}
+	innerCtx := NewVMContext(innerParams)
+
+	return deps.Apply(innerCtx)
+}
+
+func apply(ctx *VMContext) interface{} {
+	filValue := ctx.message.Value
+	if !filValue.Equal(types.ZeroAttoFIL) {
+		if filValue.IsNegative() {
+			runtime.Abort("Can not transfer negative FIL value")
+		}
+		if err := Transfer(ctx.from, ctx.to, filValue); err != nil {
+			panic(exitcode.InsufficientFunds)
+		}
+	}
+
+	msg := ctx.message
+
+	if msg.Method == types.SendMethodID {
+		// if only tokens are transferred there is no need for a method
+		// this means we can shortcircuit execution
+		return nil
+	}
+
+	if msg.Method == types.InvalidMethodID {
+		// your test should not be getting here..
+		// Note: this method is not materialized in production but could occur on tests
+		panic("trying to execute fake method on the actual VM, fix test")
+	}
+
+	// TODO: use chain height based protocol version here (#3360)
+	toExecutable, err := ctx.Actors().GetActorCode(ctx.To().Code, 0)
+	if err != nil {
+		panic(exitcode.ActorCodeNotFound)
+	}
+
+	exportedFn, ok := makeTypedExport(toExecutable, msg.Method)
+	if !ok {
+		panic(exitcode.InvalidMethod)
+	}
+
+	vals, code, err := exportedFn(ctx)
+
+	// Handle legacy codes and errors
+	if err != nil {
+		runtime.Abort("Legacy actor code returned an error")
+	}
+
+	if code != 0 {
+		runtime.Abort("Legacy actor code returned with non-zero error code")
+	}
+
+	// validate state access
+	ctx.stateHandle.Validate()
+
+	if len(vals) > 0 {
+		return vals[0]
+	}
+	return nil
 }
 
 var _ runtime.MessageInfo = (*VMContext)(nil)
@@ -306,12 +423,14 @@ func (ctx *VMContext) CreateActor(actorID types.Uint64, code cid.Cid, params []i
 	newActor.Code = code
 
 	// send message containing actor's initial balance to construct it with the given params
-	_, _, err = ctx.Runtime().LegacySend(idAddr, types.ConstructorMethodID, ctx.Message().ValueReceived(), params)
-	if err != nil {
-		runtime.Abort("Constructor failed on actor")
-	}
+	ctx.Runtime().Send(idAddr, types.ConstructorMethodID, ctx.Message().ValueReceived(), params)
 
 	return actorAddr
+}
+
+// VerifySignature implemenets the ExtendedInvocationContext interface.
+func (*VMContext) VerifySignature(signer address.Address, signature types.Signature, msg []byte) bool {
+	return types.IsValidSignature(msg, signer, signature)
 }
 
 var _ runtime.LegacyInvocationContext = (*VMContext)(nil)
@@ -392,8 +511,9 @@ func (ctx *VMContext) To() *actor.Actor {
 func makeDeps(st *state.CachedTree) *deps {
 	deps := deps{
 		EncodeValues: abi.EncodeValues,
-		Send:         Send,
+		LegacySend:   LegacySend,
 		ToValues:     abi.ToValues,
+		Apply:        apply,
 	}
 	if st != nil {
 		deps.GetOrCreateActor = st.GetOrCreateActor
@@ -404,13 +524,14 @@ func makeDeps(st *state.CachedTree) *deps {
 type deps struct {
 	EncodeValues     func([]*abi.Value) ([]byte, error)
 	GetOrCreateActor func(context.Context, address.Address, func() (*actor.Actor, error)) (*actor.Actor, error)
-	Send             func(context.Context, ExtendedRuntime) ([][]byte, uint8, error)
+	LegacySend       func(context.Context, ExtendedRuntime) ([][]byte, uint8, error)
+	Apply            func(*VMContext) interface{}
 	ToValues         func([]interface{}) ([]*abi.Value, error)
 }
 
-// Send executes a message pass inside the VM. If error is set it
+// LegacySend executes a message pass inside the VM. If error is set it
 // will always satisfy either ShouldRevert() or IsFault().
-func Send(ctx context.Context, vmCtx ExtendedRuntime) ([][]byte, uint8, error) {
+func LegacySend(ctx context.Context, vmCtx ExtendedRuntime) (out [][]byte, code uint8, err error) {
 	return send(ctx, Transfer, vmCtx)
 }
 
@@ -456,14 +577,21 @@ func send(ctx context.Context, transfer TransferFn, vmCtx ExtendedRuntime) ([][]
 		return nil, 1, errors.Errors[errors.ErrMissingExport]
 	}
 
-	r, code, err := exportedFn(vmCtx)
-	if r != nil {
-		var rv [][]byte
-		err = encoding.Decode(r, &rv)
+	vals, code, err := exportedFn(vmCtx)
+	if vals != nil {
+		r, err := abi.ToEncodedValues(vals...)
 		if err != nil {
-			return nil, 1, errors.NewRevertErrorf("method return doesn't decode as array: %s", err)
+			return nil, 1, errors.FaultErrorWrap(err, "failed to marshal output value")
 		}
-		return rv, code, err
+
+		if r != nil {
+			var rv [][]byte
+			err = encoding.Decode(r, &rv)
+			if err != nil {
+				return nil, 1, errors.NewRevertErrorf("method return doesn't decode as array: %s", err)
+			}
+			return rv, code, err
+		}
 	}
 	return nil, code, err
 }

--- a/internal/pkg/vm/internal/vmcontext/vmcontext_test.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext_test.go
@@ -131,9 +131,9 @@ func TestVMContextCreateActor(t *testing.T) {
 			paramsForwarded = params
 			return []*abi.Value{}, nil
 		}
-		vm.deps.Send = func(ctx context.Context, vmCtx ExtendedRuntime) ([][]byte, uint8, error) {
+		vm.deps.Apply = func(vmCtx *VMContext) interface{} {
 			valueForwarded = vmCtx.LegacyMessage().Value
-			return nil, 0, nil
+			return nil
 		}
 
 		ctx := context.Background()
@@ -324,7 +324,7 @@ func TestVMContextSendFailures(t *testing.T) {
 				calls = append(calls, "GetOrCreateActor")
 				return f()
 			},
-			Send: func(ctx context.Context, vmCtx ExtendedRuntime) ([][]byte, uint8, error) {
+			LegacySend: func(ctx context.Context, vmCtx ExtendedRuntime) ([][]byte, uint8, error) {
 				calls = append(calls, "Send")
 				return nil, 123, expectedVMSendErr
 			},

--- a/internal/pkg/vm/internal/vmcontext/vmcontext_test.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext_test.go
@@ -217,7 +217,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		ctx := NewVMContext(vmCtxParams())
 		ctx.deps = deps
 
-		_, code, err := ctx.Send(newAddress(), fooID, types.ZeroAttoFIL, []interface{}{})
+		_, code, err := ctx.LegacySend(newAddress(), fooID, types.ZeroAttoFIL, []interface{}{})
 
 		assert.Error(t, err)
 		assert.Equal(t, 1, int(code))
@@ -241,7 +241,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		ctx := NewVMContext(vmCtxParams())
 		ctx.deps = deps
 
-		_, code, err := ctx.Send(newAddress(), fooID, types.ZeroAttoFIL, []interface{}{})
+		_, code, err := ctx.LegacySend(newAddress(), fooID, types.ZeroAttoFIL, []interface{}{})
 
 		assert.Error(t, err)
 		assert.Equal(t, 1, int(code))
@@ -272,7 +272,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		ctx.deps = deps
 		ctx.toAddr = msg.To
 
-		_, code, err := ctx.Send(to, fooID, types.ZeroAttoFIL, []interface{}{})
+		_, code, err := ctx.LegacySend(to, fooID, types.ZeroAttoFIL, []interface{}{})
 
 		assert.Error(t, err)
 		assert.Equal(t, 1, int(code))
@@ -303,7 +303,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		ctx := NewVMContext(params)
 		ctx.deps = deps
 
-		_, code, err := ctx.Send(newAddress(), fooID, types.ZeroAttoFIL, []interface{}{})
+		_, code, err := ctx.LegacySend(newAddress(), fooID, types.ZeroAttoFIL, []interface{}{})
 
 		assert.Error(t, err)
 		assert.Equal(t, 1, int(code))
@@ -337,7 +337,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		ctx := NewVMContext(vmCtxParams())
 		ctx.deps = deps
 
-		_, code, err := ctx.Send(newAddress(), fooID, types.ZeroAttoFIL, []interface{}{})
+		_, code, err := ctx.LegacySend(newAddress(), fooID, types.ZeroAttoFIL, []interface{}{})
 
 		assert.Error(t, err)
 		assert.Equal(t, 123, int(code))

--- a/internal/pkg/vm/internal/vmcontext/vmcontext_test.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext_test.go
@@ -69,7 +69,7 @@ func TestVMContextStorage(t *testing.T) {
 
 	cid, err := vmCtx.Storage().Put(node.RawData())
 	require.NoError(t, err)
-	err = vmCtx.Storage().Commit(cid, vmCtx.Storage().Head())
+	err = vmCtx.Storage().LegacyCommit(cid, vmCtx.Storage().LegacyHead())
 	require.NoError(t, err)
 	assert.NoError(t, cstate.Commit(ctx))
 
@@ -77,7 +77,7 @@ func TestVMContextStorage(t *testing.T) {
 	toActorBack, err := st.GetActor(ctx, toAddr)
 	assert.NoError(t, err)
 	vmCtxParams.To = toActorBack
-	storage, err := vmCtx.Storage().Get(vmCtx.Storage().Head())
+	storage, err := vmCtx.Storage().Get(vmCtx.Storage().LegacyHead())
 	assert.NoError(t, err)
 	assert.Equal(t, storage, node.RawData())
 }

--- a/internal/pkg/vm/testing.go
+++ b/internal/pkg/vm/testing.go
@@ -69,7 +69,7 @@ func NewFakeVMContext(message *types.UnsignedMessage, state interface{}) *FakeVM
 		},
 		allowSideEffects: true,
 	}
-	aux.stateHandle = vmcontext.NewActorStateHandle(&aux, aux.StorageValue.Head())
+	aux.stateHandle = vmcontext.NewActorStateHandle(&aux, aux.StorageValue.LegacyHead())
 	return &aux
 }
 
@@ -279,13 +279,13 @@ func (ts testStorage) CidOf(v interface{}) (cid.Cid, error) {
 	return cid.NewCidV1(cid.Raw, raw), nil
 }
 
-// Commit satisfies the Storage interface but does nothing
-func (ts testStorage) Commit(cid.Cid, cid.Cid) error {
+// LegacyCommit satisfies the Storage interface but does nothing
+func (ts testStorage) LegacyCommit(cid.Cid, cid.Cid) error {
 	return nil
 }
 
-// Head returns the Cid of the current state.
-func (ts testStorage) Head() cid.Cid {
+// LegacyHead returns the Cid of the current state.
+func (ts testStorage) LegacyHead() cid.Cid {
 	if ts.state == nil {
 		return cid.Undef
 	}

--- a/internal/pkg/vm/testing.go
+++ b/internal/pkg/vm/testing.go
@@ -89,8 +89,8 @@ func (tc *FakeVMContext) Randomness(epoch types.BlockHeight, offset uint64) runt
 	return rnd
 }
 
-// Send sends a message to another actor
-func (tc *FakeVMContext) Send(to address.Address, method types.MethodID, value types.AttoFIL, params []interface{}) ([][]byte, uint8, error) {
+// LegacySend sends a message to another actor
+func (tc *FakeVMContext) LegacySend(to address.Address, method types.MethodID, value types.AttoFIL, params []interface{}) ([][]byte, uint8, error) {
 	// check if side-effects are allowed
 	if !tc.allowSideEffects {
 		runtime.Abort("Calling Send() is not allowed during side-effet lock")

--- a/internal/pkg/vm/vm.go
+++ b/internal/pkg/vm/vm.go
@@ -46,7 +46,7 @@ func NewVMContext(params NewContextParams) *vmcontext.VMContext {
 // Send executes a message pass inside the VM. If error is set it
 // will always satisfy either ShouldRevert() or IsFault().
 func Send(ctx context.Context, vmCtx vmcontext.ExtendedRuntime) ([][]byte, uint8, error) {
-	return vmcontext.Send(ctx, vmCtx)
+	return vmcontext.LegacySend(ctx, vmCtx)
 }
 
 // Transfer transfers the given value between two actors.


### PR DESCRIPTION
### Motivation

The new spec defines methods to result either in a success with a value returned or they Abort. 

### Proposed changes

- This PR renames the old Send to `LegacySend` while
- Adds a new `Send` with a single value being returned. 

See #3681.
