### PR TITLE
Messages field moves to cid from TxMeta

### DIFF
--- a/cmd/go-filecoin/show.go
+++ b/cmd/go-filecoin/show.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	e "github.com/filecoin-project/go-filecoin/internal/pkg/enccid"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 
 	"github.com/ipfs/go-cid"
@@ -127,9 +126,9 @@ Timestamp:  %s
 
 var showMessagesCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
-		Tagline: "Show a filecoin message collection by its CID",
+		Tagline: "Show a filecoin message collection by txmeta CID",
 		ShortDescription: `Prints info for all messages in a collection,
-at the given CID.  Message collection CIDs are found in the "Messages" field of 
+at the given CID.  This CID is found in the "Messages" field of 
 the filecoin block header.`,
 	},
 	Arguments: []cmdkit.Argument{
@@ -141,10 +140,7 @@ the filecoin block header.`,
 			return err
 		}
 
-		messages, err := GetPorcelainAPI(env).ChainGetMessages(
-			req.Context,
-			types.TxMeta{SecpRoot: e.NewCid(cid), BLSRoot: e.NewCid(types.EmptyMessagesCID)},
-		)
+		messages, err := GetPorcelainAPI(env).ChainGetMessages(req.Context, cid)
 		if err != nil {
 			return err
 		}

--- a/cmd/go-filecoin/show_test.go
+++ b/cmd/go-filecoin/show_test.go
@@ -204,7 +204,7 @@ func TestBlockDaemon(t *testing.T) {
 		assert.Equal(t, from, blockGetBlock.Messages[0].Message.From)
 
 		// Full block matches show messages
-		messagesGetLine := cmdClient.RunSuccessFirstLine(ctx, "show", "messages", blockGetBlock.Header.Messages.SecpRoot.String(), "--enc", "json")
+		messagesGetLine := cmdClient.RunSuccessFirstLine(ctx, "show", "messages", blockGetBlock.Header.Messages.String(), "--enc", "json")
 		var messages []*types.SignedMessage
 		require.NoError(t, json.Unmarshal([]byte(messagesGetLine), &messages))
 		assert.Equal(t, blockGetBlock.Messages, messages)

--- a/internal/app/go-filecoin/plumbing/api.go
+++ b/internal/app/go-filecoin/plumbing/api.go
@@ -144,8 +144,8 @@ func (api *API) ChainGetBlock(ctx context.Context, id cid.Cid) (*block.Block, er
 }
 
 // ChainGetMessages gets a message collection by CID
-func (api *API) ChainGetMessages(ctx context.Context, meta types.TxMeta) ([]*types.SignedMessage, error) {
-	return api.chain.GetMessages(ctx, meta)
+func (api *API) ChainGetMessages(ctx context.Context, metaCid cid.Cid) ([]*types.SignedMessage, error) {
+	return api.chain.GetMessages(ctx, metaCid)
 }
 
 // ChainGetReceipts gets a receipt collection by CID

--- a/internal/app/go-filecoin/plumbing/cst/chain_state.go
+++ b/internal/app/go-filecoin/plumbing/cst/chain_state.go
@@ -122,8 +122,8 @@ func (chn *ChainStateReadWriter) GetBlock(ctx context.Context, id cid.Cid) (*blo
 }
 
 // GetMessages gets a message collection by CID.
-func (chn *ChainStateReadWriter) GetMessages(ctx context.Context, meta types.TxMeta) ([]*types.SignedMessage, error) {
-	secp, _, err := chn.messageProvider.LoadMessages(ctx, meta)
+func (chn *ChainStateReadWriter) GetMessages(ctx context.Context, metaCid cid.Cid) ([]*types.SignedMessage, error) {
+	secp, _, err := chn.messageProvider.LoadMessages(ctx, metaCid)
 	if err != nil {
 		return []*types.SignedMessage{}, err
 	}

--- a/internal/app/go-filecoin/plumbing/msg/waiter.go
+++ b/internal/app/go-filecoin/plumbing/msg/waiter.go
@@ -172,7 +172,7 @@ func (w *Waiter) receiptForTipset(ctx context.Context, ts block.TipSet, pred Wai
 	tsMessages := make([][]*types.UnsignedMessage, ts.Len())
 	for i := 0; i < ts.Len(); i++ {
 		blk := ts.At(i)
-		secpMsgs, blsMsgs, err := w.messageProvider.LoadMessages(ctx, blk.Messages)
+		secpMsgs, blsMsgs, err := w.messageProvider.LoadMessages(ctx, blk.Messages.Cid)
 		if err != nil {
 			return nil, false, err
 		}

--- a/internal/app/go-filecoin/plumbing/msg/waiter_test.go
+++ b/internal/app/go-filecoin/plumbing/msg/waiter_test.go
@@ -194,7 +194,7 @@ func newChainWithMessages(store cbor.IpldStore, msgStore *chain.MessageStore, ro
 			child := &block.Block{
 				Height:          height,
 				Parents:         parents.Key(),
-				Messages:        emptyTxMeta,
+				Messages:        e.NewCid(emptyTxMeta),
 				MessageReceipts: e.NewCid(emptyReceiptsCid),
 			}
 			mustPut(store, child)
@@ -214,7 +214,7 @@ func newChainWithMessages(store cbor.IpldStore, msgStore *chain.MessageStore, ro
 			}
 
 			child := &block.Block{
-				Messages:  txMeta,
+				Messages:  e.NewCid(txMeta),
 				Parents:   parents.Key(),
 				Height:    height,
 				StateRoot: e.NewCid(stateRootCidGetter()), // Differentiate all blocks

--- a/internal/app/go-filecoin/porcelain/chain.go
+++ b/internal/app/go-filecoin/porcelain/chain.go
@@ -28,7 +28,7 @@ func ChainHead(plumbing chainHeadPlumbing) (block.TipSet, error) {
 
 type fullBlockPlumbing interface {
 	ChainGetBlock(context.Context, cid.Cid) (*block.Block, error)
-	ChainGetMessages(context.Context, types.TxMeta) ([]*types.SignedMessage, error)
+	ChainGetMessages(context.Context, cid.Cid) ([]*types.SignedMessage, error)
 }
 
 // GetFullBlock returns a full block: header, messages, receipts.
@@ -41,7 +41,7 @@ func GetFullBlock(ctx context.Context, plumbing fullBlockPlumbing, id cid.Cid) (
 		return nil, err
 	}
 
-	out.Messages, err = plumbing.ChainGetMessages(ctx, out.Header.Messages)
+	out.Messages, err = plumbing.ChainGetMessages(ctx, out.Header.Messages.Cid)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/block/block.go
+++ b/internal/pkg/block/block.go
@@ -50,7 +50,7 @@ type Block struct {
 	MessageReceipts e.Cid `json:"messageReceipts,omitempty"`
 
 	// Messages is the set of messages included in this block
-	Messages types.TxMeta `json:"messages,omitempty"`
+	Messages e.Cid `json:"messages,omitempty"`
 
 	// The aggregate signature of all BLS signed messages in the block
 	BLSAggregateSig types.Signature `json:"blsAggregateSig"`

--- a/internal/pkg/block/block_test.go
+++ b/internal/pkg/block/block_test.go
@@ -67,7 +67,7 @@ func TestTriangleEncoding(t *testing.T) {
 			Miner:           newAddress(),
 			Ticket:          blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
 			Height:          2,
-			Messages:        types.TxMeta{SecpRoot: e.NewCid(types.CidFromString(t, "somecid")), BLSRoot: e.NewCid(types.EmptyMessagesCID)},
+			Messages:        e.NewCid(types.CidFromString(t, "somecid")),
 			MessageReceipts: e.NewCid(types.CidFromString(t, "somecid")),
 			Parents:         blk.NewTipSetKey(types.CidFromString(t, "somecid")),
 			ParentWeight:    fbig.NewInt(1000),
@@ -119,7 +119,7 @@ func TestDecodeBlock(t *testing.T) {
 			Parents:         blk.NewTipSetKey(c1),
 			Height:          2,
 			ParentWeight:    fbig.Zero(),
-			Messages:        types.TxMeta{SecpRoot: e.NewCid(cM), BLSRoot: e.NewCid(types.EmptyMessagesCID)},
+			Messages:        e.NewCid(cM),
 			StateRoot:       e.NewCid(c2),
 			MessageReceipts: e.NewCid(cR),
 		}
@@ -189,7 +189,7 @@ func TestBlockJsonMarshal(t *testing.T) {
 	child.Parents = blk.NewTipSetKey(parent.Cid())
 	child.StateRoot = e.NewCid(parent.Cid())
 
-	child.Messages = types.TxMeta{SecpRoot: e.NewCid(types.CidFromString(t, "somecid")), BLSRoot: e.NewCid(types.EmptyMessagesCID)}
+	child.Messages = e.NewCid(types.CidFromString(t, "somecid"))
 	child.MessageReceipts = e.NewCid(types.CidFromString(t, "somecid"))
 
 	marshalled, e1 := json.Marshal(&child)
@@ -198,7 +198,7 @@ func TestBlockJsonMarshal(t *testing.T) {
 
 	assert.Contains(t, str, child.Miner.String())
 	assert.Contains(t, str, parent.Cid().String())
-	assert.Contains(t, str, child.Messages.SecpRoot.String())
+	assert.Contains(t, str, child.Messages.String())
 	assert.Contains(t, str, child.MessageReceipts.String())
 
 	// marshal/unmarshal symmetry
@@ -222,7 +222,7 @@ func TestSignatureData(t *testing.T) {
 		Miner:           newAddress(),
 		Ticket:          blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
 		Height:          2,
-		Messages:        types.TxMeta{SecpRoot: e.NewCid(types.CidFromString(t, "somecid")), BLSRoot: e.NewCid(types.EmptyMessagesCID)},
+		Messages:        e.NewCid(types.CidFromString(t, "somecid")),
 		MessageReceipts: e.NewCid(types.CidFromString(t, "somecid")),
 		Parents:         blk.NewTipSetKey(types.CidFromString(t, "somecid")),
 		ParentWeight:    fbig.NewInt(1000),
@@ -241,7 +241,7 @@ func TestSignatureData(t *testing.T) {
 		Miner:           newAddress(),
 		Ticket:          blk.Ticket{VRFProof: []byte{0x03, 0x01, 0x02}},
 		Height:          3,
-		Messages:        types.TxMeta{SecpRoot: e.NewCid(types.CidFromString(t, "someothercid")), BLSRoot: e.NewCid(types.EmptyMessagesCID)},
+		Messages:        e.NewCid(types.CidFromString(t, "someothercid")),
 		MessageReceipts: e.NewCid(types.CidFromString(t, "someothercid")),
 		Parents:         blk.NewTipSetKey(types.CidFromString(t, "someothercid")),
 		ParentWeight:    fbig.NewInt(1001),

--- a/internal/pkg/block/tipset_test.go
+++ b/internal/pkg/block/tipset_test.go
@@ -39,7 +39,7 @@ func block(t *testing.T, ticket []byte, height int, parentCid cid.Cid, parentWei
 		Parents:         blk.NewTipSetKey(parentCid),
 		ParentWeight:    fbig.NewInt(int64(parentWeight)),
 		Height:          42 + uint64(height),
-		Messages:        types.TxMeta{SecpRoot: e.NewCid(cidGetter()), BLSRoot: e.NewCid(types.EmptyMessagesCID)},
+		Messages:        e.NewCid(cidGetter()),
 		StateRoot:       e.NewCid(cidGetter()),
 		MessageReceipts: e.NewCid(cidGetter()),
 		Timestamp:       timestamp,

--- a/internal/pkg/chain/message_store.go
+++ b/internal/pkg/chain/message_store.go
@@ -6,11 +6,11 @@ import (
 	"github.com/filecoin-project/go-amt-ipld/v2"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/cborutil"
 	e "github.com/filecoin-project/go-filecoin/internal/pkg/enccid"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-ipfs-blockstore"
-	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/multiformats/go-multihash"
 	"github.com/pkg/errors"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -19,15 +19,17 @@ import (
 // MessageProvider is an interface exposing the load methods of the
 // MessageStore.
 type MessageProvider interface {
-	LoadMessages(context.Context, types.TxMeta) ([]*types.SignedMessage, []*types.UnsignedMessage, error)
+	LoadMessages(context.Context, cid.Cid) ([]*types.SignedMessage, []*types.UnsignedMessage, error)
 	LoadReceipts(context.Context, cid.Cid) ([]*types.MessageReceipt, error)
+	LoadTxMeta(context.Context, cid.Cid) (types.TxMeta, error)
 }
 
 // MessageWriter is an interface exposing the write methods of the
 // MessageStore.
 type MessageWriter interface {
-	StoreMessages(ctx context.Context, secpMessages []*types.SignedMessage, blsMessages []*types.UnsignedMessage) (types.TxMeta, error)
+	StoreMessages(ctx context.Context, secpMessages []*types.SignedMessage, blsMessages []*types.UnsignedMessage) (cid.Cid, error)
 	StoreReceipts(context.Context, []*types.MessageReceipt) (cid.Cid, error)
+	StoreTxMeta(context.Context, types.TxMeta) (cid.Cid, error)
 }
 
 // MessageStore stores and loads collections of signed messages and receipts.
@@ -42,7 +44,13 @@ func NewMessageStore(bs blockstore.Blockstore) *MessageStore {
 
 // LoadMessages loads the signed messages in the collection with cid c from ipld
 // storage.
-func (ms *MessageStore) LoadMessages(ctx context.Context, meta types.TxMeta) ([]*types.SignedMessage, []*types.UnsignedMessage, error) {
+func (ms *MessageStore) LoadMessages(ctx context.Context, metaCid cid.Cid) ([]*types.SignedMessage, []*types.UnsignedMessage, error) {
+	// load txmeta
+	meta, err := ms.LoadTxMeta(ctx, metaCid)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	secpCids, err := ms.loadAMTCids(ctx, meta.SecpRoot.Cid)
 	if err != nil {
 		return nil, nil, err
@@ -57,7 +65,7 @@ func (ms *MessageStore) LoadMessages(ctx context.Context, meta types.TxMeta) ([]
 		}
 
 		message := &types.SignedMessage{}
-		if err := cbor.DecodeInto(messageBlock.RawData(), message); err != nil {
+		if err := encoding.Decode(messageBlock.RawData(), message); err != nil {
 			return nil, nil, errors.Wrapf(err, "could not decode secp message %s", c)
 		}
 		secpMsgs[i] = message
@@ -77,7 +85,7 @@ func (ms *MessageStore) LoadMessages(ctx context.Context, meta types.TxMeta) ([]
 		}
 
 		message := &types.UnsignedMessage{}
-		if err := cbor.DecodeInto(messageBlock.RawData(), message); err != nil {
+		if err := encoding.Decode(messageBlock.RawData(), message); err != nil {
 			return nil, nil, errors.Wrapf(err, "could not decode bls message %s", c)
 		}
 		blsMsgs[i] = message
@@ -88,34 +96,34 @@ func (ms *MessageStore) LoadMessages(ctx context.Context, meta types.TxMeta) ([]
 
 // StoreMessages puts the input signed messages to a collection and then writes
 // this collection to ipld storage.  The cid of the collection is returned.
-func (ms *MessageStore) StoreMessages(ctx context.Context, secpMessages []*types.SignedMessage, blsMessages []*types.UnsignedMessage) (types.TxMeta, error) {
+func (ms *MessageStore) StoreMessages(ctx context.Context, secpMessages []*types.SignedMessage, blsMessages []*types.UnsignedMessage) (cid.Cid, error) {
 	var ret types.TxMeta
 	var err error
 
 	// store secp messages
 	secpCids, err := ms.storeSignedMessages(secpMessages)
 	if err != nil {
-		return types.TxMeta{}, errors.Wrap(err, "could not store secp messages")
+		return cid.Undef, errors.Wrap(err, "could not store secp messages")
 	}
 
 	secpRaw, err := ms.storeAMTCids(ctx, secpCids)
 	if err != nil {
-		return types.TxMeta{}, errors.Wrap(err, "could not store secp cids as AMT")
+		return cid.Undef, errors.Wrap(err, "could not store secp cids as AMT")
 	}
 	ret.SecpRoot = e.NewCid(secpRaw)
 
 	// store bls messages
 	blsCids, err := ms.storeUnsignedMessages(blsMessages)
 	if err != nil {
-		return types.TxMeta{}, errors.Wrap(err, "could not store secp cids as AMT")
+		return cid.Undef, errors.Wrap(err, "could not store secp cids as AMT")
 	}
 	blsRaw, err := ms.storeAMTCids(ctx, blsCids)
 	if err != nil {
-		return types.TxMeta{}, errors.Wrap(err, "could not store bls cids as AMT")
+		return cid.Undef, errors.Wrap(err, "could not store bls cids as AMT")
 	}
 	ret.BLSRoot = e.NewCid(blsRaw)
 
-	return ret, nil
+	return ms.StoreTxMeta(ctx, ret)
 }
 
 // LoadReceipts loads the signed messages in the collection with cid c from ipld
@@ -135,7 +143,7 @@ func (ms *MessageStore) LoadReceipts(ctx context.Context, c cid.Cid) ([]*types.M
 		}
 
 		receipt := &types.MessageReceipt{}
-		if err := cbor.DecodeInto(receiptBlock.RawData(), receipt); err != nil {
+		if err := encoding.Decode(receiptBlock.RawData(), receipt); err != nil {
 			return nil, errors.Wrapf(err, "could not decode receipt %s", c)
 		}
 		receipts[i] = receipt
@@ -176,6 +184,20 @@ func (ms *MessageStore) loadAMTCids(ctx context.Context, c cid.Cid) ([]cid.Cid, 
 	return cids, nil
 }
 
+// LoadTxMeta loads the secproot, blsroot data from the message store
+func (ms *MessageStore) LoadTxMeta(ctx context.Context, c cid.Cid) (types.TxMeta, error) {
+	metaBlock, err := ms.bs.Get(c)
+	if err != nil {
+		return types.TxMeta{}, errors.Wrapf(err, "failed to get tx meta %s", c)
+	}
+
+	var meta types.TxMeta
+	if err := encoding.Decode(metaBlock.RawData(), &meta); err != nil {
+		return types.TxMeta{}, errors.Wrapf(err, "could not decode tx meta %s", c)
+	}
+	return meta, nil
+}
+
 func (ms *MessageStore) storeUnsignedMessages(messages []*types.UnsignedMessage) ([]cid.Cid, error) {
 	cids := make([]cid.Cid, len(messages))
 	var err error
@@ -198,6 +220,11 @@ func (ms *MessageStore) storeSignedMessages(messages []*types.SignedMessage) ([]
 		}
 	}
 	return cids, nil
+}
+
+// StoreTxMeta writes the secproot, blsroot block to the message store
+func (ms *MessageStore) StoreTxMeta(ctx context.Context, meta types.TxMeta) (cid.Cid, error) {
+	return ms.storeBlock(meta)
 }
 
 func (ms *MessageStore) storeMessageReceipts(receipts []*types.MessageReceipt) ([]cid.Cid, error) {
@@ -226,7 +253,7 @@ func (ms *MessageStore) storeBlock(data interface{}) (cid.Cid, error) {
 }
 
 func makeBlock(obj interface{}) (blocks.Block, error) {
-	data, err := cbor.DumpObject(obj)
+	data, err := encoding.Encode(obj)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/chainsync/fetcher/graphsync_helpers_test.go
+++ b/internal/pkg/chainsync/fetcher/graphsync_helpers_test.go
@@ -349,16 +349,12 @@ func requireBlockStorePut(t *testing.T, bs bstore.Blockstore, data format.Node) 
 }
 
 func simpleBlock() *block.Block {
-	meta := types.TxMeta{
-		SecpRoot: e.NewCid(types.EmptyMessagesCID),
-		BLSRoot:  e.NewCid(types.EmptyMessagesCID),
-	}
 	return &block.Block{
 		ParentWeight:    fbig.Zero(),
 		Parents:         block.NewTipSetKey(),
 		Height:          0,
 		StateRoot:       e.NewCid(types.EmptyMessagesCID),
-		Messages:        meta,
+		Messages:        e.NewCid(types.EmptyTxMetaCID),
 		MessageReceipts: e.NewCid(types.EmptyReceiptsCID),
 	}
 }

--- a/internal/pkg/chainsync/internal/syncer/syncer.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer.go
@@ -88,7 +88,7 @@ type ChainReaderWriter interface {
 }
 
 type messageStore interface {
-	LoadMessages(context.Context, types.TxMeta) ([]*types.SignedMessage, []*types.UnsignedMessage, error)
+	LoadMessages(context.Context, cid.Cid) ([]*types.SignedMessage, []*types.UnsignedMessage, error)
 	LoadReceipts(context.Context, cid.Cid) ([]*types.MessageReceipt, error)
 	StoreReceipts(context.Context, []*types.MessageReceipt) (cid.Cid, error)
 }
@@ -269,7 +269,7 @@ func (syncer *Syncer) syncOne(ctx context.Context, grandParent, parent, next blo
 	var nextBlsMessages [][]*types.UnsignedMessage
 	for i := 0; i < next.Len(); i++ {
 		blk := next.At(i)
-		secpMsgs, blsMsgs, err := syncer.messageProvider.LoadMessages(ctx, blk.Messages)
+		secpMsgs, blsMsgs, err := syncer.messageProvider.LoadMessages(ctx, blk.Messages.Cid)
 		if err != nil {
 			return errors.Wrapf(err, "syncing tip %s failed loading message list %s for block %s", next.Key(), blk.Messages, blk.Cid())
 		}

--- a/internal/pkg/consensus/genesis.go
+++ b/internal/pkg/consensus/genesis.go
@@ -246,10 +246,15 @@ func MakeGenesisFunc(opts ...GenOption) GenesisInitFunc {
 		}
 
 		emptyBLSSignature := bls.Aggregate([]bls.Signature{})
+		emptyMeta := types.TxMeta{SecpRoot: e.NewCid(emptyAMTCid), BLSRoot: e.NewCid(emptyAMTCid)}
+		emptyMetaCid, err := cst.Put(ctx, emptyMeta)
+		if err != nil {
+			return nil, err
+		}
 
 		genesis := &block.Block{
 			StateRoot:       e.NewCid(c),
-			Messages:        types.TxMeta{SecpRoot: e.NewCid(emptyAMTCid), BLSRoot: e.NewCid(emptyAMTCid)},
+			Messages:        e.NewCid(emptyMetaCid),
 			MessageReceipts: e.NewCid(emptyAMTCid),
 			BLSAggregateSig: emptyBLSSignature[:],
 			Ticket:          block.Ticket{VRFProof: []byte{0xec}},

--- a/internal/pkg/message/inbox.go
+++ b/internal/pkg/message/inbox.go
@@ -29,7 +29,7 @@ type Inbox struct {
 
 // messageProvider provides message collections given their cid.
 type messageProvider interface {
-	LoadMessages(context.Context, types.TxMeta) ([]*types.SignedMessage, []*types.UnsignedMessage, error)
+	LoadMessages(context.Context, cid.Cid) ([]*types.SignedMessage, []*types.UnsignedMessage, error)
 }
 
 // NewInbox constructs a new inbox.
@@ -77,7 +77,7 @@ func (ib *Inbox) HandleNewHead(ctx context.Context, oldChain, newChain []block.T
 	for _, tipset := range oldChain {
 		for i := 0; i < tipset.Len(); i++ {
 			block := tipset.At(i)
-			secpMsgs, _, err := ib.messageProvider.LoadMessages(ctx, block.Messages)
+			secpMsgs, _, err := ib.messageProvider.LoadMessages(ctx, block.Messages.Cid)
 			if err != nil {
 				return err
 			}
@@ -97,7 +97,7 @@ func (ib *Inbox) HandleNewHead(ctx context.Context, oldChain, newChain []block.T
 	var removeCids []cid.Cid
 	for _, tipset := range newChain {
 		for i := 0; i < tipset.Len(); i++ {
-			secpMsgs, _, err := ib.messageProvider.LoadMessages(ctx, tipset.At(i).Messages)
+			secpMsgs, _, err := ib.messageProvider.LoadMessages(ctx, tipset.At(i).Messages.Cid)
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/message/policy.go
+++ b/internal/pkg/message/policy.go
@@ -66,7 +66,7 @@ func (p *DefaultQueuePolicy) HandleNewHead(ctx context.Context, target PolicyTar
 	chain.Reverse(newTips)
 	for _, tipset := range newTips {
 		for i := 0; i < tipset.Len(); i++ {
-			secpMsgs, _, err := p.messageProvider.LoadMessages(ctx, tipset.At(i).Messages)
+			secpMsgs, _, err := p.messageProvider.LoadMessages(ctx, tipset.At(i).Messages.Cid)
 			if err != nil {
 				return err
 			}
@@ -94,7 +94,7 @@ func (p *DefaultQueuePolicy) HandleNewHead(ctx context.Context, target PolicyTar
 	// Traverse these in descending height order.
 	for _, tipset := range oldTips {
 		for i := 0; i < tipset.Len(); i++ {
-			secpMsgs, _, err := p.messageProvider.LoadMessages(ctx, tipset.At(i).Messages)
+			secpMsgs, _, err := p.messageProvider.LoadMessages(ctx, tipset.At(i).Messages.Cid)
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/metrics/heartbeat_test.go
+++ b/internal/pkg/metrics/heartbeat_test.go
@@ -195,7 +195,7 @@ func mustMakeTipset(t *testing.T, height uint64) block.TipSet {
 		ParentWeight:    fbig.Zero(),
 		Height:          height,
 		MessageReceipts: e.NewCid(types.EmptyMessagesCID),
-		Messages:        types.TxMeta{SecpRoot: e.NewCid(types.EmptyReceiptsCID), BLSRoot: e.NewCid(types.EmptyMessagesCID)},
+		Messages:        e.NewCid(types.EmptyTxMetaCID),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -85,7 +85,7 @@ func (w *DefaultWorker) Generate(
 	}
 
 	// Persist messages to ipld storage
-	txMeta, err := w.messageStore.StoreMessages(ctx, secpAccepted, unwrappedBLSMessages)
+	txMetaCid, err := w.messageStore.StoreMessages(ctx, secpAccepted, unwrappedBLSMessages)
 	if err != nil {
 		return nil, errors.Wrap(err, "error persisting messages")
 	}
@@ -105,7 +105,7 @@ func (w *DefaultWorker) Generate(
 	next := &block.Block{
 		Miner:           w.minerAddr,
 		Height:          blockHeight,
-		Messages:        txMeta,
+		Messages:        e.NewCid(txMetaCid),
 		MessageReceipts: e.NewCid(baseReceiptRoot),
 		Parents:         baseTipSet.Key(),
 		ParentWeight:    weight,

--- a/internal/pkg/types/message.go
+++ b/internal/pkg/types/message.go
@@ -51,13 +51,21 @@ var EmptyMessagesCID cid.Cid
 // EmptyReceiptsCID is the cid of an empty collection of receipts.
 var EmptyReceiptsCID cid.Cid
 
+// EmptyTxMetaCID is the cid of a TxMeta wrapping empty cids
+var EmptyTxMetaCID cid.Cid
+
 func init() {
-	emptyAMTCid, err := amt.FromArray(context.Background(), cborutil.NewIpldStore(blockstore.NewBlockstore(datastore.NewMapDatastore())), []typegen.CBORMarshaler{})
+	tmpCst := cborutil.NewIpldStore(blockstore.NewBlockstore(datastore.NewMapDatastore()))
+	emptyAMTCid, err := amt.FromArray(context.Background(), tmpCst, []typegen.CBORMarshaler{})
 	if err != nil {
 		panic("could not create CID for empty AMT")
 	}
 	EmptyMessagesCID = emptyAMTCid
 	EmptyReceiptsCID = emptyAMTCid
+	EmptyTxMetaCID, err = tmpCst.Put(context.Background(), TxMeta{SecpRoot: e.NewCid(EmptyMessagesCID), BLSRoot: e.NewCid(EmptyMessagesCID)})
+	if err != nil {
+		panic("could not create CID for empty TxMeta")
+	}
 }
 
 var (

--- a/tools/fast/series/wait_for_chain_message.go
+++ b/tools/fast/series/wait_for_chain_message.go
@@ -53,7 +53,7 @@ func WaitForChainMessage(ctx context.Context, node *fast.Filecoin, fn MsgSearchF
 
 func findMessageInBlockSlice(ctx context.Context, node *fast.Filecoin, blks []block.Block, fn MsgSearchFn) (*MsgInfo, error) {
 	for _, blk := range blks {
-		msgs, err := node.ShowMessages(ctx, blk.Messages.SecpRoot.Cid)
+		msgs, err := node.ShowMessages(ctx, blk.Messages.Cid)
 		if err != nil {
 			return nil, err
 		}

--- a/tools/gengen/util/gengen.go
+++ b/tools/gengen/util/gengen.go
@@ -159,10 +159,15 @@ func GenGen(ctx context.Context, cfg *GenesisCfg, cst cbor.IpldStore, bs blockst
 	}
 
 	emptyBLSSignature := bls.Aggregate([]bls.Signature{})
+	meta := types.TxMeta{SecpRoot: e.NewCid(emptyAMTCid), BLSRoot: e.NewCid(emptyAMTCid)}
+	metaCid, err := cst.Put(ctx, meta)
+	if err != nil {
+		return nil, err
+	}
 
 	geneblk := &block.Block{
 		StateRoot:       e.NewCid(stateRoot),
-		Messages:        types.TxMeta{SecpRoot: e.NewCid(emptyAMTCid), BLSRoot: e.NewCid(emptyAMTCid)},
+		Messages:        e.NewCid(metaCid),
 		MessageReceipts: e.NewCid(emptyAMTCid),
 		BLSAggregateSig: emptyBLSSignature[:],
 		Ticket:          block.Ticket{VRFProof: []byte{0xec}},


### PR DESCRIPTION
### Motivation
We read the spec wrong a while back and put the txmeta datastructure directly in the header instead of a cid to it.  This PR moves the datastructure to a cid.

### Proposed changes
Move txmeta to cid, modify message store interface slightly for convenience, modify graphsync fetcher behavior to handle new subcomponent of full blocks, fix up some trailing ipld-cbor encoding dependencies in the messaging system.

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

