### PR TITLE
Election PoSt prefactor: header data changes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -833,6 +833,8 @@ github.com/polydawn/refmt v0.0.0-20190221155625-df39d6c2d992 h1:bzMe+2coZJYHnhGg
 github.com/polydawn/refmt v0.0.0-20190221155625-df39d6c2d992/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
 github.com/polydawn/refmt v0.0.0-20190408063855-01bf1e26dd14 h1:2m16U/rLwVaRdz7ANkHtHTodP3zTP3N451MADg64x5k=
 github.com/polydawn/refmt v0.0.0-20190408063855-01bf1e26dd14/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
+github.com/polydawn/refmt v0.0.0-20190807091052-3d65705ee9f1 h1:CskT+S6Ay54OwxBGB0R3Rsx4Muto6UnEYTyKJbyRIAI=
+github.com/polydawn/refmt v0.0.0-20190807091052-3d65705ee9f1/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 h1:D+CiwcpGTW6pL6bv6KI3KbyEyCKyS+1JWS2h8PNDnGA=
@@ -902,6 +904,7 @@ github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa/go.mod h1:2
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v0.0.0-20190710185942-9d28bd7c0945 h1:N8Bg45zpk/UcpNGnfJt2y/3lRWASHNTUET8owPYCgYI=
 github.com/smartystreets/goconvey v0.0.0-20190710185942-9d28bd7c0945/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smola/gocompat v0.2.0 h1:6b1oIMlUXIpz//VKEDzPVBK8KG7beVwmHIUEBIs/Pns=
 github.com/smola/gocompat v0.2.0/go.mod h1:1B0MlxbmoZNo3h8guHp8HztB3BSYR5itql9qtVc0ypY=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -37,7 +37,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	vmerr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/errors"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
 )
 
 var log = logging.Logger("node") // nolint: deadcode
@@ -733,7 +732,7 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (*mining.DefaultWorker
 		MinerOwnerAddr: minerOwnerAddr,
 		WorkerSigner:   node.Wallet.Wallet,
 
-		GetStateTree:   node.getStateTree,
+		GetStateTree:   node.chain.ChainReader.GetTipSetState,
 		GetWeight:      node.getWeight,
 		GetAncestors:   node.getAncestors,
 		Election:       consensus.ElectionMachine{},
@@ -746,11 +745,6 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (*mining.DefaultWorker
 		Blockstore:    node.Blockstore.Blockstore,
 		Clock:         node.ChainClock,
 	}), nil
-}
-
-// getStateTree is the default GetStateTree function for the mining worker.
-func (node *Node) getStateTree(ctx context.Context, ts block.TipSet) (state.Tree, error) {
-	return node.chain.ChainReader.GetTipSetState(ctx, ts.Key())
 }
 
 // getWeight is the default GetWeight function for the mining worker.

