### PR TITLE
Feat/epost prep

### DIFF
--- a/cmd/go-filecoin/payment_channel_integration_test.go
+++ b/cmd/go-filecoin/payment_channel_integration_test.go
@@ -355,8 +355,8 @@ func TestPaymentChannelCloseSuccess(t *testing.T) {
 	require.NoError(t, err)
 	_, err = rsrc.miner.BlockMining.BlockMiningAPI.MiningOnce(ctx)
 	require.NoError(t, err)
-
 	rcpt, err := rsrc.target.PorcelainAPI.MessageWaitDone(ctx, mcid)
+
 	require.NoError(t, err)
 	assert.Equal(t, 0, int(rcpt.ExitCode))
 
@@ -366,6 +366,7 @@ func TestPaymentChannelCloseSuccess(t *testing.T) {
 
 	// payer must wait for close message to see correct balance
 	_, err = rsrc.payer.PorcelainAPI.MessageWaitDone(ctx, mcid)
+
 	require.NoError(t, err)
 
 	payerBalanceAfter, err := rsrc.payer.PorcelainAPI.WalletBalance(ctx, rsrc.payerAddr)
@@ -518,8 +519,8 @@ func requireNewPaychResource(ctx context.Context, t *testing.T) *paychResources 
 	payerNode := builder2.BuildAndStart(ctx)
 
 	node.ConnectNodes(t, minerNode, targetNode)
+	node.ConnectNodes(t, minerNode, payerNode)
 	node.ConnectNodes(t, targetNode, payerNode)
-	node.ConnectNodes(t, payerNode, minerNode)
 
 	return &paychResources{
 		t: t,

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	go.opencensus.io v0.22.1
 	go.uber.org/multierr v1.4.0 // indirect
 	go.uber.org/zap v1.12.0
-	golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708 // indirect
+	golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708
 	golang.org/x/net v0.0.0-20191101175033-0deb6923b6d9 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e

--- a/internal/pkg/consensus/election.go
+++ b/internal/pkg/consensus/election.go
@@ -12,9 +12,39 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 )
 
-// CompareElectionPower return true if the input electionProof is below the
+// ElectionMachine generates and validates PoSt partial tickets and PoSt
+// proofs.
+type ElectionMachine struct{}
+
+// func (em ElectionMachine) GeneratePoStRandomness(ticket block.Ticket, candidateAddr address.Address, signer types.Signer, nullBlockCount uint64) (block.VRFPi, error) {
+// 	seedBuf := make([]byte, binary.MaxVarintLen64)
+// 	n := binary.PutUvarint(seedBuf, nullBlockCount)
+// 	buf := append(ticket.VRFProof, seedBuf[:n]...)
+
+// 	// TODO get the domain tag up in here
+// 	vrfPi, err := signer.SignBytes(buf[:], candidateAddr)
+// 	if err != nil {
+// 		return block.VRFPi{}, err
+// 	}
+
+// 	return block.VRFPi(vrfPi), nil
+// }
+
+// func (em ElectionMachine) GenerateCandidates(poStRand []byte, candidateAddr address.Address, sb SectorBuilderThingy) {
+// 	// get em from state machine
+// 	sectorInfos := _
+// 	// nothing for now
+// 	dummyFaults := []uint64{}
+// 	return sb.GenerateEPostCandidates(sectorInfos, poStRand, dummyFaults)
+// }
+
+// func (em ElectionMachine) FilterWinners(candidates []types.PoStCandidates) []types.PoStCandidates {
+
+// }
+
+// DeprecatedCompareElectionPower return true if the input electionProof is below the
 // election victory threshold for the input miner and global power values.
-func CompareElectionPower(electionProof block.VRFPi, minerPower *types.BytesAmount, totalPower *types.BytesAmount) bool {
+func DeprecatedCompareElectionPower(electionProof block.VRFPi, minerPower *types.BytesAmount, totalPower *types.BytesAmount) bool {
 	lhs := &big.Int{}
 	lhs.SetBytes(electionProof)
 	lhs.Mul(lhs, totalPower.BigInt())
@@ -24,12 +54,9 @@ func CompareElectionPower(electionProof block.VRFPi, minerPower *types.BytesAmou
 	return lhs.Cmp(rhs) < 0
 }
 
-// ElectionMachine generates and validates election proofs from tickets.
-type ElectionMachine struct{}
-
-// RunElection uses a VRF to run a secret, verifiable election with respect to
+// DeprecatedRunElection uses a VRF to run a secret, verifiable election with respect to
 // an input ticket.
-func (em ElectionMachine) RunElection(ticket block.Ticket, candidateAddr address.Address, signer types.Signer, nullBlockCount uint64) (block.VRFPi, error) {
+func (em ElectionMachine) DeprecatedRunElection(ticket block.Ticket, candidateAddr address.Address, signer types.Signer, nullBlockCount uint64) (block.VRFPi, error) {
 	seedBuf := make([]byte, binary.MaxVarintLen64)
 	n := binary.PutUvarint(seedBuf, nullBlockCount)
 	buf := append(ticket.VRFProof, seedBuf[:n]...)
@@ -42,9 +69,9 @@ func (em ElectionMachine) RunElection(ticket block.Ticket, candidateAddr address
 	return block.VRFPi(vrfPi), nil
 }
 
-// IsElectionWinner verifies that an election proof was validly generated and
+// DeprecatedIsElectionWinner verifies that an election proof was validly generated and
 // is a winner.  TODO #3418 improve state management to clean up interface.
-func (em ElectionMachine) IsElectionWinner(ctx context.Context, ptv PowerTableView, ticket block.Ticket, nullBlockCount uint64, electionProof block.VRFPi, signingAddr, minerAddr address.Address) (bool, error) {
+func (em ElectionMachine) DeprecatedIsElectionWinner(ctx context.Context, ptv PowerTableView, ticket block.Ticket, nullBlockCount uint64, electionProof block.VRFPi, signingAddr, minerAddr address.Address) (bool, error) {
 	seedBuf := make([]byte, binary.MaxVarintLen64)
 	n := binary.PutUvarint(seedBuf, nullBlockCount)
 	buf := append(ticket.VRFProof, seedBuf[:n]...)
@@ -66,7 +93,7 @@ func (em ElectionMachine) IsElectionWinner(ctx context.Context, ptv PowerTableVi
 		return false, errors.Wrap(err, "Couldn't get minerPower")
 	}
 
-	return CompareElectionPower(electionProof, minerPower, totalPower), nil
+	return DeprecatedCompareElectionPower(electionProof, minerPower, totalPower), nil
 }
 
 // TicketMachine uses a VRF and VDF to generate deterministic, unpredictable

--- a/internal/pkg/consensus/election.go
+++ b/internal/pkg/consensus/election.go
@@ -16,6 +16,7 @@ import (
 // proofs.
 type ElectionMachine struct{}
 
+// Dragons -- turn this pseudo code real
 // func (em ElectionMachine) GeneratePoStRandomness(ticket block.Ticket, candidateAddr address.Address, signer types.Signer, nullBlockCount uint64) (block.VRFPi, error) {
 // 	seedBuf := make([]byte, binary.MaxVarintLen64)
 // 	n := binary.PutUvarint(seedBuf, nullBlockCount)

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -76,7 +76,8 @@ type TicketValidator interface {
 
 // ElectionValidator validates that an election fairly produced a winner.
 type ElectionValidator interface {
-	IsElectionWinner(context.Context, PowerTableView, block.Ticket, uint64, block.VRFPi, address.Address, address.Address) (bool, error)
+	DeprecatedIsElectionWinner(context.Context, PowerTableView, block.Ticket, uint64, block.VRFPi, address.Address, address.Address) (bool, error)
+
 }
 
 // SnapshotGenerator produces snapshots to examine actor state
@@ -241,7 +242,7 @@ func (c *Expected) validateMining(
 
 		// Validate DeprecatedElectionProof
 		nullBlkCount := uint64(blk.Height) - prevHeight - 1
-		result, err := c.IsElectionWinner(ctx, pwrTableView, electionTicket, nullBlkCount, blk.DeprecatedElectionProof, workerAddr, blk.Miner)
+		result, err := c.DeprecatedIsElectionWinner(ctx, pwrTableView, electionTicket, nullBlkCount, blk.DeprecatedElectionProof, workerAddr, blk.Miner)
 		if err != nil {
 			return errors.Wrap(err, "failed checking election proof")
 		}

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -77,7 +77,6 @@ type TicketValidator interface {
 // ElectionValidator validates that an election fairly produced a winner.
 type ElectionValidator interface {
 	DeprecatedIsElectionWinner(context.Context, PowerTableView, block.Ticket, uint64, block.VRFPi, address.Address, address.Address) (bool, error)
-
 }
 
 // SnapshotGenerator produces snapshots to examine actor state

--- a/internal/pkg/consensus/power_table_view.go
+++ b/internal/pkg/consensus/power_table_view.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/power"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
+	sector "github.com/filecoin-project/go-sectorbuilder"
 )
 
 // PowerTableView defines the set of functions used by the ChainManager to view
@@ -92,4 +93,25 @@ func (v PowerTableView) HasPower(ctx context.Context, mAddr address.Address) (bo
 		return false, err
 	}
 	return numBytes.GreaterThan(types.ZeroBytes), nil
+}
+
+// SortedSectorInfos returns the sector information for the given miner
+func (v PowerTableView) SortedSectorInfos(ctx context.Context, mAddr address.Address) (sector.SortedSectorInfo, error) {
+	// Dragons: once we have a real VM we must get the sector infos from the
+	// miner actor.  For now we return a fake constant.
+	var fakeCommR1, fakeCommR2 [sector.CommitmentBytesLen]byte
+	fakeCommR1[0], fakeCommR1[1] = 0xa, 0xb
+	fakeCommR2[0], fakeCommR2[1] = 0xc, 0xd
+	sectorID1, sectorID2 := uint64(0), uint64(1)
+
+	psi1 := sector.SectorInfo{
+		SectorID: sectorID1,
+		CommR:    fakeCommR1,
+	}
+	psi2 := sector.SectorInfo{
+		SectorID: sectorID2,
+		CommR:    fakeCommR2,
+	}
+
+	return sector.NewSortedSectorInfo(psi1, psi2), nil
 }

--- a/internal/pkg/consensus/power_table_view.go
+++ b/internal/pkg/consensus/power_table_view.go
@@ -83,15 +83,13 @@ func (v PowerTableView) WorkerAddr(ctx context.Context, mAddr address.Address) (
 
 // HasPower returns true if the provided address belongs to a miner with power
 // in the storage market
-func (v PowerTableView) HasPower(ctx context.Context, mAddr address.Address) bool {
+func (v PowerTableView) HasPower(ctx context.Context, mAddr address.Address) (bool, error) {
 	numBytes, err := v.Miner(ctx, mAddr)
 	if err != nil {
 		if state.IsActorNotFoundError(err) {
-			return false
+			return false, nil
 		}
-
-		panic(err) //hey guys, dropping errors is BAD
+		return false, err
 	}
-
-	return numBytes.GreaterThan(types.ZeroBytes)
+	return numBytes.GreaterThan(types.ZeroBytes), nil
 }

--- a/internal/pkg/consensus/testing.go
+++ b/internal/pkg/consensus/testing.go
@@ -135,13 +135,13 @@ func NewFakeProcessor(actors builtin.Actors) *DefaultProcessor {
 // FakeElectionMachine generates fake election proofs and verifies all proofs
 type FakeElectionMachine struct{}
 
-// RunElection returns a fake election proof.
-func (fem *FakeElectionMachine) RunElection(ticket block.Ticket, candidateAddr address.Address, signer types.Signer, nullCount uint64) (block.VRFPi, error) {
+// DeprecatedRunElection returns a fake election proof.
+func (fem *FakeElectionMachine) DeprecatedRunElection(ticket block.Ticket, candidateAddr address.Address, signer types.Signer, nullCount uint64) (block.VRFPi, error) {
 	return MakeFakeDeprecatedElectionProofForTest(), nil
 }
 
-// IsElectionWinner always returns true
-func (fem *FakeElectionMachine) IsElectionWinner(ctx context.Context, ptv PowerTableView, ticket block.Ticket, nullCount uint64, electionProof block.VRFPi, signerAddr, minerAddr address.Address) (bool, error) {
+// DeprecatedIsElectionWinner always returns true
+func (fem *FakeElectionMachine) DeprecatedIsElectionWinner(ctx context.Context, ptv PowerTableView, ticket block.Ticket, nullCount uint64, electionProof block.VRFPi, signerAddr, minerAddr address.Address) (bool, error) {
 	return true, nil
 }
 
@@ -169,8 +169,8 @@ func (ftv *FailingTicketValidator) IsValidTicket(parent, ticket block.Ticket, si
 // FailingElectionValidator marks all elections as invalid
 type FailingElectionValidator struct{}
 
-// IsElectionWinner always returns false
-func (fev *FailingElectionValidator) IsElectionWinner(ctx context.Context, ptv PowerTableView, ticket block.Ticket, nullCount uint64, electionProof block.VRFPi, signerAddr, minerAddr address.Address) (bool, error) {
+// DeprecatedIsElectionWinner always returns false
+func (fev *FailingElectionValidator) DeprecatedIsElectionWinner(ctx context.Context, ptv PowerTableView, ticket block.Ticket, nullCount uint64, electionProof block.VRFPi, signerAddr, minerAddr address.Address) (bool, error) {
 	return false, nil
 }
 
@@ -218,10 +218,10 @@ func SeedFirstWinnerInNRounds(t *testing.T, n int, ki *types.KeyInfo, minerPower
 
 	for {
 		// does it win at n rounds?
-		proof, err := em.RunElection(curr, wAddr, signer, uint64(n))
+		proof, err := em.DeprecatedRunElection(curr, wAddr, signer, uint64(n))
 		require.NoError(t, err)
 
-		wins, err := em.IsElectionWinner(ctx, ptv, curr, uint64(n), proof, wAddr, wAddr)
+		wins, err := em.DeprecatedIsElectionWinner(ctx, ptv, curr, uint64(n), proof, wAddr, wAddr)
 		require.NoError(t, err)
 		if wins {
 			// does it have no wins before n rounds?
@@ -245,10 +245,10 @@ func losesAllRounds(t *testing.T, n int, ticket block.Ticket, wAddr address.Addr
 }
 
 func losesAtRound(t *testing.T, n int, ticket block.Ticket, wAddr address.Address, signer types.Signer, ptv PowerTableView, em ElectionMachine) bool {
-	proof, err := em.RunElection(ticket, wAddr, signer, uint64(n))
+	proof, err := em.DeprecatedRunElection(ticket, wAddr, signer, uint64(n))
 	require.NoError(t, err)
 
-	wins, err := em.IsElectionWinner(context.Background(), ptv, ticket, uint64(n), proof, wAddr, wAddr)
+	wins, err := em.DeprecatedIsElectionWinner(context.Background(), ptv, ticket, uint64(n), proof, wAddr, wAddr)
 	require.NoError(t, err)
 	return !wins
 }
@@ -311,14 +311,14 @@ func NewMockElectionMachine(f func(block.Ticket)) *MockElectionMachine {
 	return &MockElectionMachine{fn: f}
 }
 
-// RunElection calls the registered callback and returns a fake proof
-func (mem *MockElectionMachine) RunElection(ticket block.Ticket, candidateAddr address.Address, signer types.Signer, nullCount uint64) (block.VRFPi, error) {
+// DeprecatedRunElection calls the registered callback and returns a fake proof
+func (mem *MockElectionMachine) DeprecatedRunElection(ticket block.Ticket, candidateAddr address.Address, signer types.Signer, nullCount uint64) (block.VRFPi, error) {
 	mem.fn(ticket)
 	return MakeFakeDeprecatedElectionProofForTest(), nil
 }
 
-// IsElectionWinner calls the registered callback and returns true
-func (mem *MockElectionMachine) IsElectionWinner(ctx context.Context, ptv PowerTableView, ticket block.Ticket, nullCount uint64, electionProof block.VRFPi, signerAddr, minerAddr address.Address) (bool, error) {
+// DeprecatedIsElectionWinner calls the registered callback and returns true
+func (mem *MockElectionMachine) DeprecatedIsElectionWinner(ctx context.Context, ptv PowerTableView, ticket block.Ticket, nullCount uint64, electionProof block.VRFPi, signerAddr, minerAddr address.Address) (bool, error) {
 	mem.fn(ticket)
 	return true, nil
 }

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -39,7 +39,11 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 		return nil, errors.Wrap(err, "get power table")
 	}
 
-	if !powerTable.HasPower(ctx, w.minerAddr) {
+	hasPower, err := powerTable.HasPower(ctx, w.minerAddr)
+	if err != nil {
+		return nil, err
+	}
+	if !hasPower {
 		return nil, errors.Errorf("bad miner address, miner must store files before mining: %s", w.minerAddr)
 	}
 

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -78,8 +78,8 @@ type workerPorcelainAPI interface {
 }
 
 type electionUtil interface {
-	RunElection(block.Ticket, address.Address, types.Signer, uint64) (block.VRFPi, error)
-	IsElectionWinner(context.Context, consensus.PowerTableView, block.Ticket, uint64, block.VRFPi, address.Address, address.Address) (bool, error)
+	DeprecatedRunElection(block.Ticket, address.Address, types.Signer, uint64) (block.VRFPi, error)
+	DeprecatedIsElectionWinner(context.Context, consensus.PowerTableView, block.Ticket, uint64, block.VRFPi, address.Address, address.Address) (bool, error)
 }
 
 // ticketGenerator creates tickets.
@@ -235,7 +235,7 @@ func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCoun
 	}
 
 	// Run an election to check if this miner has won the right to mine
-	electionProof, err := w.election.RunElection(electionTicket, workerAddr, w.workerSigner, nullBlkCount)
+	electionProof, err := w.election.DeprecatedRunElection(electionTicket, workerAddr, w.workerSigner, nullBlkCount)
 	if err != nil {
 		log.Errorf("failed to run local election: %s", err)
 		outCh <- Output{Err: err}
@@ -247,7 +247,7 @@ func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCoun
 		outCh <- Output{Err: err}
 		return
 	}
-	weHaveAWinner, err := w.election.IsElectionWinner(ctx, powerTable, electionTicket, nullBlkCount, electionProof, workerAddr, w.minerAddr)
+	weHaveAWinner, err := w.election.DeprecatedIsElectionWinner(ctx, powerTable, electionTicket, nullBlkCount, electionProof, workerAddr, w.minerAddr)
 	if err != nil {
 		log.Errorf("Worker.Mine couldn't run election: %s", err.Error())
 		outCh <- Output{Err: err}

--- a/internal/pkg/proofs/election_poster.go
+++ b/internal/pkg/proofs/election_poster.go
@@ -1,0 +1,53 @@
+package proofs
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/util/hasher"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
+	sector "github.com/filecoin-project/go-sectorbuilder"
+)
+
+// EPoStCandidate wraps the input data needed to verify an election PoSt
+type EPoStCandidate struct {
+	SectorID             uint64
+	PartialTicket        []byte
+	SectorChallengeIndex uint64
+}
+
+// ElectionPoster generates and verifies electoin PoSts
+// Dragons: once we have a proper eposter this type should either be
+// replaced or it should be a thin wrapper around the proper eposter
+type ElectionPoster struct{}
+
+// VerifyElectionPost returns the validity of the input PoSt proof
+func (ep *ElectionPoster) VerifyElectionPost(ctx context.Context, sectorSize uint64, sectorInfo sector.SortedSectorInfo, challengeSeed []byte, proof []byte, candidates []*EPoStCandidate, proverID address.Address) (bool, error) {
+	return true, nil
+}
+
+// ComputeElectionPoSt returns an election post proving that the partial
+// tickets are linked to the sector commitments.
+func (ep *ElectionPoster) ComputeElectionPoSt(sectorInfo sector.SortedSectorInfo, challengeSeed []byte, winners []EPoStCandidate) ([]byte, error) {
+	fakePoSt := make([]byte, 1)
+	fakePoSt[0] = 0xe
+	return fakePoSt, nil
+}
+
+// GenerateEPostCandidates generates election post candidates
+func (ep *ElectionPoster) GenerateEPostCandidates(sectorInfo sector.SortedSectorInfo, challengeSeed []byte, faults []uint64) ([]*EPoStCandidate, error) {
+	// Current fake behavior: generate one partial ticket per sector,
+	// each partial ticket is the hash of the challengeSeed and sectorID
+	var candidates []*EPoStCandidate
+	hasher := hasher.NewHasher()
+	for _, si := range sectorInfo.Values() {
+		hasher.Int(si.SectorID)
+		hasher.Bytes(challengeSeed)
+		nextCandidate := &EPoStCandidate{
+			SectorID:             si.SectorID,
+			SectorChallengeIndex: 0, //fake value of 0 for all candidates
+			PartialTicket:        hasher.Hash(),
+		}
+		candidates = append(candidates, nextCandidate)
+	}
+	return candidates, nil
+}

--- a/internal/pkg/util/hasher/hasher.go
+++ b/internal/pkg/util/hasher/hasher.go
@@ -1,0 +1,44 @@
+package hasher
+
+import (
+	"encoding/binary"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+// Hasher takes in an ordered series of data and hashes it together
+type Hasher struct {
+	toHash [][]byte
+}
+
+// NewHasher creates a new Hasher
+func NewHasher() *Hasher {
+	return &Hasher{
+		toHash: make([][]byte, 0),
+	}
+}
+
+// Int adds a uint64 to the data to be hashed
+func (h *Hasher) Int(i uint64) {
+	intData := make([]byte, binary.MaxVarintLen64)
+	n := binary.PutUvarint(intData, i)
+	h.toHash = append(h.toHash, intData[:n])
+}
+
+// Bytes adds a byte slice to the data to be hashed
+func (h *Hasher) Bytes(bs []byte) {
+	h.toHash = append(h.toHash, bs[:])
+}
+
+// Hash returns the hash value of the provided data
+func (h *Hasher) Hash() []byte {
+	var accum []byte
+	for _, s := range h.toHash {
+		accum = append(accum, s...)
+	}
+	hash := blake2b.Sum256(accum)
+
+	// clear the hasher for reuse
+	h.toHash = make([][]byte, 0)
+	return hash[:]
+}


### PR DESCRIPTION
### Motivation
If we plan to integrate election post right now we need to fake out the underlying proofs system (go-sectorbuilder repo) and the soon to be deprecated vm (miner and proving set will soon be gone).  This PR does this faking out.

### Proposed changes
I also added a simple `Hasher` util because I was tired of manipulating bytes buffers every time I want to hash something.

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

