### PR TITLE
Feat/timing rules

### DIFF
--- a/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
@@ -47,7 +47,7 @@ type nodeChainSelector interface {
 func NewSyncerSubmodule(ctx context.Context, config syncerConfig, repo chainRepo, blockstore *BlockstoreSubmodule, network *NetworkSubmodule, discovery *DiscoverySubmodule, chn *ChainSubmodule) (SyncerSubmodule, error) {
 	// setup block validation
 	// TODO when #2961 is resolved do the needful here.
-	blkValid := consensus.NewDefaultBlockValidator(config.BlockTime(), config.ChainClock())
+	blkValid := consensus.NewDefaultBlockValidator(config.ChainClock())
 
 	// register block validation on floodsub
 	btv := net.NewBlockTopicValidator(blkValid)

--- a/internal/pkg/block/tipset.go
+++ b/internal/pkg/block/tipset.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"sort"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/ipfs/go-cid"
 	"github.com/pkg/errors"
 )
@@ -116,20 +115,6 @@ func (ts TipSet) MinTicket() (Ticket, error) {
 		return Ticket{}, errUndefTipSet
 	}
 	return ts.blocks[0].Ticket, nil
-}
-
-// MinTimestamp returns the smallest timestamp of all blocks in the tipset.
-func (ts TipSet) MinTimestamp() (types.Uint64, error) {
-	if len(ts.blocks) == 0 {
-		return 0, errUndefTipSet
-	}
-	min := ts.blocks[0].Timestamp
-	for i := 1; i < len(ts.blocks); i++ {
-		if ts.blocks[i].Timestamp < min {
-			min = ts.blocks[i].Timestamp
-		}
-	}
-	return min, nil
 }
 
 // Height returns the height of a tipset.

--- a/internal/pkg/block/tipset_test.go
+++ b/internal/pkg/block/tipset_test.go
@@ -116,11 +116,6 @@ func TestTipSet(t *testing.T) {
 		assert.Equal(t, b1.Ticket, tsTicket)
 	})
 