--- a/internal/pkg/block/block.go
+++ b/internal/pkg/block/block.go
@@ -33,7 +33,6 @@ type Block struct {
 	Height types.Uint64 `json:"height"`
 
 	// Messages is the set of messages included in this block
-	// TODO: should be a merkletree-ish thing
 	Messages types.TxMeta `json:"messages,omitempty" refmt:",omitempty"`
 
 	// StateRoot is a cid pointer to the state tree after application of the
@@ -46,6 +45,21 @@ type Block struct {
 	// DeprecatedElectionProof is the "scratched ticket" proving that this block won
 	// an election.
 	DeprecatedElectionProof VRFPi `json:"proof"`
+
+	// PoStRandomness is the verifiable randomness used to generate postCandidates
+	PoStRandomness VRFPi `json:"postRandomness"`
+
+	// PoStCandidatePartialTickets are the winning PoSt tickets submitted with this block
+	PoStPartialTickets [][]byte `json:"postCandidates"`
+
+	// PoStSectorIDs are the sector ids of the winning PoSt tickets
+	PoStSectorIDs []types.Uint64 `json:"postSectorIDs"`
+
+	// PoStChallengeIDXs are the challenge indexes within the sector for the winning PoSt tickets
+	PoStChallengeIDXs []types.Uint64 `json:"postChallengeIDXs"`
+
+	// PoStProof is the snark output proving that the PoSt tickets are valid
+	PoStProof types.PoStProof `json:"postProof"`
 
 	// The timestamp, in seconds since the Unix epoch, at which this block was created.
 	Timestamp types.Uint64 `json:"timestamp"`
@@ -146,6 +160,11 @@ func (b *Block) SignatureData() []byte {
 		StateRoot:               b.StateRoot,
 		MessageReceipts:         b.MessageReceipts,
 		DeprecatedElectionProof: b.DeprecatedElectionProof,
+		PoStRandomness:          b.PoStRandomness,
+		PoStPartialTickets:      b.PoStPartialTickets,
+		PoStSectorIDs:           b.PoStSectorIDs,
+		PoStChallengeIDXs:       b.PoStChallengeIDXs,
+		PoStProof:               b.PoStProof,
 		Timestamp:               b.Timestamp,
 		BLSAggregateSig:         b.BLSAggregateSig,
 		// BlockSig omitted

--- a/internal/pkg/block/block.go
+++ b/internal/pkg/block/block.go
@@ -43,9 +43,9 @@ type Block struct {
 	// MessageReceipts is a set of receipts matching to the sending of the `Messages`.
 	MessageReceipts cid.Cid `json:"messageReceipts,omitempty" refmt:",omitempty"`
 
-	// ElectionProof is the "scratched ticket" proving that this block won
+	// DeprecatedElectionProof is the "scratched ticket" proving that this block won
 	// an election.
-	ElectionProof VRFPi `json:"proof"`
+	DeprecatedElectionProof VRFPi `json:"proof"`
 
 	// The timestamp, in seconds since the Unix epoch, at which this block was created.
 	Timestamp types.Uint64 `json:"timestamp"`
@@ -137,17 +137,17 @@ func (b *Block) Equals(other *Block) bool {
 // creating and verification
 func (b *Block) SignatureData() []byte {
 	tmp := &Block{
-		Miner:           b.Miner,
-		Ticket:          b.Ticket,  // deep copy needed??
-		Parents:         b.Parents, // deep copy needed??
-		ParentWeight:    b.ParentWeight,
-		Height:          b.Height,
-		Messages:        b.Messages,
-		StateRoot:       b.StateRoot,
-		MessageReceipts: b.MessageReceipts,
-		ElectionProof:   b.ElectionProof,
-		Timestamp:       b.Timestamp,
-		BLSAggregateSig: b.BLSAggregateSig,
+		Miner:                   b.Miner,
+		Ticket:                  b.Ticket,  // deep copy needed??
+		Parents:                 b.Parents, // deep copy needed??
+		ParentWeight:            b.ParentWeight,
+		Height:                  b.Height,
+		Messages:                b.Messages,
+		StateRoot:               b.StateRoot,
+		MessageReceipts:         b.MessageReceipts,
+		DeprecatedElectionProof: b.DeprecatedElectionProof,
+		Timestamp:               b.Timestamp,
+		BLSAggregateSig:         b.BLSAggregateSig,
 		// BlockSig omitted
 	}
 

--- a/internal/pkg/block/block_test.go
+++ b/internal/pkg/block/block_test.go
@@ -63,18 +63,18 @@ func TestTriangleEncoding(t *testing.T) {
 		// pass when non-zero values do not due to nil/null encoding.
 
 		b := &blk.Block{
-			Miner:           newAddress(),
-			Ticket:          blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
-			Height:          types.Uint64(2),
-			Messages:        types.TxMeta{SecpRoot: types.CidFromString(t, "somecid"), BLSRoot: types.EmptyMessagesCID},
-			MessageReceipts: types.CidFromString(t, "somecid"),
-			Parents:         blk.NewTipSetKey(types.CidFromString(t, "somecid")),
-			ParentWeight:    types.Uint64(1000),
-			ElectionProof:   types.NewTestPoSt(),
-			StateRoot:       types.CidFromString(t, "somecid"),
-			Timestamp:       types.Uint64(1),
-			BlockSig:        []byte{0x3},
-			BLSAggregateSig: []byte{0x3},
+			Miner:                   newAddress(),
+			Ticket:                  blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
+			Height:                  types.Uint64(2),
+			Messages:                types.TxMeta{SecpRoot: types.CidFromString(t, "somecid"), BLSRoot: types.EmptyMessagesCID},
+			MessageReceipts:         types.CidFromString(t, "somecid"),
+			Parents:                 blk.NewTipSetKey(types.CidFromString(t, "somecid")),
+			ParentWeight:            types.Uint64(1000),
+			DeprecatedElectionProof: types.NewTestPoSt(),
+			StateRoot:               types.CidFromString(t, "somecid"),
+			Timestamp:               types.Uint64(1),
+			BlockSig:                []byte{0x3},
+			BLSAggregateSig:         []byte{0x3},
 		}
 		s := reflect.TypeOf(*b)
 		// This check is here to request that you add a non-zero value for new fields
@@ -227,31 +227,31 @@ func TestSignatureData(t *testing.T) {
 	newAddress := address.NewForTestGetter()
 
 	b := &blk.Block{
-		Miner:           newAddress(),
-		Ticket:          blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
-		Height:          types.Uint64(2),
-		Messages:        types.TxMeta{SecpRoot: types.CidFromString(t, "somecid"), BLSRoot: types.EmptyMessagesCID},
-		MessageReceipts: types.CidFromString(t, "somecid"),
-		Parents:         blk.NewTipSetKey(types.CidFromString(t, "somecid")),
-		ParentWeight:    types.Uint64(1000),
-		ElectionProof:   []byte{0x1},
-		StateRoot:       types.CidFromString(t, "somecid"),
-		Timestamp:       types.Uint64(1),
-		BlockSig:        []byte{0x3},
+		Miner:                   newAddress(),
+		Ticket:                  blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
+		Height:                  types.Uint64(2),
+		Messages:                types.TxMeta{SecpRoot: types.CidFromString(t, "somecid"), BLSRoot: types.EmptyMessagesCID},
+		MessageReceipts:         types.CidFromString(t, "somecid"),
+		Parents:                 blk.NewTipSetKey(types.CidFromString(t, "somecid")),
+		ParentWeight:            types.Uint64(1000),
+		DeprecatedElectionProof: []byte{0x1},
+		StateRoot:               types.CidFromString(t, "somecid"),
+		Timestamp:               types.Uint64(1),
+		BlockSig:                []byte{0x3},
 	}
 
 	diff := &blk.Block{
-		Miner:           newAddress(),
-		Ticket:          blk.Ticket{VRFProof: []byte{0x03, 0x01, 0x02}},
-		Height:          types.Uint64(3),
-		Messages:        types.TxMeta{SecpRoot: types.CidFromString(t, "someothercid"), BLSRoot: types.EmptyMessagesCID},
-		MessageReceipts: types.CidFromString(t, "someothercid"),
-		Parents:         blk.NewTipSetKey(types.CidFromString(t, "someothercid")),
-		ParentWeight:    types.Uint64(1001),
-		ElectionProof:   []byte{0x2},
-		StateRoot:       types.CidFromString(t, "someothercid"),
-		Timestamp:       types.Uint64(4),
-		BlockSig:        []byte{0x4},
+		Miner:                   newAddress(),
+		Ticket:                  blk.Ticket{VRFProof: []byte{0x03, 0x01, 0x02}},
+		Height:                  types.Uint64(3),
+		Messages:                types.TxMeta{SecpRoot: types.CidFromString(t, "someothercid"), BLSRoot: types.EmptyMessagesCID},
+		MessageReceipts:         types.CidFromString(t, "someothercid"),
+		Parents:                 blk.NewTipSetKey(types.CidFromString(t, "someothercid")),
+		ParentWeight:            types.Uint64(1001),
+		DeprecatedElectionProof: []byte{0x2},
+		StateRoot:               types.CidFromString(t, "someothercid"),
+		Timestamp:               types.Uint64(4),
+		BlockSig:                []byte{0x4},
 	}
 
 	// Changing BlockSig does not affect output
@@ -349,10 +349,10 @@ func TestSignatureData(t *testing.T) {
 	func() {
 		before := b.SignatureData()
 
-		cpy := b.ElectionProof
-		defer func() { b.ElectionProof = cpy }()
+		cpy := b.DeprecatedElectionProof
+		defer func() { b.DeprecatedElectionProof = cpy }()
 
-		b.ElectionProof = diff.ElectionProof
+		b.DeprecatedElectionProof = diff.DeprecatedElectionProof
 		after := b.SignatureData()
 		assert.False(t, bytes.Equal(before, after))
 	}()

--- a/internal/pkg/block/block_test.go
+++ b/internal/pkg/block/block_test.go
@@ -75,6 +75,11 @@ func TestTriangleEncoding(t *testing.T) {
 			Timestamp:               types.Uint64(1),
 			BlockSig:                []byte{0x3},
 			BLSAggregateSig:         []byte{0x3},
+			PoStPartialTickets:      [][]byte{{0x05}, {0x04}},
+			PoStSectorIDs:           []types.Uint64{types.Uint64(5), types.Uint64(3)},
+			PoStChallengeIDXs:       []types.Uint64{types.Uint64(52), types.Uint64(3000)},
+			PoStProof:               []byte{0x07},
+			PoStRandomness:          []byte{0x02, 0x06},
 		}
 		s := reflect.TypeOf(*b)
 		// This check is here to request that you add a non-zero value for new fields
@@ -82,7 +87,7 @@ func TestTriangleEncoding(t *testing.T) {
 		// Also please add non zero fields to "b" and "diff" in TestSignatureData
 		// and add a new check that different values of the new field result in
 		// different output data.
-		require.Equal(t, 14, s.NumField()) // Note: this also counts private fields
+		require.Equal(t, 19, s.NumField()) // Note: this also counts private fields
 		testRoundTrip(t, b)
 	})
 }
@@ -237,6 +242,11 @@ func TestSignatureData(t *testing.T) {
 		DeprecatedElectionProof: []byte{0x1},
 		StateRoot:               types.CidFromString(t, "somecid"),
 		Timestamp:               types.Uint64(1),
+		PoStPartialTickets:      [][]byte{{0x05}, {0x04}},
+		PoStSectorIDs:           []types.Uint64{types.Uint64(5), types.Uint64(3)},
+		PoStChallengeIDXs:       []types.Uint64{types.Uint64(52), types.Uint64(3000)},
+		PoStProof:               []byte{0x07},
+		PoStRandomness:          []byte{0x02, 0x06},
 		BlockSig:                []byte{0x3},
 	}
 
@@ -251,6 +261,11 @@ func TestSignatureData(t *testing.T) {
 		DeprecatedElectionProof: []byte{0x2},
 		StateRoot:               types.CidFromString(t, "someothercid"),
 		Timestamp:               types.Uint64(4),
+		PoStPartialTickets:      [][]byte{{0x04}, {0x05}},
+		PoStSectorIDs:           []types.Uint64{types.Uint64(0), types.Uint64(1)},
+		PoStChallengeIDXs:       []types.Uint64{types.Uint64(25), types.Uint64(3001)},
+		PoStProof:               []byte{0x17},
+		PoStRandomness:          []byte{0x12, 0x16},
 		BlockSig:                []byte{0x4},
 	}
 
@@ -375,6 +390,61 @@ func TestSignatureData(t *testing.T) {
 		defer func() { b.Timestamp = cpy }()
 
 		b.Timestamp = diff.Timestamp
+		after := b.SignatureData()
+		assert.False(t, bytes.Equal(before, after))
+	}()
+
+	func() {
+		before := b.SignatureData()
+
+		cpy := b.PoStRandomness
+		defer func() { b.PoStRandomness = cpy }()
+
+		b.PoStRandomness = diff.PoStRandomness
+		after := b.SignatureData()
+		assert.False(t, bytes.Equal(before, after))
+	}()
+
+	func() {
+		before := b.SignatureData()
+
+		cpy := b.PoStProof
+		defer func() { b.PoStProof = cpy }()
+
+		b.PoStProof = diff.PoStProof
+		after := b.SignatureData()
+		assert.False(t, bytes.Equal(before, after))
+	}()
+
+	func() {
+		before := b.SignatureData()
+
+		cpy := b.PoStPartialTickets
+		defer func() { b.PoStPartialTickets = cpy }()
+
+		b.PoStPartialTickets = diff.PoStPartialTickets
+		after := b.SignatureData()
+		assert.False(t, bytes.Equal(before, after))
+	}()
+
+	func() {
+		before := b.SignatureData()
+
+		cpy := b.PoStSectorIDs
+		defer func() { b.PoStSectorIDs = cpy }()
+
+		b.PoStSectorIDs = diff.PoStSectorIDs
+		after := b.SignatureData()
+		assert.False(t, bytes.Equal(before, after))
+	}()
+
+	func() {
+		before := b.SignatureData()
+
+		cpy := b.PoStChallengeIDXs
+		defer func() { b.PoStChallengeIDXs = cpy }()
+
+		b.PoStChallengeIDXs = diff.PoStChallengeIDXs
 		after := b.SignatureData()
 		assert.False(t, bytes.Equal(before, after))
 	}()

--- a/internal/pkg/block/ticket.go
+++ b/internal/pkg/block/ticket.go
@@ -6,9 +6,9 @@ import (
 
 // A Ticket is a marker of a tick of the blockchain's clock.  It is the source
 // of randomness for proofs of storage and leader election.  It is generated
-// by the miner of a block using a VRF and a VDF.
+// by the miner of a block using a VRF.
 type Ticket struct {
-	// A proof output by running a VRF on the VDFResult of the parent ticket
+	// A proof output by running a VRF on the VRFProof of the parent ticket
 	VRFProof VRFPi
 }
 

--- a/internal/pkg/consensus/block_validation.go
+++ b/internal/pkg/consensus/block_validation.go
@@ -125,6 +125,13 @@ func (dv *DefaultBlockValidator) ValidateSyntax(ctx context.Context, blk *block.
 		return fmt.Errorf("block %s has nil ticket", blk.Cid().String())
 	}
 
+	ptl := len(blk.PoStPartialTickets)
+	sil := len(blk.PoStSectorIDs)
+	cil := len(blk.PoStChallengeIDXs)
+	if ptl != sil || sil != cil {
+		return fmt.Errorf("block %s has invalid PoSt data fields of different lengths", blk.Cid().String())
+	}
+
 	return nil
 }
 

--- a/internal/pkg/consensus/block_validation_test.go
+++ b/internal/pkg/consensus/block_validation_test.go
@@ -102,9 +102,9 @@ func TestBlockValidSyntax(t *testing.T) {
 	validSt := types.NewCidForTestGetter()()
 	validAd := address.NewForTestGetter()()
 	validTi := block.Ticket{VRFProof: []byte{1}}
-	validPoStPartialTickets := [][]byte{[]byte{1}}
-	validPoStSectorIDs := []types.Uint64{1}	
-	validPoStChallengeIDXs := []types.Uint64{1}		
+	validPoStPartialTickets := [][]byte{{1}}
+	validPoStSectorIDs := []types.Uint64{1}
+	validPoStChallengeIDXs := []types.Uint64{1}
 	// create a valid block
 	blk := &block.Block{
 		Timestamp: validTs,
@@ -146,8 +146,8 @@ func TestBlockValidSyntax(t *testing.T) {
 	blk.Ticket = validTi
 	require.NoError(t, validator.ValidateSyntax(ctx, blk))
 
-	// invalidate PoSt 
-	blk.PoStSectorIDs = []types.Uint64{0,5,3}
+	// invalidate PoSt
+	blk.PoStSectorIDs = []types.Uint64{0, 5, 3}
 	require.Error(t, validator.ValidateSyntax(ctx, blk))
 	blk.PoStSectorIDs = validPoStSectorIDs
 	require.NoError(t, validator.ValidateSyntax(ctx, blk))

--- a/internal/pkg/consensus/block_validation_test.go
+++ b/internal/pkg/consensus/block_validation_test.go
@@ -102,6 +102,9 @@ func TestBlockValidSyntax(t *testing.T) {
 	validSt := types.NewCidForTestGetter()()
 	validAd := address.NewForTestGetter()()
 	validTi := block.Ticket{VRFProof: []byte{1}}
+	validPoStPartialTickets := [][]byte{[]byte{1}}
+	validPoStSectorIDs := []types.Uint64{1}	
+	validPoStChallengeIDXs := []types.Uint64{1}		
 	// create a valid block
 	blk := &block.Block{
 		Timestamp: validTs,
@@ -109,6 +112,10 @@ func TestBlockValidSyntax(t *testing.T) {
 		Miner:     validAd,
 		Ticket:    validTi,
 		Height:    1,
+
+		PoStPartialTickets: validPoStPartialTickets,
+		PoStSectorIDs:      validPoStSectorIDs,
+		PoStChallengeIDXs:  validPoStChallengeIDXs,
 	}
 	require.NoError(t, validator.ValidateSyntax(ctx, blk))
 
@@ -137,6 +144,12 @@ func TestBlockValidSyntax(t *testing.T) {
 	blk.Ticket = block.Ticket{}
 	require.Error(t, validator.ValidateSyntax(ctx, blk))
 	blk.Ticket = validTi
+	require.NoError(t, validator.ValidateSyntax(ctx, blk))
+
+	// invalidate PoSt 
+	blk.PoStSectorIDs = []types.Uint64{0,5,3}
+	require.Error(t, validator.ValidateSyntax(ctx, blk))
+	blk.PoStSectorIDs = validPoStSectorIDs
 	require.NoError(t, validator.ValidateSyntax(ctx, blk))
 
 }

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -239,9 +239,9 @@ func (c *Expected) validateMining(
 			}
 		}
 
-		// Validate ElectionProof
+		// Validate DeprecatedElectionProof
 		nullBlkCount := uint64(blk.Height) - prevHeight - 1
-		result, err := c.IsElectionWinner(ctx, pwrTableView, electionTicket, nullBlkCount, blk.ElectionProof, workerAddr, blk.Miner)
+		result, err := c.IsElectionWinner(ctx, pwrTableView, electionTicket, nullBlkCount, blk.DeprecatedElectionProof, workerAddr, blk.Miner)
 		if err != nil {
 			return errors.Wrap(err, "failed checking election proof")
 		}

--- a/internal/pkg/consensus/testing.go
+++ b/internal/pkg/consensus/testing.go
@@ -137,7 +137,7 @@ type FakeElectionMachine struct{}
 
 // RunElection returns a fake election proof.
 func (fem *FakeElectionMachine) RunElection(ticket block.Ticket, candidateAddr address.Address, signer types.Signer, nullCount uint64) (block.VRFPi, error) {
-	return MakeFakeElectionProofForTest(), nil
+	return MakeFakeDeprecatedElectionProofForTest(), nil
 }
 
 // IsElectionWinner always returns true
@@ -183,8 +183,8 @@ func MakeFakeTicketForTest() block.Ticket {
 	}
 }
 
-// MakeFakeElectionProofForTest creates a fake election proof
-func MakeFakeElectionProofForTest() []byte {
+// MakeFakeDeprecatedElectionProofForTest creates a fake election proof
+func MakeFakeDeprecatedElectionProofForTest() []byte {
 	proof := make([]byte, 65)
 	proof[0] = 42
 	return proof
@@ -314,7 +314,7 @@ func NewMockElectionMachine(f func(block.Ticket)) *MockElectionMachine {
 // RunElection calls the registered callback and returns a fake proof
 func (mem *MockElectionMachine) RunElection(ticket block.Ticket, candidateAddr address.Address, signer types.Signer, nullCount uint64) (block.VRFPi, error) {
 	mem.fn(ticket)
-	return MakeFakeElectionProofForTest(), nil
+	return MakeFakeDeprecatedElectionProofForTest(), nil
 }
 
 // IsElectionWinner calls the registered callback and returns true

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -129,17 +129,17 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 
 	now := w.clock.Now()
 	next := &block.Block{
-		Miner:           w.minerAddr,
-		Height:          types.Uint64(blockHeight),
-		Messages:        txMeta,
-		MessageReceipts: baseReceiptRoot,
-		Parents:         baseTipSet.Key(),
-		ParentWeight:    types.Uint64(weight),
-		ElectionProof:   electionProof,
-		StateRoot:       baseStateRoot,
-		Ticket:          ticket,
-		Timestamp:       types.Uint64(now.Unix()),
-		BLSAggregateSig: blsAggregateSig,
+		Miner:                   w.minerAddr,
+		Height:                  types.Uint64(blockHeight),
+		Messages:                txMeta,
+		MessageReceipts:         baseReceiptRoot,
+		Parents:                 baseTipSet.Key(),
+		ParentWeight:            types.Uint64(weight),
+		DeprecatedElectionProof: electionProof,
+		StateRoot:               baseStateRoot,
+		Ticket:                  ticket,
+		Timestamp:               types.Uint64(now.Unix()),
+		BLSAggregateSig:         blsAggregateSig,
 	}
 
 	workerAddr, err := w.api.MinerGetWorkerAddress(ctx, w.minerAddr, baseTipSet.Key())

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -29,7 +29,7 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 		log.Infof("[TIMER] DefaultWorker.Generate baseTipset: %s - elapsed time: %s", baseTipSet.String(), time.Since(generateTimer).Round(time.Millisecond))
 	}()
 
-	stateTree, err := w.getStateTree(ctx, baseTipSet)
+	stateTree, err := w.getStateTree(ctx, baseTipSet.Key())
 	if err != nil {
 		return nil, errors.Wrap(err, "get state tree")
 	}

--- a/internal/pkg/mining/scheduler_test.go
+++ b/internal/pkg/mining/scheduler_test.go
@@ -43,7 +43,7 @@ func TestMineOnce10Null(t *testing.T) {
 	require.NoError(t, err)
 
 	st, pool, _, bs := sharedSetup(t, mockSigner)
-	getStateTree := func(c context.Context, ts block.TipSet) (state.Tree, error) {
+	getStateTree := func(c context.Context, tsKey block.TipSetKey) (state.Tree, error) {
 		return st, nil
 	}
 	getAncestors := func(ctx context.Context, ts block.TipSet, newBlockHeight *types.BlockHeight) ([]block.TipSet, error) {
@@ -106,7 +106,7 @@ func TestMineOneEpoch10Null(t *testing.T) {
 	require.NoError(t, err)
 
 	st, pool, _, bs := sharedSetup(t, mockSigner)
-	getStateTree := func(c context.Context, ts block.TipSet) (state.Tree, error) {
+	getStateTree := func(c context.Context, tsKey block.TipSetKey) (state.Tree, error) {
 		return st, nil
 	}
 	getAncestors := func(ctx context.Context, ts block.TipSet, newBlockHeight *types.BlockHeight) ([]block.TipSet, error) {

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -47,7 +47,7 @@ type Worker interface {
 
 // GetStateTree is a function that gets the aggregate state tree of a TipSet. It's
 // its own function to facilitate testing.
-type GetStateTree func(context.Context, block.TipSet) (state.Tree, error)
+type GetStateTree func(context.Context, block.TipSetKey) (state.Tree, error)
 
 // GetWeight is a function that calculates the weight of a TipSet.  Weight is
 // expressed as two uint64s comprising a rational number.

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -44,7 +44,7 @@ func TestLookbackElection(t *testing.T) {
 	ancestors := builder.RequireTipSets(head.Key(), lookback)
 
 	st, pool, addrs, bs := sharedSetup(t, mockSignerVal)
-	getStateTree := func(c context.Context, ts block.TipSet) (state.Tree, error) {
+	getStateTree := func(c context.Context, tsKey block.TipSetKey) (state.Tree, error) {
 		return st, nil
 	}
 	getAncestors := func(ctx context.Context, ts block.TipSet, newBlockHeight *types.BlockHeight) ([]block.TipSet, error) {
@@ -142,7 +142,7 @@ func Test_Mine(t *testing.T) {
 	tipSet := th.RequireNewTipSet(t, baseBlock)
 
 	st, pool, addrs, bs := sharedSetup(t, mockSignerVal)
-	getStateTree := func(c context.Context, ts block.TipSet) (state.Tree, error) {
+	getStateTree := func(c context.Context, tsKey block.TipSetKey) (state.Tree, error) {
 		return st, nil
 	}
 	getAncestors := func(ctx context.Context, ts block.TipSet, newBlockHeight *types.BlockHeight) ([]block.TipSet, error) {
@@ -357,7 +357,7 @@ func TestApplyBLSMessages(t *testing.T) {
 	tipSet := th.RequireNewTipSet(t, baseBlock)
 
 	st, pool, addrs, bs := sharedSetup(t, mockSignerVal)
-	getStateTree := func(c context.Context, ts block.TipSet) (state.Tree, error) {
+	getStateTree := func(c context.Context, tsKey block.TipSetKey) (state.Tree, error) {
 		return st, nil
 	}
 	getAncestors := func(ctx context.Context, ts block.TipSet, newBlockHeight *types.BlockHeight) ([]block.TipSet, error) {
@@ -474,7 +474,7 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 
 	mockSigner, blockSignerAddr := setupSigner()
 	st, pool, addrs, bs := sharedSetup(t, mockSigner)
-	getStateTree := func(c context.Context, ts block.TipSet) (state.Tree, error) {
+	getStateTree := func(c context.Context, tsKey block.TipSetKey) (state.Tree, error) {
 		return st, nil
 	}
 	getAncestors := func(ctx context.Context, ts block.TipSet, newBlockHeight *types.BlockHeight) ([]block.TipSet, error) {
@@ -543,7 +543,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 	newCid := types.NewCidForTestGetter()
 	st, pool, addrs, bs := sharedSetup(t, mockSigner)
 
-	getStateTree := func(c context.Context, ts block.TipSet) (state.Tree, error) {
+	getStateTree := func(c context.Context, tsKey block.TipSetKey) (state.Tree, error) {
 		return st, nil
 	}
 	getAncestors := func(ctx context.Context, ts block.TipSet, newBlockHeight *types.BlockHeight) ([]block.TipSet, error) {
@@ -646,7 +646,7 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 
 	st, pool, addrs, bs := sharedSetup(t, mockSigner)
 
-	getStateTree := func(c context.Context, ts block.TipSet) (state.Tree, error) {
+	getStateTree := func(c context.Context, tsKey block.TipSetKey) (state.Tree, error) {
 		return st, nil
 	}
 	getAncestors := func(ctx context.Context, ts block.TipSet, newBlockHeight *types.BlockHeight) ([]block.TipSet, error) {
@@ -712,7 +712,7 @@ func TestGenerateWithoutMessages(t *testing.T) {
 	newCid := types.NewCidForTestGetter()
 
 	st, pool, addrs, bs := sharedSetup(t, mockSigner)
-	getStateTree := func(c context.Context, ts block.TipSet) (state.Tree, error) {
+	getStateTree := func(c context.Context, tsKey block.TipSetKey) (state.Tree, error) {
 		return st, nil
 	}
 	getAncestors := func(ctx context.Context, ts block.TipSet, newBlockHeight *types.BlockHeight) ([]block.TipSet, error) {
@@ -769,7 +769,7 @@ func TestGenerateError(t *testing.T) {
 
 	st, pool, addrs, bs := sharedSetup(t, mockSigner)
 
-	getStateTree := func(c context.Context, ts block.TipSet) (state.Tree, error) {
+	getStateTree := func(c context.Context, tsKey block.TipSetKey) (state.Tree, error) {
 		return st, nil
 	}
 	getAncestors := func(ctx context.Context, ts block.TipSet, newBlockHeight *types.BlockHeight) ([]block.TipSet, error) {

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -515,7 +515,7 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 	baseTipset := builder.AppendOn(parentTipset, 2)
 	assert.Equal(t, 2, baseTipset.Len())
 
-	blk, err := worker.Generate(ctx, baseTipset, block.Ticket{VRFProof: []byte{2}}, consensus.MakeFakeElectionProofForTest(), 0)
+	blk, err := worker.Generate(ctx, baseTipset, block.Ticket{VRFProof: []byte{2}}, consensus.MakeFakeDeprecatedElectionProofForTest(), 0)
 
 	assert.NoError(t, err)
 
@@ -616,12 +616,12 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 	require.NoError(t, err)
 
 	baseBlock := block.Block{
-		Parents:       block.NewTipSetKey(newCid()),
-		Height:        types.Uint64(100),
-		StateRoot:     stateRoot,
-		ElectionProof: consensus.MakeFakeElectionProofForTest(),
+		Parents:                 block.NewTipSetKey(newCid()),
+		Height:                  types.Uint64(100),
+		StateRoot:               stateRoot,
+		DeprecatedElectionProof: consensus.MakeFakeDeprecatedElectionProofForTest(),
 	}
-	blk, err := worker.Generate(ctx, th.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeElectionProofForTest(), 0)
+	blk, err := worker.Generate(ctx, th.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeDeprecatedElectionProofForTest(), 0)
 	assert.NoError(t, err)
 
 	// This is the temporary failure + the good message,
@@ -682,21 +682,21 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 	h := types.Uint64(100)
 	w := types.Uint64(1000)
 	baseBlock := block.Block{
-		Height:        h,
-		ParentWeight:  w,
-		StateRoot:     newCid(),
-		ElectionProof: consensus.MakeFakeElectionProofForTest(),
+		Height:                  h,
+		ParentWeight:            w,
+		StateRoot:               newCid(),
+		DeprecatedElectionProof: consensus.MakeFakeDeprecatedElectionProofForTest(),
 	}
 	baseTipSet := th.RequireNewTipSet(t, &baseBlock)
 	ticket := mining.NthTicket(7)
-	blk, err := worker.Generate(ctx, baseTipSet, ticket, consensus.MakeFakeElectionProofForTest(), 0)
+	blk, err := worker.Generate(ctx, baseTipSet, ticket, consensus.MakeFakeDeprecatedElectionProofForTest(), 0)
 	assert.NoError(t, err)
 
 	assert.Equal(t, h+1, blk.Height)
 	assert.Equal(t, minerAddr, blk.Miner)
 	assert.Equal(t, ticket, blk.Ticket)
 
-	blk, err = worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeElectionProofForTest(), 1)
+	blk, err = worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeDeprecatedElectionProofForTest(), 1)
 	assert.NoError(t, err)
 
 	assert.Equal(t, h+2, blk.Height)
@@ -744,12 +744,12 @@ func TestGenerateWithoutMessages(t *testing.T) {
 
 	assert.Len(t, pool.Pending(), 0)
 	baseBlock := block.Block{
-		Parents:       block.NewTipSetKey(newCid()),
-		Height:        types.Uint64(100),
-		StateRoot:     newCid(),
-		ElectionProof: consensus.MakeFakeElectionProofForTest(),
+		Parents:                 block.NewTipSetKey(newCid()),
+		Height:                  types.Uint64(100),
+		StateRoot:               newCid(),
+		DeprecatedElectionProof: consensus.MakeFakeDeprecatedElectionProofForTest(),
 	}
-	blk, err := worker.Generate(ctx, th.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeElectionProofForTest(), 0)
+	blk, err := worker.Generate(ctx, th.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeDeprecatedElectionProofForTest(), 0)
 	assert.NoError(t, err)
 
 	assert.Len(t, pool.Pending(), 0) // This is the temporary failure.
@@ -807,13 +807,13 @@ func TestGenerateError(t *testing.T) {
 
 	assert.Len(t, pool.Pending(), 1)
 	baseBlock := block.Block{
-		Parents:       block.NewTipSetKey(newCid()),
-		Height:        types.Uint64(100),
-		StateRoot:     newCid(),
-		ElectionProof: consensus.MakeFakeElectionProofForTest(),
+		Parents:                 block.NewTipSetKey(newCid()),
+		Height:                  types.Uint64(100),
+		StateRoot:               newCid(),
+		DeprecatedElectionProof: consensus.MakeFakeDeprecatedElectionProofForTest(),
 	}
 	baseTipSet := th.RequireNewTipSet(t, &baseBlock)
-	blk, err := worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeElectionProofForTest(), 0)
+	blk, err := worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeDeprecatedElectionProofForTest(), 0)
 	assert.Error(t, err, "boom")
 	assert.Nil(t, blk)
 

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -24,20 +24,20 @@ import (
 // RequireSignedTestBlockFromTipSet creates a block with a valid signature by
 // the passed in miner work and a Miner field set to the minerAddr.
 func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, stateRootCid cid.Cid, receiptRootCid cid.Cid, height uint64, minerAddr address.Address, minerWorker address.Address, signer types.Signer) *block.Block {
-	electionProof := consensus.MakeFakeElectionProofForTest()
+	electionProof := consensus.MakeFakeDeprecatedElectionProofForTest()
 	ticket := consensus.MakeFakeTicketForTest()
 	emptyBLSSig := (*bls.Aggregate([]bls.Signature{}))[:]
 
 	b := &block.Block{
-		Miner:           minerAddr,
-		Ticket:          ticket,
-		Parents:         baseTipSet.Key(),
-		ParentWeight:    types.Uint64(10000 * height),
-		Height:          types.Uint64(height),
-		StateRoot:       stateRootCid,
-		MessageReceipts: receiptRootCid,
-		ElectionProof:   electionProof,
-		BLSAggregateSig: emptyBLSSig,
+		Miner:                   minerAddr,
+		Ticket:                  ticket,
+		Parents:                 baseTipSet.Key(),
+		ParentWeight:            types.Uint64(10000 * height),
+		Height:                  types.Uint64(height),
+		StateRoot:               stateRootCid,
+		MessageReceipts:         receiptRootCid,
+		DeprecatedElectionProof: electionProof,
+		BLSAggregateSig:         emptyBLSSig,
 	}
 	sig, err := signer.SignBytes(b.SignatureData(), minerWorker)
 	require.NoError(t, err)


### PR DESCRIPTION
### Motivation
We need to move go-filecoin to election post.  To do this we will need to communicate data about the post process between validators and block producers using header data fields.

### Proposed changes
- Added Deprecated to the name of electionProof field that election post will make obsolete
- Add needed fields to the block header for election post
- Ensure lengths of variable length post data fields are consistent during syntax validation

Note: I've put several fields as top level slices in the block header.  Originally I had a single slice of PoStCandidates in the block header closer to the spec's data format.  I moved to this layout to get around complications with the refmt cbor encoding.  I would have had to define a custom encoding for how to (un)marshal this struct.  Since our encoding is going to change soon anyway I didn't want to bother with that.

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

