### PR TITLE
Fix encoding of address keys in the state root

### DIFF
--- a/cmd/go-filecoin/actor.go
+++ b/cmd/go-filecoin/actor.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/filecoin-project/go-address"
+
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/account"
@@ -94,7 +96,7 @@ var actorLsCmd = &cmds.Command{
 	},
 }
 
-func makeActorView(act *actor.Actor, addr string, actType interface{}) *ActorView {
+func makeActorView(act *actor.Actor, addr address.Address, actType interface{}) *ActorView {
 	var actorType string
 	if actType == nil {
 		actorType = "UnknownActor"
@@ -104,7 +106,7 @@ func makeActorView(act *actor.Actor, addr string, actType interface{}) *ActorVie
 
 	return &ActorView{
 		ActorType: actorType,
-		Address:   addr,
+		Address:   addr.String(),
 		Code:      act.Code.Cid,
 		Nonce:     uint64(act.CallSeqNum),
 		Balance:   types.NewAttoFILFromFIL(uint64(act.Balance.Int64())),

--- a/cmd/go-filecoin/address.go
+++ b/cmd/go-filecoin/address.go
@@ -39,12 +39,12 @@ var addrsCmd = &cmds.Command{
 }
 
 type addressResult struct {
-	Address string
+	Address address.Address
 }
 
 // AddressLsResult is the result of running the address list command.
 type AddressLsResult struct {
-	Addresses []string
+	Addresses []address.Address
 }
 
 var addrsNewCmd = &cmds.Command{
@@ -54,7 +54,7 @@ var addrsNewCmd = &cmds.Command{
 		if err != nil {
 			return err
 		}
-		return re.Emit(&addressResult{addr.String()})
+		return re.Emit(&addressResult{addr})
 	},
 	Options: []cmdkit.Option{
 		cmdkit.StringOption("type", "The type of address to create: bls or secp256k1 (default)").WithDefault(types.SECP256K1),
@@ -62,7 +62,7 @@ var addrsNewCmd = &cmds.Command{
 	Type: &addressResult{},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, a *addressResult) error {
-			_, err := fmt.Fprintln(w, a.Address)
+			_, err := fmt.Fprintln(w, a.Address.String())
 			return err
 		}),
 	},
@@ -74,7 +74,7 @@ var addrsLsCmd = &cmds.Command{
 
 		var alr AddressLsResult
 		for _, addr := range addrs {
-			alr.Addresses = append(alr.Addresses, addr.String())
+			alr.Addresses = append(alr.Addresses, addr)
 		}
 
 		return re.Emit(&alr)
@@ -83,7 +83,7 @@ var addrsLsCmd = &cmds.Command{
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, addrs *AddressLsResult) error {
 			for _, addr := range addrs.Addresses {
-				_, err := fmt.Fprintln(w, addr)
+				_, err := fmt.Fprintln(w, addr.String())
 				if err != nil {
 					return err
 				}
@@ -105,7 +105,7 @@ var addrsLookupCmd = &cmds.Command{
 
 		v, err := GetPorcelainAPI(env).MinerGetPeerID(req.Context, addr)
 		if err != nil {
-			return errors.Wrapf(err, "failed to find miner with address %s", addr.String())
+			return errors.Wrapf(err, "failed to find miner with address %s", addr)
 		}
 		return re.Emit(v.Pretty())
 	},
@@ -125,12 +125,12 @@ var defaultAddressCmd = &cmds.Command{
 			return err
 		}
 
-		return re.Emit(&addressResult{addr.String()})
+		return re.Emit(&addressResult{addr})
 	},
 	Type: &addressResult{},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, a *addressResult) error {
-			_, err := fmt.Fprintln(w, a.Address)
+			_, err := fmt.Fprintln(w, a.Address.String())
 			return err
 		}),
 	},
@@ -197,7 +197,7 @@ var walletImportCmd = &cmds.Command{
 
 		var alr AddressLsResult
 		for _, addr := range addrs {
-			alr.Addresses = append(alr.Addresses, addr.String())
+			alr.Addresses = append(alr.Addresses, addr)
 		}
 
 		return re.Emit(&alr)
@@ -206,7 +206,7 @@ var walletImportCmd = &cmds.Command{
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, addrs *AddressLsResult) error {
 			for _, addr := range addrs.Addresses {
-				_, err := fmt.Fprintln(w, addr)
+				_, err := fmt.Fprintln(w, addr.String())
 				if err != nil {
 					return err
 				}
@@ -249,7 +249,7 @@ var walletExportCmd = &cmds.Command{
 					return err
 				}
 				privateKeyInBase64 := base64.StdEncoding.EncodeToString(k.PrivateKey)
-				_, err = fmt.Fprintf(w, "Address:\t%s\nPrivateKey:\t%s\nCurve:\t\t%s\n\n", a.String(), privateKeyInBase64, k.CryptSystem)
+				_, err = fmt.Fprintf(w, "Address:\t%s\nPrivateKey:\t%s\nCurve:\t\t%s\n\n", a, privateKeyInBase64, k.CryptSystem)
 				if err != nil {
 					return err
 				}

--- a/cmd/go-filecoin/address_integration_test.go
+++ b/cmd/go-filecoin/address_integration_test.go
@@ -98,18 +98,18 @@ func TestAddrLookupAndUpdate(t *testing.T) {
 	minerPidForUpdate := th.RequireRandomPeerID(t)
 
 	// capture original, pre-update miner pid
-	lookupOutA := cmdClient.RunSuccessFirstLine(ctx, "address", "lookup", minerAddr)
+	lookupOutA := cmdClient.RunSuccessFirstLine(ctx, "address", "lookup", minerAddr.String())
 
 	// Not a miner address, should fail.
-	cmdClient.RunFail(ctx, "failed to find", "address", "lookup", addr)
+	cmdClient.RunFail(ctx, "failed to find", "address", "lookup", addr.String())
 
 	// update the miner's peer ID
 	updateMsg := cmdClient.RunSuccessFirstLine(ctx,
 		"miner", "update-peerid",
-		"--from", addr,
+		"--from", addr.String(),
 		"--gas-price", "1",
 		"--gas-limit", "300",
-		minerAddr,
+		minerAddr.String(),
 		minerPidForUpdate.Pretty(),
 	)
 
@@ -122,7 +122,7 @@ func TestAddrLookupAndUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	// use the address lookup command to ensure update happened
-	lookupOutB := cmdClient.RunSuccessFirstLine(ctx, "address", "lookup", minerAddr)
+	lookupOutB := cmdClient.RunSuccessFirstLine(ctx, "address", "lookup", minerAddr.String())
 	assert.Equal(t, minerPidForUpdate.Pretty(), lookupOutB)
 	assert.NotEqual(t, lookupOutA, lookupOutB)
 }
@@ -150,7 +150,7 @@ func TestWalletLoadFromFile(t *testing.T) {
 	}
 
 	// assert default amount of funds were allocated to address during genesis
-	wb := cmdClient.RunSuccess(ctx, "wallet", "balance", fixtures.TestAddresses[0]).ReadStdoutTrimNewlines()
+	wb := cmdClient.RunSuccess(ctx, "wallet", "balance", fixtures.TestAddresses[0].String()).ReadStdoutTrimNewlines()
 	assert.Contains(t, wb, "10000")
 }
 

--- a/cmd/go-filecoin/client_daemon_test.go
+++ b/cmd/go-filecoin/client_daemon_test.go
@@ -33,7 +33,7 @@ func TestListAsks(t *testing.T) {
 	minerDaemon.MinerSetPrice(fixtures.TestMiners[0], fixtures.TestAddresses[0], "20", "10")
 
 	listAsksOutput := minerDaemon.RunSuccess("client", "list-asks").ReadStdoutTrimNewlines()
-	assert.Equal(t, fixtures.TestMiners[0]+" 000 20 11", listAsksOutput)
+	assert.Equal(t, fixtures.TestMiners[0].String()+" 000 20 11", listAsksOutput)
 }
 
 func TestStorageDealsAfterRestart(t *testing.T) {
@@ -62,7 +62,7 @@ func TestStorageDealsAfterRestart(t *testing.T) {
 	clientDaemon.WaitForMessageRequireSuccess(addAskCid)
 	dataCid := clientDaemon.RunWithStdin(strings.NewReader("HODLHODLHODL"), "client", "import").ReadStdoutTrimNewlines()
 
-	proposeDealOutput := clientDaemon.RunSuccess("client", "propose-storage-deal", fixtures.TestMiners[0], dataCid, "0", "5").ReadStdoutTrimNewlines()
+	proposeDealOutput := clientDaemon.RunSuccess("client", "propose-storage-deal", fixtures.TestMiners[0].String(), dataCid, "0", "5").ReadStdoutTrimNewlines()
 
 	splitOnSpace := strings.Split(proposeDealOutput, " ")
 
@@ -227,7 +227,7 @@ func TestVoucherPersistenceAndPayments(t *testing.T) {
 	miner.MinerSetPrice(fixtures.TestMiners[0], fixtures.TestAddresses[0], "20", "10")
 	dataCid := client.RunWithStdin(strings.NewReader("HODLHODLHODL"), "client", "import").ReadStdoutTrimNewlines()
 
-	proposeDealOutput := client.RunSuccess("client", "propose-storage-deal", fixtures.TestMiners[0], dataCid, "0", "3000").ReadStdoutTrimNewlines()
+	proposeDealOutput := client.RunSuccess("client", "propose-storage-deal", fixtures.TestMiners[0].String(), dataCid, "0", "3000").ReadStdoutTrimNewlines()
 
 	splitOnSpace := strings.Split(proposeDealOutput, " ")
 
@@ -274,7 +274,7 @@ func TestPieceRejectionInProposeStorageDeal(t *testing.T) {
 
 	dataCid := clientDaemon.RunWithStdin(bytes.NewReader(make([]byte, 3000)), "client", "import").ReadStdoutTrimNewlines()
 
-	proposeDealErrors := clientDaemon.Run("client", "propose-storage-deal", fixtures.TestMiners[0], dataCid, "0", "5").ReadStderr()
+	proposeDealErrors := clientDaemon.Run("client", "propose-storage-deal", fixtures.TestMiners[0].String(), dataCid, "0", "5").ReadStderr()
 
 	assert.Contains(t, proposeDealErrors, "piece is 3000 bytes but sector size is 1016 bytes")
 }

--- a/cmd/go-filecoin/deals_daemon_test.go
+++ b/cmd/go-filecoin/deals_daemon_test.go
@@ -58,7 +58,7 @@ func TestDealsList(t *testing.T) {
 	addAskCid := minerDaemon.MinerSetPrice(fixtures.TestMiners[0], fixtures.TestAddresses[0], "20", "10")
 	clientDaemon.WaitForMessageRequireSuccess(addAskCid)
 	dataCid := clientDaemon.RunWithStdin(strings.NewReader("HODLHODLHODL"), "client", "import").ReadStdoutTrimNewlines()
-	proposeDealOutput := clientDaemon.RunSuccess("client", "propose-storage-deal", fixtures.TestMiners[0], dataCid, "0", "5").ReadStdoutTrimNewlines()
+	proposeDealOutput := clientDaemon.RunSuccess("client", "propose-storage-deal", fixtures.TestMiners[0].String(), dataCid, "0", "5").ReadStdoutTrimNewlines()
 	splitOnSpace := strings.Split(proposeDealOutput, " ")
 	dealCid1 := splitOnSpace[len(splitOnSpace)-1]
 
@@ -66,7 +66,7 @@ func TestDealsList(t *testing.T) {
 	dataCid = clientDaemon.RunWithStdin(strings.NewReader("FREEASINBEER"), "client", "import").ReadStdoutTrimNewlines()
 	addAskCid = minerDaemon.MinerSetPrice(fixtures.TestMiners[0], fixtures.TestAddresses[0], "0", "10")
 	clientDaemon.WaitForMessageRequireSuccess(addAskCid)
-	proposeDealOutput = clientDaemon.RunSuccess("client", "propose-storage-deal", fixtures.TestMiners[0], dataCid, "1", "5").ReadStdoutTrimNewlines()
+	proposeDealOutput = clientDaemon.RunSuccess("client", "propose-storage-deal", fixtures.TestMiners[0].String(), dataCid, "1", "5").ReadStdoutTrimNewlines()
 	splitOnSpace = strings.Split(proposeDealOutput, " ")
 	dealCid2 := splitOnSpace[len(splitOnSpace)-1]
 
@@ -165,7 +165,7 @@ func TestDealsShow(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(10), res.Duration)
-		assert.Equal(t, ask.Miner.String(), res.Miner.String())
+		assert.Equal(t, ask.Miner, res.Miner)
 		assert.Equal(t, storagedeal.Accepted, res.State)
 
 		duri64 := int64(res.Duration)
@@ -357,11 +357,11 @@ func assertEqualVoucherResults(t *testing.T, expected, actual []*commands.Paymen
 	var channelID *types.ChannelID
 	for i, vr := range expected {
 		assert.Equal(t, vr.Index, actual[i].Index)
-		assert.Equal(t, vr.Payer.String(), actual[i].Payer.String())
+		assert.Equal(t, vr.Payer, actual[i].Payer)
 
 		if vr.Condition != nil {
 			assert.Equal(t, vr.Condition.Method, actual[i].Condition.Method)
-			assert.Equal(t, vr.Condition.To.String(), actual[i].Condition.To.String())
+			assert.Equal(t, vr.Condition.To, actual[i].Condition.To)
 		} else {
 			assert.Nil(t, actual[i].Condition)
 		}

--- a/cmd/go-filecoin/message_integration_test.go
+++ b/cmd/go-filecoin/message_integration_test.go
@@ -22,8 +22,7 @@ func TestMessageSend(t *testing.T) {
 	tf.IntegrationTest(t)
 	ctx := context.Background()
 	builder := test.NewNodeBuilder(t)
-	defaultAddr, err := address.NewFromString(fixtures.TestAddresses[0])
-	require.NoError(t, err)
+	defaultAddr := fixtures.TestAddresses[0]
 
 	cs := node.FixtureChainSeed(t)
 	builder.WithGenesisInit(cs.GenesisInitFunc)
@@ -35,7 +34,7 @@ func TestMessageSend(t *testing.T) {
 	n, cmdClient, done := builder.BuildAndStartAPI(ctx)
 	defer done()
 
-	_, err = n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+	_, err := n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
 	require.NoError(t, err)
 
 	from, err := n.PorcelainAPI.WalletDefaultAddress() // this should = fixtures.TestAddresses[0]
@@ -58,7 +57,7 @@ func TestMessageSend(t *testing.T) {
 		"--from", from.String(),
 		"--gas-price", "1",
 		"--gas-limit", "300",
-		fixtures.TestAddresses[3],
+		fixtures.TestAddresses[3].String(),
 	)
 
 	t.Log("[success] with from and int value")
@@ -69,7 +68,7 @@ func TestMessageSend(t *testing.T) {
 		"--gas-price", "1",
 		"--gas-limit", "300",
 		"--value", "10",
-		fixtures.TestAddresses[3],
+		fixtures.TestAddresses[3].String(),
 	)
 
 	t.Log("[success] with from and decimal value")
@@ -80,7 +79,7 @@ func TestMessageSend(t *testing.T) {
 		"--gas-price", "1",
 		"--gas-limit", "300",
 		"--value", "5.5",
-		fixtures.TestAddresses[3],
+		fixtures.TestAddresses[3].String(),
 	)
 }
 
@@ -96,10 +95,10 @@ func TestMessageWait(t *testing.T) {
 
 	t.Run("[success] transfer only", func(t *testing.T) {
 		msg := cmdClient.RunSuccess(ctx, "message", "send",
-			"--from", fixtures.TestAddresses[0],
+			"--from", fixtures.TestAddresses[0].String(),
 			"--gas-price", "1",
 			"--gas-limit", "300",
-			fixtures.TestAddresses[1],
+			fixtures.TestAddresses[1].String(),
 		)
 		msgcid := msg.ReadStdoutTrimNewlines()
 
@@ -137,8 +136,7 @@ func TestMessageSendBlockGasLimit(t *testing.T) {
 
 	ctx := context.Background()
 	builder := test.NewNodeBuilder(t)
-	defaultAddr, err := address.NewFromString(fixtures.TestAddresses[0])
-	require.NoError(t, err)
+	defaultAddr := fixtures.TestAddresses[0]
 
 	buildWithMiner(t, builder)
 	builder.WithConfig(node.DefaultAddressConfigOpt(defaultAddr))
@@ -155,7 +153,7 @@ func TestMessageSendBlockGasLimit(t *testing.T) {
 			"block gas limit",
 			"message", "send",
 			"--gas-price", "1", "--gas-limit", doubleTheBlockGasLimit,
-			"--value=10", fixtures.TestAddresses[1],
+			"--value=10", fixtures.TestAddresses[1].String(),
 		)
 	})
 
@@ -164,7 +162,7 @@ func TestMessageSendBlockGasLimit(t *testing.T) {
 			ctx,
 			"message", "send",
 			"--gas-price", "1", "--gas-limit", halfTheBlockGasLimit,
-			"--value=10", fixtures.TestAddresses[1],
+			"--value=10", fixtures.TestAddresses[1].String(),
 		)
 
 		blk, err := n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
@@ -193,10 +191,10 @@ func TestMessageStatus(t *testing.T) {
 		msg := cmdClient.RunSuccess(
 			ctx,
 			"message", "send",
-			"--from", fixtures.TestAddresses[0],
+			"--from", fixtures.TestAddresses[0].String(),
 			"--gas-price", "1", "--gas-limit", "300",
 			"--value=1234",
-			fixtures.TestAddresses[1],
+			fixtures.TestAddresses[1].String(),
 		)
 
 		msgcid := msg.ReadStdoutTrimNewlines()

--- a/cmd/go-filecoin/miner.go
+++ b/cmd/go-filecoin/miner.go
@@ -265,10 +265,10 @@ This command waits for the ask to be mined.`,
 	Published ask, cid: %s.
 	Ask confirmed on chain in block: %s.
 `,
-				res.MinerSetPriceResponse.MinerAddr.String(),
-				res.MinerSetPriceResponse.Price.String(),
-				res.MinerSetPriceResponse.AddAskCid.String(),
-				res.MinerSetPriceResponse.BlockCid.String(),
+				res.MinerSetPriceResponse.MinerAddr,
+				res.MinerSetPriceResponse.Price,
+				res.MinerSetPriceResponse.AddAskCid,
+				res.MinerSetPriceResponse.BlockCid,
 			)
 			return err
 		}),
@@ -558,7 +558,7 @@ var minerWorkerAddressCmd = &cmds.Command{
 		}
 
 		res := MinerWorkerResult{WorkerAddress: workerAddr}
-		fmt.Printf("workerAddr: %s", res.WorkerAddress.String())
+		fmt.Printf("workerAddr: %s", res.WorkerAddress)
 		return re.Emit(&res)
 	},
 	Type: &MinerWorkerResult{},

--- a/cmd/go-filecoin/miner_daemon_test.go
+++ b/cmd/go-filecoin/miner_daemon_test.go
@@ -118,8 +118,7 @@ func TestMinerCreate(t *testing.T) {
 	t.Skip("Long term solution: #3642")
 	tf.IntegrationTest(t)
 
-	testAddr, err := address.NewFromString(fixtures.TestAddresses[2])
-	require.NoError(t, err)
+	testAddr := fixtures.TestAddresses[2]
 
 	t.Run("success", func(t *testing.T) {
 
@@ -263,8 +262,7 @@ func TestMinerCreateChargesGas(t *testing.T) {
 	tf.IntegrationTest(t)
 	t.Skip("new runtime")
 
-	// miningMinerOwnerAddr, err := address.NewFromString(fixtures.TestAddresses[0])
-	// require.NoError(t, err)
+	// miningMinerOwnerAddr := fixtures.TestAddresses[0]
 
 	// d1 := makeTestDaemonWithMinerAndStart(t)
 	// defer d1.ShutdownSuccess()
@@ -485,7 +483,7 @@ func TestMinerWorker(t *testing.T) {
 		res, err := minerNode.MinerWorker(ctx)
 		fmt.Println(minerNode.LastCmdStdErrStr())
 		require.NoError(t, err)
-		assert.Equal(t, workerAddr.String(), res.WorkerAddress.String())
+		assert.Equal(t, workerAddr, res.WorkerAddress)
 	})
 }
 
@@ -528,6 +526,6 @@ func TestMinerSetWorker(t *testing.T) {
 		res2, err := minerNode.MinerWorker(ctx)
 		require.NoError(t, err)
 
-		assert.Equal(t, newAddr.String(), res2.WorkerAddress.String())
+		assert.Equal(t, newAddr, res2.WorkerAddress)
 	})
 }

--- a/cmd/go-filecoin/mining.go
+++ b/cmd/go-filecoin/mining.go
@@ -169,8 +169,8 @@ End:           %s
 Proving Set:   %s
 
 `, strconv.FormatBool(res.Active),
-				res.Miner.String(),
-				res.Owner.String(),
+				res.Miner,
+				res.Owner,
 				res.Collateral.String(),
 				res.Power.Power.String(), res.Power.Total.String(),
 				res.ProvingPeriod.Start.String(),

--- a/cmd/go-filecoin/mining_integration_test.go
+++ b/cmd/go-filecoin/mining_integration_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/go-address"
 	files "github.com/ipfs/go-ipfs-files"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,8 +30,7 @@ func TestMiningGenBlock(t *testing.T) {
 	n := builder.BuildAndStart(ctx)
 	defer n.Stop(ctx)
 
-	addr, err := address.NewFromString(fixtures.TestAddresses[0])
-	require.NoError(t, err)
+	addr := fixtures.TestAddresses[0]
 
 	attoFILBefore, err := n.PorcelainAPI.WalletBalance(ctx, addr)
 	require.NoError(t, err)

--- a/cmd/go-filecoin/mpool_integration_test.go
+++ b/cmd/go-filecoin/mpool_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,11 +21,11 @@ func TestMpoolLs(t *testing.T) {
 	tf.IntegrationTest(t)
 	t.Skip("hangs")
 
-	sendMessage := func(ctx context.Context, cmdClient *test.Client, from string, to string) *th.CmdOutput {
+	sendMessage := func(ctx context.Context, cmdClient *test.Client, from address.Address, to address.Address) *th.CmdOutput {
 		return cmdClient.RunSuccess(ctx, "message", "send",
-			"--from", from,
+			"--from", from.String(),
 			"--gas-price", "1", "--gas-limit", "300",
-			"--value=10", to,
+			"--value=10", to.String(),
 		)
 	}
 	cs := node.FixtureChainSeed(t)
@@ -104,15 +105,15 @@ func TestMpoolShow(t *testing.T) {
 		defer done()
 
 		msgCid := cmdClient.RunSuccess(ctx, "message", "send",
-			"--from", fixtures.TestAddresses[0],
+			"--from", fixtures.TestAddresses[0].String(),
 			"--gas-price", "1", "--gas-limit", "300",
-			"--value=10", fixtures.TestAddresses[2],
+			"--value=10", fixtures.TestAddresses[2].String(),
 		).ReadStdoutTrimNewlines()
 
 		out := cmdClient.RunSuccess(ctx, "mpool", "show", msgCid).ReadStdoutTrimNewlines()
 
-		assert.Contains(t, out, "From:      "+fixtures.TestAddresses[0])
-		assert.Contains(t, out, "To:        "+fixtures.TestAddresses[2])
+		assert.Contains(t, out, "From:      "+fixtures.TestAddresses[0].String())
+		assert.Contains(t, out, "To:        "+fixtures.TestAddresses[2].String())
 		assert.Contains(t, out, "Value:     10")
 	})
 
@@ -148,9 +149,9 @@ func TestMpoolRm(t *testing.T) {
 		defer done()
 
 		msgCid := cmdClient.RunSuccess(ctx, "message", "send",
-			"--from", fixtures.TestAddresses[0],
+			"--from", fixtures.TestAddresses[0].String(),
 			"--gas-price", "1", "--gas-limit", "300",
-			"--value=10", fixtures.TestAddresses[2],
+			"--value=10", fixtures.TestAddresses[2].String(),
 		).ReadStdoutTrimNewlines()
 
 		// wait for the pool to have the message

--- a/cmd/go-filecoin/outbox_integration_test.go
+++ b/cmd/go-filecoin/outbox_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/filecoin-project/go-filecoin/fixtures"
@@ -17,11 +18,11 @@ func TestOutbox(t *testing.T) {
 	tf.IntegrationTest(t)
 	t.Skip("not working")
 
-	sendMessage := func(ctx context.Context, cmdClient *test.Client, from string, to string) *th.CmdOutput {
+	sendMessage := func(ctx context.Context, cmdClient *test.Client, from address.Address, to address.Address) *th.CmdOutput {
 		return cmdClient.RunSuccess(ctx, "message", "send",
-			"--from", from,
+			"--from", from.String(),
 			"--gas-price", "1", "--gas-limit", "300",
-			"--value=10", to,
+			"--value=10", to.String(),
 		)
 	}
 	cs := node.FixtureChainSeed(t)
@@ -48,7 +49,7 @@ func TestOutbox(t *testing.T) {
 		assert.Contains(t, out, c3)
 
 		// With address filter
-		out = cmdClient.RunSuccess(ctx, "outbox", "ls", fixtures.TestAddresses[1]).ReadStdout()
+		out = cmdClient.RunSuccess(ctx, "outbox", "ls", fixtures.TestAddresses[1].String()).ReadStdout()
 		assert.NotContains(t, out, fixtures.TestAddresses[0])
 		assert.Contains(t, out, fixtures.TestAddresses[1])
 		assert.NotContains(t, out, c1)
@@ -71,7 +72,7 @@ func TestOutbox(t *testing.T) {
 		c3 := sendMessage(ctx, cmdClient, fixtures.TestAddresses[1], fixtures.TestAddresses[2]).ReadStdoutTrimNewlines()
 
 		// With address filter
-		cmdClient.RunSuccess(ctx, "outbox", "clear", fixtures.TestAddresses[1])
+		cmdClient.RunSuccess(ctx, "outbox", "clear", fixtures.TestAddresses[1].String())
 		out := cmdClient.RunSuccess(ctx, "outbox", "ls").ReadStdout()
 		assert.Contains(t, out, fixtures.TestAddresses[0])
 		assert.NotContains(t, out, fixtures.TestAddresses[1]) // Cleared

--- a/cmd/go-filecoin/show_test.go
+++ b/cmd/go-filecoin/show_test.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 
 	"github.com/filecoin-project/go-filecoin/fixtures"
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
@@ -150,8 +150,7 @@ func TestBlockDaemon(t *testing.T) {
 
 	t.Run("show messages", func(t *testing.T) {
 		cs := node.FixtureChainSeed(t)
-		defaultAddr, err := address.NewFromString(fixtures.TestAddresses[0])
-		require.NoError(t, err)
+		defaultAddr := fixtures.TestAddresses[0]
 		ctx := context.Background()
 		builder := test.NewNodeBuilder(t)
 		builder.WithGenesisInit(cs.GenesisInitFunc)
@@ -163,7 +162,7 @@ func TestBlockDaemon(t *testing.T) {
 		n, cmdClient, done := builder.BuildAndStartAPI(ctx)
 		defer done()
 
-		_, err = n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+		_, err := n.BlockMining.BlockMiningAPI.MiningOnce(ctx)
 		require.NoError(t, err)
 
 		from, err := n.PorcelainAPI.WalletDefaultAddress() // this should = fixtures.TestAddresses[0]
@@ -172,7 +171,7 @@ func TestBlockDaemon(t *testing.T) {
 			"--from", from.String(),
 			"--gas-price", "1",
 			"--gas-limit", "300",
-			fixtures.TestAddresses[3],
+			fixtures.TestAddresses[3].String(),
 		)
 
 		cmdClient.RunSuccess(ctx, "message", "send",
@@ -180,7 +179,7 @@ func TestBlockDaemon(t *testing.T) {
 			"--gas-price", "1",
 			"--gas-limit", "300",
 			"--value", "10",
-			fixtures.TestAddresses[3],
+			fixtures.TestAddresses[3].String(),
 		)
 
 		cmdClient.RunSuccess(ctx, "message", "send",
@@ -188,7 +187,7 @@ func TestBlockDaemon(t *testing.T) {
 			"--gas-price", "1",
 			"--gas-limit", "300",
 			"--value", "5.5",
-			fixtures.TestAddresses[3],
+			fixtures.TestAddresses[3].String(),
 		)
 
 		blk, err := n.BlockMining.BlockMiningAPI.MiningOnce(ctx)

--- a/fixtures/constants.go
+++ b/fixtures/constants.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/filecoin-project/go-address"
 	cid "github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/build/project"
@@ -25,13 +26,13 @@ import (
 // cat ./fixtures/setup.json | ./tools/gengen/gengen --json --keypath fixtures > fixtures/genesis.car 2> fixtures/gen.json
 
 // TestAddresses is a list of pregenerated addresses.
-var TestAddresses []string
+var TestAddresses []address.Address
 
 // testKeys is a list of filenames, which contain the private keys of the pregenerated addresses.
 var testKeys []string
 
 // TestMiners is a list of pregenerated miner acccounts. They are owned by the matching TestAddress.
-var TestMiners []string
+var TestMiners []address.Address
 
 // TestGenGenConfig is the gengen config used to make the default test genesis block.
 var TestGenGenConfig gen.GenesisCfg
@@ -40,7 +41,7 @@ type detailsStruct struct {
 	Keys   []*types.KeyInfo
 	Miners []struct {
 		Owner               int
-		Address             string
+		Address             address.Address
 		NumCommittedSectors uint64
 	}
 	GenesisCid cid.Cid `refmt:",omitempty"`
@@ -106,7 +107,7 @@ func init() {
 		if err != nil {
 			panic(err)
 		}
-		TestAddresses = append(TestAddresses, addr.String())
+		TestAddresses = append(TestAddresses, addr)
 		testKeys = append(testKeys, fmt.Sprintf("%d.key", key))
 	}
 

--- a/functional-tests/faucet_test.go
+++ b/functional-tests/faucet_test.go
@@ -78,7 +78,7 @@ func TestFaucetSendFunds(t *testing.T) {
 	// Start Tests
 
 	// Make request for funds
-	msgcid := MustSendFundsFaucet(t, "localhost:9797", targetAddr.Addresses[0])
+	msgcid := MustSendFundsFaucet(t, "localhost:9797", targetAddr.Addresses[0].String())
 
 	// Wait around for message to appear
 	msgctx, msgcancel := context.WithTimeout(context.Background(), blockTime*3)
@@ -87,7 +87,7 @@ func TestFaucetSendFunds(t *testing.T) {
 
 	// Read wallet balance
 	var balanceStr string
-	node1.MustRunCmdJSON(ctx, &balanceStr, "go-filecoin", "wallet", "balance", targetAddr.Addresses[0])
+	node1.MustRunCmdJSON(ctx, &balanceStr, "go-filecoin", "wallet", "balance", targetAddr.Addresses[0].String())
 	balance, err := strconv.ParseInt(balanceStr, 10, 64)
 	require.NoError(t, err)
 

--- a/internal/app/go-filecoin/porcelain/client.go
+++ b/internal/app/go-filecoin/porcelain/client.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
-
 	"github.com/filecoin-project/go-filecoin/internal/pkg/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/miner"

--- a/internal/app/go-filecoin/porcelain/client.go
+++ b/internal/app/go-filecoin/porcelain/client.go
@@ -6,10 +6,11 @@ import (
 	"math/big"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	"github.com/ipfs/go-cid"
 	"github.com/pkg/errors"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
@@ -61,21 +62,18 @@ func ClientListAsks(ctx context.Context, plumbing claPlubming) <-chan Ask {
 	return out
 }
 
-func listAsksFromActorResult(ctx context.Context, plumbing claPlubming, actorResult state.GetAllActorsResult, out chan Ask) error {
-	if actorResult.Error != nil {
-		return actorResult.Error
+func listAsksFromActorResult(ctx context.Context, plumbing claPlubming, res state.GetAllActorsResult, out chan Ask) error {
+	if res.Error != nil {
+		return res.Error
 	}
 
-	addr, _ := address.NewFromString(actorResult.Address)
-	actor := actorResult.Actor
-
-	if !types.MinerActorCodeCid.Equals(actor.Code.Cid) && !types.BootstrapMinerActorCodeCid.Equals(actor.Code.Cid) {
+	if !types.MinerActorCodeCid.Equals(res.Actor.Code.Cid) && !types.BootstrapMinerActorCodeCid.Equals(res.Actor.Code.Cid) {
 		return nil
 	}
 
 	// TODO: at some point, we will need to check that the miners are actually part of the storage market
 	// for now, its impossible for them not to be.
-	ret, err := plumbing.MessageQuery(ctx, address.Undef, addr, miner.GetAsks, plumbing.ChainHeadKey())
+	ret, err := plumbing.MessageQuery(ctx, address.Undef, res.Address, miner.GetAsks, plumbing.ChainHeadKey())
 	if err != nil {
 		return err
 	}
@@ -87,7 +85,7 @@ func listAsksFromActorResult(ctx context.Context, plumbing claPlubming, actorRes
 	fmt.Printf("asksIds: %v\n", asksIds)
 
 	for _, id := range asksIds {
-		ask, err := getAskByID(ctx, plumbing, addr, uint64(id))
+		ask, err := getAskByID(ctx, plumbing, res.Address, uint64(id))
 		if err != nil {
 			return err
 		}

--- a/internal/app/go-filecoin/porcelain/client_test.go
+++ b/internal/app/go-filecoin/porcelain/client_test.go
@@ -48,7 +48,7 @@ func (cla *claPlumbing) ActorLs(ctx context.Context) (<-chan state.GetAllActorsR
 				cla.MinerAddress = vmaddr.NewForTestGetter()()
 				actor := actor.Actor{Code: e.NewCid(types.MinerActorCodeCid)}
 				out <- state.GetAllActorsResult{
-					Address: cla.MinerAddress.String(),
+					Address: cla.MinerAddress,
 					Actor:   &actor,
 				}
 			}

--- a/internal/app/go-filecoin/porcelain/miner_test.go
+++ b/internal/app/go-filecoin/porcelain/miner_test.go
@@ -685,7 +685,7 @@ func TestMinerSetWorkerAddress(t *testing.T) {
 
 		_, err := MinerSetWorkerAddress(context.Background(), plumbing, workerAddr, gprice, glimit)
 		assert.NoError(t, err)
-		assert.Equal(t, workerAddr.String(), plumbing.workerAddr.String())
+		assert.Equal(t, workerAddr, plumbing.workerAddr)
 	})
 
 	testCases := []struct {

--- a/internal/app/go-filecoin/storage_market_connector/common.go
+++ b/internal/app/go-filecoin/storage_market_connector/common.go
@@ -194,8 +194,7 @@ func (c *connectorCommon) OnDealSectorCommitted(ctx context.Context, provider ad
 			return false
 		}
 
-		// TODO: compare addresses directly when they share a type #3719
-		if m.From.String() != provider.String() {
+		if m.From != provider {
 			return false
 		}
 

--- a/internal/pkg/chain/store_test.go
+++ b/internal/pkg/chain/store_test.go
@@ -172,7 +172,7 @@ func TestGetTipSetState(t *testing.T) {
 	assert.NoError(t, err)
 	for actRes := range st2.GetAllActors(ctx) {
 		assert.NoError(t, actRes.Error)
-		assert.Equal(t, addr.String(), actRes.Address)
+		assert.Equal(t, addr, actRes.Address)
 		assert.Equal(t, fakeCode, actRes.Actor.Code.Cid)
 		assert.Equal(t, testActor.Head, actRes.Actor.Head)
 		assert.Equal(t, types.Uint64(0), actRes.Actor.CallSeqNum)

--- a/internal/pkg/consensus/validation.go
+++ b/internal/pkg/consensus/validation.go
@@ -81,32 +81,32 @@ func (v *DefaultMessageValidator) Validate(ctx context.Context, msg *types.Unsig
 	}
 
 	if msg.Value.IsNegative() {
-		log.Debugf("Cannot transfer negative value: %s from actor: %s", msg.Value.String(), msg.From.String())
+		log.Debugf("Cannot transfer negative value: %s from actor: %s", msg.Value, msg.From)
 		errNegativeValueCt.Inc(ctx, 1)
 		return errNegativeValue
 	}
 
 	if msg.GasLimit > types.BlockGasLimit {
-		log.Debugf("Message: %s gas limit from actor: %s above block limit: %s", msg.String(), msg.From.String(), string(types.BlockGasLimit))
+		log.Debugf("Message: %s gas limit from actor: %s above block limit: %s", msg, msg.From, types.BlockGasLimit)
 		errGasAboveBlockLimitCt.Inc(ctx, 1)
 		return errGasAboveBlockLimit
 	}
 
 	// Avoid processing messages for actors that cannot pay.
 	if !canCoverGasLimit(msg, fromActor) {
-		log.Debugf("Insufficient funds for message: %s to cover gas limit from actor: %s", msg.String(), msg.From.String())
+		log.Debugf("Insufficient funds for message: %s to cover gas limit from actor: %s", msg, msg.From)
 		errInsufficientGasCt.Inc(ctx, 1)
 		return errInsufficientGas
 	}
 
 	if msg.CallSeqNum < fromActor.CallSeqNum {
-		log.Debugf("Message: %s nonce lower than actor nonce: %s from actor: %s", msg.String(), fromActor.CallSeqNum, msg.From.String())
+		log.Debugf("Message: %s nonce lower than actor nonce: %s from actor: %s", msg, fromActor.CallSeqNum, msg.From)
 		errNonceTooLowCt.Inc(ctx, 1)
 		return errNonceTooLow
 	}
 
 	if !v.allowHighNonce && msg.CallSeqNum > fromActor.CallSeqNum {
-		log.Debugf("Message: %s nonce greater than actor nonce: %s from actor: %s", msg.String(), fromActor.CallSeqNum, msg.From.String())
+		log.Debugf("Message: %s nonce greater than actor nonce: %s from actor: %s", msg, fromActor.CallSeqNum, msg.From)
 		errNonceTooHighCt.Inc(ctx, 1)
 		return errNonceTooHigh
 	}

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -239,7 +239,7 @@ func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCoun
 	}
 	sortedSectorInfos, err := powerTable.SortedSectorInfos(ctx, w.minerAddr)
 	if err != nil {
-		log.Warnf("Worker.Mine failed to get ssi for %s", w.minerAddr.String())
+		log.Warnf("Worker.Mine failed to get ssi for %s", w.minerAddr)
 		outCh <- Output{Err: err}
 		return
 	}

--- a/internal/pkg/vm/abi/encoding_test.go
+++ b/internal/pkg/vm/abi/encoding_test.go
@@ -37,9 +37,11 @@ func TestBasicEncodingRoundTrip(t *testing.T) {
 				Params: []interface{}{uint64(3), []byte("proof")},
 			},
 		},
-		"miner post states": {
-			&map[string]uint64{vmaddr.TestAddress.String(): 1, vmaddr.TestAddress2.String(): 2},
-		},
+		// Disabled because the encoder can't round-trip non-UTF8 strings.
+		// https://github.com/filecoin-project/go-filecoin/issues/3757
+		//"miner post states": {
+		//	&map[string]uint64{string(vmaddr.TestAddress.Bytes()): 1, string(vmaddr.TestAddress2.Bytes()): 2},
+		//},
 	}
 
 	for tname, tcase := range cases {

--- a/internal/pkg/vm/actor/builtin/initactor/init.go
+++ b/internal/pkg/vm/actor/builtin/initactor/init.go
@@ -84,7 +84,7 @@ func (v *View) GetIDAddressByAddress(target address.Address) (address.Address, b
 	}
 
 	var id types.Uint64
-	err = lookup.Find(context.Background(), target.String(), &id)
+	err = lookup.Find(context.Background(), string(target.Bytes()), &id)
 	if err != nil {
 		if err == hamt.ErrNotFound {
 			return address.Undef, false
@@ -279,7 +279,7 @@ func lookupIDAddress(vmctx runtime.InvocationContext, state State, addr address.
 	}
 
 	var id types.Uint64
-	err = lookup.Find(ctx, addr.String(), &id)
+	err = lookup.Find(ctx, string(addr.Bytes()), &id)
 	if err != nil {
 		return 0, err
 	}
@@ -312,7 +312,7 @@ func setID(ctx context.Context, storage runtime.Storage, addressMap cid.Cid, add
 		return cid.Undef, fmt.Errorf("could not load lookup for cid: %s", addressMap)
 	}
 
-	err = lookup.Set(ctx, addr.String(), actorID)
+	err = lookup.Set(ctx, string(addr.Bytes()), actorID)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("could not set id")
 	}

--- a/internal/pkg/vm/state/tree_test.go
+++ b/internal/pkg/vm/state/tree_test.go
@@ -145,7 +145,7 @@ func TestGetAllActors(t *testing.T) {
 	results := tree.GetAllActors(ctx)
 
 	for result := range results {
-		assert.Equal(t, addr.String(), result.Address)
+		assert.Equal(t, addr, result.Address)
 		assert.Equal(t, actor.Code, result.Actor.Code)
 		assert.Equal(t, actor.CallSeqNum, result.Actor.CallSeqNum)
 		assert.Equal(t, actor.Balance, result.Actor.Balance)

--- a/tools/fast/action_address.go
+++ b/tools/fast/action_address.go
@@ -22,22 +22,10 @@ func (f *Filecoin) AddressNew(ctx context.Context) (address.Address, error) {
 func (f *Filecoin) AddressLs(ctx context.Context) ([]address.Address, error) {
 	// the command returns an AddressListResult
 	var alr commands.AddressLsResult
-	// we expect to interact with an array of address
-	var out []address.Address
-
 	if err := f.RunCmdJSONWithStdin(ctx, nil, &alr, "go-filecoin", "address", "ls"); err != nil {
 		return nil, err
 	}
-
-	// transform the AddressListResult to an array of addresses
-	for _, addr := range alr.Addresses {
-		a, err := address.NewFromString(addr)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, a)
-	}
-	return out, nil
+	return alr.Addresses, nil
 }
 
 // AddressLookup runs the address lookup command against the filecoin process.

--- a/tools/fast/action_miner.go
+++ b/tools/fast/action_miner.go
@@ -16,15 +16,13 @@ import (
 func (f *Filecoin) MinerCreate(ctx context.Context, collateral *big.Int, options ...ActionOption) (address.Address, error) {
 	var out commands.MinerCreateResult
 
-	sCollateral := collateral.String()
-
 	args := []string{"go-filecoin", "miner", "create"}
 
 	for _, option := range options {
 		args = append(args, option()...)
 	}
 
-	args = append(args, sCollateral)
+	args = append(args, collateral.String())
 
 	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
 		return address.Undef, err
@@ -56,9 +54,7 @@ func (f *Filecoin) MinerUpdatePeerid(ctx context.Context, minerAddr address.Addr
 func (f *Filecoin) MinerOwner(ctx context.Context, minerAddr address.Address) (address.Address, error) {
 	var out address.Address
 
-	sMinerAddr := minerAddr.String()
-
-	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "miner", "owner", sMinerAddr); err != nil {
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "miner", "owner", minerAddr.String()); err != nil {
 		return address.Undef, err
 	}
 
@@ -69,9 +65,7 @@ func (f *Filecoin) MinerOwner(ctx context.Context, minerAddr address.Address) (a
 func (f *Filecoin) MinerPower(ctx context.Context, minerAddr address.Address) (porcelain.MinerPower, error) {
 	var out porcelain.MinerPower
 
-	sMinerAddr := minerAddr.String()
-
-	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "miner", "power", sMinerAddr); err != nil {
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "miner", "power", minerAddr.String()); err != nil {
 		return porcelain.MinerPower{}, err
 	}
 
@@ -82,7 +76,6 @@ func (f *Filecoin) MinerPower(ctx context.Context, minerAddr address.Address) (p
 func (f *Filecoin) MinerSetPrice(ctx context.Context, fil *big.Float, expiry *big.Int, options ...ActionOption) (*porcelain.MinerSetPriceResponse, error) {
 	var out commands.MinerSetPriceResult
 
-	sExpiry := expiry.String()
 	sFil := fil.Text('f', -1)
 
 	args := []string{"go-filecoin", "miner", "set-price"}
@@ -91,7 +84,7 @@ func (f *Filecoin) MinerSetPrice(ctx context.Context, fil *big.Float, expiry *bi
 		args = append(args, option()...)
 	}
 
-	args = append(args, sFil, sExpiry)
+	args = append(args, sFil, expiry.String())
 
 	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, args...); err != nil {
 		return nil, err

--- a/tools/fast/action_wallet.go
+++ b/tools/fast/action_wallet.go
@@ -24,22 +24,10 @@ func (f *Filecoin) WalletBalance(ctx context.Context, addr address.Address) (typ
 func (f *Filecoin) WalletImport(ctx context.Context, file files.File) ([]address.Address, error) {
 	// the command returns an AddressListResult
 	var alr commands.AddressLsResult
-	// we expect to interact with an array of address
-	var out []address.Address
-
 	if err := f.RunCmdJSONWithStdin(ctx, file, &alr, "go-filecoin", "wallet", "import"); err != nil {
 		return nil, err
 	}
-
-	// transform the AddressListResult to an array of addresses
-	for _, addr := range alr.Addresses {
-		a, err := address.NewFromString(addr)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, a)
-	}
-	return out, nil
+	return alr.Addresses, nil
 }
 
 // WalletExport run the wallet export command against the filecoin process.

--- a/tools/faucet/main.go
+++ b/tools/faucet/main.go
@@ -81,7 +81,7 @@ func main() {
 			return
 		}
 
-		reqStr := fmt.Sprintf("http://%s/api/message/send?arg=%s&value=%d&from=%s&gas-price=1&gas-limit=0", *filapi, addr.String(), *faucetval, *filwal)
+		reqStr := fmt.Sprintf("http://%s/api/message/send?arg=%s&value=%d&from=%s&gas-price=1&gas-limit=0", *filapi, addr, *faucetval, *filwal)
 		log.Infof("Request URL: %s", reqStr)
 
 		resp, err := http.Post(reqStr, "application/json", nil)

--- a/tools/gengen/main.go
+++ b/tools/gengen/main.go
@@ -17,7 +17,7 @@ func writeKey(ki *types.KeyInfo, name string, jsonout bool) error {
 		return err
 	}
 	if !jsonout {
-		fmt.Fprintf(os.Stderr, "key: %s - %s\n", name, addr)                                                          // nolint: errcheck
+		fmt.Fprintf(os.Stderr, "key: %s - %s\n", name, addr)                                                                   // nolint: errcheck
 		fmt.Fprintf(os.Stderr, "run 'go-filecoin wallet import ./%s.key' to add private key for %[1]s to your wallet\n", name) // nolint: errcheck
 	}
 	fi, err := os.Create(name + ".key")

--- a/tools/gengen/main.go
+++ b/tools/gengen/main.go
@@ -17,7 +17,7 @@ func writeKey(ki *types.KeyInfo, name string, jsonout bool) error {
 		return err
 	}
 	if !jsonout {
-		fmt.Fprintf(os.Stderr, "key: %s - %s\n", name, addr.String())                                                          // nolint: errcheck
+		fmt.Fprintf(os.Stderr, "key: %s - %s\n", name, addr)                                                          // nolint: errcheck
 		fmt.Fprintf(os.Stderr, "run 'go-filecoin wallet import ./%s.key' to add private key for %[1]s to your wallet\n", name) // nolint: errcheck
 	}
 	fi, err := os.Create(name + ".key")


### PR DESCRIPTION
### Motivation
The top-level HAMT should be keyed by the bytes of the actor address, not the pretty string. I have confirmed this is what Lotus implements.

### Proposed changes
Replace as many uses of Address.String() as possible, especially when used as a HAMT key.