### PR TITLE
Test/in process integration 2

### DIFF
--- a/cmd/go-filecoin/address_daemon_test.go
+++ b/cmd/go-filecoin/address_daemon_test.go
@@ -122,7 +122,8 @@ func TestAddrLookupAndUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	// wait for message to be included in a block
-	require.NoError(t, n1.PorcelainAPI.MessageWaitDone(ctx, mustDecodeCid(updateMsg)))
+	_, err = n1.PorcelainAPI.MessageWaitDone(ctx, mustDecodeCid(updateMsg))
+	require.NoError(t, err)
 
 	// use the address lookup command to ensure update happened
 	lookupOutB := cmdClient.RunSuccessFirstLine(ctx, "address", "lookup", minerAddr)

--- a/cmd/go-filecoin/payment_channel_daemon_test.go
+++ b/cmd/go-filecoin/payment_channel_daemon_test.go
@@ -6,59 +6,51 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-filecoin/fixtures"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
-	"github.com/filecoin-project/go-filecoin/tools/fast"
-	"github.com/filecoin-project/go-filecoin/tools/fast/fastesting"
-	"github.com/filecoin-project/go-filecoin/tools/fast/series"
+	//	"github.com/filecoin-project/go-filecoin/tools/fast/series"
 )
 
 func TestPaymentChannelCreateSuccess(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{})
-
-	// Teardown after test ends
-	defer func() {
-		err := env.Teardown(ctx)
-		require.NoError(t, err)
-	}()
+	ctx := context.Background()
 
 	// Start test
-	rsrc := requireNewPaychResource(ctx, t, env)
+	rsrc := requireNewPaychResource(ctx, t)
 
 	channelExpiry := types.NewBlockHeight(20)
 	channelAmount := types.NewAttoFILFromFIL(1000)
 
 	rsrc.requirePaymentChannel(ctx, t, channelAmount, channelExpiry)
