### PR TITLE
Node test builder simplification

### DIFF
--- a/internal/app/go-filecoin/node/message_propagate_test.go
+++ b/internal/app/go-filecoin/node/message_propagate_test.go
@@ -37,16 +37,19 @@ func TestMessagePropagation(t *testing.T) {
 	)
 
 	// Initialize the first node to be the message sender.
-	builder := test.NewNodeBuilder(t)
-	builder.WithGenesisInit(genesis)
-	builder.WithInitOpt(DefaultKeyOpt(&ki))
-	builder.WithBuilderOpt(DefaultTestingConfig()...)
+	builder1 := test.NewNodeBuilder(t)
+	builder1.WithGenesisInit(genesis)
+	builder1.WithInitOpt(DefaultKeyOpt(&ki))
+	builder1.WithBuilderOpt(FakeProofVerifierBuilderOpts()...)
 
-	sender := builder.Build(ctx)
+	sender := builder1.Build(ctx)
 
 	// Initialize other nodes to receive the message.
+	builder2 := test.NewNodeBuilder(t)
+	builder2.WithGenesisInit(genesis)
+	builder2.WithBuilderOpt(FakeProofVerifierBuilderOpts()...)
 	receiverCount := 2
-	receivers := test.MakeNodesUnstartedWithGif(t, receiverCount, []BuilderOpt{}, genesis)
+	receivers := builder2.BuildMany(ctx, receiverCount)
 
 	nodes := append([]*Node{sender}, receivers...)
 	StartNodes(t, nodes)

--- a/internal/app/go-filecoin/node/message_propagate_test.go
+++ b/internal/app/go-filecoin/node/message_propagate_test.go
@@ -8,10 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/version"
 	. "github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
-
+	"github.com/filecoin-project/go-filecoin/internal/pkg/version"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"

--- a/internal/app/go-filecoin/node/node_test.go
+++ b/internal/app/go-filecoin/node/node_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	node "github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
-	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"	
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/config"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/proofs/verification"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/protocol/storage"
@@ -205,7 +205,7 @@ func TestNodeConfig(t *testing.T) {
 	}
 
 	initOpts := []node.InitOpt{}
-	
+
 	builder := test.NewNodeBuilder(t)
 	builder.WithGenesisInit(th.DefaultGenesis)
 	builder.WithInitOpt(initOpts...)

--- a/internal/app/go-filecoin/node/test/builder.go
+++ b/internal/app/go-filecoin/node/test/builder.go
@@ -12,7 +12,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
-
 )
 
 // NodeBuilder creates and configures Filecoin nodes for in-process testing.
@@ -51,7 +50,7 @@ func NewNodeBuilder(tb testing.TB) *NodeBuilder {
 			},
 		},
 		builderOpts: []node.BuilderOpt{},
-		tb:      tb,
+		tb:          tb,
 	}
 }
 
@@ -122,7 +121,6 @@ func (b *NodeBuilder) requireNoError(err error) {
 	require.NoError(b.tb, err)
 }
 