-	t.Run("min timestamp", func(t *testing.T) {
-		tsTime, _ := RequireNewTipSet(t, b1, b2, b3).MinTimestamp()
-		assert.Equal(t, b1.Timestamp, tsTime)
-	})
-
 	t.Run("equality", func(t *testing.T) {
 		ts1a := RequireNewTipSet(t, b3, b2, b1)
 		ts1b := RequireNewTipSet(t, b1, b2, b3)

--- a/internal/pkg/chain/testing.go
+++ b/internal/pkg/chain/testing.go
@@ -202,7 +202,7 @@ func (f *Builder) Build(parent block.TipSet, width int, build func(b *BlockBuild
 			// Omitted fields below
 			//StateRoot:       stateRoot,
 			//Proof            PoStProof
-			Timestamp:       f.stamper.Stamp(uint64(height)),
+			Timestamp: f.stamper.Stamp(uint64(height)),
 		}
 		// Nonce intentionally omitted as it will go away.
 
@@ -403,7 +403,7 @@ type TimeStamper interface {
 }
 
 // ZeroTimestamper writes a default of 0 to the timestamp
-type ZeroTimestamper struct {}
+type ZeroTimestamper struct{}
 
 // Stamp returns a stamp for the current block
 func (zt *ZeroTimestamper) Stamp(height uint64) types.Uint64 {
@@ -419,13 +419,13 @@ type ClockTimestamper struct {
 func NewClockTimestamper(chainClock clock.ChainEpochClock) *ClockTimestamper {
 	return &ClockTimestamper{
 		c: chainClock,
-	}	
-} 
+	}
+}
 
-// Stamp assigns a valid timestamp given genesis time and block time to 
+// Stamp assigns a valid timestamp given genesis time and block time to
 // a block of the provided height.
 func (ct *ClockTimestamper) Stamp(height uint64) types.Uint64 {
-	startTime := ct.c.StartTimeOfEpoch(height)
+	startTime := ct.c.StartTimeOfEpoch(types.NewBlockHeight(height))
 
 	timestamp := uint64(startTime.Unix())
 	return types.Uint64(timestamp)

--- a/internal/pkg/chain/testing.go
+++ b/internal/pkg/chain/testing.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
+
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
@@ -37,6 +39,7 @@ type Builder struct {
 	t            *testing.T
 	minerAddress address.Address
 	stateBuilder StateBuilder
+	stamper      TimeStamper
 	bs           blockstore.Blockstore
 	cstore       *hamt.CborIpldStore
 	messages     *MessageStore
@@ -52,12 +55,12 @@ var _ MessageProvider = (*Builder)(nil)
 
 // NewBuilder builds a new chain faker with default fake state building.
 func NewBuilder(t *testing.T, miner address.Address) *Builder {
-	return NewBuilderWithState(t, miner, &FakeStateBuilder{})
+	return NewBuilderWithDeps(t, miner, &FakeStateBuilder{}, &ZeroTimestamper{})
 }
 
-// NewBuilderWithState builds a new chain faker.
+// NewBuilderWithDeps builds a new chain faker.
 // Blocks will have `miner` set as the miner address, or a default if empty.
-func NewBuilderWithState(t *testing.T, miner address.Address, sb StateBuilder) *Builder {
+func NewBuilderWithDeps(t *testing.T, miner address.Address, sb StateBuilder, stamper TimeStamper) *Builder {
 	if miner.Empty() {
 		var err error
 		miner, err = address.NewSecp256k1Address([]byte("miner"))
@@ -69,6 +72,7 @@ func NewBuilderWithState(t *testing.T, miner address.Address, sb StateBuilder) *
 		t:            t,
 		minerAddress: miner,
 		stateBuilder: sb,
+		stamper:      stamper,
 		bs:           bs,
 		cstore:       hamt.CSTFromBstore(bs),
 		messages:     NewMessageStore(bs),
@@ -198,7 +202,7 @@ func (f *Builder) Build(parent block.TipSet, width int, build func(b *BlockBuild
 			// Omitted fields below
 			//StateRoot:       stateRoot,
 			//Proof            PoStProof
-			//Timestamp        Uint64
+			Timestamp:       f.stamper.Stamp(uint64(height)),
 		}
 		// Nonce intentionally omitted as it will go away.
 
@@ -389,6 +393,42 @@ func (FakeStateBuilder) Weigh(tip block.TipSet, state cid.Cid) (uint64, error) {
 		}
 	}
 	return parentWeight + uint64(tip.Len()), nil
+}
+
+///// Timestamper /////
+
+// TimeStamper is an object that timestamps blocks
+type TimeStamper interface {
+	Stamp(uint64) types.Uint64
+}
+
+// ZeroTimestamper writes a default of 0 to the timestamp
+type ZeroTimestamper struct {}
+
+// Stamp returns a stamp for the current block
+func (zt *ZeroTimestamper) Stamp(height uint64) types.Uint64 {
+	return types.Uint64(0)
+}
+
+// ClockTimestamper writes timestamps based on a blocktime and genesis time
+type ClockTimestamper struct {
+	c clock.ChainEpochClock
+}
+
+// NewClockTimestamper makes a new stamper for creating production valid timestamps
+func NewClockTimestamper(chainClock clock.ChainEpochClock) *ClockTimestamper {
+	return &ClockTimestamper{
+		c: chainClock,
+	}	
+} 
+
+// Stamp assigns a valid timestamp given genesis time and block time to 
+// a block of the provided height.
+func (ct *ClockTimestamper) Stamp(height uint64) types.Uint64 {
+	startTime := ct.c.StartTimeOfEpoch(height)
+
+	timestamp := uint64(startTime.Unix())
+	return types.Uint64(timestamp)
 }
 
 ///// State evaluator /////

--- a/internal/pkg/chainsync/fetcher/graphsync_fetcher_test.go
+++ b/internal/pkg/chainsync/fetcher/graphsync_fetcher_test.go
@@ -29,9 +29,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chainsync/fetcher"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/discovery"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
@@ -58,7 +58,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 	fc := th.NewFakeClock(time.Now())
 	genTime := uint64(1234567890)
-	blockTime := 5*time.Second
+	blockTime := 5 * time.Second
 	chainClock := clock.NewChainClockFromClock(genTime, blockTime, fc)
 	bv := consensus.NewDefaultBlockValidator(chainClock)
 	pid0 := th.RequireIntPeerID(t, 0)
@@ -422,7 +422,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 		mgs := newMockableGraphsync(ctx, bs, fc, t)
 		blk := simpleBlock()
 		blk.Height = 1
-		blk.Timestamp = types.Uint64(chainClock.StartTimeOfEpoch(uint64(blk.Height)).Unix())
+		blk.Timestamp = types.Uint64(chainClock.StartTimeOfEpoch(types.NewBlockHeight(uint64(blk.Height))).Unix())
 		key := block.NewTipSetKey(blk.Cid())
 		chain0 := block.NewChainInfo(pid0, pid0, key, uint64(blk.Height))
 		invalidSyntaxLoader := simpleLoader([]format.Node{blk.ToNode()})
@@ -804,7 +804,7 @@ func TestRealWorldGraphsyncFetchOnlyHeaders(t *testing.T) {
 	bridge1 := ipldbridge.NewIPLDBridge()
 	bridge2 := ipldbridge.NewIPLDBridge()
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
-	
+
 	bv := consensus.NewDefaultBlockValidator(chainClock)
 	pt := discovery.NewPeerTracker(peer.ID(""))
 	pt.Track(block.NewChainInfo(host2.ID(), host2.ID(), block.TipSetKey{}, 0))

--- a/internal/pkg/chainsync/internal/syncer/syncer_integration_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_integration_test.go
@@ -123,7 +123,7 @@ func TestSyncerWeighsPower(t *testing.T) {
 	cst := hamt.NewCborStore()
 	ctx := context.Background()
 	isb := newIntegrationStateBuilder(t, cst)
-	builder := chain.NewBuilderWithState(t, address.Undef, isb)
+	builder := chain.NewBuilderWithDeps(t, address.Undef, isb, &chain.ZeroTimestamper{})
 
 	// Construct genesis with readable state tree root
 	gen := builder.BuildOneOn(block.UndefTipSet, func(bb *chain.BlockBuilder) {})

--- a/internal/pkg/chainsync/internal/syncer/syncer_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_test.go
@@ -415,9 +415,7 @@ func newPoisonValidator(t *testing.T, headerFailure, fullFailure uint64) *poison
 }
 
 func (pv *poisonValidator) RunStateTransition(_ context.Context, ts block.TipSet, _ [][]*types.UnsignedMessage, _ [][]*types.SignedMessage, _ []block.TipSet, _ uint64, _ cid.Cid, _ cid.Cid) (cid.Cid, []*types.MessageReceipt, error) {
-	stamp, err := ts.MinTimestamp()
-	require.NoError(pv.t, err)
-
+	stamp := ts.At(0).Timestamp
 	if pv.fullFailureTS == uint64(stamp) {
 		return cid.Undef, nil, errors.New("run state transition fails on poison timestamp")
 	}

--- a/internal/pkg/chainsync/internal/syncer/syncer_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_test.go
@@ -407,7 +407,6 @@ func TestBlockNotLinkedRejected(t *testing.T) {
 type poisonValidator struct {
 	headerFailureTS uint64
 	fullFailureTS   uint64
-	t               *testing.T
 }
 
 func newPoisonValidator(t *testing.T, headerFailure, fullFailure uint64) *poisonValidator {

--- a/internal/pkg/consensus/block_validation_test.go
+++ b/internal/pkg/consensus/block_validation_test.go
@@ -23,10 +23,11 @@ func TestBlockValidSemantic(t *testing.T) {
 
 	blockTime := clock.DefaultEpochDuration
 	ts := time.Unix(1234567890, 0)
-	mclock := th.NewFakeClock(ts)
+	genTime := ts
+	mclock := clock.NewChainClockFromClock(uint64(genTime.Unix()), blockTime, th.NewFakeClock(ts))
 	ctx := context.Background()
 
-	validator := consensus.NewDefaultBlockValidator(blockTime, mclock)
+	validator := consensus.NewDefaultBlockValidator(mclock)
 
 	t.Run("reject block with same height as parents", func(t *testing.T) {
 		// passes with valid height
@@ -45,42 +46,44 @@ func TestBlockValidSemantic(t *testing.T) {
 
 	})
 
-	t.Run("reject block mined too soon after parent", func(t *testing.T) {
-		// Passes with correct timestamp
-		c := &block.Block{Height: 2, Timestamp: types.Uint64(ts.Add(blockTime).Unix())}
-		p := &block.Block{Height: 1, Timestamp: types.Uint64(ts.Unix())}
-		parents := consensus.RequireNewTipSet(require.New(t), p)
-		require.NoError(t, validator.ValidateSemantic(ctx, c, parents))
+}
 
-		// fails with invalid timestamp
-		c = &block.Block{Height: 2, Timestamp: types.Uint64(ts.Unix())}
-		err := validator.ValidateSemantic(ctx, c, parents)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "too far")
+func TestMismatchedTime(t *testing.T) {
+	tf.UnitTest(t)
 
-	})
+	blockTime := clock.DefaultBlockTime
+	genTime := time.Unix(1234567890, 1234567890%int64(time.Second))
+	fc := th.NewFakeClock(genTime)
+	mclock := clock.NewChainClockFromClock(uint64(genTime.Unix()), blockTime, fc)
+	validator := consensus.NewDefaultBlockValidator(mclock)
 
-	t.Run("reject block mined too soon after parent with one null block", func(t *testing.T) {
-		// Passes with correct timestamp
-		c := &block.Block{Height: 3, Timestamp: types.Uint64(ts.Add(2 * blockTime).Unix())}
-		p := &block.Block{Height: 1, Timestamp: types.Uint64(ts.Unix())}
-		parents := consensus.RequireNewTipSet(require.New(t), p)
-		err := validator.ValidateSemantic(ctx, c, parents)
-		require.NoError(t, err)
+	fc.Advance(blockTime)
 
-		// fail when nul block calc is off by one blocktime
-		c = &block.Block{Height: 3, Timestamp: types.Uint64(ts.Add(blockTime).Unix())}
-		err = validator.ValidateSemantic(ctx, c, parents)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "too far")
+	// Passes with correct timestamp
+	c := &block.Block{Height: 1, Timestamp: types.Uint64(fc.Now().Unix())}
+	require.NoError(t, validator.TimeMatchesEpoch(c))
 
-		// fail with same timestamp as parent
-		c = &block.Block{Height: 3, Timestamp: types.Uint64(ts.Unix())}
-		err = validator.ValidateSemantic(ctx, c, parents)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "too far")
+	// fails with invalid timestamp
+	c = &block.Block{Height: 1, Timestamp: types.Uint64(genTime.Unix())}
+	err := validator.TimeMatchesEpoch(c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "wrong epoch")
+}
 
-	})
+func TestFutureEpoch(t *testing.T) {
+	tf.UnitTest(t)
+
+	blockTime := clock.DefaultBlockTime
+	genTime := time.Unix(1234567890, 1234567890%int64(time.Second))
+	fc := th.NewFakeClock(genTime)
+	mclock := clock.NewChainClockFromClock(uint64(genTime.Unix()), blockTime, fc)
+	validator := consensus.NewDefaultBlockValidator(mclock)
+
+	// Fails in future epoch
+	c := &block.Block{Height: 1, Timestamp: types.Uint64(genTime.Add(blockTime).Unix())}
+	err := validator.NotFutureBlock(c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "future epoch")
 }
 
 func TestBlockValidSyntax(t *testing.T) {
@@ -90,10 +93,11 @@ func TestBlockValidSyntax(t *testing.T) {
 	ts := time.Unix(1234567890, 0)
 	mclock := th.NewFakeClock(ts)
 	ctx := context.Background()
+	fc.Advance(blockTime)
 
-	validator := consensus.NewDefaultBlockValidator(blockTime, mclock)
+	validator := consensus.NewDefaultBlockValidator(mclock)
 
-	validTs := types.Uint64(ts.Unix())
+	validTs := types.Uint64(fc.Now().Unix())
 	validSt := types.NewCidForTestGetter()()
 	validAd := address.NewForTestGetter()()
 	validTi := block.Ticket{VRFProof: []byte{1}}
@@ -111,12 +115,12 @@ func TestBlockValidSyntax(t *testing.T) {
 	// validation, then revalidate the block
 
 	// invalidate timestamp
-	blk.Timestamp = types.Uint64(ts.Add(time.Second).Unix())
+	blk.Timestamp = types.Uint64(ts.Add(time.Duration(3)*blockTime).Unix())
 	require.Error(t, validator.ValidateSyntax(ctx, blk))
 	blk.Timestamp = validTs
 	require.NoError(t, validator.ValidateSyntax(ctx, blk))
 
-	// invalidate statetooy
+	// invalidate stateroot
 	blk.StateRoot = cid.Undef
 	require.Error(t, validator.ValidateSyntax(ctx, blk))
 	blk.StateRoot = validSt

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -7,7 +7,6 @@ package mining
 import (
 	"context"
 	"time"
-	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -141,10 +140,6 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 		Ticket:          ticket,
 		Timestamp:       types.Uint64(now.Unix()),
 		BLSAggregateSig: blsAggregateSig,
-	}
-
-	if expEpoch := w.clock.EpochAtTime(now); expEpoch != uint64(next.Height) {
-		panic(fmt.Sprintf("expected epoch: %d, got epoch %d", expEpoch, next.Height))
 	}
 
 	workerAddr, err := w.api.MinerGetWorkerAddress(ctx, w.minerAddr, baseTipSet.Key())

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -113,7 +113,7 @@ type DefaultWorker struct {
 	processor     MessageApplier
 	messageStore  chain.MessageWriter // nolint: structcheck
 	blockstore    blockstore.Blockstore
-	clock         clock.Clock
+	clock         clock.ChainEpochClock
 }
 
 // WorkerParameters use for NewDefaultWorker parameters
@@ -137,7 +137,7 @@ type WorkerParameters struct {
 	Processor     MessageApplier
 	MessageStore  chain.MessageWriter
 	Blockstore    blockstore.Blockstore
-	Clock         clock.Clock
+	Clock         clock.ChainEpochClock
 }
 
 // NewDefaultWorker instantiates a new Worker.

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -113,7 +113,7 @@ type DefaultWorker struct {
 	processor     MessageApplier
 	messageStore  chain.MessageWriter // nolint: structcheck
 	blockstore    blockstore.Blockstore
-	clock         clock.ChainEpochClock
+	clock         clock.Clock
 }
 
 // WorkerParameters use for NewDefaultWorker parameters
@@ -137,7 +137,7 @@ type WorkerParameters struct {
 	Processor     MessageApplier
 	MessageStore  chain.MessageWriter
 	Blockstore    blockstore.Blockstore
-	Clock         clock.ChainEpochClock
+	Clock         clock.Clock
 }
 
 // NewDefaultWorker instantiates a new Worker.

--- a/internal/pkg/net/validators.go
+++ b/internal/pkg/net/validators.go
@@ -2,6 +2,7 @@ package net
 
 import (
 	"context"
+	"fmt"
 
 	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -39,6 +40,7 @@ func NewBlockTopicValidator(bv consensus.BlockSyntaxValidator, opts ...pubsub.Va
 				return false
 			}
 			if err := bv.ValidateSyntax(ctx, blk); err != nil {
+				fmt.Printf("Block fails syntax check: %s\n", err)
 				blockTopicLogger.Debugf("block: %s from peer: %s failed to validate: %s", blk.Cid().String(), p.String(), err.Error())
 				mInvalidBlk.Inc(ctx, 1)
 				return false


### PR DESCRIPTION
### Motivation
The timestamp validation rules should be correctly checked.

### Proposed changes
Spec compliant timestamps validation checks
1) check that the timestamp matches the epoch number
2) check that the timestamp is not from a future epoch

I decided to implement a slightly generalized version of 1) that can handle epoch durations that are not a multiple of a second.   I did this because it was very simple to write compared to moving our integration tests to properly mocked time and added only a small bit of complexity to our clock/validation code.  This can be reduced to the simpler case once we have integration tests that can readily mock out the clock.

Closes issue #3677

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