+	rsrc.Stop(ctx)
 }
 
 func TestPaymentChannelLs(t *testing.T) {
 	tf.IntegrationTest(t)
 
 	t.Run("Works with default payer", func(t *testing.T) {
-		ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{})
-
-		// Teardown after test ends
-		defer func() {
-			err := env.Teardown(ctx)
-			require.NoError(t, err)
-		}()
+		ctx := context.Background()
 
 		// Start test
-		rsrc := requireNewPaychResource(ctx, t, env)
+		rsrc := requireNewPaychResource(ctx, t)
+		defer rsrc.Stop(ctx)
 
 		channelExpiry := types.NewBlockHeight(20)
 		channelAmount := types.NewAttoFILFromFIL(1000)
 
 		chanid, _ := rsrc.requirePaymentChannel(ctx, t, channelAmount, channelExpiry)
 
-		channels, err := rsrc.payer.PaychLs(ctx)
+		channels, err := rsrc.payer.PorcelainAPI.PaymentChannelLs(ctx, rsrc.payerAddr, rsrc.payerAddr)
 		require.NoError(t, err)
 
 		assert.Len(t, channels, 1)
@@ -72,23 +64,18 @@ func TestPaymentChannelLs(t *testing.T) {
 	})
 
 	t.Run("Works with specified payer", func(t *testing.T) {
-		ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{})
-
-		// Teardown after test ends
-		defer func() {
-			err := env.Teardown(ctx)
-			require.NoError(t, err)
-		}()
+		ctx := context.Background()
 
 		// Start test
-		rsrc := requireNewPaychResource(ctx, t, env)
+		rsrc := requireNewPaychResource(ctx, t)
+		defer rsrc.Stop(ctx)
 
 		channelExpiry := types.NewBlockHeight(20)
 		channelAmount := types.NewAttoFILFromFIL(1000)
 
 		chanid, _ := rsrc.requirePaymentChannel(ctx, t, channelAmount, channelExpiry)
 
-		channels, err := rsrc.payer.PaychLs(ctx, fast.AOPayer(rsrc.payerAddr))
+		channels, err := rsrc.payer.PorcelainAPI.PaymentChannelLs(ctx, rsrc.payerAddr, rsrc.payerAddr)
 		require.NoError(t, err)
 
 		assert.Len(t, channels, 1)
@@ -105,17 +92,9 @@ func TestPaymentChannelLs(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
 		defer cancel()
 
-		// Get basic testing environment
-		ctx, env := fastesting.NewTestEnvironment(ctx, t, fast.FilecoinOpts{})
-
-		// Teardown after test ends
-		defer func() {
-			err := env.Teardown(ctx)
-			require.NoError(t, err)
-		}()
-
 		// Start test
-		rsrc := requireNewPaychResource(ctx, t, env)
+		rsrc := requireNewPaychResource(ctx, t)
+		defer rsrc.Stop(ctx)
 
 		channelExpiry := types.NewBlockHeight(20)
 		channelAmount := types.NewAttoFILFromFIL(1000)
@@ -123,7 +102,7 @@ func TestPaymentChannelLs(t *testing.T) {
 		// requirePaymentChannel sets up a channel with the rsrc.payerAddr as the from address
 		rsrc.requirePaymentChannel(ctx, t, channelAmount, channelExpiry)
 
-		channels, err := rsrc.payer.PaychLs(ctx, fast.AOFromAddr(rsrc.targetAddr))
+		channels, err := rsrc.payer.PorcelainAPI.PaymentChannelLs(ctx, rsrc.payerAddr, rsrc.targetAddr)
 		require.NoError(t, err)
 
 		assert.Len(t, channels, 0)
@@ -133,16 +112,10 @@ func TestPaymentChannelLs(t *testing.T) {
 func TestPaymentChannelVoucherSuccess(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{})
-
-	// Teardown after test ends
-	defer func() {
-		err := env.Teardown(ctx)
-		require.NoError(t, err)
-	}()
+	ctx := context.Background()
 
 	// Start test
-	rsrc := requireNewPaychResource(ctx, t, env)
+	rsrc := requireNewPaychResource(ctx, t)
 
 	channelExpiry := types.NewBlockHeight(20)
 	channelAmount := types.NewAttoFILFromFIL(1000)
@@ -151,10 +124,7 @@ func TestPaymentChannelVoucherSuccess(t *testing.T) {
 
 	voucherAmount := types.NewAttoFILFromFIL(10)
 	voucherValidAt := types.NewBlockHeight(1)
-	voucherStr, err := rsrc.payer.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(rsrc.payerAddr), fast.AOValidAt(voucherValidAt))
-	require.NoError(t, err)
-
-	voucher, err := types.DecodeVoucher(voucherStr)
+	voucher, err := rsrc.payer.PorcelainAPI.PaymentChannelVoucher(ctx, rsrc.payerAddr, chanid, voucherAmount, voucherValidAt, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, voucherAmount, voucher.Amount)
@@ -166,16 +136,10 @@ func TestPaymentChannelVoucherSuccess(t *testing.T) {
 func TestPaymentChannelRedeemSuccess(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{})
-
-	// Teardown after test ends
-	defer func() {
-		err := env.Teardown(ctx)
-		require.NoError(t, err)
-	}()
+	ctx := context.Background()
 
 	// Start test
-	rsrc := requireNewPaychResource(ctx, t, env)
+	rsrc := requireNewPaychResource(ctx, t)
 
 	channelExpiry := types.NewBlockHeight(20)
 	channelAmount := types.NewAttoFILFromFIL(1000)
@@ -184,19 +148,32 @@ func TestPaymentChannelRedeemSuccess(t *testing.T) {
 
 	voucherAmount := types.NewAttoFILFromFIL(10)
 	voucherValidAt := types.NewBlockHeight(0)
-	voucherStr, err := rsrc.payer.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(rsrc.payerAddr), fast.AOValidAt(voucherValidAt))
+
+	voucher, err := rsrc.payer.PorcelainAPI.PaymentChannelVoucher(ctx, rsrc.payerAddr, chanid, voucherAmount, voucherValidAt, nil)
 	require.NoError(t, err)
 
-	mcid, err := rsrc.target.PaychRedeem(ctx, voucherStr, fast.AOFromAddr(rsrc.targetAddr), fast.AOPrice(big.NewFloat(1)), fast.AOLimit(300))
+	params := []interface{}{
+		voucher.Payer,
+		&voucher.Channel,
+		voucher.Amount,
+		&voucher.ValidAt,
+		voucher.Condition,
+		[]byte(voucher.Signature),
+		[]interface{}{},
+	}
+	sender := newTestSender(t, types.NewAttoFIL(big.NewInt(1)), 300, rsrc.targetAddr, rsrc.target)
+	mcid := sender.requireSend(ctx, address.PaymentBrokerAddress, types.NewAttoFILFromFIL(0), paymentbroker.Redeem, params...)
+
+	_, err = rsrc.miner.PorcelainAPI.MessagePoolWait(ctx, 1)
+	require.NoError(t, err)
+	_, err = rsrc.miner.BlockMining.BlockMiningAPI.MiningOnce(ctx)
 	require.NoError(t, err)
 
-	series.CtxMiningOnce(ctx)
-
-	resp, err := rsrc.target.MessageWait(ctx, mcid)
+	rcpt, err := rsrc.target.PorcelainAPI.MessageWaitDone(ctx, mcid)
 	require.NoError(t, err)
-	assert.Equal(t, 0, int(resp.Receipt.ExitCode))
+	assert.Equal(t, 0, int(rcpt.ExitCode))
 
-	channels, err := rsrc.target.PaychLs(ctx, fast.AOFromAddr(rsrc.payerAddr))
+	channels, err := rsrc.target.PorcelainAPI.PaymentChannelLs(ctx, rsrc.targetAddr, rsrc.payerAddr)
 	require.NoError(t, err)
 
 	channel := channels[chanid.String()]
@@ -207,16 +184,10 @@ func TestPaymentChannelRedeemSuccess(t *testing.T) {
 func TestPaymentChannelRedeemTooEarlyFails(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{})
-
-	// Teardown after test ends
-	defer func() {
-		err := env.Teardown(ctx)
-		require.NoError(t, err)
-	}()
+	ctx := context.Background()
 
 	// Start test
-	rsrc := requireNewPaychResource(ctx, t, env)
+	rsrc := requireNewPaychResource(ctx, t)
 
 	channelExpiry := types.NewBlockHeight(20)
 	channelAmount := types.NewAttoFILFromFIL(1000)
@@ -225,19 +196,31 @@ func TestPaymentChannelRedeemTooEarlyFails(t *testing.T) {
 
 	voucherAmount := types.NewAttoFILFromFIL(10)
 	voucherValidAt := types.NewBlockHeight(10)
-	voucherStr, err := rsrc.payer.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(rsrc.payerAddr), fast.AOValidAt(voucherValidAt))
+	voucher, err := rsrc.payer.PorcelainAPI.PaymentChannelVoucher(ctx, rsrc.payerAddr, chanid, voucherAmount, voucherValidAt, nil)
 	require.NoError(t, err)
 
-	mcid, err := rsrc.target.PaychRedeem(ctx, voucherStr, fast.AOFromAddr(rsrc.targetAddr), fast.AOPrice(big.NewFloat(1)), fast.AOLimit(300))
+	params := []interface{}{
+		voucher.Payer,
+		&voucher.Channel,
+		voucher.Amount,
+		&voucher.ValidAt,
+		voucher.Condition,
+		[]byte(voucher.Signature),
+		[]interface{}{},
+	}
+	sender := newTestSender(t, types.NewAttoFIL(big.NewInt(1)), 300, rsrc.targetAddr, rsrc.target)
+	mcid := sender.requireSend(ctx, address.PaymentBrokerAddress, types.NewAttoFILFromFIL(0), paymentbroker.Redeem, params...)
+
+	_, err = rsrc.miner.PorcelainAPI.MessagePoolWait(ctx, 1)
+	require.NoError(t, err)
+	_, err = rsrc.miner.BlockMining.BlockMiningAPI.MiningOnce(ctx)
 	require.NoError(t, err)
 
-	series.CtxMiningOnce(ctx)
-
-	resp, err := rsrc.target.MessageWait(ctx, mcid)
+	rcpt, err := rsrc.target.PorcelainAPI.MessageWaitDone(ctx, mcid)
 	require.NoError(t, err)
-	assert.Equal(t, paymentbroker.ErrTooEarly, int(resp.Receipt.ExitCode))
+	assert.Equal(t, paymentbroker.ErrTooEarly, int(rcpt.ExitCode))
 
-	channels, err := rsrc.target.PaychLs(ctx, fast.AOFromAddr(rsrc.payerAddr))
+	channels, err := rsrc.target.PorcelainAPI.PaymentChannelLs(ctx, rsrc.targetAddr, rsrc.payerAddr)
 	require.NoError(t, err)
 
 	channel := channels[chanid.String()]
@@ -248,19 +231,15 @@ func TestPaymentChannelRedeemTooEarlyFails(t *testing.T) {
 func TestPaymentChannelReclaimSuccess(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{})
-
-	// Teardown after test ends
-	defer func() {
-		err := env.Teardown(ctx)
-		require.NoError(t, err)
-	}()
-
+	ctx := context.Background()
 	// Start test
-	rsrc := requireNewPaychResource(ctx, t, env)
+	rsrc := requireNewPaychResource(ctx, t)
 
-	bh, err := series.GetHeadBlockHeight(ctx, env.GenesisMiner)
+	head, err := rsrc.miner.PorcelainAPI.ChainHead()
 	require.NoError(t, err)
+	h, err := head.Height()
+	require.NoError(t, err)
+	bh := types.NewBlockHeight(h)
 
 	// Expiry is current height, plus 3
 	// - Setting up the payment channel
@@ -269,49 +248,66 @@ func TestPaymentChannelReclaimSuccess(t *testing.T) {
 	channelExpiry := types.NewBlockHeight(3).Add(bh)
 	channelAmount := types.NewAttoFILFromFIL(1000)
 
-	balanceBefore, err := rsrc.payer.WalletBalance(ctx, rsrc.payerAddr)
+	balanceBefore, err := rsrc.payer.PorcelainAPI.WalletBalance(ctx, rsrc.payerAddr)
 	require.NoError(t, err)
 
 	chanid, gasReceipt := rsrc.requirePaymentChannel(ctx, t, channelAmount, channelExpiry)
 
 	voucherAmount := types.NewAttoFILFromFIL(10)
 	voucherValidAt := types.NewBlockHeight(0)
-	voucherStr, err := rsrc.payer.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(rsrc.payerAddr), fast.AOValidAt(voucherValidAt))
+
+	voucher, err := rsrc.payer.PorcelainAPI.PaymentChannelVoucher(ctx, rsrc.payerAddr, chanid, voucherAmount, voucherValidAt, nil)
 	require.NoError(t, err)
 
-	mcid, err := rsrc.target.PaychRedeem(ctx, voucherStr, fast.AOFromAddr(rsrc.targetAddr), fast.AOPrice(big.NewFloat(1)), fast.AOLimit(300))
+	params := []interface{}{
+		voucher.Payer,
+		&voucher.Channel,
+		voucher.Amount,
+		&voucher.ValidAt,
+		voucher.Condition,
+		[]byte(voucher.Signature),
+		[]interface{}{},
+	}
+	targetSender := newTestSender(t, types.NewAttoFIL(big.NewInt(1)), 300, rsrc.targetAddr, rsrc.target)
+	mcid := targetSender.requireSend(ctx, address.PaymentBrokerAddress, types.NewAttoFILFromFIL(0), paymentbroker.Redeem, params...)
+
+	_, err = rsrc.miner.PorcelainAPI.MessagePoolWait(ctx, 1)
+	require.NoError(t, err)
+	_, err = rsrc.miner.BlockMining.BlockMiningAPI.MiningOnce(ctx)
 	require.NoError(t, err)
 
-	series.CtxMiningOnce(ctx)
-
-	resp, err := rsrc.target.MessageWait(ctx, mcid)
+	rcpt, err := rsrc.target.PorcelainAPI.MessageWaitDone(ctx, mcid)
 	require.NoError(t, err)
-	assert.Equal(t, 0, int(resp.Receipt.ExitCode))
+	assert.Equal(t, 0, int(rcpt.ExitCode))
 
-	channels, err := rsrc.target.PaychLs(ctx, fast.AOFromAddr(rsrc.payerAddr))
+	channels, err := rsrc.target.PorcelainAPI.PaymentChannelLs(ctx, rsrc.targetAddr, rsrc.payerAddr)
 	require.NoError(t, err)
 
 	channel := channels[chanid.String()]
 	assert.Equal(t, channelAmount, channel.Amount)
 	assert.Equal(t, voucherAmount, channel.AmountRedeemed)
 
-	series.CtxMiningOnce(ctx)
-
-	mcid, err = rsrc.payer.PaychReclaim(ctx, chanid, fast.AOFromAddr(rsrc.payerAddr), fast.AOPrice(big.NewFloat(1)), fast.AOLimit(300))
+	_, err = rsrc.miner.BlockMining.BlockMiningAPI.MiningOnce(ctx)
 	require.NoError(t, err)
 
-	series.CtxMiningOnce(ctx)
+	payerSender := newTestSender(t, types.NewAttoFIL(big.NewInt(1)), 300, rsrc.payerAddr, rsrc.payer)
+	mcid = payerSender.requireSend(ctx, address.PaymentBrokerAddress, types.NewAttoFILFromFIL(0), paymentbroker.Reclaim, chanid)
 
-	resp, err = rsrc.payer.MessageWait(ctx, mcid)
+	_, err = rsrc.miner.PorcelainAPI.MessagePoolWait(ctx, 1)
 	require.NoError(t, err)
-	assert.Equal(t, 0, int(resp.Receipt.ExitCode))
-	gasReceipt = gasReceipt.Add(resp.Receipt.GasAttoFIL)
+	_, err = rsrc.miner.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+	require.NoError(t, err)
 
-	channels, err = rsrc.payer.PaychLs(ctx, fast.AOFromAddr(rsrc.payerAddr))
+	rcpt, err = rsrc.payer.PorcelainAPI.MessageWaitDone(ctx, mcid)
+	require.NoError(t, err)
+	assert.Equal(t, 0, int(rcpt.ExitCode))
+	gasReceipt = gasReceipt.Add(rcpt.GasAttoFIL)
+
+	channels, err = rsrc.payer.PorcelainAPI.PaymentChannelLs(ctx, rsrc.payerAddr, rsrc.payerAddr)
 	require.NoError(t, err)
 	require.Len(t, channels, 0)
 
-	balanceAfter, err := rsrc.payer.WalletBalance(ctx, rsrc.payerAddr)
+	balanceAfter, err := rsrc.payer.PorcelainAPI.WalletBalance(ctx, rsrc.payerAddr)
 	require.NoError(t, err)
 
 	assert.Equal(t, balanceBefore.Sub(gasReceipt), balanceAfter.Add(voucherAmount))
@@ -320,75 +316,82 @@ func TestPaymentChannelReclaimSuccess(t *testing.T) {
 func TestPaymentChannelCloseSuccess(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{})
-
-	// Teardown after test ends
-	defer func() {
-		err := env.Teardown(ctx)
-		require.NoError(t, err)
-	}()
+	ctx := context.Background()
 
 	// Start test
-	rsrc := requireNewPaychResource(ctx, t, env)
+	rsrc := requireNewPaychResource(ctx, t)
 
 	channelExpiry := types.NewBlockHeight(5)
 	channelAmount := types.NewAttoFILFromFIL(1000)
 
-	payerBalanceBefore, err := rsrc.payer.WalletBalance(ctx, rsrc.payerAddr)
+	payerBalanceBefore, err := rsrc.payer.PorcelainAPI.WalletBalance(ctx, rsrc.payerAddr)
 	require.NoError(t, err)
 
-	targetBalanceBefore, err := rsrc.target.WalletBalance(ctx, rsrc.targetAddr)
+	targetBalanceBefore, err := rsrc.target.PorcelainAPI.WalletBalance(ctx, rsrc.targetAddr)
 	require.NoError(t, err)
 
 	chanid, gasReceiptForPaychCreate := rsrc.requirePaymentChannel(ctx, t, channelAmount, channelExpiry)
 
 	voucherAmount := types.NewAttoFILFromFIL(10)
 	voucherValidAt := types.NewBlockHeight(0)
-	voucherStr, err := rsrc.payer.PaychVoucher(ctx, chanid, voucherAmount, fast.AOFromAddr(rsrc.payerAddr), fast.AOValidAt(voucherValidAt))
+
+	voucher, err := rsrc.payer.PorcelainAPI.PaymentChannelVoucher(ctx, rsrc.payerAddr, chanid, voucherAmount, voucherValidAt, nil)
 	require.NoError(t, err)
 
-	mcid, err := rsrc.target.PaychClose(ctx, voucherStr, fast.AOFromAddr(rsrc.targetAddr), fast.AOPrice(big.NewFloat(1)), fast.AOLimit(300))
+	params := []interface{}{
+		voucher.Payer,
+		&voucher.Channel,
+		voucher.Amount,
+		&voucher.ValidAt,
+		voucher.Condition,
+		[]byte(voucher.Signature),
+		[]interface{}{},
+	}
+	sender := newTestSender(t, types.NewAttoFIL(big.NewInt(1)), 300, rsrc.targetAddr, rsrc.target)
+	mcid := sender.requireSend(ctx, address.PaymentBrokerAddress, types.NewAttoFILFromFIL(0), paymentbroker.Close, params...)
+
 	require.NoError(t, err)
 
-	series.CtxMiningOnce(ctx)
-
-	resp, err := rsrc.target.MessageWait(ctx, mcid)
+	_, err = rsrc.miner.PorcelainAPI.MessagePoolWait(ctx, 1)
 	require.NoError(t, err)
-	assert.Equal(t, 0, int(resp.Receipt.ExitCode))
+	_, err = rsrc.miner.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+	require.NoError(t, err)
 
-	channels, err := rsrc.target.PaychLs(ctx, fast.AOFromAddr(rsrc.payerAddr))
+	rcpt, err := rsrc.target.PorcelainAPI.MessageWaitDone(ctx, mcid)
+	require.NoError(t, err)
+	assert.Equal(t, 0, int(rcpt.ExitCode))
+
+	channels, err := rsrc.target.PorcelainAPI.PaymentChannelLs(ctx, rsrc.targetAddr, rsrc.payerAddr)
 	require.NoError(t, err)
 	require.Len(t, channels, 0)
 
-	payerBalanceAfter, err := rsrc.payer.WalletBalance(ctx, rsrc.payerAddr)
+	// payer must wait for close message to see correct balance
+	_, err = rsrc.payer.PorcelainAPI.MessageWaitDone(ctx, mcid)
+	require.NoError(t, err)
+
+	payerBalanceAfter, err := rsrc.payer.PorcelainAPI.WalletBalance(ctx, rsrc.payerAddr)
 	require.NoError(t, err)
 	assert.Equal(t, payerBalanceBefore.Sub(voucherAmount).Sub(gasReceiptForPaychCreate), payerBalanceAfter)
 
-	targetBalanceAfter, err := rsrc.target.WalletBalance(ctx, rsrc.targetAddr)
+	targetBalanceAfter, err := rsrc.target.PorcelainAPI.WalletBalance(ctx, rsrc.targetAddr)
 	require.NoError(t, err)
-	assert.Equal(t, targetBalanceBefore.Add(voucherAmount).Sub(resp.Receipt.GasAttoFIL), targetBalanceAfter)
+	assert.Equal(t, targetBalanceBefore.Add(voucherAmount).Sub(rcpt.GasAttoFIL), targetBalanceAfter)
 }
 
 func TestPaymentChannelExtendSuccess(t *testing.T) {
 	tf.IntegrationTest(t)
 
-	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{})
-
-	// Teardown after test ends
-	defer func() {
-		err := env.Teardown(ctx)
-		require.NoError(t, err)
-	}()
+	ctx := context.Background()
 
 	// Start test
-	rsrc := requireNewPaychResource(ctx, t, env)
+	rsrc := requireNewPaychResource(ctx, t)
 
 	channelExpiry := types.NewBlockHeight(5)
 	channelAmount := types.NewAttoFILFromFIL(1000)
 
 	chanid, _ := rsrc.requirePaymentChannel(ctx, t, channelAmount, channelExpiry)
 
-	channels, err := rsrc.payer.PaychLs(ctx)
+	channels, err := rsrc.payer.PorcelainAPI.PaymentChannelLs(ctx, rsrc.payerAddr, rsrc.payerAddr)
 	require.NoError(t, err)
 
 	assert.Len(t, channels, 1)
@@ -403,16 +406,25 @@ func TestPaymentChannelExtendSuccess(t *testing.T) {
 	extendAmount := types.NewAttoFILFromFIL(100)
 	extendExpiry := types.NewBlockHeight(100)
 
-	mcid, err := rsrc.payer.PaychExtend(ctx, chanid, extendAmount, extendExpiry, fast.AOFromAddr(rsrc.payerAddr), fast.AOPrice(big.NewFloat(1)), fast.AOLimit(300))
+	sender := newTestSender(t, types.NewAttoFIL(big.NewInt(1)), 300, rsrc.payerAddr, rsrc.payer)
+	mcid := sender.requireSend(
+		ctx,
+		address.PaymentBrokerAddress,
+		extendAmount,
+		paymentbroker.Extend,
+		chanid, extendExpiry,
+	)
+
+	_, err = rsrc.miner.PorcelainAPI.MessagePoolWait(ctx, 1)
+	require.NoError(t, err)
+	_, err = rsrc.miner.BlockMining.BlockMiningAPI.MiningOnce(ctx)
 	require.NoError(t, err)
 
-	series.CtxMiningOnce(ctx)
-
-	resp, err := rsrc.payer.MessageWait(ctx, mcid)
+	rcpt, err := rsrc.target.PorcelainAPI.MessageWaitDone(ctx, mcid)
 	require.NoError(t, err)
-	assert.Equal(t, 0, int(resp.Receipt.ExitCode))
+	assert.Equal(t, 0, int(rcpt.ExitCode))
 
-	channels, err = rsrc.payer.PaychLs(ctx)
+	channels, err = rsrc.target.PorcelainAPI.PaymentChannelLs(ctx, rsrc.targetAddr, rsrc.payerAddr)
 	require.NoError(t, err)
 
 	assert.Len(t, channels, 1)
@@ -427,23 +439,13 @@ func TestPaymentChannelExtendSuccess(t *testing.T) {
 
 func TestPaymentChannelCancelSuccess(t *testing.T) {
 	tf.IntegrationTest(t)
-
-	ctx, env := fastesting.NewTestEnvironment(context.Background(), t, fast.FilecoinOpts{})
-
-	// Teardown after test ends
-	defer func() {
-		err := env.Teardown(ctx)
-		require.NoError(t, err)
-	}()
-
+	ctx := context.Background()
 	// Start test
-	rsrc := requireNewPaychResource(ctx, t, env)
-
+	rsrc := requireNewPaychResource(ctx, t)
+	defer rsrc.Stop(ctx)
 	channelExpiry := types.NewBlockHeight(20000)
-
 	chanid, _ := rsrc.requirePaymentChannel(ctx, t, types.NewAttoFILFromFIL(1000), channelExpiry)
-
-	channels, err := rsrc.payer.PaychLs(ctx)
+	channels, err := rsrc.payer.PorcelainAPI.PaymentChannelLs(ctx, rsrc.payerAddr, address.Undef)
 	require.NoError(t, err)
 
 	assert.Len(t, channels, 1)
@@ -452,70 +454,142 @@ func TestPaymentChannelCancelSuccess(t *testing.T) {
 	assert.Equal(t, channelExpiry, channel.AgreedEol)
 	assert.Equal(t, channelExpiry, channel.Eol)
 
-	mcid, err := rsrc.payer.PaychCancel(ctx, chanid, fast.AOFromAddr(rsrc.payerAddr), fast.AOPrice(big.NewFloat(1)), fast.AOLimit(300))
+	require.NoError(t, err)
+	sender := newTestSender(t, types.NewAttoFIL(big.NewInt(1)), 300, rsrc.payerAddr, rsrc.payer)
+	mcid := sender.requireSend(
+		ctx,
+		address.PaymentBrokerAddress,
+		types.NewAttoFIL(big.NewInt(1)),
+		paymentbroker.Cancel,
+		chanid,
+	)
+
+	_, err = rsrc.miner.PorcelainAPI.MessagePoolWait(ctx, 1)
+	require.NoError(t, err)
+	_, err = rsrc.miner.BlockMining.BlockMiningAPI.MiningOnce(ctx)
 	require.NoError(t, err)
 
-	series.CtxMiningOnce(ctx)
-
-	resp, err := rsrc.payer.MessageWait(ctx, mcid)
+	rcpt, err := rsrc.payer.PorcelainAPI.MessageWaitDone(ctx, mcid)
 	require.NoError(t, err)
-	assert.Equal(t, 0, int(resp.Receipt.ExitCode))
+	assert.Equal(t, 0, int(rcpt.ExitCode))
 
-	channels, err = rsrc.payer.PaychLs(ctx)
+	channels, err = rsrc.payer.PorcelainAPI.PaymentChannelLs(ctx, rsrc.payerAddr, rsrc.payerAddr)
 	require.NoError(t, err)
 
 	assert.Len(t, channels, 1)
 
 	channel = channels[chanid.String()]
 	assert.Equal(t, channelExpiry, channel.AgreedEol)
-	assert.Equal(t, types.NewBlockHeight(10004), channel.Eol)
+	assert.Equal(t, types.NewBlockHeight(10002), channel.Eol)
 }
 
 type paychResources struct {
 	t *testing.T
 
-	target *fast.Filecoin
-	payer  *fast.Filecoin
+	target *node.Node
+	payer  *node.Node
+	miner  *node.Node
 
 	targetAddr address.Address
 	payerAddr  address.Address
 }
 
-func requireNewPaychResource(ctx context.Context, t *testing.T, env *fastesting.TestEnvironment) *paychResources {
-	targetDaemon := env.RequireNewNodeWithFunds(10000)
-	payerDaemon := env.RequireNewNodeWithFunds(10000)
+func requireNewPaychResource(ctx context.Context, t *testing.T) *paychResources {
+	cs := node.FixtureChainSeed(t)
 
-	addrs, err := targetDaemon.AddressLs(ctx)
-	require.NoError(t, err)
-	targetAddr := addrs[0]
+	builder := test.NewNodeBuilder(t)
+	buildWithMiner(t, builder)
 
-	addrs, err = payerDaemon.AddressLs(ctx)
+	builder1 := test.NewNodeBuilder(t)
+	defaultAddr1, err := address.NewFromString(fixtures.TestAddresses[1])
 	require.NoError(t, err)
-	payerAddr := addrs[0]
+	builder1.WithGenesisInit(cs.GenesisInitFunc)
+	builder1.WithConfig(node.DefaultAddressConfigOpt(defaultAddr1))
+	builder1.WithInitOpt(cs.KeyInitOpt(1))
+
+	builder2 := test.NewNodeBuilder(t)
+	defaultAddr2, err := address.NewFromString(fixtures.TestAddresses[2])
+	require.NoError(t, err)
+	builder2.WithGenesisInit(cs.GenesisInitFunc)
+	builder2.WithConfig(node.DefaultAddressConfigOpt(defaultAddr2))
+	builder2.WithInitOpt(cs.KeyInitOpt(2))
+
+	minerNode := builder.BuildAndStart(ctx)
+	targetNode := builder1.BuildAndStart(ctx)
+	payerNode := builder2.BuildAndStart(ctx)
+
+	node.ConnectNodes(t, minerNode, targetNode)
+	node.ConnectNodes(t, targetNode, payerNode)
+	node.ConnectNodes(t, payerNode, minerNode)
 
 	return &paychResources{
 		t: t,
 
-		target:     targetDaemon,
-		targetAddr: targetAddr,
+		target: targetNode,
+		payer:  payerNode,
+		miner:  minerNode,
 
-		payer:     payerDaemon,
-		payerAddr: payerAddr,
+		targetAddr: defaultAddr1,
+		payerAddr:  defaultAddr2,
 	}
 }
 
 func (rsrc *paychResources) requirePaymentChannel(ctx context.Context, t *testing.T, amt types.AttoFIL, eol *types.BlockHeight) (*types.ChannelID, types.AttoFIL) {
-	mcid, err := rsrc.payer.PaychCreate(ctx, rsrc.targetAddr, amt, eol, fast.AOFromAddr(rsrc.payerAddr), fast.AOPrice(big.NewFloat(1)), fast.AOLimit(300))
+	sender := newTestSender(t, types.NewAttoFIL(big.NewInt(1)), 300, rsrc.payerAddr, rsrc.payer)
+	mcid := sender.requireSend(ctx, address.PaymentBrokerAddress, amt, paymentbroker.CreateChannel, rsrc.targetAddr, eol)
+
+	_, err := rsrc.miner.PorcelainAPI.MessagePoolWait(ctx, 1)
+	require.NoError(t, err)
+	_, err = rsrc.miner.BlockMining.BlockMiningAPI.MiningOnce(ctx)
 	require.NoError(t, err)
 
-	series.CtxMiningOnce(ctx)
-
-	resp, err := rsrc.payer.MessageWait(ctx, mcid)
+	rcpt, err := rsrc.payer.PorcelainAPI.MessageWaitDone(ctx, mcid)
 	require.NoError(t, err)
-	assert.Equal(t, 0, int(resp.Receipt.ExitCode))
+	assert.Equal(t, 0, int(rcpt.ExitCode))
 
-	chanid := types.NewChannelIDFromBytes(resp.Receipt.Return[0])
+	chanid := types.NewChannelIDFromBytes(rcpt.Return[0])
 	require.NotNil(t, chanid)
 
-	return chanid, resp.Receipt.GasAttoFIL
+	return chanid, rcpt.GasAttoFIL
+}
+
+func (rsrc *paychResources) Stop(ctx context.Context) {
+	rsrc.miner.Stop(ctx)
+	rsrc.target.Stop(ctx)
+	rsrc.payer.Stop(ctx)
+}
+
+// messageSender is a test helper that makes message sending less verbose
+type messageSender struct {
+	t        *testing.T
+	gasPrice types.AttoFIL
+	gasLimit types.Uint64
+	from     address.Address
+
+	node *node.Node
+}
+
+func (ms *messageSender) requireSend(ctx context.Context, to address.Address, val types.AttoFIL, method types.MethodID, params ...interface{}) cid.Cid {
+	mcid, _, err := ms.node.PorcelainAPI.MessageSend(
+		ctx,
+		ms.from,
+		to,
+		val,
+		ms.gasPrice,
+		ms.gasLimit,
+		method,
+		params...,
+	)
+	require.NoError(ms.t, err)
+	return mcid
+}
+
+func newTestSender(t *testing.T, gp types.AttoFIL, gl types.Uint64, f address.Address, n *node.Node) *messageSender {
+	return &messageSender{
+		t:        t,
+		gasPrice: gp,
+		gasLimit: gl,
+		from:     f,
+		node:     n,
+	}
 }

--- a/internal/app/go-filecoin/porcelain/api.go
+++ b/internal/app/go-filecoin/porcelain/api.go
@@ -275,6 +275,6 @@ func (a *API) MinerSetWorkerAddress(ctx context.Context, toAddr address.Address,
 }
 
 // MessageWaitDone blocks until the message is on chain
-func (a *API) MessageWaitDone(ctx context.Context, msgCid cid.Cid) error {
+func (a *API) MessageWaitDone(ctx context.Context, msgCid cid.Cid) (*types.MessageReceipt, error) {
 	return MessageWaitDone(ctx, a, msgCid)
 }

--- a/internal/app/go-filecoin/porcelain/message.go
+++ b/internal/app/go-filecoin/porcelain/message.go
@@ -15,15 +15,17 @@ type waitPlumbing interface {
 }
 
 // MessageWaitDone blocks until the given message cid appears on chain
-func MessageWaitDone(ctx context.Context, plumbing waitPlumbing, msgCid cid.Cid) error {
+func MessageWaitDone(ctx context.Context, plumbing waitPlumbing, msgCid cid.Cid) (*types.MessageReceipt, error) {
 	l := moresync.NewLatch(1)
-	err := plumbing.MessageWait(ctx, msgCid, func(_ *block.Block, _ *types.SignedMessage, _ *types.MessageReceipt) error {
+	var ret *types.MessageReceipt
+	err := plumbing.MessageWait(ctx, msgCid, func(_ *block.Block, _ *types.SignedMessage, rcpt *types.MessageReceipt) error {
+		ret = rcpt
 		l.Done()
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	l.Wait()
-	return nil
+	return ret, nil
 }


### PR DESCRIPTION
### Motivation
Another follow on to #3712, this PR migrates the extensive fast-based payment channel daemon tests to in process integration tests.

### Proposed changes
This change is very straightforward and does not carry along any improvements to the framework, just migrated tests.

Closes issue #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