-
 // MakeNodeWithChainSeed makes a single node with the given chain seed, and some init options
 func MakeNodeWithChainSeed(t *testing.T, seed *node.ChainSeed, builderopts []node.BuilderOpt, initopts ...node.InitOpt) *node.Node { // nolint: golint
 	t.Helper()
@@ -156,4 +154,3 @@ func MakeNodesUnstartedWithGif(t *testing.T, numNodes int, builderopts []node.Bu
 func MakeNodesUnstarted(t *testing.T, numNodes int, builderopts []node.BuilderOpt) []*node.Node {
 	return MakeNodesUnstartedWithGif(t, numNodes, builderopts, th.DefaultGenesis)
 }
-

--- a/internal/app/go-filecoin/node/testing.go
+++ b/internal/app/go-filecoin/node/testing.go
@@ -132,8 +132,8 @@ func ConnectNodes(t *testing.T, a, b *Node) {
 	}
 }
 
-// DefaultTestingConfig returns default configuration for testing
-func DefaultTestingConfig() []BuilderOpt {
+// FakeProofVerifierBuilderOpts returns default configuration for testing
+func FakeProofVerifierBuilderOpts() []BuilderOpt {
 	return []BuilderOpt{
 		VerifierConfigOption(&verification.FakeVerifier{
 			VerifyPoStValid:                true,

--- a/internal/app/go-filecoin/node/testing.go
+++ b/internal/app/go-filecoin/node/testing.go
@@ -19,7 +19,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/wallet"
 	gengen "github.com/filecoin-project/go-filecoin/tools/gengen/util"
-	
 )
 
 // ChainSeed is a generalized struct for configuring node
@@ -118,7 +117,6 @@ func (cs *ChainSeed) Addr(t *testing.T, key int) address.Address {
 
 	return a
 }
-
 
 // ConnectNodes connects two nodes together
 func ConnectNodes(t *testing.T, a, b *Node) {

--- a/internal/pkg/protocol/mining/mining_api_test.go
+++ b/internal/pkg/protocol/mining/mining_api_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 )
 
@@ -133,7 +134,7 @@ func newAPI(t *testing.T) (bapi.API, *node.Node) {
 	seed := node.MakeChainSeed(t, node.TestGenCfg)
 	builderOpts := []node.BuilderOpt{}
 
-	nd := node.MakeNodeWithChainSeed(t, seed, builderOpts)
+	nd := test.MakeNodeWithChainSeed(t, seed, builderOpts)
 	seed.GiveKey(t, nd, 0)
 	mAddr, ownerAddr := seed.GiveMiner(t, nd, 0)
 	_, err := storage.NewMiner(mAddr, ownerAddr, &storage.FakeProver{}, types.OneKiBSectorSize, nd, nd.Repo.DealsDatastore(), nd.PorcelainAPI)

--- a/internal/pkg/protocol/mining/mining_api_test.go
+++ b/internal/pkg/protocol/mining/mining_api_test.go
@@ -132,9 +132,10 @@ func TestMiningAPI_MiningTogether(t *testing.T) {
 
 func newAPI(t *testing.T) (bapi.API, *node.Node) {
 	seed := node.MakeChainSeed(t, node.TestGenCfg)
-	builderOpts := []node.BuilderOpt{}
-
-	nd := test.MakeNodeWithChainSeed(t, seed, builderOpts)
+	ctx := context.Background()
+	builder := test.NewNodeBuilder(t)
+	builder.WithGenesisInit(seed.GenesisInitFunc)
+	nd := builder.Build(ctx)
 	seed.GiveKey(t, nd, 0)
 	mAddr, ownerAddr := seed.GiveMiner(t, nd, 0)
 	_, err := storage.NewMiner(mAddr, ownerAddr, &storage.FakeProver{}, types.OneKiBSectorSize, nd, nd.Repo.DealsDatastore(), nd.PorcelainAPI)

--- a/internal/pkg/protocol/retrieval/retrieval_protocol_test.go
+++ b/internal/pkg/protocol/retrieval/retrieval_protocol_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/protocol/retrieval"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
@@ -59,8 +60,8 @@ func configureMinerAndClient(t *testing.T) (minerNode *node.Node, clientNode *no
 	seed := node.MakeChainSeed(t, node.TestGenCfg)
 
 	// make two nodes, one of which is the minerNode (and gets the miner peer key)
-	minerNode = node.MakeNodeWithChainSeed(t, seed, []node.BuilderOpt{}, node.PeerKeyOpt(node.PeerKeys[0]))
-	clientNode = node.MakeNodeWithChainSeed(t, seed, []node.BuilderOpt{})
+	minerNode = test.MakeNodeWithChainSeed(t, seed, []node.BuilderOpt{}, node.PeerKeyOpt(node.PeerKeys[0]))
+	clientNode = test.MakeNodeWithChainSeed(t, seed, []node.BuilderOpt{})
 
 	// give the minerNode node a key and the miner associated with that key
 	seed.GiveKey(t, minerNode, 0)

--- a/internal/pkg/protocol/retrieval/retrieval_protocol_test.go
+++ b/internal/pkg/protocol/retrieval/retrieval_protocol_test.go
@@ -58,10 +58,15 @@ func configureMinerAndClient(t *testing.T) (minerNode *node.Node, clientNode *no
 	ctx := context.Background()
 
 	seed := node.MakeChainSeed(t, node.TestGenCfg)
+	builder1 := test.NewNodeBuilder(t)
+	builder1.WithInitOpt(node.PeerKeyOpt(node.PeerKeys[0]))
+	builder1.WithGenesisInit(seed.GenesisInitFunc)
+	builder2 := test.NewNodeBuilder(t)
+	builder2.WithGenesisInit(seed.GenesisInitFunc)
 
 	// make two nodes, one of which is the minerNode (and gets the miner peer key)
-	minerNode = test.MakeNodeWithChainSeed(t, seed, []node.BuilderOpt{}, node.PeerKeyOpt(node.PeerKeys[0]))
-	clientNode = test.MakeNodeWithChainSeed(t, seed, []node.BuilderOpt{})
+	minerNode = builder1.Build(ctx)
+	clientNode = builder2.Build(ctx)
 
 	// give the minerNode node a key and the miner associated with that key
 	seed.GiveKey(t, minerNode, 0)


### PR DESCRIPTION
### Motivation
As part of ongoing work to move integration tests to an in-process framework it's in our best interest to simplify that framework.  This PR does so by removing a legacy function `GenNode` with the similar new `node/test.Builder` abstraction

### Proposed changes
All calls to `GenNode` call the node test builder
Node test builder takes in node builder options (need to check in with @anorth about this one)
Move some things around to remove cyclic dependencies.  Mostly achieved by moving our node tests to the `node_test` package from the `node` package(!!)

Closes issue #3484

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

