### PR TITLE
Small Epost fixes

### DIFF
--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -251,10 +251,10 @@ func (c *Expected) validateMining(
 		challengeIndexes := make(map[uint64]struct{})
 		for _, winner := range blk.EPoStInfo.Winners {
 			index := winner.SectorChallengeIndex
-			if _, dup := challengeIndexes[uint64(index)]; dup {
+			if _, dup := challengeIndexes[index]; dup {
 				return errors.Errorf("Duplicate partial ticket submitted, challenge idx: %d", index)
 			}
-			challengeIndexes[uint64(index)] = struct{}{}
+			challengeIndexes[index] = struct{}{}
 		}
 
 		// Verify all partial tickets are winners

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -247,6 +247,16 @@ func (c *Expected) validateMining(
 			return errors.New("PoStRandomness invalid")
 		}
 
+		// Verify no duplicate challenge indexes
+		challengeIndexes := make(map[uint64]struct{})
+		for _, winner := range blk.EPoStInfo.Winners {
+			index := winner.SectorChallengeIndex
+			if _, dup := challengeIndexes[uint64(index)]; dup {
+				return errors.Errorf("Duplicate partial ticket submitted, challenge idx: %d", index)
+			}
+			challengeIndexes[uint64(index)] = struct{}{}
+		}
+
 		// Verify all partial tickets are winners
 		sectorNum, err := powerTable.NumSectors(ctx, blk.Miner)
 		if err != nil {

--- a/internal/pkg/proofs/election_poster.go
+++ b/internal/pkg/proofs/election_poster.go
@@ -41,14 +41,14 @@ func (ep *ElectionPoster) GenerateEPostCandidates(sectorInfo ffi.SortedPublicSec
 	// each partial ticket is the hash of the challengeSeed and sectorID
 	var candidates []ffi.Candidate
 	hasher := hasher.NewHasher()
-	for _, si := range sectorInfo.Values() {
+	for i, si := range sectorInfo.Values() {
 		hasher.Int(si.SectorID)
 		hasher.Bytes(challengeSeed[:])
 		nextCandidate := ffi.Candidate{
 			SectorID:             si.SectorID,
 			PartialTicket:        convert.To32ByteArray(hasher.Hash()),
 			Ticket:               [32]byte{},
-			SectorChallengeIndex: 0, //fake value of 0 for all candidates
+			SectorChallengeIndex: uint64(i), //fake value of sector idx
 		}
 		candidates = append(candidates, nextCandidate)
 	}


### PR DESCRIPTION
### Motivation
Two imperfections perfected --
1. We were filtering sectorinfos before passing into the gen and verify post ffi methods.  This works fine now but not with a real election poster
2. We were not filtering duplicate challenge indexes which is needed to prevent replaying partial tickets for more rewards


### Proposed changes

Closes issue #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

