### PR TITLE
Feat/msg format interop

### DIFF
--- a/cmd/go-filecoin/actor.go
+++ b/cmd/go-filecoin/actor.go
@@ -108,7 +108,7 @@ func makeActorView(act *actor.Actor, addr address.Address, actType interface{}) 
 		ActorType: actorType,
 		Address:   addr.String(),
 		Code:      act.Code.Cid,
-		Nonce:     uint64(act.CallSeqNum),
+		Nonce:     act.CallSeqNum,
 		Balance:   types.NewAttoFILFromFIL(uint64(act.Balance.Int64())),
 		Head:      act.Head.Cid,
 	}

--- a/cmd/go-filecoin/mpool.go
+++ b/cmd/go-filecoin/mpool.go
@@ -93,7 +93,7 @@ Signature: %s
 `,
 				msg.To,
 				msg.From,
-				strconv.FormatUint(uint64(msg.CallSeqNum), 10),
+				strconv.FormatUint(msg.CallSeqNum, 10),
 				msg.Value,
 				msg.Method,
 				base64.StdEncoding.EncodeToString(msg.Params),

--- a/internal/pkg/block/block_test.go
+++ b/internal/pkg/block/block_test.go
@@ -3,14 +3,12 @@ package block_test
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	fbig "github.com/filecoin-project/specs-actors/actors/abi/big"
-	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -79,9 +77,6 @@ func TestTriangleEncoding(t *testing.T) {
 			ForkSignaling:   6,
 		}
 		s := reflect.TypeOf(*b)
-		cidBytesOld, err := cbor.DumpObject(types.CidFromString(t, "somecid"))
-		require.NoError(t, err)
-		fmt.Printf("old cid bytes: %x\n", cidBytesOld)
 		// This check is here to request that you add a non-zero value for new fields
 		// to the above (and update the field count below).
 		// Also please add non zero fields to "b" and "diff" in TestSignatureData

--- a/internal/pkg/chain/store_test.go
+++ b/internal/pkg/chain/store_test.go
@@ -175,7 +175,7 @@ func TestGetTipSetState(t *testing.T) {
 		assert.Equal(t, addr, actRes.Address)
 		assert.Equal(t, fakeCode, actRes.Actor.Code.Cid)
 		assert.Equal(t, testActor.Head, actRes.Actor.Head)
-		assert.Equal(t, types.Uint64(0), actRes.Actor.CallSeqNum)
+		assert.Equal(t, uint64(0), actRes.Actor.CallSeqNum)
 		assert.Equal(t, balance, actRes.Actor.Balance)
 	}
 }

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -205,7 +205,7 @@ type MessagePoolConfig struct {
 	// MaxPoolSize is the maximum number of pending messages will will allow in the message pool at any time
 	MaxPoolSize uint `json:"maxPoolSize"`
 	// MaxNonceGap is the maximum nonce of a message past the last received on chain
-	MaxNonceGap types.Uint64 `json:"maxNonceGap"`
+	MaxNonceGap uint64 `json:"maxNonceGap"`
 }
 
 func newDefaultMessagePoolConfig() *MessagePoolConfig {

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -79,7 +79,7 @@ func TestWriteFile(t *testing.T) {
 	},
 	"mpool": {
 		"maxPoolSize": 10000,
-		"maxNonceGap": "100"
+		"maxNonceGap": 100
 	},
 	"observability": {
 		"metrics": {

--- a/internal/pkg/consensus/genesis.go
+++ b/internal/pkg/consensus/genesis.go
@@ -217,7 +217,7 @@ func MakeGenesisFunc(opts ...GenOption) GenesisInitFunc {
 			if err != nil {
 				return nil, err
 			}
-			a.CallSeqNum = types.Uint64(nonce)
+			a.CallSeqNum = nonce
 			if err := st.SetActor(ctx, addr, a); err != nil {
 				return nil, err
 			}

--- a/internal/pkg/consensus/validation_test.go
+++ b/internal/pkg/consensus/validation_test.go
@@ -185,7 +185,7 @@ func TestIngestionValidator(t *testing.T) {
 func newActor(t *testing.T, balanceAF int, nonce uint64) *actor.Actor {
 	actor, err := account.NewActor(abi.NewTokenAmount(int64(balanceAF)))
 	require.NoError(t, err)
-	actor.CallSeqNum = types.Uint64(nonce)
+	actor.CallSeqNum = nonce
 	return actor
 }
 

--- a/internal/pkg/consensus/validation_test.go
+++ b/internal/pkg/consensus/validation_test.go
@@ -153,7 +153,7 @@ func TestIngestionValidator(t *testing.T) {
 		require.NoError(t, err)
 		assert.NoError(t, validator.Validate(ctx, msg))
 
-		highNonce := uint64(act.CallSeqNum + mpoolCfg.MaxNonceGap + 10)
+		highNonce := act.CallSeqNum + mpoolCfg.MaxNonceGap + 10
 		msg, err = types.NewSignedMessage(*newMessage(t, alice, bob, highNonce, 5, 1, 0), signer)
 		require.NoError(t, err)
 		err = validator.Validate(ctx, msg)

--- a/internal/pkg/message/outbox_test.go
+++ b/internal/pkg/message/outbox_test.go
@@ -66,7 +66,7 @@ func TestOutbox(t *testing.T) {
 
 		testCases := []struct {
 			bcast  bool
-			nonce  types.Uint64
+			nonce  uint64
 			height int
 		}{{true, actr.CallSeqNum, 1000}, {false, actr.CallSeqNum + 1, 1000}}
 

--- a/internal/pkg/message/outbox_test.go
+++ b/internal/pkg/message/outbox_test.go
@@ -130,13 +130,13 @@ func TestOutbox(t *testing.T) {
 		nonces := map[uint64]bool{}
 		for _, message := range enqueued {
 			assert.Equal(t, uint64(1000), message.Stamp)
-			_, found := nonces[uint64(message.Msg.Message.CallSeqNum)]
+			_, found := nonces[message.Msg.Message.CallSeqNum]
 			require.False(t, found)
-			nonces[uint64(message.Msg.Message.CallSeqNum)] = true
+			nonces[message.Msg.Message.CallSeqNum] = true
 		}
 
 		for i := 0; i < 60; i++ {
-			assert.True(t, nonces[uint64(actr.CallSeqNum)+uint64(i)])
+			assert.True(t, nonces[actr.CallSeqNum+uint64(i)])
 
 		}
 	})

--- a/internal/pkg/message/policy.go
+++ b/internal/pkg/message/policy.go
@@ -71,7 +71,7 @@ func (p *DefaultQueuePolicy) HandleNewHead(ctx context.Context, target PolicyTar
 				return err
 			}
 			for _, minedMsg := range secpMsgs {
-				removed, found, err := target.RemoveNext(ctx, minedMsg.Message.From, uint64(minedMsg.Message.CallSeqNum))
+				removed, found, err := target.RemoveNext(ctx, minedMsg.Message.From, minedMsg.Message.CallSeqNum)
 				if err != nil {
 					return err
 				}

--- a/internal/pkg/message/pool.go
+++ b/internal/pkg/message/pool.go
@@ -47,7 +47,7 @@ type addressNonce struct {
 }
 
 func newAddressNonce(msg *types.SignedMessage) addressNonce {
-	return addressNonce{addr: msg.Message.From, nonce: uint64(msg.Message.CallSeqNum)}
+	return addressNonce{addr: msg.Message.From, nonce: msg.Message.CallSeqNum}
 }
 
 // NewPool constructs a new Pool.
@@ -132,8 +132,8 @@ func (pool *Pool) LargestNonce(address address.Address) (largest uint64, found b
 	for _, m := range pool.Pending() {
 		if m.Message.From == address {
 			found = true
-			if uint64(m.Message.CallSeqNum) > largest {
-				largest = uint64(m.Message.CallSeqNum)
+			if m.Message.CallSeqNum > largest {
+				largest = m.Message.CallSeqNum
 			}
 		}
 	}

--- a/internal/pkg/message/pool_test.go
+++ b/internal/pkg/message/pool_test.go
@@ -206,7 +206,7 @@ func TestLargestNonce(t *testing.T) {
 	})
 }
 
-func mustSetNonce(signer types.Signer, message *types.SignedMessage, nonce types.Uint64) *types.SignedMessage {
+func mustSetNonce(signer types.Signer, message *types.SignedMessage, nonce uint64) *types.SignedMessage {
 	return mustResignMessage(signer, message, func(m *types.UnsignedMessage) {
 		m.CallSeqNum = nonce
 	})

--- a/internal/pkg/message/queue.go
+++ b/internal/pkg/message/queue.go
@@ -106,11 +106,11 @@ func (mq *Queue) RemoveNext(ctx context.Context, sender address.Address, expecte
 	q := mq.queues[sender]
 	if len(q) > 0 {
 		head := q[0]
-		if expectedNonce == uint64(head.Msg.Message.CallSeqNum) {
+		if expectedNonce == head.Msg.Message.CallSeqNum {
 			mq.queues[sender] = q[1:] // pop the head
 			msg = head.Msg
 			found = true
-		} else if expectedNonce > uint64(head.Msg.Message.CallSeqNum) {
+		} else if expectedNonce > head.Msg.Message.CallSeqNum {
 			err = errors.Errorf("Next message for %s has nonce %d, expected %d", sender, head.Msg.Message.CallSeqNum, expectedNonce)
 		}
 		// else expected nonce was before the head of the queue, already removed
@@ -169,7 +169,7 @@ func (mq *Queue) LargestNonce(sender address.Address) (largest uint64, found boo
 	defer mq.lk.RUnlock()
 	q := mq.queues[sender]
 	if len(q) > 0 {
-		return uint64(q[len(q)-1].Msg.Message.CallSeqNum), true
+		return q[len(q)-1].Msg.Message.CallSeqNum, true
 	}
 	return 0, false
 }

--- a/internal/pkg/mining/mqueue_test.go
+++ b/internal/pkg/mining/mqueue_test.go
@@ -26,7 +26,7 @@ func TestMessageQueueOrder(t *testing.T) {
 		msg := types.UnsignedMessage{
 			From:       from,
 			To:         to,
-			CallSeqNum: types.Uint64(nonce),
+			CallSeqNum: nonce,
 			GasPrice:   types.NewGasPrice(price),
 			GasLimit:   types.NewGasUnits(units),
 		}

--- a/internal/pkg/mining/mqueue_test.go
+++ b/internal/pkg/mining/mqueue_test.go
@@ -68,9 +68,9 @@ func TestMessageQueueOrder(t *testing.T) {
 		for msg, more := q.Pop(); more == true; msg, more = q.Pop() {
 			last, seen := lastFromAddr[msg.Message.From]
 			if seen {
-				assert.True(t, last <= uint64(msg.Message.CallSeqNum))
+				assert.True(t, last <= msg.Message.CallSeqNum)
 			}
-			lastFromAddr[msg.Message.From] = uint64(msg.Message.CallSeqNum)
+			lastFromAddr[msg.Message.From] = msg.Message.CallSeqNum
 		}
 		assert.True(t, q.Empty())
 	})

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -628,7 +628,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 	act, actID := th.RequireLookupActor(ctx, t, st, vm.NewStorage(bs), addrs[1])
 	require.NoError(t, err)
 
-	act.CallSeqNum = types.Uint64(2)
+	act.CallSeqNum = 2
 	err = st.SetActor(ctx, actID, act)
 	require.NoError(t, err)
 

--- a/internal/pkg/repo/fsrepo_test.go
+++ b/internal/pkg/repo/fsrepo_test.go
@@ -57,7 +57,7 @@ const (
 	},
 	"mpool": {
 		"maxPoolSize": 10000,
-		"maxNonceGap": "100"
+		"maxNonceGap": 100
 	},
 	"observability": {
 		"metrics": {

--- a/internal/pkg/types/message.go
+++ b/internal/pkg/types/message.go
@@ -77,14 +77,14 @@ var (
 
 // UnsignedMessage is an exchange of information between two actors modeled
 // as a function call.
-// Messages are the equivalent of transactions in Ethereum.
 type UnsignedMessage struct {
+	_ struct{}	`cbor:",toarray"`
 	To   address.Address `json:"to"`
 	From address.Address `json:"from"`
 	// When receiving a message from a user account the nonce in
 	// the message must match the expected nonce in the from actor.
 	// This prevents replay attacks.
-	CallSeqNum Uint64 `json:"callSeqNum"`
+	CallSeqNum uint64 `json:"callSeqNum"`
 
 	Value AttoFIL `json:"value"`
 
@@ -101,7 +101,7 @@ func NewUnsignedMessage(from, to address.Address, nonce uint64, value AttoFIL, m
 	return &UnsignedMessage{
 		From:       from,
 		To:         to,
-		CallSeqNum: Uint64(nonce),
+		CallSeqNum: nonce,
 		Value:      value,
 		Method:     method,
 		Params:     params,
@@ -113,7 +113,7 @@ func NewMeteredMessage(from, to address.Address, nonce uint64, value AttoFIL, me
 	return &UnsignedMessage{
 		From:       from,
 		To:         to,
-		CallSeqNum: Uint64(nonce),
+		CallSeqNum: nonce,
 		Value:      value,
 		Method:     method,
 		Params:     params,

--- a/internal/pkg/types/message.go
+++ b/internal/pkg/types/message.go
@@ -79,8 +79,8 @@ var (
 // as a function call.
 type UnsignedMessage struct {
 	// control field for encoding struct as an array
-	_    struct{}        `cbor:",toarray"`
-	
+	_ struct{} `cbor:",toarray"`
+
 	To   address.Address `json:"to"`
 	From address.Address `json:"from"`
 	// When receiving a message from a user account the nonce in

--- a/internal/pkg/types/message.go
+++ b/internal/pkg/types/message.go
@@ -78,7 +78,7 @@ var (
 // UnsignedMessage is an exchange of information between two actors modeled
 // as a function call.
 type UnsignedMessage struct {
-	_ struct{}	`cbor:",toarray"`
+	_    struct{}        `cbor:",toarray"`
 	To   address.Address `json:"to"`
 	From address.Address `json:"from"`
 	// When receiving a message from a user account the nonce in

--- a/internal/pkg/types/message.go
+++ b/internal/pkg/types/message.go
@@ -78,7 +78,9 @@ var (
 // UnsignedMessage is an exchange of information between two actors modeled
 // as a function call.
 type UnsignedMessage struct {
+	// control field for encoding struct as an array
 	_    struct{}        `cbor:",toarray"`
+	
 	To   address.Address `json:"to"`
 	From address.Address `json:"from"`
 	// When receiving a message from a user account the nonce in

--- a/internal/pkg/types/message_test.go
+++ b/internal/pkg/types/message_test.go
@@ -32,7 +32,7 @@ func TestMessageMarshal(t *testing.T) {
 
 	// This check requests that you add a non-zero value for new fields above,
 	// then update the field count below.
-	require.Equal(t, 8, reflect.TypeOf(*msg).NumField())
+	require.Equal(t, 9, reflect.TypeOf(*msg).NumField())
 
 	marshalled, err := msg.Marshal()
 	assert.NoError(t, err)

--- a/internal/pkg/types/signed_message.go
+++ b/internal/pkg/types/signed_message.go
@@ -23,6 +23,7 @@ var (
 // TODO do not export these fields as it increases the chances of producing a
 // `SignedMessage` with an empty signature.
 type SignedMessage struct {
+	_         struct{}        `cbor:",toarray"`
 	Message   UnsignedMessage `json:"meteredMessage"`
 	Signature Signature       `json:"signature"`
 	// Pay attention to Equals() if updating this struct.

--- a/internal/pkg/types/signed_message.go
+++ b/internal/pkg/types/signed_message.go
@@ -23,7 +23,9 @@ var (
 // TODO do not export these fields as it increases the chances of producing a
 // `SignedMessage` with an empty signature.
 type SignedMessage struct {
-	_         struct{}        `cbor:",toarray"`
+	// control field for encoding struct as an array
+	_ struct{} `cbor:",toarray"`
+
 	Message   UnsignedMessage `json:"meteredMessage"`
 	Signature Signature       `json:"signature"`
 	// Pay attention to Equals() if updating this struct.

--- a/internal/pkg/types/signed_message_test.go
+++ b/internal/pkg/types/signed_message_test.go
@@ -91,7 +91,7 @@ func makeMessage(t *testing.T, signer MockSigner, nonce uint64) *SignedMessage {
 
 	// This check requests that you add a non-zero value for new fields above,
 	// then update the field count below.
-	require.Equal(t, 2, reflect.TypeOf(*smsg).NumField())
+	require.Equal(t, 3, reflect.TypeOf(*smsg).NumField())
 
 	return smsg
 }

--- a/internal/pkg/types/testing.go
+++ b/internal/pkg/types/testing.go
@@ -243,7 +243,7 @@ func NewMsgs(n int) []*UnsignedMessage {
 	msgs := make([]*UnsignedMessage, n)
 	for i := 0; i < n; i++ {
 		msgs[i] = newMsg()
-		msgs[i].CallSeqNum = Uint64(i)
+		msgs[i].CallSeqNum = uint64(i)
 	}
 	return msgs
 }
@@ -258,7 +258,7 @@ func NewSignedMsgs(n uint, ms MockSigner) []*SignedMessage {
 	for i := uint(0); i < n; i++ {
 		msg := newMsg()
 		msg.From = ms.Addresses[0]
-		msg.CallSeqNum = Uint64(i)
+		msg.CallSeqNum = uint64(i)
 		msg.GasPrice = ZeroAttoFIL // NewGasPrice(1)
 		msg.GasLimit = NewGasUnits(0)
 		smsgs[i], err = NewSignedMessage(*msg, ms)

--- a/internal/pkg/vm/actor/actor.go
+++ b/internal/pkg/vm/actor/actor.go
@@ -46,7 +46,7 @@ type Actor struct {
 	Head e.Cid
 	// CallSeqNum is the number expected on the next message from this actor.
 	// Messages are processed in strict, contiguous order.
-	CallSeqNum types.Uint64
+	CallSeqNum uint64
 	// Balance is the amount of FIL in the actor's account.
 	Balance abi.TokenAmount
 }
@@ -131,7 +131,7 @@ func NextNonce(actor *Actor) (uint64, error) {
 	if !(actor.Empty() || actor.Code.Equals(types.AccountActorCodeCid)) {
 		return 0, errors.New("next nonce only defined for account or empty actors")
 	}
-	return uint64(actor.CallSeqNum), nil
+	return actor.CallSeqNum, nil
 }
 
 // InitBuiltinActorCodeObjs writes all builtin actor code objects to `cst`. This method should be called when initializing a genesis

--- a/internal/pkg/vm/internal/vmcontext/invocation_context.go
+++ b/internal/pkg/vm/internal/vmcontext/invocation_context.go
@@ -311,7 +311,7 @@ func (ctx *invocationContext) CreateActor(actorID types.Uint64, code cid.Cid, co
 			runtime.Abortf(exitcode.SysErrorIllegalActor, "Parameter for account actor creation is not an address")
 		}
 	} else {
-		actorAddr, err = computeActorAddress(ctx.msg.from, uint64(ctx.msg.callSeqNumber))
+		actorAddr, err = computeActorAddress(ctx.msg.from, ctx.msg.callSeqNumber)
 		if err != nil {
 			panic("Could not create address for actor")
 		}

--- a/internal/pkg/vm/internal/vmcontext/runtime_adapter.go
+++ b/internal/pkg/vm/internal/vmcontext/runtime_adapter.go
@@ -122,7 +122,7 @@ func (a *runtimeAdapter) Abortf(errExitCode exitcode.ExitCode, msg string, args 
 
 // NewActorAddress implements Runtime.
 func (a *runtimeAdapter) NewActorAddress() address.Address {
-	actorAddr, err := computeActorAddress(a.ctx.msg.from, uint64(a.ctx.msg.callSeqNumber))
+	actorAddr, err := computeActorAddress(a.ctx.msg.from, a.ctx.msg.callSeqNumber)
 	if err != nil {
 		panic("Could not create address for actor")
 	}

--- a/internal/pkg/vm/internal/vmcontext/vmcontext.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext.go
@@ -62,7 +62,7 @@ type internalMessage struct {
 	value         abi.TokenAmount
 	method        types.MethodID
 	params        []byte
-	callSeqNumber types.Uint64
+	callSeqNumber uint64
 }
 
 // actorStorage hides the storage methods from the actors and turns the errors into runtime panics.

--- a/internal/pkg/vm/state/cached_tree_test.go
+++ b/internal/pkg/vm/state/cached_tree_test.go
@@ -48,7 +48,7 @@ func TestCachedStateGetCommit(t *testing.T) {
 	cAct1, err := tree.GetActor(ctx, addr1)
 	require.NoError(t, err)
 
-	assert.Equal(t, uint64(1), uint64(cAct1.CallSeqNum))
+	assert.Equal(t, uint64(1), cAct1.CallSeqNum)
 	assert.Equal(t, act1Cid, cAct1.Head.Cid)
 
 	// altering act1 doesn't alter it in underlying cache
@@ -81,7 +81,7 @@ func TestCachedStateGetCommit(t *testing.T) {
 	uAct2, err := underlying.GetActor(ctx, addr2)
 	require.NoError(t, err)
 
-	assert.Equal(t, uint64(0), uint64(uAct2.CallSeqNum))
+	assert.Equal(t, uint64(0), uAct2.CallSeqNum)
 	assert.Equal(t, act2Cid, uAct2.Head.Cid)
 }
 

--- a/internal/pkg/vm/state/cached_tree_test.go
+++ b/internal/pkg/vm/state/cached_tree_test.go
@@ -59,7 +59,7 @@ func TestCachedStateGetCommit(t *testing.T) {
 	uAct1, err := underlying.GetActor(ctx, addr1)
 	require.NoError(t, err)
 
-	assert.Equal(t, uint64(1), uint64(uAct1.CallSeqNum))
+	assert.Equal(t, uint64(1), uAct1.CallSeqNum)
 	assert.Equal(t, act1.Head.Cid, uAct1.Head.Cid)
 
 	// retrieving from the cache again returns the same instance
@@ -74,7 +74,7 @@ func TestCachedStateGetCommit(t *testing.T) {
 	uAct1Again, err := underlying.GetActor(ctx, addr1)
 	require.NoError(t, err)
 
-	assert.Equal(t, uint64(2), uint64(uAct1Again.CallSeqNum))
+	assert.Equal(t, uint64(2), uAct1Again.CallSeqNum)
 	assert.Equal(t, cAct1Cid, uAct1Again.Head.Cid)
 
 	// commit doesn't affect untouched actors

--- a/internal/pkg/wallet/signature_test.go
+++ b/internal/pkg/wallet/signature_test.go
@@ -162,6 +162,6 @@ func TestSignedMessageCorrupted(t *testing.T) {
 	smsg, err := types.NewSignedMessage(*msg, fs)
 	require.NoError(t, err)
 
-	smsg.Message.CallSeqNum = types.Uint64(uint64(42))
+	smsg.Message.CallSeqNum = uint64(42)
 	assert.False(t, smsg.VerifySignature())
 }


### PR DESCRIPTION
### Motivation
Message and actor object correct serialization is needed for interop.

Using verbose deprecated types is technical debt we should clear.

### Proposed changes
1. Remove Uint64 type from message and actor `CallSeqNum` in favor of uint64.
2. Tuple encode unsiged message and signed message

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

