### PR TITLE
Move daemon integration tests to in process node tests

### DIFF
--- a/cmd/go-filecoin/actor_daemon_test.go
+++ b/cmd/go-filecoin/actor_daemon_test.go
@@ -2,6 +2,7 @@ package commands_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -9,18 +10,21 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/cmd/go-filecoin"
-	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 )
 
 func TestActorDaemon(t *testing.T) {
 	tf.IntegrationTest(t)
-
+	ctx := context.Background()
 	t.Run("actor ls --enc json returns NDJSON containing all actors in the state tree", func(t *testing.T) {
-		d := th.NewDaemon(t).Start()
-		defer d.ShutdownSuccess()
+		builder := test.NewNodeBuilder(t)
+		n := builder.BuildAndStart(ctx)
+		defer n.Stop(ctx)
+		cmdClient, done := test.RunNodeAPI(ctx, n, t)
+		defer done()
 
-		op1 := d.RunSuccess("actor", "ls", "--enc", "json")
+		op1 := cmdClient.RunSuccess(ctx, "actor", "ls", "--enc", "json")
 		result1 := op1.ReadStdoutTrimNewlines()
 
 		var avs []commands.ActorView

--- a/cmd/go-filecoin/bootstrap_daemon_test.go
+++ b/cmd/go-filecoin/bootstrap_daemon_test.go
@@ -1,21 +1,26 @@
 package commands_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 )
 
 func TestBootstrapList(t *testing.T) {
 	tf.IntegrationTest(t)
+	ctx := context.Background()
+	builder := test.NewNodeBuilder(t)
 
-	d := th.NewDaemon(t).Start()
-	defer d.ShutdownSuccess()
+	n := builder.BuildAndStart(ctx)
+	defer n.Stop(ctx)
+	cmdClient, done := test.RunNodeAPI(ctx, n, t)
+	defer done()
 
-	bs := d.RunSuccess("bootstrap ls")
+	bs := cmdClient.RunSuccess(ctx, "bootstrap", "ls")
 
 	assert.Equal(t, "&{[]}\n", bs.ReadStdout())
 }

--- a/cmd/go-filecoin/chain_daemon_test.go
+++ b/cmd/go-filecoin/chain_daemon_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/fixtures"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
+
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 )
@@ -25,10 +27,10 @@ func TestChainHead(t *testing.T) {
 
 	n := builder.BuildAndStart(ctx)
 	defer n.Stop(ctx)
-
 	cmdClient, done := test.RunNodeAPI(ctx, n, t)
 	defer done()
 
+	node.FixtureChainSeed(t)
 	jsonResult := cmdClient.RunSuccess(ctx, "chain", "head", "--enc", "json").ReadStdoutTrimNewlines()
 	var cidsFromJSON []cid.Cid
 	err := json.Unmarshal([]byte(jsonResult), &cidsFromJSON)
@@ -37,7 +39,6 @@ func TestChainHead(t *testing.T) {
 	textResult := cmdClient.RunSuccess(ctx, "chain", "ls", "--enc", "text").ReadStdoutTrimNewlines()
 	textCid, err := cid.Decode(textResult)
 	require.NoError(t, err)
-
 	assert.Equal(t, textCid, cidsFromJSON[0])
 }
 

--- a/cmd/go-filecoin/dag_daemon_test.go
+++ b/cmd/go-filecoin/dag_daemon_test.go
@@ -2,44 +2,36 @@ package commands_test
 
 import (
 	"bytes"
-	"encoding/json"
+	"context"
 	"testing"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	cbor "github.com/ipfs/go-ipld-cbor"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
 func TestDagDaemon(t *testing.T) {
 	tf.IntegrationTest(t)
+	ctx := context.Background()
 
 	t.Run("dag get <cid> returning the genesis block", func(t *testing.T) {
-		d := th.NewDaemon(t).Start()
-		defer d.ShutdownSuccess()
+		builder := test.NewNodeBuilder(t)
 
-		// get the CID of the genesis block from the "chain ls" command output
+		n := builder.BuildAndStart(ctx)
+		defer n.Stop(ctx)
+		cmdClient, done := test.RunNodeAPI(ctx, n, t)
+		defer done()
 
-		op1 := d.RunSuccess("chain", "ls", "--enc", "json")
-		result1 := op1.ReadStdoutTrimNewlines()
-		genesisBlockJSONStr := bytes.Split([]byte(result1), []byte{'\n'})[0]
-
-		var expectedRaw []block.Block
-		err := json.Unmarshal(genesisBlockJSONStr, &expectedRaw)
-		assert.NoError(t, err)
-		require.Equal(t, 1, len(expectedRaw))
-		expected := expectedRaw[0]
+		c := n.PorcelainAPI.ChainHeadKey().Iter().Value()
 
 		// get an IPLD node from the DAG by its CID
-
-		op2 := d.RunSuccess("dag", "get", expected.Cid().String(), "--enc", "json")
-
-		result2 := op2.ReadStdoutTrimNewlines()
+		op := cmdClient.RunSuccess(ctx, "dag", "get", c.String(), "--enc", "json")
+		result2 := op.ReadStdoutTrimNewlines()
 
 		ipldnode, err := cbor.FromJSON(bytes.NewReader([]byte(result2)), types.DefaultHashFunction, -1)
 		require.NoError(t, err)

--- a/cmd/go-filecoin/dht_daemon_test.go
+++ b/cmd/go-filecoin/dht_daemon_test.go
@@ -1,34 +1,37 @@
 package commands_test
 
 import (
+	"context"
 	"testing"
 
-	ast "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 
-	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 )
 
 func TestDhtFindPeer(t *testing.T) {
 	tf.IntegrationTest(t)
+	ctx := context.Background()
 
-	assert := ast.New(t)
+	builder1 := test.NewNodeBuilder(t)
+	n1 := builder1.BuildAndStart(ctx)
+	defer n1.Stop(ctx)
+	cmdClient, done := test.RunNodeAPI(ctx, n1, t)
+	defer done()
 
-	d1 := th.NewDaemon(t).Start()
-	defer d1.ShutdownSuccess()
+	builder2 := test.NewNodeBuilder(t)
+	n2 := builder2.BuildAndStart(ctx)
+	defer n2.Stop(ctx)
 
-	d2 := th.NewDaemon(t).Start()
-	defer d2.ShutdownSuccess()
+	node.ConnectNodes(t, n1, n2)
 
-	d1.ConnectSuccess(d2)
+	n2Id := n2.PorcelainAPI.NetworkGetPeerID()
+	findpeerOutput := cmdClient.RunSuccess(ctx, "dht", "findpeer", n2Id.String()).ReadStdoutTrimNewlines()
+	n2Addr := n2.PorcelainAPI.NetworkGetPeerAddresses()[0]
 
-	d2Id := d2.GetID()
-
-	findpeerOutput := d1.RunSuccess("dht", "findpeer", d2Id).ReadStdoutTrimNewlines()
-
-	d2Addr := d2.GetAddresses()[0]
-
-	assert.Contains(d2Addr, findpeerOutput)
+	assert.Contains(t, n2Addr.String(), findpeerOutput)
 }
 
 // TODO: findprovs will have to be untested until

--- a/cmd/go-filecoin/id_daemon_test.go
+++ b/cmd/go-filecoin/id_daemon_test.go
@@ -1,12 +1,14 @@
 package commands_test
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 )
@@ -14,24 +16,35 @@ import (
 func TestId(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	d := th.NewDaemon(t).Start()
-	defer d.ShutdownSuccess()
+	ctx := context.Background()
 
-	id := d.RunSuccess("id")
+	builder := test.NewNodeBuilder(t)
+	n := builder.BuildAndStart(ctx)
+	defer n.Stop(ctx)
+	cmdClient, done := test.RunNodeAPI(ctx, n, t)
+	defer done()
+
+	id := cmdClient.RunSuccess(ctx, "id")
 
 	idContent := id.ReadStdout()
 	assert.Containsf(t, idContent, "/ip4/127.0.0.1/tcp/", "default addr")
 	assert.Contains(t, idContent, "ID")
-
 }
 
 func TestIdFormat(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	d := th.NewDaemon(t).Start()
-	defer d.ShutdownSuccess()
+	ctx := context.Background()
 
-	idContent := d.RunSuccess("id",
+	builder := test.NewNodeBuilder(t)
+	n := builder.BuildAndStart(ctx)
+	defer n.Stop(ctx)
+	cmdClient, done := test.RunNodeAPI(ctx, n, t)
+	defer done()
+
+	idContent := cmdClient.RunSuccess(
+		ctx,
+		"id",
 		"--format=\"<id>\\t<aver>\\t<pver>\\t<pubkey>\\n<addrs>\"",
 	).ReadStdout()
 

--- a/cmd/go-filecoin/leb128_test.go
+++ b/cmd/go-filecoin/leb128_test.go
@@ -1,10 +1,12 @@
 package commands_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 )
 
@@ -18,11 +20,15 @@ func TestLeb128Decode(t *testing.T) {
 		{"A==", "65"},
 	}
 
-	d := makeTestDaemonWithMinerAndStart(t)
-	defer d.ShutdownSuccess()
+	ctx := context.Background()
+	builder := test.NewNodeBuilder(t)
+	n := builder.BuildAndStart(ctx)
+	defer n.Stop(ctx)
+	cmdClient, done := test.RunNodeAPI(ctx, n, t)
+	defer done()
 
 	for _, tt := range decodeTests {
-		output := d.RunSuccess("leb128", "decode", tt.Text).ReadStdoutTrimNewlines()
+		output := cmdClient.RunSuccess(ctx, "leb128", "decode", tt.Text).ReadStdoutTrimNewlines()
 
 		require.Equal(t, tt.Want, output)
 	}
@@ -38,11 +44,15 @@ func TestLeb128Encode(t *testing.T) {
 		{"65", "A=="},
 	}
 
-	d := makeTestDaemonWithMinerAndStart(t)
-	defer d.ShutdownSuccess()
+	ctx := context.Background()
+	builder := test.NewNodeBuilder(t)
+	n := builder.BuildAndStart(ctx)
+	defer n.Stop(ctx)
+	cmdClient, done := test.RunNodeAPI(ctx, n, t)
+	defer done()
 
 	for _, tt := range encodeTests {
-		output := d.RunSuccess("leb128", "encode", tt.Text).ReadStdoutTrimNewlines()
+		output := cmdClient.RunSuccess(ctx, "leb128", "encode", tt.Text).ReadStdoutTrimNewlines()
 
 		require.Contains(t, output, tt.Want)
 	}

--- a/cmd/go-filecoin/main.go
+++ b/cmd/go-filecoin/main.go
@@ -232,6 +232,12 @@ func (e *executor) Execute(req *cmds.Request, re cmds.ResponseEmitter, env cmds.
 		if isConnectionRefused(err) {
 			return cmdkit.Errorf(cmdkit.ErrFatal, "Connection Refused. Is the daemon running?")
 		}
+		if cmdKitErr, ok := err.(*cmdkit.Error); ok && cmdKitErr.Code == cmdkit.ErrNormal {
+			return re.CloseWithError(err)
+		}
+		if urlErr, ok := err.(*url.Error); ok && urlErr.Timeout() {
+			return re.CloseWithError(err)
+		}
 		return cmdkit.Errorf(cmdkit.ErrFatal, err.Error())
 	}
 

--- a/cmd/go-filecoin/message_daemon_test.go
+++ b/cmd/go-filecoin/message_daemon_test.go
@@ -1,16 +1,17 @@
 package commands_test
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/fixtures"
-	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
@@ -18,41 +19,54 @@ import (
 
 func TestMessageSend(t *testing.T) {
 	tf.IntegrationTest(t)
+	ctx := context.Background()
+	builder := test.NewNodeBuilder(t)
+	defaultAddr, err := address.NewFromString(fixtures.TestAddresses[0])
+	require.NoError(t, err)
 
-	d := th.NewDaemon(
-		t,
-		th.DefaultAddress(fixtures.TestAddresses[0]),
-		th.KeyFile(fixtures.KeyFilePaths()[1]),
-		// must include same-index KeyFilePath when configuring with a TestMiner.
-		th.WithMiner(fixtures.TestMiners[0]),
-		th.KeyFile(fixtures.KeyFilePaths()[0]),
-	).Start()
-	defer d.ShutdownSuccess()
+	cs := node.FixtureChainSeed(t)
+	builder.WithGenesisInit(cs.GenesisInitFunc)
+	builder.WithConfig(cs.MinerConfigOpt(0))
+	builder.WithConfig(node.DefaultAddressConfigOpt(defaultAddr))
+	builder.WithInitOpt(cs.KeyInitOpt(1))
+	builder.WithInitOpt(cs.KeyInitOpt(0))
 
-	d.RunSuccess("mining", "once")
+	n := builder.BuildAndStart(ctx)
+	defer n.Stop(ctx)
+	cmdClient, done := test.RunNodeAPI(ctx, n, t)
+	defer done()
 
-	from := d.GetDefaultAddress() // this should = fixtures.TestAddresses[0]
+	_, err = n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+	require.NoError(t, err)
+
+	from, err := n.PorcelainAPI.WalletDefaultAddress() // this should = fixtures.TestAddresses[0]
+	require.NoError(t, err)
 
 	t.Log("[failure] invalid target")
-	d.RunFail(
+	cmdClient.RunFail(
+		ctx,
 		address.ErrUnknownNetwork.Error(),
 		"message", "send",
-		"--from", from,
+		"--from", from.String(),
 		"--gas-price", "0", "--gas-limit", "300",
 		"--value=10", "xyz",
 	)
 
 	t.Log("[success] with from")
-	d.RunSuccess("message", "send",
-		"--from", from,
+	cmdClient.RunSuccess(
+		ctx,
+		"message", "send",
+		"--from", from.String(),
 		"--gas-price", "1",
 		"--gas-limit", "300",
 		fixtures.TestAddresses[3],
 	)
 
 	t.Log("[success] with from and int value")
-	d.RunSuccess("message", "send",
-		"--from", from,
+	cmdClient.RunSuccess(
+		ctx,
+		"message", "send",
+		"--from", from.String(),
 		"--gas-price", "1",
 		"--gas-limit", "300",
 		"--value", "10",
@@ -60,8 +74,10 @@ func TestMessageSend(t *testing.T) {
 	)
 
 	t.Log("[success] with from and decimal value")
-	d.RunSuccess("message", "send",
-		"--from", from,
+	cmdClient.RunSuccess(
+		ctx,
+		"message", "send",
+		"--from", from.String(),
 		"--gas-price", "1",
 		"--gas-limit", "300",
 		"--value", "5.5",
@@ -71,12 +87,17 @@ func TestMessageSend(t *testing.T) {
 
 func TestMessageWait(t *testing.T) {
 	tf.IntegrationTest(t)
+	ctx := context.Background()
+	builder := test.NewNodeBuilder(t)
 
-	d := makeTestDaemonWithMinerAndStart(t)
-	defer d.ShutdownSuccess()
+	buildWithMiner(t, builder)
+	n := builder.BuildAndStart(ctx)
+	defer n.Stop(ctx)
+	cmdClient, done := test.RunNodeAPI(ctx, n, t)
+	defer done()
 
 	t.Run("[success] transfer only", func(t *testing.T) {
-		msg := d.RunSuccess("message", "send",
+		msg := cmdClient.RunSuccess(ctx, "message", "send",
 			"--from", fixtures.TestAddresses[0],
 			"--gas-price", "1",
 			"--gas-limit", "300",
@@ -85,7 +106,8 @@ func TestMessageWait(t *testing.T) {
 		msgcid := msg.ReadStdoutTrimNewlines()
 
 		// Fail with timeout before the message has been mined
-		d.RunFail(
+		cmdClient.RunFail(
+			ctx,
 			"deadline exceeded",
 			"message", "wait",
 			"--message=false",
@@ -95,9 +117,11 @@ func TestMessageWait(t *testing.T) {
 			msgcid,
 		)
 
-		d.RunSuccess("mining once")
+		_, err := n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+		require.NoError(t, err)
 
-		wait := d.RunSuccess(
+		wait := cmdClient.RunSuccess(
+			ctx,
 			"message", "wait",
 			"--message=false",
 			"--receipt=false",
@@ -111,22 +135,26 @@ func TestMessageWait(t *testing.T) {
 
 func TestMessageSendBlockGasLimit(t *testing.T) {
 	tf.IntegrationTest(t)
+	ctx := context.Background()
+	builder := test.NewNodeBuilder(t)
+	defaultAddr, err := address.NewFromString(fixtures.TestAddresses[0])
+	require.NoError(t, err)
 
-	d := th.NewDaemon(
-		t,
-		// default address required
-		th.DefaultAddress(fixtures.TestAddresses[0]),
-		th.WithMiner(fixtures.TestMiners[0]),
-		th.KeyFile(fixtures.KeyFilePaths()[0]),
-	).Start()
-	defer d.ShutdownSuccess()
+	buildWithMiner(t, builder)
+	builder.WithConfig(node.DefaultAddressConfigOpt(defaultAddr))
+	n := builder.BuildAndStart(ctx)
+	defer n.Stop(ctx)
+	cmdClient, done := test.RunNodeAPI(ctx, n, t)
+	defer done()
 
 	doubleTheBlockGasLimit := strconv.Itoa(int(types.BlockGasLimit) * 2)
 	halfTheBlockGasLimit := strconv.Itoa(int(types.BlockGasLimit) / 2)
 	result := struct{ Messages types.TxMeta }{}
 
 	t.Run("when the gas limit is above the block limit, the message fails", func(t *testing.T) {
-		d.RunFail("block gas limit",
+		cmdClient.RunFail(
+			ctx,
+			"block gas limit",
 			"message", "send",
 			"--gas-price", "1", "--gas-limit", doubleTheBlockGasLimit,
 			"--value=10", fixtures.TestAddresses[1],
@@ -134,15 +162,18 @@ func TestMessageSendBlockGasLimit(t *testing.T) {
 	})
 
 	t.Run("when the gas limit is below the block limit, the message succeeds", func(t *testing.T) {
-		d.RunSuccess(
+		cmdClient.RunSuccess(
+			ctx,
 			"message", "send",
 			"--gas-price", "1", "--gas-limit", halfTheBlockGasLimit,
 			"--value=10", fixtures.TestAddresses[1],
 		)
 
-		blockCid := d.RunSuccess("mining", "once").ReadStdoutTrimNewlines()
+		blk, err := n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+		require.NoError(t, err)
+		blkCid := blk.Cid().String()
 
-		blockInfo := d.RunSuccess("show", "header", blockCid, "--enc", "json").ReadStdoutTrimNewlines()
+		blockInfo := cmdClient.RunSuccess(ctx, "show", "header", blkCid, "--enc", "json").ReadStdoutTrimNewlines()
 
 		require.NoError(t, json.Unmarshal([]byte(blockInfo), &result))
 		assert.NotEmpty(t, result.Messages.SecpRoot, "msg under the block gas limit passes validation and is run in the block")
@@ -151,12 +182,18 @@ func TestMessageSendBlockGasLimit(t *testing.T) {
 
 func TestMessageStatus(t *testing.T) {
 	tf.IntegrationTest(t)
+	ctx := context.Background()
+	builder := test.NewNodeBuilder(t)
 
-	d := makeTestDaemonWithMinerAndStart(t)
-	defer d.ShutdownSuccess()
+	buildWithMiner(t, builder)
+	n := builder.BuildAndStart(ctx)
+	defer n.Stop(ctx)
+	cmdClient, done := test.RunNodeAPI(ctx, n, t)
+	defer done()
 
 	t.Run("queue then on chain", func(t *testing.T) {
-		msg := d.RunSuccess(
+		msg := cmdClient.RunSuccess(
+			ctx,
 			"message", "send",
 			"--from", fixtures.TestAddresses[0],
 			"--gas-price", "1", "--gas-limit", "300",
@@ -164,24 +201,25 @@ func TestMessageStatus(t *testing.T) {
 			fixtures.TestAddresses[1],
 		)
 
-		msgcid := strings.Trim(msg.ReadStdout(), "\n")
-		status := d.RunSuccess("message", "status", msgcid).ReadStdout()
+		msgcid := msg.ReadStdoutTrimNewlines()
+		status := cmdClient.RunSuccess(ctx, "message", "status", msgcid).ReadStdout()
 
 		assert.Contains(t, status, "In outbox")
 		assert.Contains(t, status, "In mpool")
 		assert.NotContains(t, status, "On chain") // not found on chain (yet)
 		assert.Contains(t, status, "1234")        // the "value"
 
-		d.RunSuccess("mining once")
+		_, err := n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+		require.NoError(t, err)
 
-		status = d.RunSuccess("message", "status", msgcid).ReadStdout()
+		status = cmdClient.RunSuccess(ctx, "message", "status", msgcid).ReadStdout()
 
 		assert.NotContains(t, status, "In outbox")
 		assert.NotContains(t, status, "In mpool")
 		assert.Contains(t, status, "On chain")
 		assert.Contains(t, status, "1234") // the "value"
 
-		status = d.RunSuccess("message", "status", "QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS").ReadStdout()
+		status = cmdClient.RunSuccess(ctx, "message", "status", "QmPVkJMTeRC6iBByPWdrRkD3BE5UXsj5HPzb4kPqL186mS").ReadStdout()
 		assert.NotContains(t, status, "In outbox")
 		assert.NotContains(t, status, "In mpool")
 		assert.NotContains(t, status, "On chain")

--- a/cmd/go-filecoin/outbox_daemon_test.go
+++ b/cmd/go-filecoin/outbox_daemon_test.go
@@ -1,11 +1,14 @@
 package commands_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/filecoin-project/go-filecoin/fixtures"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 )
@@ -13,24 +16,32 @@ import (
 func TestOutbox(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	sendMessage := func(d *th.TestDaemon, from string, to string) *th.CmdOutput {
-		return d.RunSuccess("message", "send",
+	sendMessage := func(ctx context.Context, cmdClient *test.Client, from string, to string) *th.CmdOutput {
+		return cmdClient.RunSuccess(ctx, "message", "send",
 			"--from", from,
 			"--gas-price", "1", "--gas-limit", "300",
 			"--value=10", to,
 		)
 	}
+	cs := node.FixtureChainSeed(t)
 
 	t.Run("list queued messages", func(t *testing.T) {
+		ctx := context.Background()
+		builder := test.NewNodeBuilder(t)
+		builder.WithInitOpt(cs.KeyInitOpt(0))
+		builder.WithInitOpt(cs.KeyInitOpt(1))
+		builder.WithGenesisInit(cs.GenesisInitFunc)
 
-		d := th.NewDaemon(t, th.KeyFile(fixtures.KeyFilePaths()[0]), th.KeyFile(fixtures.KeyFilePaths()[1])).Start()
-		defer d.ShutdownSuccess()
+		n := builder.BuildAndStart(ctx)
+		defer n.Stop(ctx)
+		cmdClient, done := test.RunNodeAPI(ctx, n, t)
+		defer done()
 
-		c1 := sendMessage(d, fixtures.TestAddresses[0], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
-		c2 := sendMessage(d, fixtures.TestAddresses[0], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
-		c3 := sendMessage(d, fixtures.TestAddresses[1], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
+		c1 := sendMessage(ctx, cmdClient, fixtures.TestAddresses[0], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
+		c2 := sendMessage(ctx, cmdClient, fixtures.TestAddresses[0], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
+		c3 := sendMessage(ctx, cmdClient, fixtures.TestAddresses[1], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
 
-		out := d.RunSuccess("outbox", "ls").ReadStdout()
+		out := cmdClient.RunSuccess(ctx, "outbox", "ls").ReadStdout()
 		assert.Contains(t, out, fixtures.TestAddresses[0])
 		assert.Contains(t, out, fixtures.TestAddresses[1])
 		assert.Contains(t, out, c1)
@@ -38,7 +49,7 @@ func TestOutbox(t *testing.T) {
 		assert.Contains(t, out, c3)
 
 		// With address filter
-		out = d.RunSuccess("outbox", "ls", fixtures.TestAddresses[1]).ReadStdout()
+		out = cmdClient.RunSuccess(ctx, "outbox", "ls", fixtures.TestAddresses[1]).ReadStdout()
 		assert.NotContains(t, out, fixtures.TestAddresses[0])
 		assert.Contains(t, out, fixtures.TestAddresses[1])
 		assert.NotContains(t, out, c1)
@@ -47,17 +58,24 @@ func TestOutbox(t *testing.T) {
 	})
 
 	t.Run("clear queue", func(t *testing.T) {
+		ctx := context.Background()
+		builder := test.NewNodeBuilder(t)
+		builder.WithInitOpt(cs.KeyInitOpt(0))
+		builder.WithInitOpt(cs.KeyInitOpt(1))
+		builder.WithGenesisInit(cs.GenesisInitFunc)
 
-		d := th.NewDaemon(t, th.KeyFile(fixtures.KeyFilePaths()[0]), th.KeyFile(fixtures.KeyFilePaths()[1])).Start()
-		defer d.ShutdownSuccess()
+		n := builder.BuildAndStart(ctx)
+		defer n.Stop(ctx)
+		cmdClient, done := test.RunNodeAPI(ctx, n, t)
+		defer done()
 
-		c1 := sendMessage(d, fixtures.TestAddresses[0], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
-		c2 := sendMessage(d, fixtures.TestAddresses[0], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
-		c3 := sendMessage(d, fixtures.TestAddresses[1], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
+		c1 := sendMessage(ctx, cmdClient, fixtures.TestAddresses[0], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
+		c2 := sendMessage(ctx, cmdClient, fixtures.TestAddresses[0], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
+		c3 := sendMessage(ctx, cmdClient, fixtures.TestAddresses[1], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
 
 		// With address filter
-		d.RunSuccess("outbox", "clear", fixtures.TestAddresses[1])
-		out := d.RunSuccess("outbox", "ls").ReadStdout()
+		cmdClient.RunSuccess(ctx, "outbox", "clear", fixtures.TestAddresses[1])
+		out := cmdClient.RunSuccess(ctx, "outbox", "ls").ReadStdout()
 		assert.Contains(t, out, fixtures.TestAddresses[0])
 		assert.NotContains(t, out, fixtures.TestAddresses[1]) // Cleared
 		assert.Contains(t, out, c1)
@@ -65,16 +83,16 @@ func TestOutbox(t *testing.T) {
 		assert.NotContains(t, out, c3) // cleared
 
 		// Repopulate
-		sendMessage(d, fixtures.TestAddresses[1], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
+		sendMessage(ctx, cmdClient, fixtures.TestAddresses[1], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
 
 		// #nofilter
-		d.RunSuccess("outbox", "clear")
-		out = d.RunSuccess("outbox", "ls").ReadStdoutTrimNewlines()
+		cmdClient.RunSuccess(ctx, "outbox", "clear")
+		out = cmdClient.RunSuccess(ctx, "outbox", "ls").ReadStdoutTrimNewlines()
 		assert.Empty(t, out)
 
 		// Clearing empty queue
-		d.RunSuccess("outbox", "clear")
-		out = d.RunSuccess("outbox", "ls").ReadStdoutTrimNewlines()
+		cmdClient.RunSuccess(ctx, "outbox", "clear")
+		out = cmdClient.RunSuccess(ctx, "outbox", "ls").ReadStdoutTrimNewlines()
 		assert.Empty(t, out)
 	})
 }

--- a/cmd/go-filecoin/show_test.go
+++ b/cmd/go-filecoin/show_test.go
@@ -1,6 +1,7 @@
 package commands_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -9,7 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/fixtures"
-	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
@@ -19,14 +21,22 @@ func TestBlockDaemon(t *testing.T) {
 	tf.IntegrationTest(t)
 
 	t.Run("show block <cid-of-genesis-block> returns human readable output for the filecoin block", func(t *testing.T) {
-		d := makeTestDaemonWithMinerAndStart(t)
-		defer d.ShutdownSuccess()
+		ctx := context.Background()
+		builder := test.NewNodeBuilder(t)
+		buildWithMiner(t, builder)
+
+		n := builder.BuildAndStart(ctx)
+		defer n.Stop(ctx)
+		cmdClient, done := test.RunNodeAPI(ctx, n, t)
+		defer done()
 
 		// mine a block and get its CID
-		minedBlockCidStr := th.RunSuccessFirstLine(d, "mining", "once")
+		minedBlock, err := n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+		require.NoError(t, err)
+		minedBlockCid := minedBlock.Cid()
 
 		// get the mined block by its CID
-		output := d.RunSuccess("show", "block", minedBlockCidStr).ReadStdoutTrimNewlines()
+		output := cmdClient.RunSuccess(ctx, "show", "block", minedBlockCid.String()).ReadStdoutTrimNewlines()
 
 		assert.Contains(t, output, "Block Details")
 		assert.Contains(t, output, "Weight: 0")
@@ -35,14 +45,21 @@ func TestBlockDaemon(t *testing.T) {
 	})
 
 	t.Run("show block --messages <cid-of-genesis-block> returns human readable output for the filecoin block including messages", func(t *testing.T) {
-		d := makeTestDaemonWithMinerAndStart(t)
-		defer d.ShutdownSuccess()
+		ctx := context.Background()
+		builder := test.NewNodeBuilder(t)
+		buildWithMiner(t, builder)
+
+		n := builder.BuildAndStart(ctx)
+		defer n.Stop(ctx)
+		cmdClient, done := test.RunNodeAPI(ctx, n, t)
+		defer done()
 
 		// mine a block and get its CID
-		minedBlockCidStr := th.RunSuccessFirstLine(d, "mining", "once")
+		minedBlock, err := n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+		require.NoError(t, err)
 
 		// get the mined block by its CID
-		output := d.RunSuccess("show", "block", "--messages", minedBlockCidStr).ReadStdoutTrimNewlines()
+		output := cmdClient.RunSuccess(ctx, "show", "block", "--messages", minedBlock.Cid().String()).ReadStdoutTrimNewlines()
 
 		assert.Contains(t, output, "Block Details")
 		assert.Contains(t, output, "Weight: 0")
@@ -52,54 +69,68 @@ func TestBlockDaemon(t *testing.T) {
 	})
 
 	t.Run("show block <cid-of-genesis-block> --enc json returns JSON for a filecoin block", func(t *testing.T) {
-		d := th.NewDaemon(t,
-			th.KeyFile(fixtures.KeyFilePaths()[0]),
-			th.WithMiner(fixtures.TestMiners[0])).Start()
-		defer d.ShutdownSuccess()
+		ctx := context.Background()
+		builder := test.NewNodeBuilder(t)
+		buildWithMiner(t, builder)
+
+		n := builder.BuildAndStart(ctx)
+		defer n.Stop(ctx)
+		cmdClient, done := test.RunNodeAPI(ctx, n, t)
+		defer done()
 
 		// mine a block and get its CID
-		minedBlockCidStr := th.RunSuccessFirstLine(d, "mining", "once")
+		minedBlock, err := n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+		require.NoError(t, err)
 
 		// get the mined block by its CID
-		blockGetLine := th.RunSuccessFirstLine(d, "show", "block", minedBlockCidStr, "--enc", "json")
+		blockGetLine := cmdClient.RunSuccessFirstLine(ctx, "show", "block", minedBlock.Cid().String(), "--enc", "json")
 		var blockGetBlock block.FullBlock
 		require.NoError(t, json.Unmarshal([]byte(blockGetLine), &blockGetBlock))
 
 		// ensure that we were returned the correct block
 
-		require.Equal(t, minedBlockCidStr, blockGetBlock.Header.Cid().String())
+		require.Equal(t, minedBlock.Cid().String(), blockGetBlock.Header.Cid().String())
 	})
 
 	t.Run("show header <cid-of-genesis-block> --enc json returns JSON for a filecoin block header", func(t *testing.T) {
-		d := th.NewDaemon(t,
-			th.KeyFile(fixtures.KeyFilePaths()[0]),
-			th.WithMiner(fixtures.TestMiners[0])).Start()
-		defer d.ShutdownSuccess()
+		ctx := context.Background()
+		builder := test.NewNodeBuilder(t)
+		buildWithMiner(t, builder)
+
+		n := builder.BuildAndStart(ctx)
+		defer n.Stop(ctx)
+		cmdClient, done := test.RunNodeAPI(ctx, n, t)
+		defer done()
 
 		// mine a block and get its CID
-		minedBlockCidStr := th.RunSuccessFirstLine(d, "mining", "once")
+		minedBlock, err := n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+		require.NoError(t, err)
 
 		// get the mined block by its CID
-		headerGetLine := th.RunSuccessFirstLine(d, "show", "header", minedBlockCidStr, "--enc", "json")
+		headerGetLine := cmdClient.RunSuccessFirstLine(ctx, "show", "header", minedBlock.Cid().String(), "--enc", "json")
 
 		var headerGetBlock block.Block
 		require.NoError(t, json.Unmarshal([]byte(headerGetLine), &headerGetBlock))
 
 		// ensure that we were returned the correct block
 
-		require.Equal(t, minedBlockCidStr, headerGetBlock.Cid().String())
+		require.Equal(t, minedBlock.Cid().String(), headerGetBlock.Cid().String())
 	})
 
 	t.Run("show messages <empty-collection-cid> returns empty message collection", func(t *testing.T) {
-		d := th.NewDaemon(t,
-			th.KeyFile(fixtures.KeyFilePaths()[0]),
-			th.WithMiner(fixtures.TestMiners[0])).Start()
-		defer d.ShutdownSuccess()
+		ctx := context.Background()
+		builder := test.NewNodeBuilder(t)
+		buildWithMiner(t, builder)
 
-		// mine a block
-		th.RunSuccessFirstLine(d, "mining", "once")
+		n := builder.BuildAndStart(ctx)
+		defer n.Stop(ctx)
+		cmdClient, done := test.RunNodeAPI(ctx, n, t)
+		defer done()
 
-		emptyMessagesLine := th.RunSuccessFirstLine(d, "show", "messages", types.EmptyMessagesCID.String(), "--enc", "json")
+		_, err := n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+		require.NoError(t, err)
+
+		emptyMessagesLine := cmdClient.RunSuccessFirstLine(ctx, "show", "messages", types.EmptyMessagesCID.String(), "--enc", "json")
 
 		var messageCollection []*types.SignedMessage
 		require.NoError(t, json.Unmarshal([]byte(emptyMessagesLine), &messageCollection))
@@ -108,15 +139,19 @@ func TestBlockDaemon(t *testing.T) {
 	})
 
 	t.Run("show receipts <empty-collection-cid> returns empty receipt collection", func(t *testing.T) {
-		d := th.NewDaemon(t,
-			th.KeyFile(fixtures.KeyFilePaths()[0]),
-			th.WithMiner(fixtures.TestMiners[0])).Start()
-		defer d.ShutdownSuccess()
+		ctx := context.Background()
+		builder := test.NewNodeBuilder(t)
+		buildWithMiner(t, builder)
 
-		// mine a block
-		th.RunSuccessFirstLine(d, "mining", "once")
+		n := builder.BuildAndStart(ctx)
+		defer n.Stop(ctx)
+		cmdClient, done := test.RunNodeAPI(ctx, n, t)
+		defer done()
 
-		emptyReceiptsLine := th.RunSuccessFirstLine(d, "show", "receipts", types.EmptyReceiptsCID.String(), "--enc", "json")
+		_, err := n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+		require.NoError(t, err)
+
+		emptyReceiptsLine := cmdClient.RunSuccessFirstLine(ctx, "show", "receipts", types.EmptyReceiptsCID.String(), "--enc", "json")
 
 		var receipts []*types.MessageReceipt
 		require.NoError(t, json.Unmarshal([]byte(emptyReceiptsLine), &receipts))
@@ -125,58 +160,64 @@ func TestBlockDaemon(t *testing.T) {
 	})
 
 	t.Run("show messages", func(t *testing.T) {
-		d := th.NewDaemon(
-			t,
-			th.DefaultAddress(fixtures.TestAddresses[0]),
-			th.KeyFile(fixtures.KeyFilePaths()[1]),
-			// must include same-index KeyFilePath when configuring with a TestMiner.
-			th.WithMiner(fixtures.TestMiners[0]),
-			th.KeyFile(fixtures.KeyFilePaths()[0]),
-		).Start()
-		defer d.ShutdownSuccess()
+		cs := node.FixtureChainSeed(t)
+		defaultAddr, err := address.NewFromString(fixtures.TestAddresses[0])
+		require.NoError(t, err)
+		ctx := context.Background()
+		builder := test.NewNodeBuilder(t)
+		builder.WithGenesisInit(cs.GenesisInitFunc)
+		builder.WithConfig(cs.MinerConfigOpt(0))
+		builder.WithConfig(node.DefaultAddressConfigOpt(defaultAddr))
+		builder.WithInitOpt(cs.KeyInitOpt(1))
+		builder.WithInitOpt(cs.KeyInitOpt(0))
 
-		d.RunSuccess("mining", "once")
+		n := builder.BuildAndStart(ctx)
+		defer n.Stop(ctx)
+		cmdClient, done := test.RunNodeAPI(ctx, n, t)
+		defer done()
 
-		from := d.GetDefaultAddress() // this should = fixtures.TestAddresses[0]
+		_, err = n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+		require.NoError(t, err)
 
-		d.RunSuccess("message", "send",
-			"--from", from,
+		from, err := n.PorcelainAPI.WalletDefaultAddress() // this should = fixtures.TestAddresses[0]
+		require.NoError(t, err)
+		cmdClient.RunSuccess(ctx, "message", "send",
+			"--from", from.String(),
 			"--gas-price", "1",
 			"--gas-limit", "300",
 			fixtures.TestAddresses[3],
 		)
 
-		d.RunSuccess("message", "send",
-			"--from", from,
+		cmdClient.RunSuccess(ctx, "message", "send",
+			"--from", from.String(),
 			"--gas-price", "1",
 			"--gas-limit", "300",
 			"--value", "10",
 			fixtures.TestAddresses[3],
 		)
 
-		d.RunSuccess("message", "send",
-			"--from", from,
+		cmdClient.RunSuccess(ctx, "message", "send",
+			"--from", from.String(),
 			"--gas-price", "1",
 			"--gas-limit", "300",
 			"--value", "5.5",
 			fixtures.TestAddresses[3],
 		)
 
-		minedBlockCidStr := th.RunSuccessFirstLine(d, "mining", "once")
+		blk, err := n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+		require.NoError(t, err)
 
 		// Full block checks out
-		blockGetLine := th.RunSuccessFirstLine(d, "show", "block", minedBlockCidStr, "--enc", "json")
+		blockGetLine := cmdClient.RunSuccessFirstLine(ctx, "show", "block", blk.Cid().String(), "--enc", "json")
 		var blockGetBlock block.FullBlock
 		require.NoError(t, json.Unmarshal([]byte(blockGetLine), &blockGetBlock))
 
 		assert.Equal(t, 3, len(blockGetBlock.Messages))
 
-		fromAddr, err := address.NewFromString(from)
-		require.NoError(t, err)
-		assert.Equal(t, fromAddr, blockGetBlock.Messages[0].Message.From)
+		assert.Equal(t, from, blockGetBlock.Messages[0].Message.From)
 
 		// Full block matches show messages
-		messagesGetLine := th.RunSuccessFirstLine(d, "show", "messages", blockGetBlock.Header.Messages.SecpRoot.String(), "--enc", "json")
+		messagesGetLine := cmdClient.RunSuccessFirstLine(ctx, "show", "messages", blockGetBlock.Header.Messages.SecpRoot.String(), "--enc", "json")
 		var messages []*types.SignedMessage
 		require.NoError(t, json.Unmarshal([]byte(messagesGetLine), &messages))
 		assert.Equal(t, blockGetBlock.Messages, messages)

--- a/cmd/go-filecoin/stats_daemon_test.go
+++ b/cmd/go-filecoin/stats_daemon_test.go
@@ -1,21 +1,26 @@
 package commands_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 )
 
 func TestStatsBandwidth(t *testing.T) {
 	tf.IntegrationTest(t)
+	ctx := context.Background()
+	builder := test.NewNodeBuilder(t)
 
-	d := th.NewDaemon(t).Start()
-	defer d.ShutdownSuccess()
+	n := builder.BuildAndStart(ctx)
+	defer n.Stop(ctx)
+	cmdClient, done := test.RunNodeAPI(ctx, n, t)
+	defer done()
 
-	stats := d.RunSuccess("stats", "bandwidth").ReadStdoutTrimNewlines()
+	stats := cmdClient.RunSuccess(ctx, "stats", "bandwidth").ReadStdoutTrimNewlines()
 
 	assert.Equal(t, "{\"TotalIn\":0,\"TotalOut\":0,\"RateIn\":0,\"RateOut\":0}", stats)
 }

--- a/cmd/go-filecoin/swarm_daemon_test.go
+++ b/cmd/go-filecoin/swarm_daemon_test.go
@@ -1,31 +1,40 @@
 package commands_test
 
 import (
+	"context"
 	"testing"
 
-	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 )
 
 func TestSwarmConnectPeersValid(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	d1 := th.NewDaemon(t).Start()
-	defer d1.ShutdownSuccess()
+	ctx := context.Background()
+	builder := test.NewNodeBuilder(t)
 
-	d2 := th.NewDaemon(t).Start()
-	defer d2.ShutdownSuccess()
+	n1 := builder.BuildAndStart(ctx)
+	defer n1.Stop(ctx)
+	n2 := builder.BuildAndStart(ctx)
+	defer n2.Stop(ctx)
 
-	d1.ConnectSuccess(d2)
+	node.ConnectNodes(t, n1, n2)
 }
 
 func TestSwarmConnectPeersInvalid(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	d1 := th.NewDaemon(t).Start()
-	defer d1.ShutdownSuccess()
+	ctx := context.Background()
+	builder := test.NewNodeBuilder(t)
 
-	d1.RunFail("failed to parse ip4 addr",
-		"swarm connect /ip4/hello",
+	n := builder.BuildAndStart(ctx)
+	cmdClient, done := test.RunNodeAPI(ctx, n, t)
+	defer done()
+	n.Stop(ctx)
+
+	cmdClient.RunFail(ctx, "failed to parse ip4 addr",
+		"swarm", "connect", "/ip4/hello",
 	)
 }

--- a/internal/app/go-filecoin/node/message.go
+++ b/internal/app/go-filecoin/node/message.go
@@ -8,6 +8,13 @@ import (
 )
 
 func (node *Node) processMessage(ctx context.Context, pubSubMsg pubsub.Message) (err error) {
+	sender := pubSubMsg.GetSender()
+
+	// ignore messages from self
+	if sender == node.Host().ID() {
+		return nil
+	}
+
 	unmarshaled := &types.SignedMessage{}
 	if err := unmarshaled.Unmarshal(pubSubMsg.GetData()); err != nil {
 		return err

--- a/internal/app/go-filecoin/node/test/api.go
+++ b/internal/app/go-filecoin/node/test/api.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
@@ -98,7 +97,7 @@ func (c *Client) Run(ctx context.Context, command ...string) *th.CmdOutput {
 	} else {
 		out.SetStatus(exitCode)
 	}
-	assert.NoError(c.tb, err, "client execution error")
+	require.NoError(c.tb, err, "client execution error")
 
 	return out
 }

--- a/internal/app/go-filecoin/node/test/api.go
+++ b/internal/app/go-filecoin/node/test/api.go
@@ -72,7 +72,7 @@ func (c *Client) Address() string {
 }
 
 // Run runs a CLI command and returns its output.
-func (c *Client) Run(ctx context.Context, shouldFail bool, command ...string) *th.CmdOutput {
+func (c *Client) Run(ctx context.Context, command ...string) *th.CmdOutput {
 	c.tb.Helper()
 	args := []string{
 		"go-filecoin", // A dummy first arg is required, simulating shell invocation.
@@ -94,30 +94,25 @@ func (c *Client) Run(ctx context.Context, shouldFail bool, command ...string) *t
 
 	out := th.ReadOutput(c.tb, command, readStdOut, readStdErr)
 	if err != nil {
-		if !shouldFail {
-			out.SetInvocationError(err)
-		}
+		out.SetInvocationError(err)
 	} else {
 		out.SetStatus(exitCode)
 	}
-	if !shouldFail {
-		require.NoError(c.tb, err, "client execution error")
-		assert.Equal(c.tb, 0, exitCode, "client returned non-zero status")
-	}
+	assert.NoError(c.tb, err, "client execution error")
 
 	return out
 }
 
 // RunSuccess runs a command and asserts that it succeeds (status of zero and logs no errors).
 func (c *Client) RunSuccess(ctx context.Context, command ...string) *th.CmdOutput {
-	output := c.Run(ctx, false, command...)
+	output := c.Run(ctx, command...)
 	output.AssertSuccess()
 	return output
 }
 
 // RunFail runs a command and asserts that it fails with a specified message on stderr.
 func (c *Client) RunFail(ctx context.Context, err string, command ...string) *th.CmdOutput {
-	output := c.Run(ctx, true, command...)
+	output := c.Run(ctx, command...)
 	output.AssertFail(err)
 	return output
 }

--- a/internal/app/go-filecoin/node/testing.go
+++ b/internal/app/go-filecoin/node/testing.go
@@ -142,6 +142,13 @@ func FixtureChainSeed(t *testing.T) *ChainSeed {
 	return MakeChainSeed(t, &fixtures.TestGenGenConfig)
 }
 
+// DefaultAddressConfigOpt is a node config option setting the default address
+func DefaultAddressConfigOpt(addr address.Address) ConfigOpt {
+	return func(cfg *config.Config) {
+		cfg.Wallet.DefaultAddress = addr
+	}
+}
+
 // ConnectNodes connects two nodes together
 func ConnectNodes(t *testing.T, a, b *Node) {
 	t.Helper()

--- a/internal/app/go-filecoin/porcelain/api.go
+++ b/internal/app/go-filecoin/porcelain/api.go
@@ -273,3 +273,8 @@ func (a *API) PingMinerWithTimeout(
 func (a *API) MinerSetWorkerAddress(ctx context.Context, toAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits) (cid.Cid, error) {
 	return MinerSetWorkerAddress(ctx, a, toAddr, gasPrice, gasLimit)
 }
+
+// MessageWaitDone blocks until the message is on chain
+func (a *API) MessageWaitDone(ctx context.Context, msgCid cid.Cid) error {
+	return MessageWaitDone(ctx, a, msgCid)
+}

--- a/internal/app/go-filecoin/porcelain/message.go
+++ b/internal/app/go-filecoin/porcelain/message.go
@@ -1,0 +1,29 @@
+package porcelain
+
+import (
+	"context"
+
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/util/moresync"
+)
+
+type waitPlumbing interface {
+	MessageWait(context.Context, cid.Cid, func(*block.Block, *types.SignedMessage, *types.MessageReceipt) error) error
+}
+
+// MessageWaitDone blocks until the given message cid appears on chain
+func MessageWaitDone(ctx context.Context, plumbing waitPlumbing, msgCid cid.Cid) error {
+	l := moresync.NewLatch(1)
+	err := plumbing.MessageWait(ctx, msgCid, func(_ *block.Block, _ *types.SignedMessage, _ *types.MessageReceipt) error {
+		l.Done()
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	l.Wait()
+	return nil
+}

--- a/internal/pkg/message/pool.go
+++ b/internal/pkg/message/pool.go
@@ -91,6 +91,7 @@ func (pool *Pool) Add(ctx context.Context, msg *types.SignedMessage, height uint
 func (pool *Pool) Pending() []*types.SignedMessage {
 	pool.lk.Lock()
 	defer pool.lk.Unlock()
+
 	out := make([]*types.SignedMessage, 0, len(pool.pending))
 	for _, msg := range pool.pending {
 		out = append(out, msg.message)
@@ -116,12 +117,12 @@ func (pool *Pool) Get(c cid.Cid) (*types.SignedMessage, bool) {
 func (pool *Pool) Remove(c cid.Cid) {
 	pool.lk.Lock()
 	defer pool.lk.Unlock()
-
 	msg, ok := pool.pending[c]
 	if ok {
 		delete(pool.addressNonces, newAddressNonce(msg.message))
 		delete(pool.pending, c)
 	}
+
 	mpSize.Set(context.TODO(), int64(len(pool.pending)))
 }
 

--- a/internal/pkg/testhelpers/output.go
+++ b/internal/pkg/testhelpers/output.go
@@ -100,6 +100,7 @@ func (o *CmdOutput) ReadStdoutTrimNewlines() string {
 // AssertSuccess asserts that the output represents a successful execution.
 func (o *CmdOutput) AssertSuccess() *CmdOutput {
 	o.tb.Helper()
+	assert.Equal(o.tb, 0, o.status, "client returned non-zero status")
 	oErr := o.ReadStderr() // Also checks no invocation error.
 
 	assert.NotContains(o.tb, oErr, "CRITICAL")
@@ -113,6 +114,7 @@ func (o *CmdOutput) AssertSuccess() *CmdOutput {
 // matching the passed in error.
 func (o *CmdOutput) AssertFail(err string) *CmdOutput {
 	o.tb.Helper()
+	assert.NotEqual(o.tb, 0, o.status, "client returned zero status")
 	assert.Empty(o.tb, o.ReadStdout()) // Also checks no invocation error.
 	assert.Contains(o.tb, o.ReadStderr(), err)
 	return o


### PR DESCRIPTION
### Motivation
Follow on to #3712, see that PR for motivation

### Proposed changes
More changes to tests removing dependence on test daemon
Minor improvements to testing infrastructure to enable tests, particularly fixing Run and RunFail to correctly test failed runs.

Closes issue #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

