### PR TITLE
Election machine functionality for epost

### DIFF
--- a/internal/pkg/consensus/election.go
+++ b/internal/pkg/consensus/election.go
@@ -70,6 +70,8 @@ func (em ElectionMachine) CandidateWins(candidate proofs.EPoStCandidate, ep *pro
 	rhs = rhs.Mul(rhs, big.NewInt(expectedLeadersPerEpoch))
 
 	// lhs < rhs?
+	// (challengeTicket / maxChallengeTicket) < expectedLeadersPerEpoch * (effective miner power) / networkPower
+	// effective miner power = sectorSize * numberSectors / numSectorsSampled
 	return lhs.Cmp(rhs) == -1
 }
 
@@ -82,7 +84,9 @@ func (em ElectionMachine) VerifyPoSt(ctx context.Context, ep *proofs.ElectionPos
 	}
 	var candidateSectorInfos []sector.SectorInfo
 	for _, si := range allSectorInfos.Values() {
-		candidateSectorInfos = append(candidateSectorInfos, si)
+		if _, ok := candidateSectorID[si.SectorID]; ok {
+			candidateSectorInfos = append(candidateSectorInfos, si)
+		}
 	}
 
 	return ep.VerifyElectionPost(

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -33,7 +33,7 @@ var (
 
 func init() {
 	ticketDomain = &big.Int{}
-	// The size of the ticket domain must equal the size of the Signature (ticket) generated.
+	// DEPRECATED: The size of the ticket domain must equal the size of the Signature (ticket) generated.
 	// Currently this is a secp256k1.Sign signature, which is 65 bytes.
 	ticketDomain.Exp(big.NewInt(2), big.NewInt(65*8), nil)
 	ticketDomain.Sub(ticketDomain, big.NewInt(1))
@@ -53,6 +53,12 @@ var (
 // ElectionLookback is the number of tipsets past the head (inclusive)) that
 // must be traversed to sample the election ticket.
 const ElectionLookback = 5
+
+// challengeBits is the number of bits in the challenge ticket's domain
+const challengeBits = 256
+
+// expectedLeadersPerEpoch is the mean number of leaders per epoch
+const expectedLeadersPerEpoch = 5
 
 // AncestorRoundsNeeded is the number of rounds of the ancestor chain needed
 // to process all state transitions.

--- a/internal/pkg/proofs/election_poster.go
+++ b/internal/pkg/proofs/election_poster.go
@@ -8,6 +8,9 @@ import (
 	sector "github.com/filecoin-project/go-sectorbuilder"
 )
 
+// SectorChallengeRatioDiv is
+const SectorChallengeRatioDiv = 25
+
 // EPoStCandidate wraps the input data needed to verify an election PoSt
 type EPoStCandidate struct {
 	SectorID             uint64
@@ -27,7 +30,7 @@ func (ep *ElectionPoster) VerifyElectionPost(ctx context.Context, sectorSize uin
 
 // ComputeElectionPoSt returns an election post proving that the partial
 // tickets are linked to the sector commitments.
-func (ep *ElectionPoster) ComputeElectionPoSt(sectorInfo sector.SortedSectorInfo, challengeSeed []byte, winners []EPoStCandidate) ([]byte, error) {
+func (ep *ElectionPoster) ComputeElectionPoSt(sectorInfo sector.SortedSectorInfo, challengeSeed []byte, winners []*EPoStCandidate) ([]byte, error) {
 	fakePoSt := make([]byte, 1)
 	fakePoSt[0] = 0xe
 	return fakePoSt, nil
@@ -50,4 +53,14 @@ func (ep *ElectionPoster) GenerateEPostCandidates(sectorInfo sector.SortedSector
 		candidates = append(candidates, nextCandidate)
 	}
 	return candidates, nil
+}
+
+// ElectionPostChallengeCount is the total number of partial tickets allowed by
+// the system
+func (ep *ElectionPoster) ElectionPostChallengeCount(sectors, faults uint64) uint64 {
+	if sectors-faults == 0 {
+		return 0
+	}
+	// ceil(sectors / SectorChallengeRatioDiv)
+	return (sectors-faults-1)/SectorChallengeRatioDiv + 1
 }

--- a/internal/pkg/proofs/election_poster.go
+++ b/internal/pkg/proofs/election_poster.go
@@ -8,7 +8,8 @@ import (
 	sector "github.com/filecoin-project/go-sectorbuilder"
 )
 
-// SectorChallengeRatioDiv is
+// SectorChallengeRatioDiv is the number of sectors per candidate partial
+// ticket
 const SectorChallengeRatioDiv = 25
 
 // EPoStCandidate wraps the input data needed to verify an election PoSt


### PR DESCRIPTION
### Motivation
To implement Election post we need a new set of election machine endpoints to create and verify filecoin block elections.  This PR introduces these new endpoints.

### Proposed changes
Add epost endpoints.  Correctly preprocess data from election machine function calls to provide to the epost interface.  The ticket winning condition is now up to spec.

I've been assessing how close to spec our randomness drawing and VRF generation is and it is pretty lacking.  I'm saving that change for a follow on.

I'm saving election machine unit testing until the behavior is up to spec, likely in the same followup with correct crypto operations.

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

