### PR TITLE
Tipset key encoding tweak

### DIFF
--- a/internal/pkg/block/tipset_key.go
+++ b/internal/pkg/block/tipset_key.go
@@ -152,6 +152,11 @@ func (s *TipSetKey) UnmarshalJSON(b []byte) error {
 
 // MarshalCBOR marshals the tipset key as an array of cids
 func (s TipSetKey) MarshalCBOR() ([]byte, error) {
+	// encode the zero value as length zero slice instead of nil per spec
+	if s.cids == nil {
+		encodableZero := make([]e.Cid, 0)
+		return encoding.Encode(encodableZero)
+	}
 	return encoding.Encode(s.cids)
 }
 


### PR DESCRIPTION
### Motivation
Get our encoding up to spec

### Proposed changes
Our tipsetkey's zero value is kept as nil rather than the empty slice.  This is a good thing for internal reasons but it causes a minor discrepency in encoding that keeps us from being able to write the spec compliant `0x80` bytes for an empty tipset key, instead writing `0xf6`.  This PR tweak our encoding to handle the zero value correctly.

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

