### PR TITLE
Replaced all remaining uses of query-message

### DIFF
--- a/cmd/go-filecoin/miner.go
+++ b/cmd/go-filecoin/miner.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"math/big"
 	"strconv"
-	"strings"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-cid"
@@ -62,27 +61,9 @@ additional sectors.`,
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		var err error
 
-		pp, err := GetPorcelainAPI(env).ProtocolParameters(req.Context)
+		sectorSize, err := optionalSectorSizeWithDefault(req.Options["sectorsize"], types.OneKiBSectorSize)
 		if err != nil {
 			return err
-		}
-
-		sectorSize, err := optionalSectorSizeWithDefault(req.Options["sectorsize"], pp.SupportedSectors[0].Size)
-		if err != nil {
-			return err
-		}
-
-		// TODO: It may become the case that the protocol does not specify an
-		// enumeration of supported sector sizes, but rather that any sector
-		// size for which a miner has Groth parameters and a verifying key is
-		// supported.
-		// https://github.com/filecoin-project/specs/pull/318
-		if !pp.IsSupportedSectorSize(sectorSize) {
-			supportedStrs := make([]string, len(pp.SupportedSectors))
-			for i, si := range pp.SupportedSectors {
-				supportedStrs[i] = si.Size.String()
-			}
-			return fmt.Errorf("unsupported sector size: %s (supported sizes: %s)", sectorSize, strings.Join(supportedStrs, ", "))
 		}
 
 		fromAddr, err := fromAddrOrDefault(req, env)

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -360,7 +360,8 @@ func (node *Node) SetupMining(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get mining address")
 	}
-	_, err = node.PorcelainAPI.ActorGetStable(ctx, minerAddr)
+	head := node.PorcelainAPI.ChainHeadKey()
+	_, err = node.PorcelainAPI.MinerGetStatus(ctx, minerAddr, head)
 	if err != nil {
 		return errors.Wrap(err, "failed to get miner actor")
 	}

--- a/internal/app/go-filecoin/plumbing/api.go
+++ b/internal/app/go-filecoin/plumbing/api.go
@@ -247,20 +247,6 @@ func (api *API) MessagePreview(ctx context.Context, from, to address.Address, me
 	return api.msgPreviewer.Preview(ctx, from, to, method, params...)
 }
 
-// MessageQuery calls an actor's method using the most recent chain state. It is read-only,
-// it does not change any state. It is use to interrogate actor state. The from address
-// is optional; if not provided, an address will be chosen from the node's wallet.
-func (api *API) MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, baseKey block.TipSetKey, params ...interface{}) ([][]byte, error) {
-	// Dragons: delete
-
-	// snapshot, err := api.actorState.Snapshot(ctx, baseKey)
-	// if err != nil {
-	// 	return [][]byte{}, err
-	// }
-	// return snapshot.Query(ctx, optFrom, to, method, params...)
-	return [][]byte{}, nil
-}
-
 // StateView loads the state view for a tipset, i.e. the state *after* the application of the tipset's messages.
 func (api *API) StateView(baseKey block.TipSetKey) (*appstate.View, error) {
 	return api.actorState.StateView(baseKey)

--- a/internal/app/go-filecoin/porcelain/api.go
+++ b/internal/app/go-filecoin/porcelain/api.go
@@ -16,8 +16,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/protocol/storage/storagedeal"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	minerActor "github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/miner"
 )
 
@@ -47,16 +45,6 @@ type API struct {
 // New returns a new porcelain.API.
 func New(plumbing *plumbing.API) *API {
 	return &API{plumbing}
-}
-
-// ActorGetStable gets an actor by address, converting the address to an id address if necessary
-func (a *API) ActorGetStable(ctx context.Context, addr address.Address) (*actor.Actor, error) {
-	return GetStableActor(ctx, a, addr)
-}
-
-// ActorGetStableSignature gets an actor signature by address, converting the address to an id address if necessary
-func (a *API) ActorGetStableSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (_ vm.ActorMethodSignature, err error) {
-	return GetStableActorSignature(ctx, a, actorAddr, method)
 }
 
 // ChainHead returns the current head tipset
@@ -174,12 +162,14 @@ func (a *API) MessageWaitDone(ctx context.Context, msgCid cid.Cid) (*types.Messa
 	return MessageWaitDone(ctx, a, msgCid)
 }
 
-// PowerStateView interprets StateView as a power state view
 func (a *API) PowerStateView(baseKey block.TipSetKey) (consensus.PowerStateView, error) {
 	return a.StateView(baseKey)
 }
 
-// MinerStateView interprets StateView as a power state view
 func (a *API) MinerStateView(baseKey block.TipSetKey) (MinerStateView, error) {
+	return a.StateView(baseKey)
+}
+
+func (a *API) ProtocolStateView(baseKey block.TipSetKey) (ProtocolStateView, error) {
 	return a.StateView(baseKey)
 }

--- a/internal/app/go-filecoin/porcelain/chain.go
+++ b/internal/app/go-filecoin/porcelain/chain.go
@@ -2,17 +2,10 @@ package porcelain
 
 import (
 	"context"
-	"math/big"
 
-	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/abi"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/initactor"
-	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	"github.com/ipfs/go-cid"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
@@ -47,53 +40,4 @@ func GetFullBlock(ctx context.Context, plumbing fullBlockPlumbing, id cid.Cid) (
 	}
 
 	return &out, nil
-}
-
-type getStableActorPlumbing interface {
-	ActorGet(ctx context.Context, addr address.Address) (*actor.Actor, error)
-	ChainHeadKey() block.TipSetKey
-	MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, baseKey block.TipSetKey, params ...interface{}) ([][]byte, error)
-	ActorGetSignature(ctx context.Context, actorAddr address.Address, method types.MethodID) (_ vm.ActorMethodSignature, err error)
-}
-
-// GetStableActor looks up an actor by address. If the address is an actor address it will first convert it to an id address.
-func GetStableActor(ctx context.Context, plumbing getStableActorPlumbing, addr address.Address) (*actor.Actor, error) {
-	stateAddr, err := retrieveActorIDForActorAddress(ctx, plumbing, addr)
-	if err != nil {
-		return nil, err
-	}
-
-	// get actor
-	return plumbing.ActorGet(ctx, stateAddr)
-}
-
-// GetStableActorSignature looks up and actor method signature by address. If the addresss is an actor address it will first convert it to an id address.
-func GetStableActorSignature(ctx context.Context, plumbing getStableActorPlumbing, actorAddr address.Address, method types.MethodID) (_ vm.ActorMethodSignature, err error) {
-	stateAddr, err := retrieveActorIDForActorAddress(ctx, plumbing, actorAddr)
-	if err != nil {
-		return nil, err
-	}
-
-	// get actor
-	return plumbing.ActorGetSignature(ctx, stateAddr, method)
-}
-
-func retrieveActorIDForActorAddress(ctx context.Context, plumbing getStableActorPlumbing, addr address.Address) (address.Address, error) {
-	if addr.Protocol() != address.Actor {
-		return addr, nil
-	}
-
-	head := plumbing.ChainHeadKey()
-	ret, err := plumbing.MessageQuery(ctx, address.Undef, vmaddr.InitAddress, initactor.GetActorIDForAddressMethodID, head, addr)
-	if err != nil {
-		return address.Undef, err
-	}
-
-	idVal, err := abi.Deserialize(ret[0], abi.Integer)
-	if err != nil {
-		return address.Undef, err
-	}
-
-	return address.NewIDAddress(idVal.Val.(*big.Int).Uint64())
-
 }

--- a/internal/app/go-filecoin/porcelain/protocol.go
+++ b/internal/app/go-filecoin/porcelain/protocol.go
@@ -4,17 +4,11 @@ import (
 	"context"
 	"time"
 
-	ffi "github.com/filecoin-project/filecoin-ffi"
-	"github.com/filecoin-project/go-address"
-
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	"github.com/pkg/errors"
 
+	ffi "github.com/filecoin-project/filecoin-ffi"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/initactor"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/storagemarket"
-	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 )
 
 // SectorInfo provides information about a sector construction
@@ -28,15 +22,18 @@ type ProtocolParams struct {
 	Network          string
 	AutoSealInterval uint
 	BlockTime        time.Duration
-	ProofsMode       types.ProofsMode
 	SupportedSectors []SectorInfo
 }
 
 type protocolParamsPlumbing interface {
 	ConfigGet(string) (interface{}, error)
 	ChainHeadKey() block.TipSetKey
-	MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, baseKey block.TipSetKey, params ...interface{}) ([][]byte, error)
+	ProtocolStateView(baseKey block.TipSetKey) (ProtocolStateView, error)
 	BlockTime() time.Duration
+}
+
+type ProtocolStateView interface {
+	InitNetworkName(ctx context.Context) (string, error)
 }
 
 // ProtocolParameters returns protocol parameter information about the node
@@ -51,22 +48,14 @@ func ProtocolParameters(ctx context.Context, plumbing protocolParamsPlumbing) (*
 		return nil, errors.New("Failed to read autoSealInterval from config")
 	}
 
-	proofsMode, err := getProofsMode(ctx, plumbing)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not retrieve proofs mode")
-	}
-
 	networkName, err := getNetworkName(ctx, plumbing)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not retrieve network name")
 	}
 
-	sectorSizes := []*types.BytesAmount{types.OneKiBSectorSize}
-	if proofsMode == types.LiveProofsMode {
-		sectorSizes[0] = types.TwoHundredFiftySixMiBSectorSize
-	}
+	sectorSizes := []*types.BytesAmount{types.OneKiBSectorSize, types.TwoHundredFiftySixMiBSectorSize}
 
-	supportedSectors := []SectorInfo{}
+	var supportedSectors []SectorInfo
 	for _, sectorSize := range sectorSizes {
 		maxUserBytes := types.NewBytesAmount(ffi.GetMaxUserBytesPerStagedSector(sectorSize.Uint64()))
 		supportedSectors = append(supportedSectors, SectorInfo{sectorSize, maxUserBytes})
@@ -76,42 +65,14 @@ func ProtocolParameters(ctx context.Context, plumbing protocolParamsPlumbing) (*
 		Network:          networkName,
 		AutoSealInterval: autoSealInterval,
 		BlockTime:        plumbing.BlockTime(),
-		ProofsMode:       proofsMode,
 		SupportedSectors: supportedSectors,
 	}, nil
 }
 
-// IsSupportedSectorSize returns true if the given sector size is supported by
-// the network.
-func (pp *ProtocolParams) IsSupportedSectorSize(sectorSize *types.BytesAmount) bool {
-	for _, sector := range pp.SupportedSectors {
-		if sector.Size.Equal(sectorSize) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func getProofsMode(ctx context.Context, plumbing protocolParamsPlumbing) (types.ProofsMode, error) {
-	var proofsMode types.ProofsMode
-	values, err := plumbing.MessageQuery(ctx, address.Address{}, vmaddr.StorageMarketAddress, storagemarket.GetProofsMode, plumbing.ChainHeadKey())
-	if err != nil {
-		return 0, errors.Wrap(err, "'GetProofsMode' query message failed")
-	}
-
-	if err := encoding.Decode(values[0], &proofsMode); err != nil {
-		return 0, errors.Wrap(err, "could not convert query message result to ProofsMode")
-	}
-
-	return proofsMode, nil
-}
-
 func getNetworkName(ctx context.Context, plumbing protocolParamsPlumbing) (string, error) {
-	nameBytes, err := plumbing.MessageQuery(ctx, address.Address{}, vmaddr.InitAddress, initactor.GetNetworkMethodID, plumbing.ChainHeadKey())
+	view, err := plumbing.ProtocolStateView(plumbing.ChainHeadKey())
 	if err != nil {
-		return "", errors.Wrap(err, "'getNetwork' query message failed")
+		return "", errors.Wrap(err, "failed to query state")
 	}
-
-	return string(nameBytes[0]), nil
+	return view.InitNetworkName(ctx)
 }

--- a/internal/app/go-filecoin/porcelain/protocol_test.go
+++ b/internal/app/go-filecoin/porcelain/protocol_test.go
@@ -6,18 +6,14 @@ import (
 	"time"
 
 	ffi "github.com/filecoin-project/filecoin-ffi"
-	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/state"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/initactor"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin/storagemarket"
-	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
-	"github.com/pkg/errors"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const protocolTestParamBlockTime = time.Second
@@ -36,17 +32,14 @@ func (tppp *testProtocolParamsPlumbing) ChainHeadKey() block.TipSetKey {
 	return block.NewTipSetKey()
 }
 
-func (tppp *testProtocolParamsPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, _ block.TipSetKey, params ...interface{}) ([][]byte, error) {
-	if to == vmaddr.StorageMarketAddress && method == storagemarket.GetProofsMode {
-		return [][]byte{{byte(types.TestProofsMode)}}, nil
-	} else if to == vmaddr.InitAddress && method == initactor.GetNetworkMethodID {
-		return [][]byte{[]byte("protocolTest")}, nil
-	}
-	return [][]byte{}, errors.Errorf("call to unknown method %s", method)
-}
-
 func (tppp *testProtocolParamsPlumbing) BlockTime() time.Duration {
 	return protocolTestParamBlockTime
+}
+
+func (tppp *testProtocolParamsPlumbing) ProtocolStateView(_ block.TipSetKey) (porcelain.ProtocolStateView, error) {
+	return &state.FakeStateView{
+		NetworkName: "protocolTest",
+	}, nil
 }
 
 func TestProtocolParams(t *testing.T) {
@@ -60,15 +53,14 @@ func TestProtocolParams(t *testing.T) {
 			autoSealInterval: 120,
 		}
 
-		sectorSize := types.OneKiBSectorSize
-		maxUserBytes := types.NewBytesAmount(ffi.GetMaxUserBytesPerStagedSector(sectorSize.Uint64()))
-
 		expected := &porcelain.ProtocolParams{
 			AutoSealInterval: 120,
 			Network:          "protocolTest",
-			ProofsMode:       types.TestProofsMode,
-			SupportedSectors: []porcelain.SectorInfo{{sectorSize, maxUserBytes}},
-			BlockTime:        protocolTestParamBlockTime,
+			SupportedSectors: []porcelain.SectorInfo{
+				{types.OneKiBSectorSize, types.NewBytesAmount(ffi.GetMaxUserBytesPerStagedSector(types.OneKiBSectorSize.Uint64()))},
+				{types.TwoHundredFiftySixMiBSectorSize, types.NewBytesAmount(ffi.GetMaxUserBytesPerStagedSector(types.TwoHundredFiftySixMiBSectorSize.Uint64()))},
+			},
+			BlockTime: protocolTestParamBlockTime,
 		}
 
 		out, err := porcelain.ProtocolParameters(context.TODO(), plumbing)

--- a/internal/pkg/protocol/storage/client_test.go
+++ b/internal/pkg/protocol/storage/client_test.go
@@ -337,7 +337,3 @@ func (ctp *clientTestAPI) DealPut(storageDeal *storagedeal.Deal) error {
 	ctp.deals[storageDeal.Response.ProposalCid] = storageDeal
 	return nil
 }
-
-func (ctp *clientTestAPI) MessageQuery(ctx context.Context, optFrom, to address.Address, method types.MethodID, _ block.TipSetKey, params ...interface{}) ([][]byte, error) {
-	return [][]byte{{byte(types.TestProofsMode)}}, nil
-}

--- a/internal/pkg/state/testing.go
+++ b/internal/pkg/state/testing.go
@@ -13,6 +13,7 @@ import (
 
 // FakeStateView is a fake state view.
 type FakeStateView struct {
+	NetworkName  string
 	NetworkPower abi.StoragePower
 	Miners       map[address.Address]*FakeMinerState
 }
@@ -44,6 +45,10 @@ type FakeMinerState struct {
 type FakeSectorInfo struct {
 	ID        abi.SectorNumber
 	SealedCID cid.Cid
+}
+
+func (v *FakeStateView) InitNetworkName(_ context.Context) (string, error) {
+	return v.NetworkName, nil
 }
 
 // MinerSectorSize reports a miner's sector size.

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	bls "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-address"
 	cid "github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
+
+	bls "github.com/filecoin-project/filecoin-ffi"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
@@ -131,34 +132,6 @@ func (mbv *StubBlockValidator) StubSemanticValidationForBlock(child *block.Block
 // NewFakeProcessor creates a processor with a test validator and test rewarder
 func NewFakeProcessor() *consensus.DefaultProcessor {
 	return consensus.NewConfiguredProcessor(vm.DefaultActors)
-}
-
-type testSigner struct{}
-
-func (ms testSigner) SignBytes(data []byte, addr address.Address) (types.Signature, error) {
-	return types.Signature{}, nil
-}
-
-// RequireActorIDAddress looks up an actor address in the init actor and returns the associated id address
-func RequireActorIDAddress(ctx context.Context, t *testing.T, st state.Tree, store vm.Storage, addr address.Address) address.Address {
-	// Dragons: why is this needed? delete
-
-	// processor := consensus.NewConfiguredProcessor(vm.DefaultActors)
-	// params, err := abi.ToEncodedValues(addr)
-	// require.NoError(t, err)
-
-	// result, _, err := processor.CallQueryMethod(ctx, st, store, address.InitAddress, initactor.GetActorIDForAddressMethodID, params, address.Undef, nil)
-	// require.NoError(t, err)
-
-	// idVal, err := abi.Deserialize(result[0], abi.Integer)
-	// require.NoError(t, err)
-
-	// idAddr, err := address.NewIDAddress(idVal.Val.(*big.Int).Uint64())
-	// require.NoError(t, err)
-
-	// return idAddr
-
-	return address.Undef
 }
 
 // ApplyTestMessage sends a message directly to the vm, bypassing message


### PR DESCRIPTION
### Motivation
Remove the final uses of query-message so that the new VM is simpler to integrate.
