### PR TITLE
Replace a bunch of verbose miner status plumbing with a single state-view based access

### DIFF
--- a/cmd/go-filecoin/address.go
+++ b/cmd/go-filecoin/address.go
@@ -10,7 +10,6 @@ import (
 	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	files "github.com/ipfs/go-ipfs-files"
-	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
@@ -33,7 +32,6 @@ var addrsCmd = &cmds.Command{
 	Subcommands: map[string]*cmds.Command{
 		"ls":      addrsLsCmd,
 		"new":     addrsNewCmd,
-		"lookup":  addrsLookupCmd,
 		"default": defaultAddressCmd,
 	},
 }
@@ -89,31 +87,6 @@ var addrsLsCmd = &cmds.Command{
 				}
 			}
 			return nil
-		}),
-	},
-}
-
-var addrsLookupCmd = &cmds.Command{
-	Arguments: []cmdkit.Argument{
-		cmdkit.StringArg("address", true, false, "Miner address to find peerId for"),
-	},
-	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
-		addr, err := address.NewFromString(req.Arguments[0])
-		if err != nil {
-			return err
-		}
-
-		v, err := GetPorcelainAPI(env).MinerGetPeerID(req.Context, addr)
-		if err != nil {
-			return errors.Wrapf(err, "failed to find miner with address %s", addr)
-		}
-		return re.Emit(v.Pretty())
-	},
-	Type: string(""),
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, pid string) error {
-			_, err := fmt.Fprintln(w, pid)
-			return err
 		}),
 	},
 }

