### PR TITLE
go-storage-miner should pass state identifiers to methods which access chain state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/filecoin-project/go-paramfetch v0.0.1
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200211164318-76f24b9797d4
-	github.com/filecoin-project/go-storage-miner v0.0.0-20200218205809-c258369a5ba0
+	github.com/filecoin-project/go-storage-miner v0.0.0-20200219181035-ae329ea82b1a
 	github.com/filecoin-project/specs-actors v0.0.0-20200214231017-c3be15e301c4
 	github.com/fxamacker/cbor v1.5.0
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
@@ -120,5 +120,3 @@ require (
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./vendors/filecoin-ffi
-
-replace github.com/filecoin-project/go-storage-miner => /Users/erinswenson-healey/dev/go-storage-mining

--- a/go.mod
+++ b/go.mod
@@ -120,3 +120,5 @@ require (
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./vendors/filecoin-ffi
+
+replace github.com/filecoin-project/go-storage-miner => /Users/erinswenson-healey/dev/go-storage-mining

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/filecoin-project/go-paramfetch v0.0.1
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200211164318-76f24b9797d4
-	github.com/filecoin-project/go-storage-miner v0.0.0-20200219181035-ae329ea82b1a
+	github.com/filecoin-project/go-storage-miner v0.0.0-20200219183610-a3cfe4033120
 	github.com/filecoin-project/specs-actors v0.0.0-20200214231017-c3be15e301c4
 	github.com/fxamacker/cbor v1.5.0
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/filecoin-project/go-storage-miner v0.0.0-20200218205809-c258369a5ba0 
 github.com/filecoin-project/go-storage-miner v0.0.0-20200218205809-c258369a5ba0/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
 github.com/filecoin-project/go-storage-miner v0.0.0-20200219181035-ae329ea82b1a h1:KhrgP+dJBwRflODnzTRVTiYXE/hKBZUxCsMWeja3NEY=
 github.com/filecoin-project/go-storage-miner v0.0.0-20200219181035-ae329ea82b1a/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
+github.com/filecoin-project/go-storage-miner v0.0.0-20200219183610-a3cfe4033120 h1:YZ3+GBp0tWXoKS4iBb7nL20xdIv5/tzpHNiJK0xp8Wg=
+github.com/filecoin-project/go-storage-miner v0.0.0-20200219183610-a3cfe4033120/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.0.0-20200214231017-c3be15e301c4 h1:b3OMVUavBYJsgKIMpqpfsNsR6Y+VVQTHVPhCbI6yfgg=
 github.com/filecoin-project/specs-actors v0.0.0-20200214231017-c3be15e301c4/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIi
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-storage-miner v0.0.0-20200218205809-c258369a5ba0 h1:Zr5VcFB3ll+QDUq4g62s4BlSVr0YhcVTTMDA/K4uEQs=
 github.com/filecoin-project/go-storage-miner v0.0.0-20200218205809-c258369a5ba0/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
+github.com/filecoin-project/go-storage-miner v0.0.0-20200219181035-ae329ea82b1a h1:KhrgP+dJBwRflODnzTRVTiYXE/hKBZUxCsMWeja3NEY=
+github.com/filecoin-project/go-storage-miner v0.0.0-20200219181035-ae329ea82b1a/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.0.0-20200214231017-c3be15e301c4 h1:b3OMVUavBYJsgKIMpqpfsNsR6Y+VVQTHVPhCbI6yfgg=
 github.com/filecoin-project/specs-actors v0.0.0-20200214231017-c3be15e301c4/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=

--- a/go.sum
+++ b/go.sum
@@ -163,10 +163,6 @@ github.com/filecoin-project/go-statemachine v0.0.0-20200129214539-c78c5f7e9f9c h
 github.com/filecoin-project/go-statemachine v0.0.0-20200129214539-c78c5f7e9f9c/go.mod h1:1K7s8n65xznskrVYhwalQDO5blLMIZlf96OYQilZVJY=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
-github.com/filecoin-project/go-storage-miner v0.0.0-20200218205809-c258369a5ba0 h1:Zr5VcFB3ll+QDUq4g62s4BlSVr0YhcVTTMDA/K4uEQs=
-github.com/filecoin-project/go-storage-miner v0.0.0-20200218205809-c258369a5ba0/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
-github.com/filecoin-project/go-storage-miner v0.0.0-20200219181035-ae329ea82b1a h1:KhrgP+dJBwRflODnzTRVTiYXE/hKBZUxCsMWeja3NEY=
-github.com/filecoin-project/go-storage-miner v0.0.0-20200219181035-ae329ea82b1a/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
 github.com/filecoin-project/go-storage-miner v0.0.0-20200219183610-a3cfe4033120 h1:YZ3+GBp0tWXoKS4iBb7nL20xdIv5/tzpHNiJK0xp8Wg=
 github.com/filecoin-project/go-storage-miner v0.0.0-20200219183610-a3cfe4033120/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=

--- a/internal/app/go-filecoin/storage_miner_connector/connector.go
+++ b/internal/app/go-filecoin/storage_miner_connector/connector.go
@@ -365,7 +365,7 @@ func (m *StorageMinerNodeConnector) GetSealTicket(ctx context.Context, tok stora
 }
 
 func (m *StorageMinerNodeConnector) GetChainHead(ctx context.Context) (storagenode.TipSetToken, error) {
-	tok, err := m.chainState.Head().MarshalCBOR()
+	tok, err := encoding.Encode(m.chainState.Head())
 	if err != nil {
 		return nil, xerrors.Errorf("failed to marshal TipSetKey to CBOR byte slice for TipSetToken")
 	}
@@ -437,7 +437,7 @@ func (m *StorageMinerNodeConnector) waitForMessageHeight(ctx context.Context, mc
 
 func (m *StorageMinerNodeConnector) GetMinerWorkerAddress(ctx context.Context, tok storagenode.TipSetToken) (address.Address, error) {
 	var tsk block.TipSetKey
-	if err := tsk.UnmarshalCBOR(tok); err != nil {
+	if err := encoding.Decode(tok, &tsk); err != nil {
 		return address.Undef, xerrors.Errorf("failed to marshal TipSetToken into a TipSetKey: %w", err)
 	}
 

--- a/internal/app/go-filecoin/storage_miner_connector/connector.go
+++ b/internal/app/go-filecoin/storage_miner_connector/connector.go
@@ -490,26 +490,26 @@ func (m *StorageMinerNodeConnector) WaitForReportFaults(ctx context.Context, msg
 	return exitCode, err
 }
 
-func (m *StorageMinerNodeConnector) GetReplicaCommitment(ctx context.Context, tok storagenode.TipSetToken, sectorNum abi.SectorNumber) (commR []byte, wasFound bool, err error) {
+func (m *StorageMinerNodeConnector) GetSealedCID(ctx context.Context, tok storagenode.TipSetToken, sectorNum abi.SectorNumber) (sealedCID cid.Cid, wasFound bool, err error) {
 	var tsk block.TipSetKey
 	if err := tsk.UnmarshalCBOR(tok); err != nil {
-		return nil, false, xerrors.Errorf("failed to marshal TipSetToken into a TipSetKey: %w", err)
+		return cid.Undef, false, xerrors.Errorf("failed to marshal TipSetToken into a TipSetKey: %w", err)
 	}
 
 	var minerState miner.State
 	err = m.chainState.GetActorStateAt(ctx, tsk, m.minerAddr, &minerState)
 
 	if err != nil {
-		return nil, false, err
+		return cid.Undef, false, err
 	}
 
 	preCommitInfo, found, err := minerState.GetPrecommittedSector(state.StoreFromCbor(ctx, m.chainState.IpldStore), sectorNum)
 
 	if !found || err != nil {
-		return nil, found, err
+		return cid.Undef, found, err
 	}
 
-	return preCommitInfo.Info.SealedCID.Bytes(), true, nil
+	return preCommitInfo.Info.SealedCID, true, nil
 }
 
 func (m *StorageMinerNodeConnector) CheckPieces(ctx context.Context, sectorNum abi.SectorNumber, pieces []storagenode.Piece) *storagenode.CheckPiecesError {


### PR DESCRIPTION
## Why does this exist?

None of our getter methods accepted a state identifier; they were all implicitly scoped to the chain head. See [this convo](https://filecoinproject.slack.com/archives/CPLLE0ZQX/p1582128754110800?thread_ts=1582128521.110500&cid=CPLLE0ZQX) for more background information.

## Proposed changes

- add an implementation-nonspecific, opaque `TipSetToken`, used to identify a TipSet
- add `TipSetToken` parameter to `GetSealTicket` and `GetSealedCID` and `GetMinerWorkerAddress`
- add `GetChainHead` method
- drop address parameter from `GetMinerWorkerAddress`

## Notes

The go-filecoin node controls the lifecycle of the go-storage-miner `Miner` struct (which is provided a value which satisfies its "node API" interface). The node passes the `Miner` constructor the miner address X, so it is in a good position (in its connector code) to map from X to the worker address.