### PR TITLE
Election Post Header Data to Spec

### DIFF
--- a/internal/pkg/block/block.go
+++ b/internal/pkg/block/block.go
@@ -21,31 +21,6 @@ type Block struct {
 	// Ticket is the ticket submitted with this block.
 	Ticket Ticket `json:"ticket"`
 
-	// Parents is the set of parents this block was based on. Typically one,
-	// but can be several in the case where there were multiple winning ticket-
-	// holders for an epoch.
-	Parents TipSetKey `json:"parents"`
-
-	// ParentWeight is the aggregate chain weight of the parent set.
-	ParentWeight types.Uint64 `json:"parentWeight"`
-
-	// Height is the chain height of this block.
-	Height types.Uint64 `json:"height"`
-
-	// Messages is the set of messages included in this block
-	Messages types.TxMeta `json:"messages,omitempty" refmt:",omitempty"`
-
-	// StateRoot is a cid pointer to the state tree after application of the
-	// transactions state transitions.
-	StateRoot cid.Cid `json:"stateRoot,omitempty" refmt:",omitempty"`
-
-	// MessageReceipts is a set of receipts matching to the sending of the `Messages`.
-	MessageReceipts cid.Cid `json:"messageReceipts,omitempty" refmt:",omitempty"`
-
-	// DeprecatedElectionProof is the "scratched ticket" proving that this block won
-	// an election.
-	DeprecatedElectionProof VRFPi `json:"proof"`
-
 	// PoStRandomness is the verifiable randomness used to generate postCandidates
 	PoStRandomness VRFPi `json:"postRandomness"`
 
@@ -61,14 +36,38 @@ type Block struct {
 	// PoStProof is the snark output proving that the PoSt tickets are valid
 	PoStProof types.PoStProof `json:"postProof"`
 
+	// Parents is the set of parents this block was based on. Typically one,
+	// but can be several in the case where there were multiple winning ticket-
+	// holders for an epoch.
+	Parents TipSetKey `json:"parents"`
+
+	// ParentWeight is the aggregate chain weight of the parent set.
+	ParentWeight types.Uint64 `json:"parentWeight"`
+
+	// Height is the chain height of this block.
+	Height types.Uint64 `json:"height"`
+
+	// StateRoot is a cid pointer to the state tree after application of the
+	// transactions state transitions.
+	StateRoot cid.Cid `json:"stateRoot,omitempty" refmt:",omitempty"`
+
+	// MessageReceipts is a set of receipts matching to the sending of the `Messages`.
+	MessageReceipts cid.Cid `json:"messageReceipts,omitempty" refmt:",omitempty"`
+
+	// Messages is the set of messages included in this block
+	Messages types.TxMeta `json:"messages,omitempty" refmt:",omitempty"`
+
+	// The aggregate signature of all BLS signed messages in the block
+	BLSAggregateSig types.Signature `json:"blsAggregateSig"`
+
 	// The timestamp, in seconds since the Unix epoch, at which this block was created.
 	Timestamp types.Uint64 `json:"timestamp"`
 
 	// The signature of the miner's worker key over the block
 	BlockSig types.Signature `json:"blocksig"`
 
-	// The aggregate signature of all BLS signed messages in the block
-	BLSAggregateSig types.Signature `json:"blsAggregateSig"`
+	// ForkSignaling is extra data used by miners to communicate
+	ForkSignaling types.Uint64
 
 	cachedCid cid.Cid
 
@@ -151,22 +150,22 @@ func (b *Block) Equals(other *Block) bool {
 // creating and verification
 func (b *Block) SignatureData() []byte {
 	tmp := &Block{
-		Miner:                   b.Miner,
-		Ticket:                  b.Ticket,  // deep copy needed??
-		Parents:                 b.Parents, // deep copy needed??
-		ParentWeight:            b.ParentWeight,
-		Height:                  b.Height,
-		Messages:                b.Messages,
-		StateRoot:               b.StateRoot,
-		MessageReceipts:         b.MessageReceipts,
-		DeprecatedElectionProof: b.DeprecatedElectionProof,
-		PoStRandomness:          b.PoStRandomness,
-		PoStPartialTickets:      b.PoStPartialTickets,
-		PoStSectorIDs:           b.PoStSectorIDs,
-		PoStChallengeIDXs:       b.PoStChallengeIDXs,
-		PoStProof:               b.PoStProof,
-		Timestamp:               b.Timestamp,
-		BLSAggregateSig:         b.BLSAggregateSig,
+		Miner:              b.Miner,
+		Ticket:             b.Ticket,  // deep copy needed??
+		Parents:            b.Parents, // deep copy needed??
+		ParentWeight:       b.ParentWeight,
+		Height:             b.Height,
+		Messages:           b.Messages,
+		StateRoot:          b.StateRoot,
+		MessageReceipts:    b.MessageReceipts,
+		PoStRandomness:     b.PoStRandomness,
+		PoStPartialTickets: b.PoStPartialTickets,
+		PoStSectorIDs:      b.PoStSectorIDs,
+		PoStChallengeIDXs:  b.PoStChallengeIDXs,
+		PoStProof:          b.PoStProof,
+		Timestamp:          b.Timestamp,
+		BLSAggregateSig:    b.BLSAggregateSig,
+		ForkSignaling:      b.ForkSignaling,
 		// BlockSig omitted
 	}
 

--- a/internal/pkg/block/block.go
+++ b/internal/pkg/block/block.go
@@ -21,20 +21,23 @@ type Block struct {
 	// Ticket is the ticket submitted with this block.
 	Ticket Ticket `json:"ticket"`
 
-	// PoStRandomness is the verifiable randomness used to generate postCandidates
-	PoStRandomness VRFPi `json:"postRandomness"`
+	// EPoStInfo wraps all data for verifying this block's Election PoSt
+	EPoStInfo EPoStInfo `json:EPoStInfo`
 
-	// PoStCandidatePartialTickets are the winning PoSt tickets submitted with this block
-	PoStPartialTickets [][]byte `json:"postCandidates"`
+	// // PoStRandomness is the verifiable randomness used to generate postCandidates
+	// PoStRandomness VRFPi `json:"postRandomness"`
 
-	// PoStSectorIDs are the sector ids of the winning PoSt tickets
-	PoStSectorIDs []types.Uint64 `json:"postSectorIDs"`
+	// // PoStCandidatePartialTickets are the winning PoSt tickets submitted with this block
+	// PoStPartialTickets [][]byte `json:"postCandidates"`
 
-	// PoStChallengeIDXs are the challenge indexes within the sector for the winning PoSt tickets
-	PoStChallengeIDXs []types.Uint64 `json:"postChallengeIDXs"`
+	// // PoStSectorIDs are the sector ids of the winning PoSt tickets
+	// PoStSectorIDs []types.Uint64 `json:"postSectorIDs"`
 
-	// PoStProof is the snark output proving that the PoSt tickets are valid
-	PoStProof types.PoStProof `json:"postProof"`
+	// // PoStChallengeIDXs are the challenge indexes within the sector for the winning PoSt tickets
+	// PoStChallengeIDXs []types.Uint64 `json:"postChallengeIDXs"`
+
+	// // PoStProof is the snark output proving that the PoSt tickets are valid
+	// PoStProof types.PoStProof `json:"postProof"`
 
 	// Parents is the set of parents this block was based on. Typically one,
 	// but can be several in the case where there were multiple winning ticket-
@@ -150,22 +153,18 @@ func (b *Block) Equals(other *Block) bool {
 // creating and verification
 func (b *Block) SignatureData() []byte {
 	tmp := &Block{
-		Miner:              b.Miner,
-		Ticket:             b.Ticket,  // deep copy needed??
-		Parents:            b.Parents, // deep copy needed??
-		ParentWeight:       b.ParentWeight,
-		Height:             b.Height,
-		Messages:           b.Messages,
-		StateRoot:          b.StateRoot,
-		MessageReceipts:    b.MessageReceipts,
-		PoStRandomness:     b.PoStRandomness,
-		PoStPartialTickets: b.PoStPartialTickets,
-		PoStSectorIDs:      b.PoStSectorIDs,
-		PoStChallengeIDXs:  b.PoStChallengeIDXs,
-		PoStProof:          b.PoStProof,
-		Timestamp:          b.Timestamp,
-		BLSAggregateSig:    b.BLSAggregateSig,
-		ForkSignaling:      b.ForkSignaling,
+		Miner:           b.Miner,
+		Ticket:          b.Ticket,  // deep copy needed??
+		Parents:         b.Parents, // deep copy needed??
+		ParentWeight:    b.ParentWeight,
+		Height:          b.Height,
+		Messages:        b.Messages,
+		StateRoot:       b.StateRoot,
+		MessageReceipts: b.MessageReceipts,
+		EPoStInfo:       b.EPoStInfo,
+		Timestamp:       b.Timestamp,
+		BLSAggregateSig: b.BLSAggregateSig,
+		ForkSignaling:   b.ForkSignaling,
 		// BlockSig omitted
 	}
 

--- a/internal/pkg/block/block.go
+++ b/internal/pkg/block/block.go
@@ -22,22 +22,7 @@ type Block struct {
 	Ticket Ticket `json:"ticket"`
 
 	// EPoStInfo wraps all data for verifying this block's Election PoSt
-	EPoStInfo EPoStInfo `json:EPoStInfo`
-
-	// // PoStRandomness is the verifiable randomness used to generate postCandidates
-	// PoStRandomness VRFPi `json:"postRandomness"`
-
-	// // PoStCandidatePartialTickets are the winning PoSt tickets submitted with this block
-	// PoStPartialTickets [][]byte `json:"postCandidates"`
-
-	// // PoStSectorIDs are the sector ids of the winning PoSt tickets
-	// PoStSectorIDs []types.Uint64 `json:"postSectorIDs"`
-
-	// // PoStChallengeIDXs are the challenge indexes within the sector for the winning PoSt tickets
-	// PoStChallengeIDXs []types.Uint64 `json:"postChallengeIDXs"`
-
-	// // PoStProof is the snark output proving that the PoSt tickets are valid
-	// PoStProof types.PoStProof `json:"postProof"`
+	EPoStInfo EPoStInfo `json:"ePoStInfo"`
 
 	// Parents is the set of parents this block was based on. Typically one,
 	// but can be several in the case where there were multiple winning ticket-

--- a/internal/pkg/block/block_test.go
+++ b/internal/pkg/block/block_test.go
@@ -61,24 +61,22 @@ func TestTriangleEncoding(t *testing.T) {
 	t.Run("encoding block with nonzero fields works", func(t *testing.T) {
 		// We should ensure that every field is set -- zero values might
 		// pass when non-zero values do not due to nil/null encoding.
-
+		candidate1 := blk.NewEPoStCandidate(5, []byte{0x05}, 52)
+		candidate2 := blk.NewEPoStCandidate(3, []byte{0x04}, 3000)
+		postInfo := blk.NewEPoStInfo([]byte{0x07}, []byte{0x02, 0x06}, candidate1, candidate2)
 		b := &blk.Block{
-			Miner:              newAddress(),
-			Ticket:             blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
-			Height:             types.Uint64(2),
-			Messages:           types.TxMeta{SecpRoot: types.CidFromString(t, "somecid"), BLSRoot: types.EmptyMessagesCID},
-			MessageReceipts:    types.CidFromString(t, "somecid"),
-			Parents:            blk.NewTipSetKey(types.CidFromString(t, "somecid")),
-			ParentWeight:       types.Uint64(1000),
-			StateRoot:          types.CidFromString(t, "somecid"),
-			Timestamp:          types.Uint64(1),
-			BlockSig:           []byte{0x3},
-			BLSAggregateSig:    []byte{0x3},
-			PoStPartialTickets: [][]byte{{0x05}, {0x04}},
-			PoStSectorIDs:      []types.Uint64{types.Uint64(5), types.Uint64(3)},
-			PoStChallengeIDXs:  []types.Uint64{types.Uint64(52), types.Uint64(3000)},
-			PoStProof:          []byte{0x07},
-			PoStRandomness:     []byte{0x02, 0x06},
+			Miner:           newAddress(),
+			Ticket:          blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
+			Height:          types.Uint64(2),
+			Messages:        types.TxMeta{SecpRoot: types.CidFromString(t, "somecid"), BLSRoot: types.EmptyMessagesCID},
+			MessageReceipts: types.CidFromString(t, "somecid"),
+			Parents:         blk.NewTipSetKey(types.CidFromString(t, "somecid")),
+			ParentWeight:    types.Uint64(1000),
+			StateRoot:       types.CidFromString(t, "somecid"),
+			Timestamp:       types.Uint64(1),
+			BlockSig:        []byte{0x3},
+			BLSAggregateSig: []byte{0x3},
+			EPoStInfo:       postInfo,
 		}
 		s := reflect.TypeOf(*b)
 		// This check is here to request that you add a non-zero value for new fields
@@ -86,7 +84,7 @@ func TestTriangleEncoding(t *testing.T) {
 		// Also please add non zero fields to "b" and "diff" in TestSignatureData
 		// and add a new check that different values of the new field result in
 		// different output data.
-		require.Equal(t, 19, s.NumField()) // Note: this also counts private fields
+		require.Equal(t, 15, s.NumField()) // Note: this also counts private fields
 		testRoundTrip(t, b)
 	})
 }
@@ -229,43 +227,42 @@ func TestBlockJsonMarshal(t *testing.T) {
 func TestSignatureData(t *testing.T) {
 	tf.UnitTest(t)
 	newAddress := address.NewForTestGetter()
+	candidate1 := blk.NewEPoStCandidate(5, []byte{0x05}, 52)
+	candidate2 := blk.NewEPoStCandidate(3, []byte{0x04}, 3000)
+	postInfo := blk.NewEPoStInfo([]byte{0x07}, []byte{0x02, 0x06}, candidate1, candidate2)
 
 	b := &blk.Block{
-		Miner:              newAddress(),
-		Ticket:             blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
-		Height:             types.Uint64(2),
-		Messages:           types.TxMeta{SecpRoot: types.CidFromString(t, "somecid"), BLSRoot: types.EmptyMessagesCID},
-		MessageReceipts:    types.CidFromString(t, "somecid"),
-		Parents:            blk.NewTipSetKey(types.CidFromString(t, "somecid")),
-		ParentWeight:       types.Uint64(1000),
-		ForkSignaling:      types.Uint64(3),
-		StateRoot:          types.CidFromString(t, "somecid"),
-		Timestamp:          types.Uint64(1),
-		PoStPartialTickets: [][]byte{{0x05}, {0x04}},
-		PoStSectorIDs:      []types.Uint64{types.Uint64(5), types.Uint64(3)},
-		PoStChallengeIDXs:  []types.Uint64{types.Uint64(52), types.Uint64(3000)},
-		PoStProof:          []byte{0x07},
-		PoStRandomness:     []byte{0x02, 0x06},
-		BlockSig:           []byte{0x3},
+		Miner:           newAddress(),
+		Ticket:          blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
+		Height:          types.Uint64(2),
+		Messages:        types.TxMeta{SecpRoot: types.CidFromString(t, "somecid"), BLSRoot: types.EmptyMessagesCID},
+		MessageReceipts: types.CidFromString(t, "somecid"),
+		Parents:         blk.NewTipSetKey(types.CidFromString(t, "somecid")),
+		ParentWeight:    types.Uint64(1000),
+		ForkSignaling:   types.Uint64(3),
+		StateRoot:       types.CidFromString(t, "somecid"),
+		Timestamp:       types.Uint64(1),
+		EPoStInfo:       postInfo,
+		BlockSig:        []byte{0x3},
 	}
 
+	diffCandidate1 := blk.NewEPoStCandidate(0, []byte{0x04}, 25)
+	diffCandidate2 := blk.NewEPoStCandidate(1, []byte{0x05}, 3001)
+	diffPoStInfo := blk.NewEPoStInfo([]byte{0x17}, []byte{0x12, 0x16}, diffCandidate1, diffCandidate2)
+
 	diff := &blk.Block{
-		Miner:              newAddress(),
-		Ticket:             blk.Ticket{VRFProof: []byte{0x03, 0x01, 0x02}},
-		Height:             types.Uint64(3),
-		Messages:           types.TxMeta{SecpRoot: types.CidFromString(t, "someothercid"), BLSRoot: types.EmptyMessagesCID},
-		MessageReceipts:    types.CidFromString(t, "someothercid"),
-		Parents:            blk.NewTipSetKey(types.CidFromString(t, "someothercid")),
-		ParentWeight:       types.Uint64(1001),
-		ForkSignaling:      types.Uint64(2),
-		StateRoot:          types.CidFromString(t, "someothercid"),
-		Timestamp:          types.Uint64(4),
-		PoStPartialTickets: [][]byte{{0x04}, {0x05}},
-		PoStSectorIDs:      []types.Uint64{types.Uint64(0), types.Uint64(1)},
-		PoStChallengeIDXs:  []types.Uint64{types.Uint64(25), types.Uint64(3001)},
-		PoStProof:          []byte{0x17},
-		PoStRandomness:     []byte{0x12, 0x16},
-		BlockSig:           []byte{0x4},
+		Miner:           newAddress(),
+		Ticket:          blk.Ticket{VRFProof: []byte{0x03, 0x01, 0x02}},
+		Height:          types.Uint64(3),
+		Messages:        types.TxMeta{SecpRoot: types.CidFromString(t, "someothercid"), BLSRoot: types.EmptyMessagesCID},
+		MessageReceipts: types.CidFromString(t, "someothercid"),
+		Parents:         blk.NewTipSetKey(types.CidFromString(t, "someothercid")),
+		ParentWeight:    types.Uint64(1001),
+		ForkSignaling:   types.Uint64(2),
+		StateRoot:       types.CidFromString(t, "someothercid"),
+		Timestamp:       types.Uint64(4),
+		EPoStInfo:       diffPoStInfo,
+		BlockSig:        []byte{0x4},
 	}
 
 	// Changing BlockSig does not affect output
@@ -396,10 +393,10 @@ func TestSignatureData(t *testing.T) {
 	func() {
 		before := b.SignatureData()
 
-		cpy := b.PoStRandomness
-		defer func() { b.PoStRandomness = cpy }()
+		cpy := b.EPoStInfo.PoStRandomness
+		defer func() { b.EPoStInfo.PoStRandomness = cpy }()
 
-		b.PoStRandomness = diff.PoStRandomness
+		b.EPoStInfo.PoStRandomness = diff.EPoStInfo.PoStRandomness
 		after := b.SignatureData()
 		assert.False(t, bytes.Equal(before, after))
 	}()
@@ -407,10 +404,10 @@ func TestSignatureData(t *testing.T) {
 	func() {
 		before := b.SignatureData()
 
-		cpy := b.PoStProof
-		defer func() { b.PoStProof = cpy }()
+		cpy := b.EPoStInfo.PoStProof
+		defer func() { b.EPoStInfo.PoStProof = cpy }()
 
-		b.PoStProof = diff.PoStProof
+		b.EPoStInfo.PoStProof = diff.EPoStInfo.PoStProof
 		after := b.SignatureData()
 		assert.False(t, bytes.Equal(before, after))
 	}()
@@ -418,33 +415,50 @@ func TestSignatureData(t *testing.T) {
 	func() {
 		before := b.SignatureData()
 
-		cpy := b.PoStPartialTickets
-		defer func() { b.PoStPartialTickets = cpy }()
+		cpy0 := b.EPoStInfo.Winners[0].PartialTicket
+		cpy1 := b.EPoStInfo.Winners[1].PartialTicket
+		defer func() {
+			b.EPoStInfo.Winners[0].PartialTicket = cpy0
+			b.EPoStInfo.Winners[1].PartialTicket = cpy1
 
-		b.PoStPartialTickets = diff.PoStPartialTickets
+		}()
+
+		b.EPoStInfo.Winners[0].PartialTicket = diff.EPoStInfo.Winners[0].PartialTicket
+		b.EPoStInfo.Winners[1].PartialTicket = diff.EPoStInfo.Winners[1].PartialTicket
 		after := b.SignatureData()
 		assert.False(t, bytes.Equal(before, after))
 	}()
 
 	func() {
 		before := b.SignatureData()
+		cpy0 := b.EPoStInfo.Winners[0].SectorID
+		cpy1 := b.EPoStInfo.Winners[1].SectorID
+		defer func() {
+			b.EPoStInfo.Winners[0].SectorID = cpy0
+			b.EPoStInfo.Winners[1].SectorID = cpy1
+		}()
 
-		cpy := b.PoStSectorIDs
-		defer func() { b.PoStSectorIDs = cpy }()
-
-		b.PoStSectorIDs = diff.PoStSectorIDs
+		b.EPoStInfo.Winners[0].SectorID = diff.EPoStInfo.Winners[0].SectorID
+		b.EPoStInfo.Winners[1].SectorID = diff.EPoStInfo.Winners[1].SectorID
 		after := b.SignatureData()
+
 		assert.False(t, bytes.Equal(before, after))
 	}()
 
 	func() {
 		before := b.SignatureData()
+		cpy0 := b.EPoStInfo.Winners[0].SectorChallengeIndex
+		cpy1 := b.EPoStInfo.Winners[1].SectorChallengeIndex
+		defer func() {
+			b.EPoStInfo.Winners[0].SectorChallengeIndex = cpy0
+			b.EPoStInfo.Winners[1].SectorChallengeIndex = cpy1
 
-		cpy := b.PoStChallengeIDXs
-		defer func() { b.PoStChallengeIDXs = cpy }()
+		}()
 
-		b.PoStChallengeIDXs = diff.PoStChallengeIDXs
+		b.EPoStInfo.Winners[0].SectorChallengeIndex = diff.EPoStInfo.Winners[0].SectorChallengeIndex
+		b.EPoStInfo.Winners[1].SectorChallengeIndex = diff.EPoStInfo.Winners[1].SectorChallengeIndex
 		after := b.SignatureData()
+
 		assert.False(t, bytes.Equal(before, after))
 	}()
 

--- a/internal/pkg/block/block_test.go
+++ b/internal/pkg/block/block_test.go
@@ -63,23 +63,22 @@ func TestTriangleEncoding(t *testing.T) {
 		// pass when non-zero values do not due to nil/null encoding.
 
 		b := &blk.Block{
-			Miner:                   newAddress(),
-			Ticket:                  blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
-			Height:                  types.Uint64(2),
-			Messages:                types.TxMeta{SecpRoot: types.CidFromString(t, "somecid"), BLSRoot: types.EmptyMessagesCID},
-			MessageReceipts:         types.CidFromString(t, "somecid"),
-			Parents:                 blk.NewTipSetKey(types.CidFromString(t, "somecid")),
-			ParentWeight:            types.Uint64(1000),
-			DeprecatedElectionProof: types.NewTestPoSt(),
-			StateRoot:               types.CidFromString(t, "somecid"),
-			Timestamp:               types.Uint64(1),
-			BlockSig:                []byte{0x3},
-			BLSAggregateSig:         []byte{0x3},
-			PoStPartialTickets:      [][]byte{{0x05}, {0x04}},
-			PoStSectorIDs:           []types.Uint64{types.Uint64(5), types.Uint64(3)},
-			PoStChallengeIDXs:       []types.Uint64{types.Uint64(52), types.Uint64(3000)},
-			PoStProof:               []byte{0x07},
-			PoStRandomness:          []byte{0x02, 0x06},
+			Miner:              newAddress(),
+			Ticket:             blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
+			Height:             types.Uint64(2),
+			Messages:           types.TxMeta{SecpRoot: types.CidFromString(t, "somecid"), BLSRoot: types.EmptyMessagesCID},
+			MessageReceipts:    types.CidFromString(t, "somecid"),
+			Parents:            blk.NewTipSetKey(types.CidFromString(t, "somecid")),
+			ParentWeight:       types.Uint64(1000),
+			StateRoot:          types.CidFromString(t, "somecid"),
+			Timestamp:          types.Uint64(1),
+			BlockSig:           []byte{0x3},
+			BLSAggregateSig:    []byte{0x3},
+			PoStPartialTickets: [][]byte{{0x05}, {0x04}},
+			PoStSectorIDs:      []types.Uint64{types.Uint64(5), types.Uint64(3)},
+			PoStChallengeIDXs:  []types.Uint64{types.Uint64(52), types.Uint64(3000)},
+			PoStProof:          []byte{0x07},
+			PoStRandomness:     []byte{0x02, 0x06},
 		}
 		s := reflect.TypeOf(*b)
 		// This check is here to request that you add a non-zero value for new fields
@@ -232,41 +231,41 @@ func TestSignatureData(t *testing.T) {
 	newAddress := address.NewForTestGetter()
 
 	b := &blk.Block{
-		Miner:                   newAddress(),
-		Ticket:                  blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
-		Height:                  types.Uint64(2),
-		Messages:                types.TxMeta{SecpRoot: types.CidFromString(t, "somecid"), BLSRoot: types.EmptyMessagesCID},
-		MessageReceipts:         types.CidFromString(t, "somecid"),
-		Parents:                 blk.NewTipSetKey(types.CidFromString(t, "somecid")),
-		ParentWeight:            types.Uint64(1000),
-		DeprecatedElectionProof: []byte{0x1},
-		StateRoot:               types.CidFromString(t, "somecid"),
-		Timestamp:               types.Uint64(1),
-		PoStPartialTickets:      [][]byte{{0x05}, {0x04}},
-		PoStSectorIDs:           []types.Uint64{types.Uint64(5), types.Uint64(3)},
-		PoStChallengeIDXs:       []types.Uint64{types.Uint64(52), types.Uint64(3000)},
-		PoStProof:               []byte{0x07},
-		PoStRandomness:          []byte{0x02, 0x06},
-		BlockSig:                []byte{0x3},
+		Miner:              newAddress(),
+		Ticket:             blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
+		Height:             types.Uint64(2),
+		Messages:           types.TxMeta{SecpRoot: types.CidFromString(t, "somecid"), BLSRoot: types.EmptyMessagesCID},
+		MessageReceipts:    types.CidFromString(t, "somecid"),
+		Parents:            blk.NewTipSetKey(types.CidFromString(t, "somecid")),
+		ParentWeight:       types.Uint64(1000),
+		ForkSignaling:      types.Uint64(3),
+		StateRoot:          types.CidFromString(t, "somecid"),
+		Timestamp:          types.Uint64(1),
+		PoStPartialTickets: [][]byte{{0x05}, {0x04}},
+		PoStSectorIDs:      []types.Uint64{types.Uint64(5), types.Uint64(3)},
+		PoStChallengeIDXs:  []types.Uint64{types.Uint64(52), types.Uint64(3000)},
+		PoStProof:          []byte{0x07},
+		PoStRandomness:     []byte{0x02, 0x06},
+		BlockSig:           []byte{0x3},
 	}
 
 	diff := &blk.Block{
-		Miner:                   newAddress(),
-		Ticket:                  blk.Ticket{VRFProof: []byte{0x03, 0x01, 0x02}},
-		Height:                  types.Uint64(3),
-		Messages:                types.TxMeta{SecpRoot: types.CidFromString(t, "someothercid"), BLSRoot: types.EmptyMessagesCID},
-		MessageReceipts:         types.CidFromString(t, "someothercid"),
-		Parents:                 blk.NewTipSetKey(types.CidFromString(t, "someothercid")),
-		ParentWeight:            types.Uint64(1001),
-		DeprecatedElectionProof: []byte{0x2},
-		StateRoot:               types.CidFromString(t, "someothercid"),
-		Timestamp:               types.Uint64(4),
-		PoStPartialTickets:      [][]byte{{0x04}, {0x05}},
-		PoStSectorIDs:           []types.Uint64{types.Uint64(0), types.Uint64(1)},
-		PoStChallengeIDXs:       []types.Uint64{types.Uint64(25), types.Uint64(3001)},
-		PoStProof:               []byte{0x17},
-		PoStRandomness:          []byte{0x12, 0x16},
-		BlockSig:                []byte{0x4},
+		Miner:              newAddress(),
+		Ticket:             blk.Ticket{VRFProof: []byte{0x03, 0x01, 0x02}},
+		Height:             types.Uint64(3),
+		Messages:           types.TxMeta{SecpRoot: types.CidFromString(t, "someothercid"), BLSRoot: types.EmptyMessagesCID},
+		MessageReceipts:    types.CidFromString(t, "someothercid"),
+		Parents:            blk.NewTipSetKey(types.CidFromString(t, "someothercid")),
+		ParentWeight:       types.Uint64(1001),
+		ForkSignaling:      types.Uint64(2),
+		StateRoot:          types.CidFromString(t, "someothercid"),
+		Timestamp:          types.Uint64(4),
+		PoStPartialTickets: [][]byte{{0x04}, {0x05}},
+		PoStSectorIDs:      []types.Uint64{types.Uint64(0), types.Uint64(1)},
+		PoStChallengeIDXs:  []types.Uint64{types.Uint64(25), types.Uint64(3001)},
+		PoStProof:          []byte{0x17},
+		PoStRandomness:     []byte{0x12, 0x16},
+		BlockSig:           []byte{0x4},
 	}
 
 	// Changing BlockSig does not affect output
@@ -364,10 +363,10 @@ func TestSignatureData(t *testing.T) {
 	func() {
 		before := b.SignatureData()
 
-		cpy := b.DeprecatedElectionProof
-		defer func() { b.DeprecatedElectionProof = cpy }()
+		cpy := b.ForkSignaling
+		defer func() { b.ForkSignaling = cpy }()
 
-		b.DeprecatedElectionProof = diff.DeprecatedElectionProof
+		b.ForkSignaling = diff.ForkSignaling
 		after := b.SignatureData()
 		assert.False(t, bytes.Equal(before, after))
 	}()

--- a/internal/pkg/block/epost_info.go
+++ b/internal/pkg/block/epost_info.go
@@ -1,0 +1,43 @@
+package block
+
+import (
+	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+)
+
+func init() {
+	encoding.RegisterIpldCborType(EPoStCandidate{})
+	encoding.RegisterIpldCborType(EPoStInfo{})
+}
+
+// EPoStInfo wraps all data needed to verify an election post proof
+type EPoStInfo struct {
+	PoStProof      types.PoStProof
+	PoStRandomness VRFPi
+	Winners        []EPoStCandidate
+}
+
+// EPoStCandidate wraps the input data needed to verify an election PoSt
+type EPoStCandidate struct {
+	PartialTicket        []byte
+	SectorID             types.Uint64
+	SectorChallengeIndex types.Uint64
+}
+
+// NewEPoStCandidate constructs an epost candidate from data
+func NewEPoStCandidate(sID uint64, pt []byte, sci uint64) EPoStCandidate {
+	return EPoStCandidate{
+		SectorID:             types.Uint64(sID),
+		PartialTicket:        pt,
+		SectorChallengeIndex: types.Uint64(sci),
+	}
+}
+
+// NewEPoStInfo constructs an epost info from data
+func NewEPoStInfo(proof types.PoStProof, rand VRFPi, winners ...EPoStCandidate) EPoStInfo {
+	return EPoStInfo{
+		Winners:        winners,
+		PoStProof:      proof,
+		PoStRandomness: rand,
+	}
+}

--- a/internal/pkg/consensus/block_validation.go
+++ b/internal/pkg/consensus/block_validation.go
@@ -125,13 +125,6 @@ func (dv *DefaultBlockValidator) ValidateSyntax(ctx context.Context, blk *block.
 		return fmt.Errorf("block %s has nil ticket", blk.Cid().String())
 	}
 
-	ptl := len(blk.PoStPartialTickets)
-	sil := len(blk.PoStSectorIDs)
-	cil := len(blk.PoStChallengeIDXs)
-	if ptl != sil || sil != cil {
-		return fmt.Errorf("block %s has invalid PoSt data fields of different lengths", blk.Cid().String())
-	}
-
 	return nil
 }
 

--- a/internal/pkg/consensus/block_validation_test.go
+++ b/internal/pkg/consensus/block_validation_test.go
@@ -102,9 +102,8 @@ func TestBlockValidSyntax(t *testing.T) {
 	validSt := types.NewCidForTestGetter()()
 	validAd := address.NewForTestGetter()()
 	validTi := block.Ticket{VRFProof: []byte{1}}
-	validPoStPartialTickets := [][]byte{{1}}
-	validPoStSectorIDs := []types.Uint64{1}
-	validPoStChallengeIDXs := []types.Uint64{1}
+	validCandidate := block.NewEPoStCandidate(1, []byte{1}, 1)
+	validPoStInfo := block.NewEPoStInfo([]byte{1}, []byte{1}, validCandidate)
 	// create a valid block
 	blk := &block.Block{
 		Timestamp: validTs,
@@ -113,9 +112,7 @@ func TestBlockValidSyntax(t *testing.T) {
 		Ticket:    validTi,
 		Height:    1,
 
-		PoStPartialTickets: validPoStPartialTickets,
-		PoStSectorIDs:      validPoStSectorIDs,
-		PoStChallengeIDXs:  validPoStChallengeIDXs,
+		EPoStInfo: validPoStInfo,
 	}
 	require.NoError(t, validator.ValidateSyntax(ctx, blk))
 
@@ -144,12 +141,6 @@ func TestBlockValidSyntax(t *testing.T) {
 	blk.Ticket = block.Ticket{}
 	require.Error(t, validator.ValidateSyntax(ctx, blk))
 	blk.Ticket = validTi
-	require.NoError(t, validator.ValidateSyntax(ctx, blk))
-
-	// invalidate PoSt
-	blk.PoStSectorIDs = []types.Uint64{0, 5, 3}
-	require.Error(t, validator.ValidateSyntax(ctx, blk))
-	blk.PoStSectorIDs = validPoStSectorIDs
 	require.NoError(t, validator.ValidateSyntax(ctx, blk))
 
 }

--- a/internal/pkg/consensus/election.go
+++ b/internal/pkg/consensus/election.go
@@ -27,14 +27,14 @@ func (em ElectionMachine) GeneratePoStRandomness(ticket block.Ticket, candidateA
 
 // GenerateCandidates creates candidate partial tickets for consideration in
 // block reward election
-func (em ElectionMachine) GenerateCandidates(poStRand []byte, sectorInfos sector.SortedSectorInfo, ep *proofs.ElectionPoster) ([]*proofs.EPoStCandidate, error) {
+func (em ElectionMachine) GenerateCandidates(poStRand []byte, sectorInfos sector.SortedSectorInfo, ep *proofs.ElectionPoster) ([]block.EPoStCandidate, error) {
 	dummyFaults := []uint64{}
 	return ep.GenerateEPostCandidates(sectorInfos, poStRand, dummyFaults)
 }
 
 // GeneratePoSt creates a PoSt proof over the input PoSt candidates.  Should
 // only be called on winning candidates.
-func (em ElectionMachine) GeneratePoSt(allSectorInfos sector.SortedSectorInfo, challengeSeed []byte, winners []*proofs.EPoStCandidate, ep *proofs.ElectionPoster) ([]byte, error) {
+func (em ElectionMachine) GeneratePoSt(allSectorInfos sector.SortedSectorInfo, challengeSeed []byte, winners []block.EPoStCandidate, ep *proofs.ElectionPoster) ([]byte, error) {
 	winnerSectorInfos := filterSectorInfosByCandidates(allSectorInfos, winners)
 	return ep.ComputeElectionPoSt(winnerSectorInfos, challengeSeed, winners)
 }
@@ -70,7 +70,7 @@ func (em ElectionMachine) CandidateWins(challengeTicket []byte, ep *proofs.Elect
 }
 
 // VerifyPoSt verifies a PoSt proof.
-func (em ElectionMachine) VerifyPoSt(ctx context.Context, ep *proofs.ElectionPoster, allSectorInfos sector.SortedSectorInfo, sectorSize uint64, challengeSeed []byte, proof []byte, candidates []*proofs.EPoStCandidate, proverID address.Address) (bool, error) {
+func (em ElectionMachine) VerifyPoSt(ctx context.Context, ep *proofs.ElectionPoster, allSectorInfos sector.SortedSectorInfo, sectorSize uint64, challengeSeed []byte, proof []byte, candidates []block.EPoStCandidate, proverID address.Address) (bool, error) {
 	// filter down sector infos to only those referenced by candidates
 	return ep.VerifyElectionPost(
 		ctx,
@@ -83,10 +83,10 @@ func (em ElectionMachine) VerifyPoSt(ctx context.Context, ep *proofs.ElectionPos
 	)
 }
 
-func filterSectorInfosByCandidates(allSectorInfos sector.SortedSectorInfo, candidates []*proofs.EPoStCandidate) sector.SortedSectorInfo {
+func filterSectorInfosByCandidates(allSectorInfos sector.SortedSectorInfo, candidates []block.EPoStCandidate) sector.SortedSectorInfo {
 	candidateSectorID := make(map[uint64]struct{})
 	for _, candidate := range candidates {
-		candidateSectorID[candidate.SectorID] = struct{}{}
+		candidateSectorID[uint64(candidate.SectorID)] = struct{}{}
 	}
 	var candidateSectorInfos []sector.SectorInfo
 	for _, si := range allSectorInfos.Values() {

--- a/internal/pkg/consensus/testing.go
+++ b/internal/pkg/consensus/testing.go
@@ -163,8 +163,8 @@ func (fem *FakeElectionMachine) GeneratePoStRandomness(_ block.Ticket, _ address
 }
 
 // GenerateCandidates returns one fake election post candidate
-func (fem *FakeElectionMachine) GenerateCandidates(_ []byte, _ sector.SortedSectorInfo, _ *proofs.ElectionPoster) ([]*proofs.EPoStCandidate, error) {
-	return []*proofs.EPoStCandidate{
+func (fem *FakeElectionMachine) GenerateCandidates(_ []byte, _ sector.SortedSectorInfo, _ *proofs.ElectionPoster) ([]block.EPoStCandidate, error) {
+	return []block.EPoStCandidate{
 		{
 			SectorID:             0,
 			PartialTicket:        []byte{0xf},
@@ -174,7 +174,7 @@ func (fem *FakeElectionMachine) GenerateCandidates(_ []byte, _ sector.SortedSect
 }
 
 // GeneratePoSt returns a fake post proof
-func (fem *FakeElectionMachine) GeneratePoSt(_ sector.SortedSectorInfo, _ []byte, _ []*proofs.EPoStCandidate, _ *proofs.ElectionPoster) ([]byte, error) {
+func (fem *FakeElectionMachine) GeneratePoSt(_ sector.SortedSectorInfo, _ []byte, _ []block.EPoStCandidate, _ *proofs.ElectionPoster) ([]byte, error) {
 	return MakeFakePoStForTest(), nil
 }
 
@@ -189,7 +189,7 @@ func (fem *FakeElectionMachine) CandidateWins(_ []byte, _ *proofs.ElectionPoster
 }
 
 // VerifyPoSt return true
-func (fem *FakeElectionMachine) VerifyPoSt(_ context.Context, _ *proofs.ElectionPoster, _ sector.SortedSectorInfo, _ uint64, _ []byte, _ []byte, _ []*proofs.EPoStCandidate, _ address.Address) (bool, error) {
+func (fem *FakeElectionMachine) VerifyPoSt(_ context.Context, _ *proofs.ElectionPoster, _ sector.SortedSectorInfo, _ uint64, _ []byte, _ []byte, _ []block.EPoStCandidate, _ address.Address) (bool, error) {
 	return true, nil
 }
 
@@ -223,7 +223,7 @@ func (fev *FailingElectionValidator) CandidateWins(_ []byte, _ *proofs.ElectionP
 }
 
 // VerifyPoSt returns true without error
-func (fev *FailingElectionValidator) VerifyPoSt(_ context.Context, _ *proofs.ElectionPoster, _ sector.SortedSectorInfo, _ uint64, _ []byte, _ []byte, _ []*proofs.EPoStCandidate, _ address.Address) (bool, error) {
+func (fev *FailingElectionValidator) VerifyPoSt(_ context.Context, _ *proofs.ElectionPoster, _ sector.SortedSectorInfo, _ uint64, _ []byte, _ []byte, _ []block.EPoStCandidate, _ address.Address) (bool, error) {
 	return true, nil
 }
 
@@ -256,8 +256,8 @@ func MakeFakePoStForTest() []byte {
 }
 
 // MakeFakeWinnersForTest creats an empty winners array
-func MakeFakeWinnersForTest() []*proofs.EPoStCandidate {
-	return []*proofs.EPoStCandidate{}
+func MakeFakeWinnersForTest() []block.EPoStCandidate {
+	return []block.EPoStCandidate{}
 }
 
 // NFakeSectorInfos returns numSectors fake sector infos
@@ -412,17 +412,17 @@ func (mem *MockElectionMachine) GeneratePoStRandomness(ticket block.Ticket, cand
 }
 
 // GenerateCandidates defers to a fake election machine
-func (mem *MockElectionMachine) GenerateCandidates(poStRand []byte, sectorInfos sector.SortedSectorInfo, ep *proofs.ElectionPoster) ([]*proofs.EPoStCandidate, error) {
+func (mem *MockElectionMachine) GenerateCandidates(poStRand []byte, sectorInfos sector.SortedSectorInfo, ep *proofs.ElectionPoster) ([]block.EPoStCandidate, error) {
 	return mem.fem.GenerateCandidates(poStRand, sectorInfos, ep)
 }
 
 // GeneratePoSt defers to a fake election machine
-func (mem *MockElectionMachine) GeneratePoSt(sectorInfo sector.SortedSectorInfo, challengeSeed []byte, winners []*proofs.EPoStCandidate, ep *proofs.ElectionPoster) ([]byte, error) {
+func (mem *MockElectionMachine) GeneratePoSt(sectorInfo sector.SortedSectorInfo, challengeSeed []byte, winners []block.EPoStCandidate, ep *proofs.ElectionPoster) ([]byte, error) {
 	return mem.fem.GeneratePoSt(sectorInfo, challengeSeed, winners, ep)
 }
 
 // VerifyPoSt defers to fake
-func (mem *MockElectionMachine) VerifyPoSt(ctx context.Context, ep *proofs.ElectionPoster, allSectorInfos sector.SortedSectorInfo, sectorSize uint64, challengeSeed []byte, proof []byte, candidates []*proofs.EPoStCandidate, proverID address.Address) (bool, error) {
+func (mem *MockElectionMachine) VerifyPoSt(ctx context.Context, ep *proofs.ElectionPoster, allSectorInfos sector.SortedSectorInfo, sectorSize uint64, challengeSeed []byte, proof []byte, candidates []block.EPoStCandidate, proverID address.Address) (bool, error) {
 	return mem.fem.VerifyPoSt(ctx, ep, allSectorInfos, sectorSize, challengeSeed, proof, candidates, proverID)
 }
 

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -135,17 +135,17 @@ func (w *DefaultWorker) Generate(
 
 	now := w.clock.Now()
 	next := &block.Block{
-		Miner:              w.minerAddr,
-		Height:             types.Uint64(blockHeight),
-		Messages:           txMeta,
-		MessageReceipts:    baseReceiptRoot,
-		Parents:            baseTipSet.Key(),
-		ParentWeight:       types.Uint64(weight),
-		EPoStInfo:          ePoStInfo,
-		StateRoot:          baseStateRoot,
-		Ticket:             ticket,
-		Timestamp:          types.Uint64(now.Unix()),
-		BLSAggregateSig:    blsAggregateSig,
+		Miner:           w.minerAddr,
+		Height:          types.Uint64(blockHeight),
+		Messages:        txMeta,
+		MessageReceipts: baseReceiptRoot,
+		Parents:         baseTipSet.Key(),
+		ParentWeight:    types.Uint64(weight),
+		EPoStInfo:       ePoStInfo,
+		StateRoot:       baseStateRoot,
+		Ticket:          ticket,
+		Timestamp:       types.Uint64(now.Unix()),
+		BLSAggregateSig: blsAggregateSig,
 	}
 
 	workerAddr, err := w.api.MinerGetWorkerAddress(ctx, w.minerAddr, baseTipSet.Key())

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -6,7 +6,6 @@ package mining
 
 import (
 	"context"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/proofs"
 	"time"
 
 	"github.com/pkg/errors"
@@ -24,9 +23,7 @@ func (w *DefaultWorker) Generate(
 	baseTipSet block.TipSet,
 	ticket block.Ticket,
 	nullBlockCount uint64,
-	postRandomness []byte,
-	winners []*proofs.EPoStCandidate,
-	post []byte,
+	ePoStInfo block.EPoStInfo,
 ) (*block.Block, error) {
 
 	generateTimer := time.Now()
@@ -67,16 +64,6 @@ func (w *DefaultWorker) Generate(
 	ancestors, err := w.getAncestors(ctx, baseTipSet, types.NewBlockHeight(blockHeight))
 	if err != nil {
 		return nil, errors.Wrap(err, "get base tip set ancestors")
-	}
-
-	// Serialize winners
-	winningSectorIDs := make([]types.Uint64, len(winners))
-	winningChallengeIndexes := make([]types.Uint64, len(winners))
-	winningPartialTickets := make([][]byte, len(winners))
-	for i, candidate := range winners {
-		winningSectorIDs[i] = types.Uint64(candidate.SectorID)
-		winningChallengeIndexes[i] = types.Uint64(candidate.SectorChallengeIndex)
-		winningPartialTickets[i] = candidate.PartialTicket
 	}
 
 	// Construct list of message candidates for inclusion.
@@ -154,11 +141,7 @@ func (w *DefaultWorker) Generate(
 		MessageReceipts:    baseReceiptRoot,
 		Parents:            baseTipSet.Key(),
 		ParentWeight:       types.Uint64(weight),
-		PoStRandomness:     postRandomness,
-		PoStPartialTickets: winningPartialTickets,
-		PoStSectorIDs:      winningSectorIDs,
-		PoStChallengeIDXs:  winningChallengeIndexes,
-		PoStProof:          post,
+		EPoStInfo:          ePoStInfo,
 		StateRoot:          baseStateRoot,
 		Ticket:             ticket,
 		Timestamp:          types.Uint64(now.Unix()),

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -518,7 +518,9 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 	baseTipset := builder.AppendOn(parentTipset, 2)
 	assert.Equal(t, 2, baseTipset.Len())
 
-	blk, err := worker.Generate(ctx, baseTipset, block.Ticket{VRFProof: []byte{2}}, 0, consensus.MakeFakeVRFProofForTest(), consensus.MakeFakeWinnersForTest(), consensus.MakeFakePoStForTest())
+	fakePoStInfo := block.NewEPoStInfo(consensus.MakeFakePoStForTest(), consensus.MakeFakeVRFProofForTest(), consensus.MakeFakeWinnersForTest()...)
+
+	blk, err := worker.Generate(ctx, baseTipset, block.Ticket{VRFProof: []byte{2}}, 0, fakePoStInfo)
 
 	assert.NoError(t, err)
 
@@ -622,9 +624,10 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		Parents:                 block.NewTipSetKey(newCid()),
 		Height:                  types.Uint64(100),
 		StateRoot:               stateRoot,
-		DeprecatedElectionProof: consensus.MakeFakeVRFProofForTest(),
 	}
-	blk, err := worker.Generate(ctx, th.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, 0, consensus.MakeFakeVRFProofForTest(), consensus.MakeFakeWinnersForTest(), consensus.MakeFakePoStForTest())
+	fakePoStInfo := block.NewEPoStInfo(consensus.MakeFakePoStForTest(), consensus.MakeFakeVRFProofForTest(), consensus.MakeFakeWinnersForTest()...)
+
+	blk, err := worker.Generate(ctx, th.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, 0, fakePoStInfo)
 	assert.NoError(t, err)
 
 	// This is the temporary failure + the good message,
@@ -688,18 +691,18 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 		Height:                  h,
 		ParentWeight:            w,
 		StateRoot:               newCid(),
-		DeprecatedElectionProof: consensus.MakeFakeVRFProofForTest(),
 	}
 	baseTipSet := th.RequireNewTipSet(t, &baseBlock)
 	ticket := mining.NthTicket(7)
-	blk, err := worker.Generate(ctx, baseTipSet, ticket, 0, consensus.MakeFakeVRFProofForTest(), consensus.MakeFakeWinnersForTest(), consensus.MakeFakePoStForTest())
+	fakePoStInfo := block.NewEPoStInfo(consensus.MakeFakePoStForTest(), consensus.MakeFakeVRFProofForTest(), consensus.MakeFakeWinnersForTest()...)
+	blk, err := worker.Generate(ctx, baseTipSet, ticket, 0, fakePoStInfo)
 	assert.NoError(t, err)
 
 	assert.Equal(t, h+1, blk.Height)
 	assert.Equal(t, minerAddr, blk.Miner)
 	assert.Equal(t, ticket, blk.Ticket)
 
-	blk, err = worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, 1, consensus.MakeFakeVRFProofForTest(), consensus.MakeFakeWinnersForTest(), consensus.MakeFakePoStForTest())
+	blk, err = worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, 1, fakePoStInfo)
 	assert.NoError(t, err)
 
 	assert.Equal(t, h+2, blk.Height)
@@ -750,9 +753,9 @@ func TestGenerateWithoutMessages(t *testing.T) {
 		Parents:                 block.NewTipSetKey(newCid()),
 		Height:                  types.Uint64(100),
 		StateRoot:               newCid(),
-		DeprecatedElectionProof: consensus.MakeFakeVRFProofForTest(),
 	}
-	blk, err := worker.Generate(ctx, th.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, 0, consensus.MakeFakeVRFProofForTest(), consensus.MakeFakeWinnersForTest(), consensus.MakeFakePoStForTest())
+	fakePoStInfo := block.NewEPoStInfo(consensus.MakeFakePoStForTest(), consensus.MakeFakeVRFProofForTest(), consensus.MakeFakeWinnersForTest()...)
+	blk, err := worker.Generate(ctx, th.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, 0, fakePoStInfo)
 	assert.NoError(t, err)
 
 	assert.Len(t, pool.Pending(), 0) // This is the temporary failure.
@@ -813,10 +816,10 @@ func TestGenerateError(t *testing.T) {
 		Parents:                 block.NewTipSetKey(newCid()),
 		Height:                  types.Uint64(100),
 		StateRoot:               newCid(),
-		DeprecatedElectionProof: consensus.MakeFakeVRFProofForTest(),
 	}
+	fakePoStInfo := block.NewEPoStInfo(consensus.MakeFakePoStForTest(), consensus.MakeFakeVRFProofForTest(), consensus.MakeFakeWinnersForTest()...)
 	baseTipSet := th.RequireNewTipSet(t, &baseBlock)
-	blk, err := worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, 0, consensus.MakeFakeVRFProofForTest(), consensus.MakeFakeWinnersForTest(), consensus.MakeFakePoStForTest())
+	blk, err := worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, 0, fakePoStInfo)
 	assert.Error(t, err, "boom")
 	assert.Nil(t, blk)
 

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -621,9 +621,9 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 	require.NoError(t, err)
 
 	baseBlock := block.Block{
-		Parents:                 block.NewTipSetKey(newCid()),
-		Height:                  types.Uint64(100),
-		StateRoot:               stateRoot,
+		Parents:   block.NewTipSetKey(newCid()),
+		Height:    types.Uint64(100),
+		StateRoot: stateRoot,
 	}
 	fakePoStInfo := block.NewEPoStInfo(consensus.MakeFakePoStForTest(), consensus.MakeFakeVRFProofForTest(), consensus.MakeFakeWinnersForTest()...)
 
@@ -688,9 +688,9 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 	h := types.Uint64(100)
 	w := types.Uint64(1000)
 	baseBlock := block.Block{
-		Height:                  h,
-		ParentWeight:            w,
-		StateRoot:               newCid(),
+		Height:       h,
+		ParentWeight: w,
+		StateRoot:    newCid(),
 	}
 	baseTipSet := th.RequireNewTipSet(t, &baseBlock)
 	ticket := mining.NthTicket(7)
@@ -750,9 +750,9 @@ func TestGenerateWithoutMessages(t *testing.T) {
 
 	assert.Len(t, pool.Pending(), 0)
 	baseBlock := block.Block{
-		Parents:                 block.NewTipSetKey(newCid()),
-		Height:                  types.Uint64(100),
-		StateRoot:               newCid(),
+		Parents:   block.NewTipSetKey(newCid()),
+		Height:    types.Uint64(100),
+		StateRoot: newCid(),
 	}
 	fakePoStInfo := block.NewEPoStInfo(consensus.MakeFakePoStForTest(), consensus.MakeFakeVRFProofForTest(), consensus.MakeFakeWinnersForTest()...)
 	blk, err := worker.Generate(ctx, th.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, 0, fakePoStInfo)
@@ -813,9 +813,9 @@ func TestGenerateError(t *testing.T) {
 
 	assert.Len(t, pool.Pending(), 1)
 	baseBlock := block.Block{
-		Parents:                 block.NewTipSetKey(newCid()),
-		Height:                  types.Uint64(100),
-		StateRoot:               newCid(),
+		Parents:   block.NewTipSetKey(newCid()),
+		Height:    types.Uint64(100),
+		StateRoot: newCid(),
 	}
 	fakePoStInfo := block.NewEPoStInfo(consensus.MakeFakePoStForTest(), consensus.MakeFakeVRFProofForTest(), consensus.MakeFakeWinnersForTest()...)
 	baseTipSet := th.RequireNewTipSet(t, &baseBlock)

--- a/internal/pkg/proofs/election_poster.go
+++ b/internal/pkg/proofs/election_poster.go
@@ -3,6 +3,7 @@ package proofs
 import (
 	"context"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/util/hasher"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
@@ -13,57 +14,36 @@ import (
 // ticket
 const SectorChallengeRatioDiv = 25
 
-// EPoStCandidate wraps the input data needed to verify an election PoSt
-type EPoStCandidate struct {
-	SectorID             uint64
-	PartialTicket        []byte
-	SectorChallengeIndex uint64
-}
-
-// ZipEPoStCandidates creates a slice of EPoSt candidates given slices for the fields
-// Precondition: all slices have the same length
-func ZipEPoStCandidates(sectorIDs, sectorChallengeIndexes []types.Uint64, partialTickets [][]byte) []*EPoStCandidate {
-	candidates := make([]*EPoStCandidate, len(sectorIDs))
-	for i := 0; i < len(sectorIDs); i++ {
-		candidates[i] = &EPoStCandidate{
-			SectorID:             uint64(sectorIDs[i]),
-			PartialTicket:        partialTickets[i],
-			SectorChallengeIndex: uint64(sectorChallengeIndexes[i]),
-		}
-	}
-	return candidates
-}
-
 // ElectionPoster generates and verifies electoin PoSts
 // Dragons: once we have a proper eposter this type should either be
 // replaced or it should be a thin wrapper around the proper eposter
 type ElectionPoster struct{}
 
 // VerifyElectionPost returns the validity of the input PoSt proof
-func (ep *ElectionPoster) VerifyElectionPost(ctx context.Context, sectorSize uint64, sectorInfo sector.SortedSectorInfo, challengeSeed []byte, proof []byte, candidates []*EPoStCandidate, proverID address.Address) (bool, error) {
+func (ep *ElectionPoster) VerifyElectionPost(ctx context.Context, sectorSize uint64, sectorInfo sector.SortedSectorInfo, challengeSeed []byte, proof []byte, candidates []block.EPoStCandidate, proverID address.Address) (bool, error) {
 	return true, nil
 }
 
 // ComputeElectionPoSt returns an election post proving that the partial
 // tickets are linked to the sector commitments.
-func (ep *ElectionPoster) ComputeElectionPoSt(sectorInfo sector.SortedSectorInfo, challengeSeed []byte, winners []*EPoStCandidate) ([]byte, error) {
+func (ep *ElectionPoster) ComputeElectionPoSt(sectorInfo sector.SortedSectorInfo, challengeSeed []byte, winners []block.EPoStCandidate) ([]byte, error) {
 	fakePoSt := make([]byte, 1)
 	fakePoSt[0] = 0xe
 	return fakePoSt, nil
 }
 
 // GenerateEPostCandidates generates election post candidates
-func (ep *ElectionPoster) GenerateEPostCandidates(sectorInfo sector.SortedSectorInfo, challengeSeed []byte, faults []uint64) ([]*EPoStCandidate, error) {
+func (ep *ElectionPoster) GenerateEPostCandidates(sectorInfo sector.SortedSectorInfo, challengeSeed []byte, faults []uint64) ([]block.EPoStCandidate, error) {
 	// Current fake behavior: generate one partial ticket per sector,
 	// each partial ticket is the hash of the challengeSeed and sectorID
-	var candidates []*EPoStCandidate
+	var candidates []block.EPoStCandidate
 	hasher := hasher.NewHasher()
 	for _, si := range sectorInfo.Values() {
 		hasher.Int(si.SectorID)
 		hasher.Bytes(challengeSeed)
-		nextCandidate := &EPoStCandidate{
-			SectorID:             si.SectorID,
-			SectorChallengeIndex: 0, //fake value of 0 for all candidates
+		nextCandidate := block.EPoStCandidate{
+			SectorID:             types.Uint64(si.SectorID),
+			SectorChallengeIndex: types.Uint64(0), //fake value of 0 for all candidates
 			PartialTicket:        hasher.Hash(),
 		}
 		candidates = append(candidates, nextCandidate)

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -32,15 +32,15 @@ func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, sta
 	postInfo := block.NewEPoStInfo(electionProof, postRandomness, winner)
 
 	b := &block.Block{
-		Miner:                   minerAddr,
-		Ticket:                  ticket,
-		Parents:                 baseTipSet.Key(),
-		ParentWeight:            types.Uint64(10000 * height),
-		Height:                  types.Uint64(height),
-		StateRoot:               stateRootCid,
-		MessageReceipts:         receiptRootCid,
-		BLSAggregateSig:         emptyBLSSig,
-		EPoStInfo:                postInfo,
+		Miner:           minerAddr,
+		Ticket:          ticket,
+		Parents:         baseTipSet.Key(),
+		ParentWeight:    types.Uint64(10000 * height),
+		Height:          types.Uint64(height),
+		StateRoot:       stateRootCid,
+		MessageReceipts: receiptRootCid,
+		BLSAggregateSig: emptyBLSSig,
+		EPoStInfo:       postInfo,
 	}
 	sig, err := signer.SignBytes(b.SignatureData(), minerWorker)
 	require.NoError(t, err)

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -27,6 +27,9 @@ func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, sta
 	electionProof := consensus.MakeFakePoStForTest()
 	ticket := consensus.MakeFakeTicketForTest()
 	emptyBLSSig := (*bls.Aggregate([]bls.Signature{}))[:]
+	winner := block.NewEPoStCandidate(0, []byte{0xe}, 0)
+	postRandomness := []byte{0xff}
+	postInfo := block.NewEPoStInfo(electionProof, postRandomness, winner)
 
 	b := &block.Block{
 		Miner:                   minerAddr,
@@ -37,10 +40,7 @@ func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, sta
 		StateRoot:               stateRootCid,
 		MessageReceipts:         receiptRootCid,
 		BLSAggregateSig:         emptyBLSSig,
-		PoStPartialTickets:      [][]byte{{0xe}},
-		PoStSectorIDs:           []types.Uint64{0},
-		PoStChallengeIDXs:       []types.Uint64{0},
-		PoStProof:               electionProof,
+		EPoStInfo:                postInfo,
 	}
 	sig, err := signer.SignBytes(b.SignatureData(), minerWorker)
 	require.NoError(t, err)

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -24,7 +24,7 @@ import (
 // RequireSignedTestBlockFromTipSet creates a block with a valid signature by
 // the passed in miner work and a Miner field set to the minerAddr.
 func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, stateRootCid cid.Cid, receiptRootCid cid.Cid, height uint64, minerAddr address.Address, minerWorker address.Address, signer types.Signer) *block.Block {
-	electionProof := consensus.MakeFakeVRFProofForTest()
+	electionProof := consensus.MakeFakePoStForTest()
 	ticket := consensus.MakeFakeTicketForTest()
 	emptyBLSSig := (*bls.Aggregate([]bls.Signature{}))[:]
 
@@ -36,11 +36,11 @@ func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, sta
 		Height:                  types.Uint64(height),
 		StateRoot:               stateRootCid,
 		MessageReceipts:         receiptRootCid,
-		DeprecatedElectionProof: electionProof,
 		BLSAggregateSig:         emptyBLSSig,
 		PoStPartialTickets:      [][]byte{{0xe}},
 		PoStSectorIDs:           []types.Uint64{0},
 		PoStChallengeIDXs:       []types.Uint64{0},
+		PoStProof:               electionProof,
 	}
 	sig, err := signer.SignBytes(b.SignatureData(), minerWorker)
 	require.NoError(t, err)


### PR DESCRIPTION
### Motivation
On the road to spec compatibility we need to reckon with our encoding.  For our encoding to match the specs we need to embed the Election PoSt information in a set of datastructures matching those specified.  This PR accomplishes that work.

This has the added benefit of helping clean up EPoSt code by passing around logically connected data in a struct.

Note: I hadn't done this before because I had trouble with the refmt encoder.  After spending a little more time with encoding in previous work it turned out that I was badly informed and this is actually trivial!  So this work did not require switching base encodings first.

### Proposed changes

Closes issue #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

