### PR TITLE
Upgrade specs-actors, hamt, and amt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200114015900-4103afa82689
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/go-storage-miner v0.0.0-20200122233640-6a01988b8217
-	github.com/filecoin-project/specs-actors v0.0.0-20200208194833-b27a178cddf8
+	github.com/filecoin-project/specs-actors v0.0.0-20200208232343-e79516a258f1
 	github.com/fxamacker/cbor v1.5.0
 	github.com/go-check/check v0.0.0-20190902080502-41f04d3bba15 // indirect
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/filecoin-project/filecoin-ffi v0.0.0-20191221090835-c7bbef445934
 	github.com/filecoin-project/go-address v0.0.1
-	github.com/filecoin-project/go-amt-ipld v0.0.0-20190920035751-ae3c37184616
+	github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e
 	github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2
 	github.com/filecoin-project/go-data-transfer v0.0.0-20191219005021-4accf56bd2ce
 	github.com/filecoin-project/go-fil-markets v0.0.0-20200204152108-87675b3f9b04
@@ -25,7 +25,7 @@ require (
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200114015900-4103afa82689
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/go-storage-miner v0.0.0-20200122233640-6a01988b8217
-	github.com/filecoin-project/specs-actors v0.0.0-20200129043607-2106ca04a5c9
+	github.com/filecoin-project/specs-actors v0.0.0-20200208194833-b27a178cddf8
 	github.com/fxamacker/cbor v1.5.0
 	github.com/go-check/check v0.0.0-20190902080502-41f04d3bba15 // indirect
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
@@ -42,7 +42,7 @@ require (
 	github.com/ipfs/go-ds-badger v0.0.7
 	github.com/ipfs/go-fs-lock v0.0.1
 	github.com/ipfs/go-graphsync v0.0.4
-	github.com/ipfs/go-hamt-ipld v0.0.14
+	github.com/ipfs/go-hamt-ipld v0.0.15-0.20200131012125-dd88a59d3f2e
 	github.com/ipfs/go-ipfs-blockstore v0.1.1
 	github.com/ipfs/go-ipfs-chunker v0.0.1
 	github.com/ipfs/go-ipfs-cmdkit v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,12 @@ github.com/filecoin-project/go-address v0.0.1 h1:P8MudT6kL/c4CUk+GgjULYEfVnJ7k1E
 github.com/filecoin-project/go-address v0.0.1/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-amt-ipld v0.0.0-20190920035751-ae3c37184616 h1:e0P1b9Lam9oA7TC/YBoR23uMsDuMLQU3iTvUJXmDaqM=
 github.com/filecoin-project/go-amt-ipld v0.0.0-20190920035751-ae3c37184616/go.mod h1:lKjJYPg2kwbav5f78i5YA8kGccnZn18IySbpneXvaQs=
+github.com/filecoin-project/go-amt-ipld v1.0.0 h1:jJteqdKcwFYoN9Wgs7MzDWVWvRWUfhhFo4bltJ7wrus=
+github.com/filecoin-project/go-amt-ipld v1.0.0/go.mod h1:KsFPWjF+UUYl6n9A+qbg4bjFgAOneicFZtDH/LQEX2U=
+github.com/filecoin-project/go-amt-ipld/v2 v2.0.0 h1:rQ7GTJbWE5XqUCPiBgs4gbTKD2wC7MynZhSaf7ZzlUM=
+github.com/filecoin-project/go-amt-ipld/v2 v2.0.0/go.mod h1:PAZ5tvSfMfWE327osqFXKm7cBpCpBk2Nh0qKsJUmjjk=
+github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e h1:IOoff6yAZSJ5zHCPY2jzGNwQYQU6ygsRVe/cSnJrY+o=
+github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2 h1:av5fw6wmm58FYMgJeoB/lK9XXrgdugYiTqkdxjTy9k8=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2/go.mod h1:pqTiPHobNkOVM5thSRsHYjyQfq7O5QSCMhvuu9JoDlg=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMXdBnCiXjfCYx/hLqFxccPoqsSveQFxVLvNxy9bus=
@@ -171,6 +177,8 @@ github.com/filecoin-project/go-storage-miner v0.0.0-20200122233640-6a01988b8217 
 github.com/filecoin-project/go-storage-miner v0.0.0-20200122233640-6a01988b8217/go.mod h1:9QP2qibO+2SXJ8KKfmltupMh2qwXy8OatiIgEkL48SQ=
 github.com/filecoin-project/specs-actors v0.0.0-20200129043607-2106ca04a5c9 h1:pAm0fXDtyUq1RkJZIP1tO09nKRZbr1BVf88SJdPm06M=
 github.com/filecoin-project/specs-actors v0.0.0-20200129043607-2106ca04a5c9/go.mod h1:R6LZUV0VfaIZYFijtln0jjVHkR2n9DOW/aBYcyTfzv8=
+github.com/filecoin-project/specs-actors v0.0.0-20200208194833-b27a178cddf8 h1:EDRXSW7ABdBkp/mrm/2ovkmzqFaieRtOb3JQE2Jjy9A=
+github.com/filecoin-project/specs-actors v0.0.0-20200208194833-b27a178cddf8/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fxamacker/cbor v1.5.0 h1:idAiyeNSq/jeG9FPbCLVZLFJjsxP+g40a3UrXFapumw=
@@ -410,6 +418,8 @@ github.com/ipfs/go-graphsync v0.0.4 h1:iF98+J8pcqvEb48IM0TemqeGARsCDtwQ73P9ejMZI
 github.com/ipfs/go-graphsync v0.0.4/go.mod h1:6UACBjfOXEa8rQL3Q/JpZpWS0nZDCLx134WUkjrmFpQ=
 github.com/ipfs/go-hamt-ipld v0.0.14 h1:yNMDYacEGKg9UYZ1AmHjbetiKLMQQZRVHF8EW+2+O5w=
 github.com/ipfs/go-hamt-ipld v0.0.14/go.mod h1:9qtwSG3ADoN1lo0Y+1+nsIY7aovJ1BP8g2P++igXuPo=
+github.com/ipfs/go-hamt-ipld v0.0.15-0.20200131012125-dd88a59d3f2e h1:bUtmeXx6JpjxRPlMdlKfPXC5kKhLHuueXKgs1Txb9ZU=
+github.com/ipfs/go-hamt-ipld v0.0.15-0.20200131012125-dd88a59d3f2e/go.mod h1:9aQJu/i/TaRDW6jqB5U217dLIDopn50wxLdHXM2CTfE=
 github.com/ipfs/go-ipfs-blockstore v0.0.1 h1:O9n3PbmTYZoNhkgkEyrXTznbmktIXif62xLX+8dPHzc=
 github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma1gROTlovZKBmN08=
 github.com/ipfs/go-ipfs-blockstore v0.1.0 h1:V1GZorHFUIB6YgTJQdq7mcaIpUfCM3fCyVi+MTo9O88=

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,8 @@ github.com/filecoin-project/specs-actors v0.0.0-20200129043607-2106ca04a5c9 h1:p
 github.com/filecoin-project/specs-actors v0.0.0-20200129043607-2106ca04a5c9/go.mod h1:R6LZUV0VfaIZYFijtln0jjVHkR2n9DOW/aBYcyTfzv8=
 github.com/filecoin-project/specs-actors v0.0.0-20200208194833-b27a178cddf8 h1:EDRXSW7ABdBkp/mrm/2ovkmzqFaieRtOb3JQE2Jjy9A=
 github.com/filecoin-project/specs-actors v0.0.0-20200208194833-b27a178cddf8/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
+github.com/filecoin-project/specs-actors v0.0.0-20200208232343-e79516a258f1 h1:H33KrU/rKkHhFNeFlmkMWxs9TztR8QAwTzDAchMpDoM=
+github.com/filecoin-project/specs-actors v0.0.0-20200208232343-e79516a258f1/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fxamacker/cbor v1.5.0 h1:idAiyeNSq/jeG9FPbCLVZLFJjsxP+g40a3UrXFapumw=

--- a/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/ipfs/go-graphsync"
-	"github.com/ipfs/go-hamt-ipld"
 
 	"github.com/filecoin-project/go-address"
 	graphsyncimpl "github.com/filecoin-project/go-data-transfer/impl/graphsync"
@@ -21,6 +20,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/paths"
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/plumbing/msg"
 	storagemarketconnector "github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/storage_market_connector"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/cborutil"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/piecemanager"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/wallet"
 )
@@ -50,7 +50,7 @@ func NewStorageProtocolSubmodule(
 	wg storagemarketconnector.WorkerGetter) (*StorageProtocolSubmodule, error) {
 
 	pnode := storagemarketconnector.NewStorageProviderNodeConnector(minerAddr, c.State, m.Outbox, mw, pm, wg, wlt)
-	cnode := storagemarketconnector.NewStorageClientNodeConnector(hamt.CSTFromBstore(bs), c.State, mw, wlt, m.Outbox, clientAddr, wg)
+	cnode := storagemarketconnector.NewStorageClientNodeConnector(cborutil.NewIpldStore(bs), c.State, mw, wlt, m.Outbox, clientAddr, wg)
 
 	pieceStagingPath, err := paths.PieceStagingDir(repoPath)
 	if err != nil {

--- a/internal/app/go-filecoin/plumbing/cst/chain_state.go
+++ b/internal/app/go-filecoin/plumbing/cst/chain_state.go
@@ -37,7 +37,7 @@ type chainReadWriter interface {
 	GetTipSet(block.TipSetKey) (block.TipSet, error)
 	GetTipSetState(context.Context, block.TipSetKey) (state.Tree, error)
 	SetHead(context.Context, block.TipSet) error
-	ReadonlyIpldStore() cborutil.ReadOnlyIpldStore
+	ReadOnlyStateStore() cborutil.ReadOnlyIpldStore
 }
 
 // ChainStateReadWriter composes a:
@@ -90,7 +90,7 @@ func NewChainStateReadWriter(crw chainReadWriter, messages chain.MessageProvider
 		bstore:            bs,
 		messageProvider:   messages,
 		actors:            ba,
-		ReadOnlyIpldStore: crw.ReadonlyIpldStore(),
+		ReadOnlyIpldStore: crw.ReadOnlyStateStore(),
 	}
 }
 
@@ -240,8 +240,9 @@ func (chn *ChainStateReadWriter) SetHead(ctx context.Context, key block.TipSetKe
 	return chn.readWriter.SetHead(ctx, headTs)
 }
 
-func (chn *ChainStateReadWriter) ReadonlyIpldStore() cborutil.ReadOnlyIpldStore {
-	return chn.readWriter.ReadonlyIpldStore()
+// ReadOnlyStateStore returns a read-only state store.
+func (chn *ChainStateReadWriter) ReadOnlyStateStore() cborutil.ReadOnlyIpldStore {
+	return chn.readWriter.ReadOnlyStateStore()
 }
 
 // ChainExport exports the chain from `head` up to and including the genesis block to `out`

--- a/internal/app/go-filecoin/storage_market_connector/client.go
+++ b/internal/app/go-filecoin/storage_market_connector/client.go
@@ -11,8 +11,8 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/abi"
 	fcsm "github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/storagemarket"
-	spaminer "github.com/filecoin-project/specs-actors/actors/builtin/storage_miner"
-	spapow "github.com/filecoin-project/specs-actors/actors/builtin/storage_power"
+	spaminer "github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	spapow "github.com/filecoin-project/specs-actors/actors/builtin/power"
 
 	"github.com/filecoin-project/go-fil-markets/shared/tokenamount"
 	smtypes "github.com/filecoin-project/go-fil-markets/shared/types"
@@ -81,14 +81,14 @@ func (s *StorageClientNodeConnector) ListClientDeals(ctx context.Context, addr a
 // ListStorageProviders finds all miners that will provide storage
 func (s *StorageClientNodeConnector) ListStorageProviders(ctx context.Context) ([]*storagemarket.StorageProviderInfo, error) {
 	head := s.chainStore.Head()
-	var spState spapow.StoragePowerActorState
+	var spState spapow.State
 	err := s.chainStore.GetActorStateAt(ctx, head, vmaddr.StoragePowerAddress, &spState)
 	if err != nil {
 		return nil, err
 	}
 
 	infos := []*storagemarket.StorageProviderInfo{}
-	powerHamt, err := hamt.LoadNode(ctx, s.cborStore, spState.PowerTable)
+	powerHamt, err := hamt.LoadNode(ctx, s.cborStore, spState.Claims)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (s *StorageClientNodeConnector) ListStorageProviders(ctx context.Context) (
 			return err
 		}
 
-		var mState spaminer.StorageMinerActorState
+		var mState spaminer.State
 		err = s.chainStore.GetActorStateAt(ctx, head, minerAddr, &mState)
 		if err != nil {
 			return err

--- a/internal/app/go-filecoin/storage_market_connector/common.go
+++ b/internal/app/go-filecoin/storage_market_connector/common.go
@@ -310,6 +310,7 @@ func (c *connectorCommon) listDeals(ctx context.Context, addr address.Address) (
 	return deals, nil
 }
 
+// StoreFromCbor wraps a cbor store for ADT access.
 func StoreFromCbor(ctx context.Context, ipldStore cbor.IpldStore) adt.Store {
 	return &cstore{ctx, ipldStore}
 }

--- a/internal/app/go-filecoin/storage_market_connector/provider.go
+++ b/internal/app/go-filecoin/storage_market_connector/provider.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"io"
 
-	"github.com/ipfs/go-cid"
-	"github.com/pkg/errors"
-	"golang.org/x/xerrors"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/shared/tokenamount"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
-	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	spasm "github.com/filecoin-project/specs-actors/actors/builtin/market"
 	spaminer "github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/ipfs/go-cid"
+	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/plumbing/msg"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/message"
@@ -183,7 +183,7 @@ func (s *StorageProviderNodeConnector) LocatePieceForDealWithinSector(ctx contex
 		}
 		sectorNumber = uint64(k)
 
-		for _, deal := range sectorInfo.Info.DealIDs{
+		for _, deal := range sectorInfo.Info.DealIDs {
 			if uint64(deal) == dealID {
 				offset = uint64(0)
 				for _, did := range sectorInfo.Info.DealIDs {

--- a/internal/pkg/cborutil/ipld.go
+++ b/internal/pkg/cborutil/ipld.go
@@ -8,10 +8,12 @@ import (
 	cbor "github.com/ipfs/go-ipld-cbor"
 )
 
+// ReadOnlyIpldStore is a store that rejects writes.
 type ReadOnlyIpldStore struct {
 	cbor.IpldStore
 }
 
+// Put returns an error.
 func (s *ReadOnlyIpldStore) Put(ctx context.Context, v interface{}) (cid.Cid, error) {
 	return cid.Undef, errors.New("readonly store")
 }

--- a/internal/pkg/cborutil/ipld.go
+++ b/internal/pkg/cborutil/ipld.go
@@ -1,0 +1,17 @@
+package cborutil
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+)
+
+type ReadOnlyIpldStore struct {
+	cbor.IpldStore
+}
+
+func (s *ReadOnlyIpldStore) Put(ctx context.Context, v interface{}) (cid.Cid, error) {
+	return cid.Undef, errors.New("readonly store")
+}

--- a/internal/pkg/chain/store.go
+++ b/internal/pkg/chain/store.go
@@ -345,8 +345,8 @@ func (store *Store) SetHead(ctx context.Context, ts block.TipSet) error {
 	return nil
 }
 
-// Provides a read-only IPLD store for access to chain state.
-func (store *Store) ReadonlyIpldStore() cborutil.ReadOnlyIpldStore {
+// ReadOnlyStateStore provides a read-only IPLD store for access to chain state.
+func (store *Store) ReadOnlyStateStore() cborutil.ReadOnlyIpldStore {
 	return cborutil.ReadOnlyIpldStore{IpldStore: store.stateAndBlockSource.cborStore}
 }
 

--- a/internal/pkg/consensus/genesis.go
+++ b/internal/pkg/consensus/genesis.go
@@ -7,8 +7,10 @@ import (
 
 	bls "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-amt-ipld"
+	"github.com/filecoin-project/go-amt-ipld/v2"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/cborutil"
+
 	"github.com/ipfs/go-cid"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
@@ -231,7 +233,7 @@ func MakeGenesisFunc(opts ...GenOption) GenesisInitFunc {
 			return nil, err
 		}
 
-		emptyAMTCid, err := amt.FromArray(amt.WrapBlockstore(bs), []typegen.CBORMarshaler{})
+		emptyAMTCid, err := amt.FromArray(ctx, cborutil.NewIpldStore(bs), []typegen.CBORMarshaler{})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/types/message.go
+++ b/internal/pkg/types/message.go
@@ -2,13 +2,14 @@ package types
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-amt-ipld"
+	"github.com/filecoin-project/go-amt-ipld/v2"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
@@ -16,6 +17,7 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 	errPkg "github.com/pkg/errors"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/cborutil"
 	e "github.com/filecoin-project/go-filecoin/internal/pkg/enccid"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	typegen "github.com/whyrusleeping/cbor-gen"
@@ -50,7 +52,7 @@ var EmptyMessagesCID cid.Cid
 var EmptyReceiptsCID cid.Cid
 
 func init() {
-	emptyAMTCid, err := amt.FromArray(amt.WrapBlockstore(blockstore.NewBlockstore(datastore.NewMapDatastore())), []typegen.CBORMarshaler{})
+	emptyAMTCid, err := amt.FromArray(context.Background(), cborutil.NewIpldStore(blockstore.NewBlockstore(datastore.NewMapDatastore())), []typegen.CBORMarshaler{})
 	if err != nil {
 		panic("could not create CID for empty AMT")
 	}

--- a/tools/gengen/util/gengen.go
+++ b/tools/gengen/util/gengen.go
@@ -9,7 +9,7 @@ import (
 
 	bls "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-amt-ipld"
+	"github.com/filecoin-project/go-amt-ipld/v2"
 	bserv "github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-car"
 	"github.com/ipfs/go-cid"
@@ -152,7 +152,7 @@ func GenGen(ctx context.Context, cfg *GenesisCfg, cst cbor.IpldStore, bs blockst
 	}
 
 	// define empty cid and ensure empty components exist in blockstore
-	emptyAMTCid, err := amt.FromArray(amt.WrapBlockstore(bs), []typegen.CBORMarshaler{})
+	emptyAMTCid, err := amt.FromArray(ctx, cborutil.NewIpldStore(bs), []typegen.CBORMarshaler{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Upgrade to the new hotness.

This required fixing up the storage market connector to traverse the tree-structured state. This in turn requires read access to the state store. It was hard to work out the "best" way to do this: it's new here because previously we used the full query method execution machinery to access state. We can probably make this more obvious and straightforward later.

FYI @acruikshank , @ZenGround0 