--- a/cmd/go-filecoin/mining.go
+++ b/cmd/go-filecoin/mining.go
@@ -96,8 +96,8 @@ var miningStartCmd = &cmds.Command{
 
 // MiningStatusResult is the type returned when get mining status.
 type MiningStatusResult struct {
-	Miner         address.Address              `json:"minerAddress"`
-	Active        bool                         `json:"active"`
+	Miner  address.Address `json:"minerAddress"`
+	Active bool            `json:"active"`
 }
 
 var miningStatusCmd = &cmds.Command{
@@ -114,8 +114,8 @@ var miningStatusCmd = &cmds.Command{
 		}
 
 		return re.Emit(&MiningStatusResult{
-			Miner:         minerAddress,
-			Active:        isMining,
+			Miner:  minerAddress,
+			Active: isMining,
 		})
 	},
 	Type: &MiningStatusResult{},

--- a/cmd/go-filecoin/mining.go
+++ b/cmd/go-filecoin/mining.go
@@ -9,9 +9,6 @@ import (
 	"github.com/ipfs/go-cid"
 	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
 	cmds "github.com/ipfs/go-ipfs-cmds"
-
-	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/porcelain"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
 var miningCmd = &cmds.Command{
@@ -99,12 +96,8 @@ var miningStartCmd = &cmds.Command{
 
 // MiningStatusResult is the type returned when get mining status.
 type MiningStatusResult struct {
-	Active        bool                         `json:"active"`
 	Miner         address.Address              `json:"minerAddress"`
-	Owner         address.Address              `json:"owner"`
-	Collateral    types.AttoFIL                `json:"collateral"`
-	ProvingPeriod porcelain.MinerProvingWindow `json:"provingPeriod,omitempty"`
-	Power         porcelain.MinerPower         `json:"minerPower"`
+	Active        bool                         `json:"active"`
 }
 
 var miningStatusCmd = &cmds.Command{
@@ -120,62 +113,18 @@ var miningStatusCmd = &cmds.Command{
 			return err
 		}
 
-		mpp, err := GetPorcelainAPI(env).MinerGetProvingWindow(req.Context, minerAddress)
-		if err != nil {
-			return err
-		}
-
-		owner, err := GetPorcelainAPI(env).MinerGetOwnerAddress(req.Context, minerAddress)
-		if err != nil {
-			return err
-		}
-
-		collateral, err := GetPorcelainAPI(env).MinerGetCollateral(req.Context, minerAddress)
-		if err != nil {
-			return err
-		}
-
-		power, err := GetPorcelainAPI(env).MinerGetPower(req.Context, minerAddress)
-		if err != nil {
-			return err
-		}
-
 		return re.Emit(&MiningStatusResult{
-			Active:        isMining,
 			Miner:         minerAddress,
-			Owner:         owner,
-			Collateral:    collateral,
-			Power:         power,
-			ProvingPeriod: mpp,
+			Active:        isMining,
 		})
 	},
 	Type: &MiningStatusResult{},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *MiningStatusResult) error {
-			var pSet []string
-			for p := range res.ProvingPeriod.ProvingSet {
-				pSet = append(pSet, p)
-			}
 			_, err := fmt.Fprintf(w, `Mining Status
 Active:     %s
 Address:    %s
-Owner:      %s
-Collateral: %s
-Power:      %s / %s
-
-Proving Period
-Start:         %s
-End:           %s
-Proving Set:   %s
-
-`, strconv.FormatBool(res.Active),
-				res.Miner,
-				res.Owner,
-				res.Collateral.String(),
-				res.Power.Power.String(), res.Power.Total.String(),
-				res.ProvingPeriod.Start.String(),
-				res.ProvingPeriod.End.String(),
-				pSet)
+`, strconv.FormatBool(res.Active), res.Miner)
 
 			return err
 		}),

--- a/cmd/go-filecoin/mining_integration_test.go
+++ b/cmd/go-filecoin/mining_integration_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	fbig "github.com/filecoin-project/specs-actors/actors/abi/big"
+	specsbig "github.com/filecoin-project/specs-actors/actors/abi/big"
 	files "github.com/ipfs/go-ipfs-files"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,7 +19,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 	"github.com/filecoin-project/go-filecoin/tools/fast/fastesting"
 	"github.com/filecoin-project/go-filecoin/tools/fast/series"
-	specsbig "github.com/filecoin-project/specs-actors/actors/abi/big"
 )
 
 func TestMiningGenBlock(t *testing.T) {
@@ -98,10 +99,10 @@ func TestMiningAddPieceAndSealNow(t *testing.T) {
 	// We know the miner has sealed and committed a sector if their power increases on chain.
 	// Wait up to 300 seconds for that to happen.
 	for i := 0; i < 300; i++ {
-		power, err := minerNode.MinerPower(ctx, miningAddress)
+		power, err := minerNode.MinerStatus(ctx, miningAddress)
 		require.NoError(t, err)
 
-		if power.Power.GreaterThan(types.ZeroBytes) {
+		if power.Power.GreaterThan(fbig.Zero()) {
 			// miner has gained power, so seal was successful
 			return
 		}

--- a/internal/app/go-filecoin/plumbing/api.go
+++ b/internal/app/go-filecoin/plumbing/api.go
@@ -266,11 +266,6 @@ func (api *API) StateView(baseKey block.TipSetKey) (*appstate.View, error) {
 	return api.actorState.StateView(baseKey)
 }
 
-// PowerStateView interprets StateView as a power state view
-func (api *API) PowerStateView(baseKey block.TipSetKey) (consensus.PowerStateView, error) {
-	return api.StateView(baseKey)
-}
-
 // MessageSend sends a message. It uses the default from address if none is given and signs the
 // message using the wallet. This call "sends" in the sense that it enqueues the
 // message in the msg pool and broadcasts it to the network; it does not wait for the

--- a/internal/app/go-filecoin/porcelain/api.go
+++ b/internal/app/go-filecoin/porcelain/api.go
@@ -7,16 +7,17 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/plumbing"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	minerActor "github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/miner"
 )
 
@@ -107,59 +108,19 @@ func (a *API) MinerPreviewCreate(
 	return MinerPreviewCreate(ctx, a, fromAddr, sectorSize, pid)
 }
 
+// MinerGetStatus queries for status of a miner.
+func (a *API) MinerGetStatus(ctx context.Context, minerAddr address.Address, baseKey block.TipSetKey) (MinerStatus, error) {
+	return MinerGetStatus(ctx, a, minerAddr, baseKey)
+}
+
 // MinerGetAsk queries for an ask of the given miner
 func (a *API) MinerGetAsk(ctx context.Context, minerAddr address.Address, askID uint64) (minerActor.Ask, error) {
 	panic("implement me in terms of the storage market module")
 }
 
-// MinerGetOwnerAddress queries for the owner address of the given miner
-func (a *API) MinerGetOwnerAddress(ctx context.Context, minerAddr address.Address) (address.Address, error) {
-	return MinerGetOwnerAddress(ctx, a, minerAddr)
-}
-
-// MinerGetWorkerAddress queries for the worker address of the given miner
-func (a *API) MinerGetWorkerAddress(ctx context.Context, minerAddr address.Address, baseKey block.TipSetKey) (address.Address, error) {
-	return MinerGetWorkerAddress(ctx, a, minerAddr, baseKey)
-}
-
-// MinerGetSectorSize queries for the sector size of the given miner.
-func (a *API) MinerGetSectorSize(ctx context.Context, minerAddr address.Address) (*types.BytesAmount, error) {
-	return MinerGetSectorSize(ctx, a, minerAddr)
-}
-
-// MinerCalculateLateFee queries for the fee required for a PoSt submitted at some height.
-func (a *API) MinerCalculateLateFee(ctx context.Context, minerAddr address.Address, height *types.BlockHeight) (types.AttoFIL, error) {
-	return MinerCalculateLateFee(ctx, a, minerAddr, height)
-}
-
-// MinerGetLastCommittedSectorID queries for the sector size of the given miner.
-func (a *API) MinerGetLastCommittedSectorID(ctx context.Context, minerAddr address.Address) (uint64, error) {
-	return MinerGetLastCommittedSectorID(ctx, a, minerAddr)
-}
-
-// MinerGetPeerID queries for the peer id of the given miner
-func (a *API) MinerGetPeerID(ctx context.Context, minerAddr address.Address) (peer.ID, error) {
-	return MinerGetPeerID(ctx, a, minerAddr)
-}
-
 // MinerSetPrice configures the price of storage. See implementation for details.
 func (a *API) MinerSetPrice(ctx context.Context, from address.Address, miner address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, price types.AttoFIL, expiry *big.Int) (MinerSetPriceResponse, error) {
-	return MinerSetPrice(ctx, a, from, miner, gasPrice, gasLimit, price, expiry)
-}
-
-// MinerGetPower queries for the power of the given miner
-func (a *API) MinerGetPower(ctx context.Context, minerAddr address.Address) (MinerPower, error) {
-	return MinerGetPower(ctx, a, minerAddr)
-}
-
-// MinerGetProvingWindow queries for the proving period of the given miner
-func (a *API) MinerGetProvingWindow(ctx context.Context, minerAddr address.Address) (MinerProvingWindow, error) {
-	return MinerGetProvingWindow(ctx, a, minerAddr)
-}
-
-// MinerGetCollateral queries for the proving period of the given miner
-func (a *API) MinerGetCollateral(ctx context.Context, minerAddr address.Address) (types.AttoFIL, error) {
-	return MinerGetCollateral(ctx, a, minerAddr)
+	panic("implement me in terms of the storage market module")
 }
 
 // ProtocolParameters fetches the current protocol configuration parameters.
@@ -211,4 +172,14 @@ func (a *API) MinerSetWorkerAddress(ctx context.Context, toAddr address.Address,
 // MessageWaitDone blocks until the message is on chain
 func (a *API) MessageWaitDone(ctx context.Context, msgCid cid.Cid) (*types.MessageReceipt, error) {
 	return MessageWaitDone(ctx, a, msgCid)
+}
+
+// PowerStateView interprets StateView as a power state view
+func (api *API) PowerStateView(baseKey block.TipSetKey) (consensus.PowerStateView, error) {
+	return api.StateView(baseKey)
+}
+
+// MinerStateView interprets StateView as a power state view
+func (api *API) MinerStateView(baseKey block.TipSetKey) (MinerStateView, error) {
+	return api.StateView(baseKey)
 }

--- a/internal/app/go-filecoin/porcelain/api.go
+++ b/internal/app/go-filecoin/porcelain/api.go
@@ -175,11 +175,11 @@ func (a *API) MessageWaitDone(ctx context.Context, msgCid cid.Cid) (*types.Messa
 }
 
 // PowerStateView interprets StateView as a power state view
-func (api *API) PowerStateView(baseKey block.TipSetKey) (consensus.PowerStateView, error) {
-	return api.StateView(baseKey)
+func (a *API) PowerStateView(baseKey block.TipSetKey) (consensus.PowerStateView, error) {
+	return a.StateView(baseKey)
 }
 
 // MinerStateView interprets StateView as a power state view
-func (api *API) MinerStateView(baseKey block.TipSetKey) (MinerStateView, error) {
-	return api.StateView(baseKey)
+func (a *API) MinerStateView(baseKey block.TipSetKey) (MinerStateView, error) {
+	return a.StateView(baseKey)
 }

--- a/internal/app/go-filecoin/porcelain/miner.go
+++ b/internal/app/go-filecoin/porcelain/miner.go
@@ -212,8 +212,10 @@ func MinerGetStatus(ctx context.Context, plumbing minerStatusPlumbing, minerAddr
 	if err != nil {
 		return MinerStatus{}, err
 	}
-
 	requirement, balance, err := view.MinerPledgeCollateral(ctx, minerAddr)
+	if err != nil {
+		return MinerStatus{}, err
+	}
 
 	return MinerStatus{
 		ActorAddress:  minerAddr,

--- a/internal/app/go-filecoin/porcelain/miner.go
+++ b/internal/app/go-filecoin/porcelain/miner.go
@@ -2,22 +2,17 @@ package porcelain
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"math/big"
 
 	"github.com/filecoin-project/go-address"
+	aabi "github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/abi"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/initactor"
 	minerActor "github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/miner"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/power"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/storagemarket"
 	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 )
@@ -29,6 +24,16 @@ type mcAPI interface {
 	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, chan error, error)
 	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*block.Block, *types.SignedMessage, *types.MessageReceipt) error) error
 	WalletDefaultAddress() (address.Address, error)
+}
+
+type MinerStateView interface {
+	MinerControlAddresses(ctx context.Context, maddr address.Address) (owner, worker address.Address, err error)
+	MinerPeerID(ctx context.Context, maddr address.Address) (peer.ID, error)
+	MinerSectorSize(ctx context.Context, maddr address.Address) (aabi.SectorSize, error)
+	MinerProvingPeriod(ctx context.Context, maddr address.Address) (start aabi.ChainEpoch, end aabi.ChainEpoch, failureCount int, err error)
+	NetworkTotalPower(ctx context.Context) (aabi.StoragePower, error)
+	MinerClaimedPower(ctx context.Context, miner address.Address) (aabi.StoragePower, error)
+	MinerPledgeCollateral(ctx context.Context, miner address.Address) (locked aabi.TokenAmount, total aabi.TokenAmount, err error)
 }
 
 // MinerCreate creates a new miner actor for the given account and returns its address.
@@ -56,7 +61,7 @@ func MinerCreate(
 	if err != nil {
 		return nil, err
 	}
-	if (addr != address.Address{}) {
+	if addr != address.Undef {
 		return nil, fmt.Errorf("can only have one miner per node")
 	}
 
@@ -141,191 +146,14 @@ func MinerPreviewCreate(
 	return usedGas, nil
 }
 
-// mspAPI is the subset of the plumbing.API that MinerSetPrice uses.
-type mspAPI interface {
-	ConfigGet(dottedPath string) (interface{}, error)
-	ConfigSet(dottedKey string, jsonString string) error
-	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, chan error, error)
-	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*block.Block, *types.SignedMessage, *types.MessageReceipt) error) error
-}
-
 // MinerSetPriceResponse collects relevant stats from the set price process
 type MinerSetPriceResponse struct {
-	AddAskCid cid.Cid
-	BlockCid  cid.Cid
 	MinerAddr address.Address
 	Price     types.AttoFIL
 }
 
-// MinerSetPrice configures the price of storage, then sends an ask advertising that price and waits for it to be mined.
-// If minerAddr is empty, the default miner will be used.
-// This method is non-transactional in the sense that it will set the price whether or not it creates the ask successfully.
-func MinerSetPrice(ctx context.Context, plumbing mspAPI, from address.Address, miner address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, price types.AttoFIL, expiry *big.Int) (MinerSetPriceResponse, error) {
-	res := MinerSetPriceResponse{
-		Price: price,
-	}
-
-	// get miner address if not provided
-	if miner.Empty() {
-		minerValue, err := plumbing.ConfigGet("mining.minerAddress")
-		if err != nil {
-			return res, errors.Wrap(err, "Could not get miner address in config")
-		}
-		minerAddr, ok := minerValue.(address.Address)
-		if !ok {
-			return res, errors.Wrap(err, "Configured miner is not an address")
-		}
-		miner = minerAddr
-	}
-	res.MinerAddr = miner
-
-	// set price
-	jsonPrice, err := json.Marshal(price)
-	if err != nil {
-		return res, errors.New("Could not marshal price")
-	}
-	if err := plumbing.ConfigSet("mining.storagePrice", string(jsonPrice)); err != nil {
-		return res, err
-	}
-
-	// create ask
-	panic("implement me in terms of storage market module")
-}
-
-// minerQueryAndDeserialize is the subset of the plumbing.API that provides
-// support for sending query messages and getting method signatures.
-type minerQueryAndDeserialize interface {
-	ChainHeadKey() block.TipSetKey
-	MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, baseKey block.TipSetKey, params ...interface{}) ([][]byte, error)
-	ActorGetStableSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (vm.ActorMethodSignature, error)
-}
-
-// MinerGetOwnerAddress queries for the owner address of the given miner
-func MinerGetOwnerAddress(ctx context.Context, plumbing minerQueryAndDeserialize, minerAddr address.Address) (address.Address, error) {
-	res, err := plumbing.MessageQuery(ctx, address.Undef, minerAddr, minerActor.GetOwner, plumbing.ChainHeadKey())
-	if err != nil {
-		return address.Undef, err
-	}
-
-	return address.NewFromBytes(res[0])
-}
-
-// MinerGetWorkerAddress queries for the worker address of the given miner
-func MinerGetWorkerAddress(ctx context.Context, plumbing minerQueryAndDeserialize, minerAddr address.Address, baseKey block.TipSetKey) (address.Address, error) {
-	res, err := plumbing.MessageQuery(ctx, address.Undef, minerAddr, minerActor.GetWorker, baseKey)
-	if err != nil {
-		return address.Undef, err
-	}
-
-	workerAddr, err := address.NewFromBytes(res[0])
-	if err != nil {
-		return address.Undef, err
-	}
-
-	if minerAddr.Protocol() != address.ID {
-		return workerAddr, nil
-	}
-
-	id, err := address.IDFromAddress(minerAddr)
-	if err != nil {
-		return address.Undef, err
-	}
-
-	res, err = plumbing.MessageQuery(ctx, address.Undef, vmaddr.InitAddress, initactor.GetAddressForActorIDMethodID, baseKey, big.NewInt(int64(id)))
-	if err != nil {
-		return address.Undef, err
-	}
-
-	return address.NewFromBytes(res[0])
-}
-
-// queryAndDeserialize is a convenience method. It sends a query message to a
-// miner and, based on the method return-type, deserializes to the appropriate
-// ABI type.
-func queryAndDeserialize(ctx context.Context, plumbing minerQueryAndDeserialize, minerAddr address.Address, method types.MethodID, baseKey block.TipSetKey, params ...interface{}) (interface{}, error) {
-	rets, err := plumbing.MessageQuery(ctx, address.Address{}, minerAddr, method, baseKey, params...)
-	if err != nil {
-		return nil, errors.Wrapf(err, "'%s' query message failed", method)
-	}
-
-	methodSignature, err := plumbing.ActorGetStableSignature(ctx, minerAddr, method)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to acquire '%s' signature", method)
-	}
-
-	return methodSignature.ReturnInterface(rets[0])
-}
-
-// MinerGetSectorSize queries for the sector size of the given miner.
-func MinerGetSectorSize(ctx context.Context, plumbing minerQueryAndDeserialize, minerAddr address.Address) (*types.BytesAmount, error) {
-	out, err := queryAndDeserialize(ctx, plumbing, minerAddr, minerActor.GetSectorSize, plumbing.ChainHeadKey())
-	if err != nil {
-		return nil, errors.Wrap(err, "query and deserialize failed")
-	}
-
-	sectorSize, ok := out.(*types.BytesAmount)
-	if !ok {
-		return nil, errors.New("failed to convert returned ABI value")
-	}
-
-	return sectorSize, nil
-}
-
-// MinerCalculateLateFee calculates the fee due if a miner's PoSt were to be mined at `height`.
-func MinerCalculateLateFee(ctx context.Context, plumbing minerQueryAndDeserialize, minerAddr address.Address, height *types.BlockHeight) (types.AttoFIL, error) {
-	out, err := queryAndDeserialize(ctx, plumbing, minerAddr, minerActor.CalculateLateFee, plumbing.ChainHeadKey(), height)
-	if err != nil {
-		return types.ZeroAttoFIL, errors.Wrap(err, "query and deserialize failed")
-	}
-
-	coll, ok := out.(types.AttoFIL)
-	if !ok {
-		return types.ZeroAttoFIL, errors.New("failed to convert returned ABI value")
-	}
-
-	return coll, nil
-}
-
-// MinerGetLastCommittedSectorID queries for the id of the last sector committed
-// by the given miner.
-func MinerGetLastCommittedSectorID(ctx context.Context, plumbing minerQueryAndDeserialize, minerAddr address.Address) (uint64, error) {
-	out, err := queryAndDeserialize(ctx, plumbing, minerAddr, minerActor.GetLastUsedSectorID, plumbing.ChainHeadKey())
-	if err != nil {
-		return 0, errors.Wrap(err, "query and deserialize failed")
-	}
-
-	lastUsedSectorID, ok := out.(uint64)
-	if !ok {
-		return 0, errors.New("failed to convert returned ABI value")
-	}
-
-	return lastUsedSectorID, nil
-}
-
-// mgaAPI is the subset of the plumbing.API that MinerGetAsk uses.
-type mgaAPI interface {
-	ChainHeadKey() block.TipSetKey
-	MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, baseKey block.TipSetKey, params ...interface{}) ([][]byte, error)
-}
-
-// mgpidAPI is the subset of the plumbing.API that MinerGetPeerID uses.
-type mgpidAPI interface {
-	ChainHeadKey() block.TipSetKey
-	MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, baseKey block.TipSetKey, params ...interface{}) ([][]byte, error)
-}
-
-// MinerGetPeerID queries for the peer id of the given miner
-func MinerGetPeerID(ctx context.Context, plumbing mgpidAPI, minerAddr address.Address) (peer.ID, error) {
-	res, err := plumbing.MessageQuery(ctx, address.Undef, minerAddr, minerActor.GetPeerID, plumbing.ChainHeadKey())
-	if err != nil {
-		return "", err
-	}
-
-	pid, err := peer.IDFromBytes(res[0])
-	if err != nil {
-		return peer.ID(""), errors.Wrap(err, "could not decode to peer.ID from message-bytes")
-	}
-	return pid, nil
+type minerStatusPlumbing interface {
+	MinerStateView(baseKey block.TipSetKey) (MinerStateView, error)
 }
 
 // MinerProvingWindow contains a miners proving period start and end as well
@@ -336,124 +164,81 @@ type MinerProvingWindow struct {
 	ProvingSet map[string]types.Commitments
 }
 
-// MinerGetProvingWindow gets the proving period and commitments for miner `minerAddr`.
-func MinerGetProvingWindow(ctx context.Context, plumbing minerQueryAndDeserialize, minerAddr address.Address) (MinerProvingWindow, error) {
-	res, err := plumbing.MessageQuery(
-		ctx,
-		address.Undef,
-		minerAddr,
-		minerActor.GetProvingWindow,
-		plumbing.ChainHeadKey(),
-	)
+// MinerStatus contains a miners power and the total power of the network
+type MinerStatus struct {
+	ActorAddress  address.Address
+	OwnerAddress  address.Address
+	WorkerAddress address.Address
+	PeerID        peer.ID
+	SectorSize    aabi.SectorSize
+
+	Power             aabi.StoragePower
+	PledgeRequirement aabi.TokenAmount
+	PledgeBalance     aabi.TokenAmount
+
+	ProvingPeriodStart aabi.ChainEpoch
+	ProvingPeriodEnd   aabi.ChainEpoch
+	PoStFailureCount   int
+	NetworkPower       aabi.StoragePower
+}
+
+// MinerGetStatus queries the power of a given miner.
+func MinerGetStatus(ctx context.Context, plumbing minerStatusPlumbing, minerAddr address.Address, key block.TipSetKey) (MinerStatus, error) {
+	view, err := plumbing.MinerStateView(key)
 	if err != nil {
-		return MinerProvingWindow{}, errors.Wrap(err, "query ProvingPeriod method failed")
+		return MinerStatus{}, err
+	}
+	owner, worker, err := view.MinerControlAddresses(ctx, minerAddr)
+	if err != nil {
+		return MinerStatus{}, err
+	}
+	peerID, err := view.MinerPeerID(ctx, minerAddr)
+	if err != nil {
+		return MinerStatus{}, err
+	}
+	sectorSize, err := view.MinerSectorSize(ctx, minerAddr)
+	if err != nil {
+		return MinerStatus{}, err
+	}
+	periodStart, periodEnd, failureCount, err := view.MinerProvingPeriod(ctx, minerAddr)
+	if err != nil {
+		return MinerStatus{}, err
+	}
+	claimedPower, err := view.MinerClaimedPower(ctx, minerAddr)
+	if err != nil {
+		return MinerStatus{}, err
+	}
+	totalPower, err := view.NetworkTotalPower(ctx)
+	if err != nil {
+		return MinerStatus{}, err
 	}
 
-	window, err := abi.Deserialize(res[0], abi.UintArray)
-	if err != nil {
-		return MinerProvingWindow{}, err
-	}
-	windowVal := window.Val.([]types.Uint64)
+	requirement, balance, err := view.MinerPledgeCollateral(ctx, minerAddr)
 
-	res, err = plumbing.MessageQuery(
-		ctx,
-		address.Undef,
-		minerAddr,
-		minerActor.GetProvingSetCommitments,
-		plumbing.ChainHeadKey(),
-	)
-	if err != nil {
-		return MinerProvingWindow{}, errors.Wrap(err, "query SetCommitments method failed")
-	}
+	return MinerStatus{
+		ActorAddress:  minerAddr,
+		OwnerAddress:  owner,
+		WorkerAddress: worker,
+		PeerID:        peerID,
+		SectorSize:    sectorSize,
 
-	sig, err := plumbing.ActorGetStableSignature(ctx, minerAddr, minerActor.GetProvingSetCommitments)
-	if err != nil {
-		return MinerProvingWindow{}, errors.Wrap(err, "query method failed")
-	}
-	fmt.Printf("bad bytes: %x\n", res[0])
-	commitmentsVal, err := sig.ReturnInterface(res[0])
-	if err != nil {
-		return MinerProvingWindow{}, errors.Wrap(err, "deserialization failed")
-	}
-	commitments, ok := commitmentsVal.(map[string]types.Commitments)
-	if !ok {
-		return MinerProvingWindow{}, errors.New("type assertion failed")
-	}
+		Power:             claimedPower,
+		PledgeRequirement: requirement,
+		PledgeBalance:     balance,
 
-	return MinerProvingWindow{
-		Start:      *types.NewBlockHeight(uint64(windowVal[0])),
-		End:        *types.NewBlockHeight(uint64(windowVal[1])),
-		ProvingSet: commitments,
+		ProvingPeriodStart: periodStart,
+		ProvingPeriodEnd:   periodEnd,
+		PoStFailureCount:   failureCount,
+		NetworkPower:       totalPower,
 	}, nil
-}
-
-// MinerPower contains a miners power and the total power of the network
-type MinerPower struct {
-	Power types.BytesAmount
-	Total types.BytesAmount
-}
-
-// MinerGetPower queries the power of a given miner.
-func MinerGetPower(ctx context.Context, plumbing mgaAPI, minerAddr address.Address) (MinerPower, error) {
-	bytes, err := plumbing.MessageQuery(
-		ctx,
-		address.Undef,
-		vmaddr.StoragePowerAddress,
-		power.GetPowerReport,
-		plumbing.ChainHeadKey(),
-		minerAddr,
-	)
-	if err != nil {
-		return MinerPower{}, err
-	}
-	reportValue, err := abi.Deserialize(bytes[0], abi.PowerReport)
-	if err != nil {
-		return MinerPower{}, err
-	}
-	powerReport, ok := reportValue.Val.(types.PowerReport)
-	if !ok {
-		return MinerPower{}, errors.Errorf("invalid report bytes returned from GetPower")
-	}
-	minerPower := powerReport.ActivePower
-
-	bytes, err = plumbing.MessageQuery(
-		ctx,
-		address.Undef,
-		vmaddr.StoragePowerAddress,
-		power.GetTotalPower,
-		plumbing.ChainHeadKey(),
-	)
-	if err != nil {
-		return MinerPower{}, err
-	}
-	total := types.NewBytesAmountFromBytes(bytes[0])
-
-	return MinerPower{
-		Power: *minerPower,
-		Total: *total,
-	}, nil
-}
-
-// MinerGetCollateral queries the collateral of a given miner.
-func MinerGetCollateral(ctx context.Context, plumbing mgaAPI, minerAddr address.Address) (types.AttoFIL, error) {
-	rets, err := plumbing.MessageQuery(
-		ctx,
-		address.Undef,
-		minerAddr,
-		minerActor.GetActiveCollateral,
-		plumbing.ChainHeadKey(),
-	)
-	if err != nil {
-		return types.AttoFIL{}, err
-	}
-	return types.NewAttoFILFromBytes(rets[0]), nil
 }
 
 // mwapi is the subset of the plumbing.API that MinerSetWorkerAddress use.
 type mwapi interface {
 	ConfigGet(dottedPath string) (interface{}, error)
+	ChainHeadKey() block.TipSetKey
+	MinerStateView(baseKey block.TipSetKey) (MinerStateView, error)
 	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, chan error, error)
-	MinerGetOwnerAddress(ctx context.Context, minerAddr address.Address) (address.Address, error)
 }
 
 // MinerSetWorkerAddress sets the worker address of the miner actor to the provided new address,
@@ -475,14 +260,20 @@ func MinerSetWorkerAddress(
 		return cid.Undef, errors.New("problem converting miner address")
 	}
 
-	minerOwnerAddr, err := plumbing.MinerGetOwnerAddress(ctx, minerAddr)
+	head := plumbing.ChainHeadKey()
+	state, err := plumbing.MinerStateView(head)
+	if err != nil {
+		return cid.Undef, errors.Wrap(err, "could not get miner owner address")
+	}
+
+	owner, _, err := state.MinerControlAddresses(ctx, minerAddr)
 	if err != nil {
 		return cid.Undef, errors.Wrap(err, "could not get miner owner address")
 	}
 
 	c, _, err := plumbing.MessageSend(
 		ctx,
-		minerOwnerAddr,
+		owner,
 		minerAddr,
 		types.ZeroAttoFIL,
 		gasPrice,

--- a/internal/app/go-filecoin/porcelain/miner_test.go
+++ b/internal/app/go-filecoin/porcelain/miner_test.go
@@ -4,30 +4,23 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
-	"github.com/filecoin-project/go-leb128"
+	aabi "github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-cid"
-	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/plumbing/cfg"
 	. "github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/porcelain"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/abi"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/miner"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/power"
 	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/wallet"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type minerCreate struct {
@@ -124,244 +117,87 @@ func TestMinerCreate(t *testing.T) {
 	})
 }
 
-type minerQueryAndDeserializePlumbing struct{}
-
-func (mgop *minerQueryAndDeserializePlumbing) ChainHeadKey() block.TipSetKey {
-	return block.NewTipSetKey()
+type mStatusPlumbing struct {
+	head block.TipSetKey
 }
 
-func (mgop *minerQueryAndDeserializePlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, _ block.TipSetKey, params ...interface{}) ([][]byte, error) {
-	// Note: this currently happens to work as is, but it's wrong
-	// Note: a better mock is recommended to make sure the correct methods get dispatched
-	switch method {
-	case miner.GetOwner:
-		return [][]byte{vmaddr.TestAddress.Bytes()}, nil
-	case miner.GetWorker:
-		return [][]byte{vmaddr.TestAddress2.Bytes()}, nil
-	case power.GetPowerReport:
-		powerReport := types.NewPowerReport(2, 0)
-		val := abi.Value{
-			Val:  powerReport,
-			Type: abi.PowerReport,
-		}
-		raw, err := val.Serialize()
-		return [][]byte{raw}, err
-	case power.GetTotalPower:
-		return [][]byte{types.NewBytesAmount(4).Bytes()}, nil
-	default:
-		return nil, fmt.Errorf("unsupported method: %s", method)
-	}
+func (p *mStatusPlumbing) ChainHeadKey() block.TipSetKey {
+	return p.head
 }
 
-func (mgop *minerQueryAndDeserializePlumbing) ActorGetStableSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (vm.ActorMethodSignature, error) {
-	panic("{Dragons} delete")
+func (p *mStatusPlumbing) MinerStateView(baseKey block.TipSetKey) (MinerStateView, error) {
+	return &state.FakeStateView{
+		NetworkPower: aabi.NewStoragePower(4),
+		Miners: map[address.Address]*state.FakeMinerState{
+			vmaddr.TestAddress: {
+				Owner:        vmaddr.TestAddress2,
+				Worker:       vmaddr.TestAddress2,
+				ClaimedPower: aabi.NewStoragePower(2),
+			},
+		},
+	}, nil
 }
 
-func TestMinerGetOwnerAddress(t *testing.T) {
+func TestMinerGetStatus(t *testing.T) {
 	tf.UnitTest(t)
+	key := block.NewTipSetKey(types.NewCidForTestGetter()())
 
-	addr, err := MinerGetOwnerAddress(context.Background(), &minerQueryAndDeserializePlumbing{}, vmaddr.TestAddress2)
+	status, err := MinerGetStatus(context.Background(), &mStatusPlumbing{}, vmaddr.TestAddress, key)
 	assert.NoError(t, err)
-	assert.Equal(t, vmaddr.TestAddress, addr)
+	assert.Equal(t, vmaddr.TestAddress2, status.OwnerAddress)
+	assert.Equal(t, vmaddr.TestAddress2, status.WorkerAddress)
+	assert.Equal(t, "4", status.NetworkPower.String())
+	assert.Equal(t, "2", status.Power.String())
 }
 
-func TestMinerGetWorkerAddress(t *testing.T) {
-	tf.UnitTest(t)
-
-	addr, err := MinerGetWorkerAddress(context.Background(), &minerQueryAndDeserializePlumbing{}, vmaddr.TestAddress2, block.NewTipSetKey())
-	assert.NoError(t, err)
-	assert.Equal(t, vmaddr.TestAddress2, addr)
+type mSetWorkerPlumbing struct {
+	head                                         block.TipSetKey
+	getStatusFail, msgFail, msgWaitFail, cfgFail bool
+	minerAddr, ownerAddr, workerAddr             address.Address
 }
 
-func TestMinerGetPower(t *testing.T) {
-	tf.UnitTest(t)
-
-	power, err := MinerGetPower(context.Background(), &minerQueryAndDeserializePlumbing{}, vmaddr.TestAddress2)
-	assert.NoError(t, err)
-	assert.Equal(t, "4", power.Total.String())
-	assert.Equal(t, "2", power.Power.String())
+func (p *mSetWorkerPlumbing) ChainHeadKey() block.TipSetKey {
+	return p.head
 }
 
-type minerGetProvingPeriodPlumbing struct{}
-
-func (mpp *minerGetProvingPeriodPlumbing) ChainHeadKey() block.TipSetKey {
-	return block.NewTipSetKey()
-}
-
-func (mpp *minerGetProvingPeriodPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, _ block.TipSetKey, params ...interface{}) ([][]byte, error) {
-	if method == miner.GetProvingWindow {
-		ret, err := (&abi.Value{Type: abi.UintArray, Val: []types.Uint64{10, 20}}).Serialize()
-		if err != nil {
-			return nil, err
-		}
-		return [][]byte{ret}, nil
+func (p *mSetWorkerPlumbing) MinerStateView(baseKey block.TipSetKey) (MinerStateView, error) {
+	if p.getStatusFail {
+		return &state.FakeStateView{}, errors.New("for testing")
 	}
-	if method == miner.GetProvingSetCommitments {
-		commitments := make(map[string]types.Commitments)
-		commD := types.CommD([32]byte{1})
-		commR := types.CommR([32]byte{1})
-		commRStar := types.CommRStar([32]byte{1})
 
-		commitments["foo"] = types.Commitments{
-			CommD:     &commD,
-			CommR:     &commR,
-			CommRStar: &commRStar,
-		}
-		thing, err := encoding.Encode(commitments)
-		if err != nil {
-			return nil, err
-		}
-		return [][]byte{thing}, nil
-	}
-	return nil, fmt.Errorf("unsupported method: %s", method)
+	return &state.FakeStateView{
+		Miners: map[address.Address]*state.FakeMinerState{
+			p.minerAddr: {
+				Owner:        p.ownerAddr,
+				Worker:       p.workerAddr,
+			},
+		},
+	}, nil
 }
 
-func (mpp *minerGetProvingPeriodPlumbing) ActorGetStableSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (vm.ActorMethodSignature, error) {
-	panic("{Dragons} delete")
-}
+func (p *mSetWorkerPlumbing) MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, chan error, error) {
 
-func TestMinerProvingPeriod(t *testing.T) {
-	tf.UnitTest(t)
-	t.Skip("cbor limitation with possible workaround but not worth it for test that will be deleted")
-
-	pp, err := MinerGetProvingWindow(context.Background(), &minerGetProvingPeriodPlumbing{}, vmaddr.TestAddress2)
-	assert.NoError(t, err)
-	assert.Equal(t, "10", pp.Start.String())
-	assert.Equal(t, "20", pp.End.String())
-	assert.NotNil(t, pp.ProvingSet["foo"])
-}
-
-type minerGetPeerIDPlumbing struct{}
-
-func (mgop *minerGetPeerIDPlumbing) ChainHeadKey() block.TipSetKey {
-	return block.NewTipSetKey()
-}
-
-func (mgop *minerGetPeerIDPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, _ block.TipSetKey, params ...interface{}) ([][]byte, error) {
-
-	peerID := requirePeerID()
-	return [][]byte{[]byte(peerID)}, nil
-}
-
-func TestMinerGetPeerID(t *testing.T) {
-	tf.UnitTest(t)
-
-	id, err := MinerGetPeerID(context.Background(), &minerGetPeerIDPlumbing{}, vmaddr.TestAddress2)
-	require.NoError(t, err)
-
-	expected := requirePeerID()
-	require.NoError(t, err)
-	assert.Equal(t, expected, id)
-}
-
-type minerGetAskPlumbing struct{}
-
-func (mgop *minerGetAskPlumbing) ChainHeadKey() block.TipSetKey {
-	return block.NewTipSetKey()
-}
-
-func (mgop *minerGetAskPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, _ block.TipSetKey, params ...interface{}) ([][]byte, error) {
-	out, err := encoding.Encode(miner.Ask{
-		Price:  types.NewAttoFILFromFIL(32),
-		Expiry: types.NewBlockHeight(41),
-		ID:     big.NewInt(4),
-	})
-	if err != nil {
-		panic("Could not encode ask")
-	}
-	return [][]byte{out}, nil
-}
-
-func requirePeerID() peer.ID {
-	id, err := peer.Decode("QmWbMozPyW6Ecagtxq7SXBXXLY5BNdP1GwHB2WoZCKMvcb")
-	if err != nil {
-		panic("Could not create peer id")
-	}
-	return id
-}
-
-type minerGetSectorSizePlumbing struct{}
-
-func (minerGetSectorSizePlumbing) ChainHeadKey() block.TipSetKey {
-	return block.NewTipSetKey()
-}
-
-func (minerGetSectorSizePlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, _ block.TipSetKey, params ...interface{}) ([][]byte, error) {
-	return [][]byte{types.NewBytesAmount(1234).Bytes()}, nil
-}
-func (minerGetSectorSizePlumbing) ActorGetStableSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (vm.ActorMethodSignature, error) {
-	panic("{Dragons} delete")
-}
-
-func TestMinerGetSectorSize(t *testing.T) {
-	tf.UnitTest(t)
-	t.Skip("delte or rewrite")
-
-	sectorSize, err := MinerGetSectorSize(context.Background(), &minerGetSectorSizePlumbing{}, vmaddr.TestAddress2)
-	require.NoError(t, err)
-
-	assert.Equal(t, int(sectorSize.Uint64()), 1234)
-}
-
-type minerGetLastCommittedSectorIDPlumbing struct{}
-
-func (minerGetLastCommittedSectorIDPlumbing) ChainHeadKey() block.TipSetKey {
-	return block.NewTipSetKey()
-}
-
-func (minerGetLastCommittedSectorIDPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, _ block.TipSetKey, params ...interface{}) ([][]byte, error) {
-	return [][]byte{leb128.FromUInt64(5432)}, nil
-}
-func (minerGetLastCommittedSectorIDPlumbing) ActorGetStableSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (vm.ActorMethodSignature, error) {
-	panic("{Dragons} delete")
-
-}
-
-func TestMinerGetLastCommittedSectorID(t *testing.T) {
-	tf.UnitTest(t)
-	t.Skip("rewrite or delete")
-
-	lastCommittedSectorID, err := MinerGetLastCommittedSectorID(context.Background(), &minerGetLastCommittedSectorIDPlumbing{}, vmaddr.TestAddress2)
-	require.NoError(t, err)
-
-	assert.Equal(t, int(lastCommittedSectorID), 5432)
-}
-
-type minerSetWorkerAddressPlumbing struct {
-	getOwnerFail, getWorkerFail, msgFail, msgWaitFail, cfgFail bool
-	minerAddr, ownerAddr, workerAddr                           address.Address
-}
-
-func (mswap *minerSetWorkerAddressPlumbing) MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method types.MethodID, params ...interface{}) (cid.Cid, chan error, error) {
-
-	if mswap.msgFail {
+	if p.msgFail {
 		return cid.Cid{}, nil, errors.New("MsgFail")
 	}
 	return types.EmptyMessagesCID, nil, nil
 }
 
-func (mswap *minerSetWorkerAddressPlumbing) MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*block.Block, *types.SignedMessage, *types.MessageReceipt) error) error {
-	if mswap.msgWaitFail {
+func (p *mSetWorkerPlumbing) MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*block.Block, *types.SignedMessage, *types.MessageReceipt) error) error {
+	if p.msgWaitFail {
 		return errors.New("MsgWaitFail")
 	}
 	return nil
 }
 
-func (mswap *minerSetWorkerAddressPlumbing) ConfigGet(dottedKey string) (interface{}, error) {
-	if mswap.cfgFail {
+func (p *mSetWorkerPlumbing) ConfigGet(dottedKey string) (interface{}, error) {
+	if p.cfgFail {
 		return address.Undef, errors.New("ConfigGet failed")
 	}
 	if dottedKey == "mining.minerAddress" {
-		return mswap.minerAddr, nil
+		return p.minerAddr, nil
 	}
 	return address.Undef, fmt.Errorf("unknown config %s", dottedKey)
-}
-
-func (mswap *minerSetWorkerAddressPlumbing) MinerGetOwnerAddress(ctx context.Context, minerAddr address.Address) (address.Address, error) {
-	if mswap.getOwnerFail {
-		return address.Undef, errors.New("MinerGetOwnerAddress failed")
-	}
-	return mswap.ownerAddr, nil
 }
 
 func TestMinerSetWorkerAddress(t *testing.T) {
@@ -374,7 +210,7 @@ func TestMinerSetWorkerAddress(t *testing.T) {
 	glimit := types.NewGasUnits(0)
 
 	t.Run("Calling set worker address sets address", func(t *testing.T) {
-		plumbing := &minerSetWorkerAddressPlumbing{
+		plumbing := &mSetWorkerPlumbing{
 			workerAddr: workerAddr,
 			ownerAddr:  minerOwner,
 			minerAddr:  minerAddr,
@@ -387,22 +223,22 @@ func TestMinerSetWorkerAddress(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		plumbing *minerSetWorkerAddressPlumbing
+		plumbing *mSetWorkerPlumbing
 		error    string
 	}{
 		{
 			name:     "When MessageSend fails, returns the error and does not set worker address",
-			plumbing: &minerSetWorkerAddressPlumbing{msgFail: true},
+			plumbing: &mSetWorkerPlumbing{msgFail: true},
 			error:    "MsgFail",
 		},
 		{
 			name:     "When ConfigGet fails, returns the error and does not set worker address",
-			plumbing: &minerSetWorkerAddressPlumbing{cfgFail: true},
+			plumbing: &mSetWorkerPlumbing{cfgFail: true},
 			error:    "CfgFail",
 		},
 		{
-			name:     "When MinerGetOwnerAddress fails, returns the error and does not set worker address",
-			plumbing: &minerSetWorkerAddressPlumbing{getOwnerFail: true},
+			name:     "When MinerGetStatus fails, returns the error and does not set worker address",
+			plumbing: &mSetWorkerPlumbing{getStatusFail: true},
 			error:    "CfgFail",
 		},
 	}

--- a/internal/app/go-filecoin/porcelain/miner_test.go
+++ b/internal/app/go-filecoin/porcelain/miner_test.go
@@ -168,8 +168,8 @@ func (p *mSetWorkerPlumbing) MinerStateView(baseKey block.TipSetKey) (MinerState
 	return &state.FakeStateView{
 		Miners: map[address.Address]*state.FakeMinerState{
 			p.minerAddr: {
-				Owner:        p.ownerAddr,
-				Worker:       p.workerAddr,
+				Owner:  p.ownerAddr,
+				Worker: p.workerAddr,
 			},
 		},
 	}, nil

--- a/internal/pkg/state/view.go
+++ b/internal/pkg/state/view.go
@@ -142,14 +142,14 @@ func (v *View) MinerClaimedPower(ctx context.Context, miner addr.Address) (abi.S
 	if err != nil {
 		return big.Zero(), err
 	}
-	claim, err := v.loadPowerClaim(err, ctx, powerState, miner)
+	claim, err := v.loadPowerClaim(ctx, powerState, miner)
 	if err != nil {
 		return big.Zero(), err
 	}
 	return claim.Power, nil
 }
 
-func (v *View) loadPowerClaim(err error, ctx context.Context, powerState *power.State, miner addr.Address) (*power.Claim, error) {
+func (v *View) loadPowerClaim(ctx context.Context, powerState *power.State, miner addr.Address) (*power.Claim, error) {
 	var claim power.Claim
 	found, err := v.asMap(ctx, powerState.Claims).Get(adt.AddrKey(miner), &claim)
 	if err != nil {
@@ -166,7 +166,7 @@ func (v *View) MinerPledgeCollateral(ctx context.Context, miner addr.Address) (l
 	if err != nil {
 		return big.Zero(), big.Zero(), err
 	}
-	claim, err := v.loadPowerClaim(err, ctx, powerState, miner)
+	claim, err := v.loadPowerClaim(ctx, powerState, miner)
 	if err != nil {
 		return big.Zero(), big.Zero(), err
 	}

--- a/internal/pkg/state/view.go
+++ b/internal/pkg/state/view.go
@@ -4,18 +4,20 @@ import (
 	"context"
 
 	addr "github.com/filecoin-project/go-address"
+	commcid "github.com/filecoin-project/go-fil-commcid"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/initactor"
+	minerActor "github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/miner"
 )
 
 // Viewer builds state views from state root CIDs.
@@ -51,7 +53,7 @@ func NewView(store cbor.IpldStore, root cid.Cid) *View {
 	}
 }
 
-// InitNetworkName returns the network name from the init actor state.
+// Returns the network name from the init actor state.
 func (v *View) InitNetworkName(ctx context.Context) (string, error) {
 	initState, err := v.loadInitActor(ctx)
 	if err != nil {
@@ -60,39 +62,72 @@ func (v *View) InitNetworkName(ctx context.Context) (string, error) {
 	return initState.Network, nil
 }
 
-// MinerSectorSize returns a miner's sector size.
-func (v *View) MinerSectorSize(ctx context.Context, maddr addr.Address) (abi.SectorSize, error) {
-	minerState, err := v.loadMinerActor(ctx, maddr)
-	if err != nil {
-		return 0, err
-	}
-	return minerState.Info.SectorSize, nil
-}
-
-// MinerControlAddresses returns the owner and worker addresses for a miner actor.
 func (v *View) MinerControlAddresses(ctx context.Context, maddr addr.Address) (owner, worker addr.Address, err error) {
 	minerState, err := v.loadMinerActor(ctx, maddr)
 	if err != nil {
 		return addr.Undef, addr.Undef, err
 	}
-	return minerState.Info.Owner, minerState.Info.Worker, nil
+	return minerState.Owner, minerState.Worker, nil
 }
 
-// MinerProvingSetForEach iterates over the sectors in a miner's proving set.
+func (v *View) MinerPeerID(ctx context.Context, maddr addr.Address) (peer.ID, error) {
+	minerState, err := v.loadMinerActor(ctx, maddr)
+	if err != nil {
+		return "", err
+	}
+	return minerState.PeerID, nil
+}
+
+func (v *View) MinerSectorSize(ctx context.Context, maddr addr.Address) (abi.SectorSize, error) {
+	minerState, err := v.loadMinerActor(ctx, maddr)
+	if err != nil {
+		return 0, err
+	}
+	return abi.SectorSize(minerState.SectorSize.Uint64()), nil
+}
+
+// Returns the start and end of the miner's current/next proving window.
+func (v *View) MinerProvingPeriod(ctx context.Context, maddr addr.Address) (start abi.ChainEpoch, end abi.ChainEpoch, failureCount int, err error) {
+	minerState, err := v.loadMinerActor(ctx, maddr)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	end = abi.ChainEpoch(minerState.ProvingPeriodEnd.AsBigInt().Uint64())
+	start = end - minerActor.LargestSectorSizeProvingPeriodBlocks
+	failureCount = 0
+	return
+}
+
+// Iterates over the sectors in a miner's proving set.
 func (v *View) MinerProvingSetForEach(ctx context.Context, maddr addr.Address,
 	f func(id abi.SectorNumber, sealedCID cid.Cid) error) error {
 	minerState, err := v.loadMinerActor(ctx, maddr)
 	if err != nil {
 		return err
 	}
-	var sector miner.SectorOnChainInfo
-	return v.asArray(ctx, minerState.ProvingSet).ForEach(&sector, func(i int64) error {
-		// Add more fields here as required by new callers.
-		return f(sector.Info.SectorNumber, sector.Info.SealedCID)
-	})
+
+	for _, id := range minerState.ProvingSet.Values() {
+		comms, found := minerState.SectorCommitments.Get(id)
+		if !found {
+			return errors.Errorf("inconsistent miner state, no sector %v", id)
+		}
+		sealedCID := commcid.ReplicaCommitmentV1ToCID(comms.CommR[:])
+		err := f(abi.SectorNumber(id), sealedCID)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+
+	// This version for the new actors
+	//var sector miner.SectorOnChainInfo
+	//return v.asArray(ctx, minerState.ProvingSet).ForEach(&sector, func(i int64) error {
+	//	// Add more fields here as required by new callers.
+	//	return f(sector.Info.SectorNumber, sector.Info.SealedCID)
+	//})
 }
 
-// NetworkTotalPower returns the storage power actor's value for network total power.
+// Returns the storage power actor's value for network total power.
 func (v *View) NetworkTotalPower(ctx context.Context) (abi.StoragePower, error) {
 	powerState, err := v.loadPowerActor(ctx)
 	if err != nil {
@@ -101,21 +136,47 @@ func (v *View) NetworkTotalPower(ctx context.Context) (abi.StoragePower, error) 
 	return powerState.TotalNetworkPower, nil
 }
 
-// MinerClaimedPower returns the power of a miner's committed sectors.
+// Returns the power of a miner's committed sectors.
 func (v *View) MinerClaimedPower(ctx context.Context, miner addr.Address) (abi.StoragePower, error) {
 	powerState, err := v.loadPowerActor(ctx)
 	if err != nil {
 		return big.Zero(), err
 	}
-	var claim power.Claim
-	found, err := v.asMap(ctx, powerState.Claims).Get(adt.AddrKey(miner), &claim)
+	claim, err := v.loadPowerClaim(err, ctx, powerState, miner)
 	if err != nil {
 		return big.Zero(), err
 	}
-	if !found {
-		return big.Zero(), errors.Errorf("no registered miner %v", miner)
-	}
 	return claim.Power, nil
+}
+
+func (v *View) loadPowerClaim(err error, ctx context.Context, powerState *power.State, miner addr.Address) (*power.Claim, error) {
+	var claim power.Claim
+	found, err := v.asMap(ctx, powerState.Claims).Get(adt.AddrKey(miner), &claim)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.Errorf("no registered miner %v", miner)
+	}
+	return &claim, nil
+}
+
+func (v *View) MinerPledgeCollateral(ctx context.Context, miner addr.Address) (locked abi.TokenAmount, balance abi.TokenAmount, err error) {
+	powerState, err := v.loadPowerActor(ctx)
+	if err != nil {
+		return big.Zero(), big.Zero(), err
+	}
+	claim, err := v.loadPowerClaim(err, ctx, powerState, miner)
+	if err != nil {
+		return big.Zero(), big.Zero(), err
+	}
+	locked = claim.Pledge
+	escrow := v.asBalanceTable(ctx, powerState.EscrowTable)
+	balance, err = escrow.Get(miner)
+	if err != nil {
+		return big.Zero(), big.Zero(), err
+	}
+	return
 }
 
 func (v *View) loadInitActor(ctx context.Context) (*initactor.State, error) {
@@ -128,12 +189,12 @@ func (v *View) loadInitActor(ctx context.Context) (*initactor.State, error) {
 	return &state, err
 }
 
-func (v *View) loadMinerActor(ctx context.Context, address addr.Address) (*miner.State, error) {
+func (v *View) loadMinerActor(ctx context.Context, address addr.Address) (*minerActor.State, error) {
 	actr, err := v.loadActor(ctx, address)
 	if err != nil {
 		return nil, err
 	}
-	var state miner.State
+	var state minerActor.State
 	err = v.ipldStore.Get(ctx, actr.Head.Cid, &state)
 	return &state, err
 }
@@ -164,6 +225,10 @@ func (v *View) asArray(ctx context.Context, root cid.Cid) *adt.Array {
 
 func (v *View) asMap(ctx context.Context, root cid.Cid) *adt.Map {
 	return adt.AsMap(StoreFromCbor(ctx, v.ipldStore), root)
+}
+
+func (v *View) asBalanceTable(ctx context.Context, root cid.Cid) *adt.BalanceTable {
+	return adt.AsBalanceTable(StoreFromCbor(ctx, v.ipldStore), root)
 }
 
 // StoreFromCbor wraps a cbor ipldStore for ADT access.

--- a/tools/fast/action_miner.go
+++ b/tools/fast/action_miner.go
@@ -50,23 +50,12 @@ func (f *Filecoin) MinerUpdatePeerid(ctx context.Context, minerAddr address.Addr
 	return out.Cid, nil
 }
 
-// MinerOwner runs the `miner owner` command against the filecoin process
-func (f *Filecoin) MinerOwner(ctx context.Context, minerAddr address.Address) (address.Address, error) {
-	var out address.Address
+// MinerStatus runs the `miner power` command against the filecoin process
+func (f *Filecoin) MinerStatus(ctx context.Context, minerAddr address.Address) (porcelain.MinerStatus, error) {
+	var out porcelain.MinerStatus
 
-	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "miner", "owner", minerAddr.String()); err != nil {
-		return address.Undef, err
-	}
-
-	return out, nil
-}
-
-// MinerPower runs the `miner power` command against the filecoin process
-func (f *Filecoin) MinerPower(ctx context.Context, minerAddr address.Address) (porcelain.MinerPower, error) {
-	var out porcelain.MinerPower
-
-	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "miner", "power", minerAddr.String()); err != nil {
-		return porcelain.MinerPower{}, err
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "miner", "status", minerAddr.String()); err != nil {
+		return porcelain.MinerStatus{}, err
 	}
 
 	return out, nil
@@ -90,28 +79,10 @@ func (f *Filecoin) MinerSetPrice(ctx context.Context, fil *big.Float, expiry *bi
 		return nil, err
 	}
 
-	return &out.MinerSetPriceResponse, nil
-}
-
-// MinerProvingWindow runs the `miner proving-window` command against the filecoin process
-func (f *Filecoin) MinerProvingWindow(ctx context.Context, miner address.Address) (porcelain.MinerProvingWindow, error) {
-	var out porcelain.MinerProvingWindow
-
-	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "miner", "proving-window", miner.String()); err != nil {
-		return porcelain.MinerProvingWindow{}, err
-	}
-
-	return out, nil
-}
-
-// MinerWorker runs the `miner worker` command against the filecoin process
-func (f *Filecoin) MinerWorker(ctx context.Context) (commands.MinerWorkerResult, error) {
-	var out commands.MinerWorkerResult
-
-	if err := f.RunCmdJSONWithStdin(ctx, nil, &out, "go-filecoin", "miner", "worker"); err != nil {
-		return out, err
-	}
-	return out, nil
+	return &porcelain.MinerSetPriceResponse{
+		MinerAddr: out.MinerAddress,
+		Price:     out.Price,
+	}, nil
 }
 
 // MinerSetWorker runs the `miner set-worker` command against the filecoin process

--- a/tools/fast/action_miner_test.go
+++ b/tools/fast/action_miner_test.go
@@ -37,8 +37,8 @@ func requireGetMinerAddress(ctx context.Context, t *testing.T, daemon *fast.File
 
 func assertPowerOutput(ctx context.Context, t *testing.T, d *fast.Filecoin, expMinerPwr, expTotalPwr uint64) {
 	minerAddr := requireGetMinerAddress(ctx, t, d)
-	actualMinerPwr, err := d.MinerPower(ctx, minerAddr)
+	status, err := d.MinerStatus(ctx, minerAddr)
 	require.NoError(t, err)
-	assert.Equal(t, expMinerPwr, actualMinerPwr.Power.Uint64(), "for miner power")
-	assert.Equal(t, expTotalPwr, actualMinerPwr.Total.Uint64(), "for total power")
+	assert.Equal(t, expMinerPwr, status.Power.Uint64(), "for miner power")
+	assert.Equal(t, expTotalPwr, status.NetworkPower.Uint64(), "for total power")
 }

--- a/tools/fast/series/set_price_ask.go
+++ b/tools/fast/series/set_price_ask.go
@@ -3,11 +3,9 @@ package series
 import (
 	"context"
 	"fmt"
-	"io"
 	"math/big"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/porcelain"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/abi"
 	"github.com/filecoin-project/go-filecoin/tools/fast"
 )
 
@@ -16,47 +14,11 @@ import (
 // canceled.
 func SetPriceGetAsk(ctx context.Context, miner *fast.Filecoin, price *big.Float, expiry *big.Int) (porcelain.Ask, error) {
 	// Set a price
-	pinfo, err := miner.MinerSetPrice(ctx, price, expiry, fast.AOPrice(big.NewFloat(1.0)), fast.AOLimit(300))
+	_, err := miner.MinerSetPrice(ctx, price, expiry, fast.AOPrice(big.NewFloat(1.0)), fast.AOLimit(300))
 	if err != nil {
 		return porcelain.Ask{}, err
 	}
 
-	response, err := miner.MessageWait(ctx, pinfo.AddAskCid)
-	if err != nil {
-		return porcelain.Ask{}, err
-	}
-
-	bbs := response.Receipt.Return[0]
-	value, err := abi.Deserialize(bbs, abi.Integer)
-	if err != nil {
-		return porcelain.Ask{}, err
-	}
-
-	val, ok := value.Val.(*big.Int)
-	if !ok {
-		return porcelain.Ask{}, fmt.Errorf("could not cast askid")
-	}
-
-	var ask porcelain.Ask
-	dec, err := miner.ClientListAsks(ctx)
-	if err != nil {
-		return porcelain.Ask{}, err
-	}
-
-	for {
-		err := dec.Decode(&ask)
-		if err != nil && err != io.EOF {
-			return porcelain.Ask{}, err
-		}
-
-		if val.Uint64() == ask.ID && ask.Miner == pinfo.MinerAddr {
-			return ask, nil
-		}
-
-		if err == io.EOF {
-			break
-		}
-	}
-
+	// Dragons: must be re-integrated with storage market module
 	return porcelain.Ask{}, fmt.Errorf("could not find ask")
 }


### PR DESCRIPTION
Replacing use of query messages with state inspection, via the state view type. The porcelain pattern had left us with tons of boilerplate code for fetching individual bits of state. I centralised it, while maintaining indirection from the concrete state types.
