### PR TITLE
Feat/gen epost on mine

### DIFF
--- a/internal/app/go-filecoin/internal/submodule/sector_builder_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/sector_builder_submodule.go
@@ -3,18 +3,21 @@ package submodule
 import (
 	"context"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/proofs"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/sectorbuilder"
 )
 
 // SectorBuilderSubmodule enhances the `Node` with sector storage capabilities.
 type SectorBuilderSubmodule struct {
 	// SectorBuilder is used by the miner to fill and seal sectors.
-	SectorBuilder sectorbuilder.SectorBuilder
+	SectorBuilder  sectorbuilder.SectorBuilder
+	ElectionPoster *proofs.ElectionPoster
 }
 
 // NewSectorStorageSubmodule creates a new sector builder submodule.
 func NewSectorStorageSubmodule(ctx context.Context) (SectorBuilderSubmodule, error) {
 	return SectorBuilderSubmodule{
+		ElectionPoster: &proofs.ElectionPoster{},
 		// sectorBuilder: nil,
 	}, nil
 }

--- a/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/net"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/net/pubsub"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/proofs"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/slashing"
 )
 
@@ -48,7 +49,7 @@ type nodeChainSelector interface {
 }
 
 // NewSyncerSubmodule creates a new chain submodule.
-func NewSyncerSubmodule(ctx context.Context, config syncerConfig, repo chainRepo, blockstore *BlockstoreSubmodule, network *NetworkSubmodule, discovery *DiscoverySubmodule, chn *ChainSubmodule) (SyncerSubmodule, error) {
+func NewSyncerSubmodule(ctx context.Context, config syncerConfig, repo chainRepo, blockstore *BlockstoreSubmodule, network *NetworkSubmodule, discovery *DiscoverySubmodule, chn *ChainSubmodule, nodePoster *proofs.ElectionPoster) (SyncerSubmodule, error) {
 	// setup block validation
 	// TODO when #2961 is resolved do the needful here.
 	blkValid := consensus.NewDefaultBlockValidator(config.ChainClock())
@@ -66,7 +67,7 @@ func NewSyncerSubmodule(ctx context.Context, config syncerConfig, repo chainRepo
 	}
 
 	// set up consensus
-	nodeConsensus := consensus.NewExpected(blockstore.CborStore, blockstore.Blockstore, chn.Processor, chn.ActorState, config.BlockTime(), consensus.ElectionMachine{}, consensus.TicketMachine{})
+	nodeConsensus := consensus.NewExpected(blockstore.CborStore, blockstore.Blockstore, chn.Processor, chn.ActorState, config.BlockTime(), consensus.ElectionMachine{}, consensus.TicketMachine{}, nodePoster)
 	nodeChainSelector := consensus.NewChainSelector(blockstore.CborStore, chn.ActorState, config.GenesisCid())
 
 	// setup fecher

--- a/internal/app/go-filecoin/node/builder.go
+++ b/internal/app/go-filecoin/node/builder.go
@@ -195,7 +195,12 @@ func (b *Builder) build(ctx context.Context) (*Node, error) {
 	}
 	nd.ChainClock = b.chainClock
 
-	nd.syncer, err = submodule.NewSyncerSubmodule(ctx, (*builder)(b), b.repo, &nd.Blockstore, &nd.network, &nd.Discovery, &nd.chain)
+	nd.SectorStorage, err = submodule.NewSectorStorageSubmodule(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build node.SectorStorage")
+	}
+
+	nd.syncer, err = submodule.NewSyncerSubmodule(ctx, (*builder)(b), b.repo, &nd.Blockstore, &nd.network, &nd.Discovery, &nd.chain, nd.SectorStorage.ElectionPoster)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build node.Syncer")
 	}
@@ -218,11 +223,6 @@ func (b *Builder) build(ctx context.Context) (*Node, error) {
 	nd.BlockMining, err = submodule.NewBlockMiningSubmodule(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build node.BlockMining")
-	}
-
-	nd.SectorStorage, err = submodule.NewSectorStorageSubmodule(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to build node.SectorStorage")
 	}
 
 	nd.StorageProtocol, err = submodule.NewStorageProtocolSubmodule(ctx)

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -744,6 +744,7 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (*mining.DefaultWorker
 		Processor:     processor,
 		Blockstore:    node.Blockstore.Blockstore,
 		Clock:         node.ChainClock,
+		Poster:        node.SectorStorage.ElectionPoster,
 	}), nil
 }
 

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/metrics/tracing"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/proofs"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/sampling"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
@@ -52,7 +53,7 @@ var (
 
 // ElectionLookback is the number of tipsets past the head (inclusive)) that
 // must be traversed to sample the election ticket.
-const ElectionLookback = 5
+const ElectionLookback = 1
 
 // challengeBits is the number of bits in the challenge ticket's domain
 const challengeBits = 256
@@ -113,13 +114,16 @@ type Expected struct {
 	actorState SnapshotGenerator
 
 	blockTime time.Duration
+
+	// postVerifier verifies post proofs and associated data
+	postVerifier *proofs.ElectionPoster
 }
 
 // Ensure Expected satisfies the Protocol interface at compile time.
 var _ Protocol = (*Expected)(nil)
 
 // NewExpected is the constructor for the Expected consenus.Protocol module.
-func NewExpected(cs *hamt.CborIpldStore, bs blockstore.Blockstore, processor Processor, actorState SnapshotGenerator, bt time.Duration, ev ElectionValidator, tv TicketValidator) *Expected {
+func NewExpected(cs *hamt.CborIpldStore, bs blockstore.Blockstore, processor Processor, actorState SnapshotGenerator, bt time.Duration, ev ElectionValidator, tv TicketValidator, pv *proofs.ElectionPoster) *Expected {
 	return &Expected{
 		cstore:            cs,
 		blockTime:         bt,
@@ -128,6 +132,7 @@ func NewExpected(cs *hamt.CborIpldStore, bs blockstore.Blockstore, processor Pro
 		actorState:        actorState,
 		ElectionValidator: ev,
 		TicketValidator:   tv,
+		postVerifier:      pv,
 	}
 }
 

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -24,7 +24,7 @@ import (
 // RequireSignedTestBlockFromTipSet creates a block with a valid signature by
 // the passed in miner work and a Miner field set to the minerAddr.
 func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, stateRootCid cid.Cid, receiptRootCid cid.Cid, height uint64, minerAddr address.Address, minerWorker address.Address, signer types.Signer) *block.Block {
-	electionProof := consensus.MakeFakeDeprecatedElectionProofForTest()
+	electionProof := consensus.MakeFakeVRFProofForTest()
 	ticket := consensus.MakeFakeTicketForTest()
 	emptyBLSSig := (*bls.Aggregate([]bls.Signature{}))[:]
 

--- a/internal/pkg/testhelpers/mining.go
+++ b/internal/pkg/testhelpers/mining.go
@@ -56,6 +56,7 @@ func (t *FakeWorkerPorcelainAPI) Snapshot(ctx context.Context, tsk block.TipSetK
 	return &consensus.FakePowerTableViewSnapshot{
 		MinerPower:    types.NewBytesAmount(1),
 		TotalPower:    types.NewBytesAmount(t.totalPower),
+		SectorSize:    types.NewBytesAmount(1),
 		MinerToWorker: t.minerToWorker,
 	}, nil
 }


### PR DESCRIPTION
### Motivation
To move to election post we need our mining worker to call the new election machine generate / candidate win check endpoints.  We also need to pass this data into the block header when creating a block after winning.

### Proposed changes
This PR forces the miner worker to make the new epost calls and create epost data.  When blocks are created they include the correct epost data.

To pull this off and maintain test coverage I had to tweak the power actor very slightly and expand the power table's fake behavior.

This PR expands the ugly code in the miner worker and block generator which are in need of a good cleanup.  I decided against cleanup here but welcome suggestions on how to trim down tech debt introduced here within this PR.

I've also held off on testing.  I believe that testing at a higher level once we totally remove the deprecated election mechanism and add in consensus checks is going to be more useful than unit testing this intermediate stage.

Closes issue #3703 


<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

