### PR TITLE
Use BLS for miner worker key in genesis

### DIFF
--- a/cmd/go-filecoin/address.go
+++ b/cmd/go-filecoin/address.go
@@ -11,6 +11,7 @@ import (
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	files "github.com/ipfs/go-ipfs-files"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
@@ -55,7 +56,7 @@ var addrsNewCmd = &cmds.Command{
 		return re.Emit(&addressResult{addr})
 	},
 	Options: []cmdkit.Option{
-		cmdkit.StringOption("type", "The type of address to create: bls or secp256k1 (default)").WithDefault(types.SECP256K1),
+		cmdkit.StringOption("type", "The type of address to create: bls or secp256k1 (default)").WithDefault(crypto.SECP256K1),
 	},
 	Type: &addressResult{},
 	Encoders: cmds.EncoderMap{
@@ -135,7 +136,7 @@ var balanceCmd = &cmds.Command{
 
 // WalletSerializeResult is the type wallet export and import return and expect.
 type WalletSerializeResult struct {
-	KeyInfo []*types.KeyInfo
+	KeyInfo []*crypto.KeyInfo
 }
 
 var walletImportCmd = &cmds.Command{

--- a/cmd/go-filecoin/address_integration_test.go
+++ b/cmd/go-filecoin/address_integration_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/filecoin-project/go-filecoin/fixtures"
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 )
 
@@ -33,7 +33,7 @@ func TestAddrsNewAndList(t *testing.T) {
 	addrs := make([]address.Address, 10)
 	var err error
 	for i := 0; i < 10; i++ {
-		addrs[i], err = n.PorcelainAPI.WalletNewAddress(types.SECP256K1)
+		addrs[i], err = n.PorcelainAPI.WalletNewAddress(crypto.SECP256K1)
 		require.NoError(t, err)
 	}
 
@@ -54,7 +54,7 @@ func TestWalletBalance(t *testing.T) {
 
 	n, cmdClient, done := builder.BuildAndStartAPI(ctx)
 	defer done()
-	addr, err := n.PorcelainAPI.WalletNewAddress(types.SECP256K1)
+	addr, err := n.PorcelainAPI.WalletNewAddress(crypto.SECP256K1)
 	require.NoError(t, err)
 
 	t.Log("[success] not found, zero")

--- a/fixtures/constants.go
+++ b/fixtures/constants.go
@@ -12,7 +12,7 @@ import (
 	cid "github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/build/project"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	gen "github.com/filecoin-project/go-filecoin/tools/gengen/util"
 )
 
@@ -38,7 +38,7 @@ var TestMiners []address.Address
 var TestGenGenConfig gen.GenesisCfg
 
 type detailsStruct struct {
-	Keys   []*types.KeyInfo
+	Keys   []*crypto.KeyInfo
 	Miners []struct {
 		Owner               int
 		Address             address.Address

--- a/internal/app/go-filecoin/node/init.go
+++ b/internal/app/go-filecoin/node/init.go
@@ -11,8 +11,8 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/cborutil"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
+	crypto2 "github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/wallet"
 )
 
@@ -21,8 +21,8 @@ const defaultPeerKeyBits = 2048
 // initCfg contains configuration for initializing a node's repo.
 type initCfg struct {
 	peerKey     crypto.PrivKey
-	defaultKey  *types.KeyInfo
-	initImports []*types.KeyInfo
+	defaultKey  *crypto2.KeyInfo
+	initImports []*crypto2.KeyInfo
 }
 
 // InitOpt is an option for initialization of a node's repo.
@@ -38,14 +38,14 @@ func PeerKeyOpt(k crypto.PrivKey) InitOpt {
 
 // DefaultKeyOpt sets the private key for the wallet's default account.
 // If unspecified, initialization will create a new one.
-func DefaultKeyOpt(ki *types.KeyInfo) InitOpt {
+func DefaultKeyOpt(ki *crypto2.KeyInfo) InitOpt {
 	return func(opts *initCfg) {
 		opts.defaultKey = ki
 	}
 }
 
 // ImportKeyOpt imports the provided key during initialization.
-func ImportKeyOpt(ki *types.KeyInfo) InitOpt {
+func ImportKeyOpt(ki *crypto2.KeyInfo) InitOpt {
 	return func(opts *initCfg) {
 		opts.initImports = append(opts.initImports, ki)
 	}
@@ -112,7 +112,7 @@ func initPeerKey(store keystore.Keystore, key crypto.PrivKey) error {
 	return nil
 }
 
-func initDefaultKey(w *wallet.Wallet, key *types.KeyInfo) (*types.KeyInfo, error) {
+func initDefaultKey(w *wallet.Wallet, key *crypto2.KeyInfo) (*crypto2.KeyInfo, error) {
 	var err error
 	if key == nil {
 		key, err = w.NewKeyInfo()
@@ -127,7 +127,7 @@ func initDefaultKey(w *wallet.Wallet, key *types.KeyInfo) (*types.KeyInfo, error
 	return key, nil
 }
 
-func importInitKeys(w *wallet.Wallet, importKeys []*types.KeyInfo) error {
+func importInitKeys(w *wallet.Wallet, importKeys []*crypto2.KeyInfo) error {
 	for _, ki := range importKeys {
 		_, err := w.Import(ki)
 		if err != nil {

--- a/internal/app/go-filecoin/node/init.go
+++ b/internal/app/go-filecoin/node/init.go
@@ -5,13 +5,13 @@ import (
 
 	bstore "github.com/ipfs/go-ipfs-blockstore"
 	keystore "github.com/ipfs/go-ipfs-keystore"
-	"github.com/libp2p/go-libp2p-core/crypto"
+	acrypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/cborutil"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
-	crypto2 "github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/wallet"
 )
@@ -20,9 +20,9 @@ const defaultPeerKeyBits = 2048
 
 // initCfg contains configuration for initializing a node's repo.
 type initCfg struct {
-	peerKey     crypto.PrivKey
-	defaultKey  *crypto2.KeyInfo
-	initImports []*crypto2.KeyInfo
+	peerKey     acrypto.PrivKey
+	defaultKey  *crypto.KeyInfo
+	initImports []*crypto.KeyInfo
 }
 
 // InitOpt is an option for initialization of a node's repo.
@@ -30,7 +30,7 @@ type InitOpt func(*initCfg)
 
 // PeerKeyOpt sets the private key for a node's 'self' libp2p identity.
 // If unspecified, initialization will create a new one.
-func PeerKeyOpt(k crypto.PrivKey) InitOpt {
+func PeerKeyOpt(k acrypto.PrivKey) InitOpt {
 	return func(opts *initCfg) {
 		opts.peerKey = k
 	}
@@ -38,14 +38,14 @@ func PeerKeyOpt(k crypto.PrivKey) InitOpt {
 
 // DefaultKeyOpt sets the private key for the wallet's default account.
 // If unspecified, initialization will create a new one.
-func DefaultKeyOpt(ki *crypto2.KeyInfo) InitOpt {
+func DefaultKeyOpt(ki *crypto.KeyInfo) InitOpt {
 	return func(opts *initCfg) {
 		opts.defaultKey = ki
 	}
 }
 
 // ImportKeyOpt imports the provided key during initialization.
-func ImportKeyOpt(ki *crypto2.KeyInfo) InitOpt {
+func ImportKeyOpt(ki *crypto.KeyInfo) InitOpt {
 	return func(opts *initCfg) {
 		opts.initImports = append(opts.initImports, ki)
 	}
@@ -98,10 +98,10 @@ func Init(ctx context.Context, r repo.Repo, gen consensus.GenesisInitFunc, opts 
 	return nil
 }
 
-func initPeerKey(store keystore.Keystore, key crypto.PrivKey) error {
+func initPeerKey(store keystore.Keystore, key acrypto.PrivKey) error {
 	var err error
 	if key == nil {
-		key, _, err = crypto.GenerateKeyPair(crypto.RSA, defaultPeerKeyBits)
+		key, _, err = acrypto.GenerateKeyPair(acrypto.RSA, defaultPeerKeyBits)
 		if err != nil {
 			return errors.Wrap(err, "failed to create peer key")
 		}
@@ -112,7 +112,7 @@ func initPeerKey(store keystore.Keystore, key crypto.PrivKey) error {
 	return nil
 }
 
-func initDefaultKey(w *wallet.Wallet, key *crypto2.KeyInfo) (*crypto2.KeyInfo, error) {
+func initDefaultKey(w *wallet.Wallet, key *crypto.KeyInfo) (*crypto.KeyInfo, error) {
 	var err error
 	if key == nil {
 		key, err = w.NewKeyInfo()
@@ -127,7 +127,7 @@ func initDefaultKey(w *wallet.Wallet, key *crypto2.KeyInfo) (*crypto2.KeyInfo, e
 	return key, nil
 }
 
-func importInitKeys(w *wallet.Wallet, importKeys []*crypto2.KeyInfo) error {
+func importInitKeys(w *wallet.Wallet, importKeys []*crypto.KeyInfo) error {
 	for _, ki := range importKeys {
 		_, err := w.Import(ki)
 		if err != nil {

--- a/internal/app/go-filecoin/plumbing/api.go
+++ b/internal/app/go-filecoin/plumbing/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chainsync/status"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/message"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/net"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/piecemanager"
@@ -335,9 +336,9 @@ func (api *API) WalletGetPubKeyForAddress(addr address.Address) ([]byte, error) 
 // WalletNewAddress generates a new wallet address
 func (api *API) WalletNewAddress(addressType string) (address.Address, error) {
 	switch strings.ToLower(addressType) { //this assumes that any additions to types/helpers.go will be lowercase
-	case types.BLS:
+	case crypto.BLS:
 		return wallet.NewAddress(api.wallet, address.BLS)
-	case types.SECP256K1:
+	case crypto.SECP256K1:
 		return wallet.NewAddress(api.wallet, address.SECP256K1)
 	default:
 		return address.Undef, fmt.Errorf("invalid address type: %s", addressType)
@@ -345,12 +346,12 @@ func (api *API) WalletNewAddress(addressType string) (address.Address, error) {
 }
 
 // WalletImport adds a given set of KeyInfos to the wallet
-func (api *API) WalletImport(kinfos ...*types.KeyInfo) ([]address.Address, error) {
+func (api *API) WalletImport(kinfos ...*crypto.KeyInfo) ([]address.Address, error) {
 	return api.wallet.Import(kinfos...)
 }
 
 // WalletExport returns the KeyInfos for the given wallet addresses
-func (api *API) WalletExport(addrs []address.Address) ([]*types.KeyInfo, error) {
+func (api *API) WalletExport(addrs []address.Address) ([]*crypto.KeyInfo, error) {
 	return api.wallet.Export(addrs)
 }
 

--- a/internal/pkg/consensus/election_test.go
+++ b/internal/pkg/consensus/election_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
+	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
@@ -56,7 +58,7 @@ func TestNextTicketFailsWithInvalidSigner(t *testing.T) {
 	assert.Nil(t, badTicket.VRFProof)
 }
 
-func requireAddress(t *testing.T, ki *types.KeyInfo) address.Address {
+func requireAddress(t *testing.T, ki *crypto.KeyInfo) address.Address {
 	addr, err := ki.Address()
 	require.NoError(t, err)
 	return addr

--- a/internal/pkg/consensus/expected_test.go
+++ b/internal/pkg/consensus/expected_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/cborutil"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/proofs"
 	appstate "github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
@@ -276,7 +277,7 @@ func requireMakeNBlocks(t *testing.T, n int, pTipSet block.TipSet, root cid.Cid,
 	return blocks
 }
 
-func minerToWorkerFromAddrs(ctx context.Context, t *testing.T, tree state.Tree, vms vm.Storage, kis []types.KeyInfo) ([]address.Address, map[address.Address]address.Address) {
+func minerToWorkerFromAddrs(ctx context.Context, t *testing.T, tree state.Tree, vms vm.Storage, kis []crypto.KeyInfo) ([]address.Address, map[address.Address]address.Address) {
 	minerAddrs := make([]address.Address, len(kis))
 	require.Equal(t, len(kis), len(minerAddrs))
 	minerToWorker := make(map[address.Address]address.Address, len(kis))
@@ -291,7 +292,7 @@ func minerToWorkerFromAddrs(ctx context.Context, t *testing.T, tree state.Tree, 
 	return minerAddrs, minerToWorker
 }
 
-func setTree(ctx context.Context, t *testing.T, kis []types.KeyInfo, cstore cbor.IpldStore, bstore blockstore.Blockstore, inRoot cid.Cid) (cid.Cid, []address.Address, map[address.Address]address.Address) {
+func setTree(ctx context.Context, t *testing.T, kis []crypto.KeyInfo, cstore cbor.IpldStore, bstore blockstore.Blockstore, inRoot cid.Cid) (cid.Cid, []address.Address, map[address.Address]address.Address) {
 	tree, err := state.NewTreeLoader().LoadStateTree(ctx, cstore, inRoot)
 	require.NoError(t, err)
 	miners := make([]address.Address, len(kis))

--- a/internal/pkg/consensus/testing.go
+++ b/internal/pkg/consensus/testing.go
@@ -13,6 +13,7 @@ import (
 
 	ffi "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/postgenerator"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/proofs"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/proofs/verification"
@@ -207,9 +208,9 @@ func NFakeSectorInfos(numSectors uint64) ffi.SortedPublicSectorInfo {
 // inputs as miner power might be so low that winning a ticket is very
 // unlikely.  However runtime is deterministic so if it runs fast once on
 // given inputs is safe to use in tests.
-func SeedFirstWinnerInNRounds(t *testing.T, n int, ki *types.KeyInfo, networkPower, numSectors, sectorSize uint64) block.Ticket {
+func SeedFirstWinnerInNRounds(t *testing.T, n int, ki *crypto.KeyInfo, networkPower, numSectors, sectorSize uint64) block.Ticket {
 	tm := TicketMachine{}
-	signer := types.NewMockSigner([]types.KeyInfo{*ki})
+	signer := types.NewMockSigner([]crypto.KeyInfo{*ki})
 	wAddr, err := ki.Address()
 	require.NoError(t, err)
 
@@ -238,8 +239,8 @@ func SeedFirstWinnerInNRounds(t *testing.T, n int, ki *types.KeyInfo, networkPow
 	}
 }
 
-func winsAtEpoch(t *testing.T, epoch uint64, ticket block.Ticket, ki *types.KeyInfo, networkPower, numSectors, sectorSize uint64, sectorInfos ffi.SortedPublicSectorInfo) bool {
-	signer := types.NewMockSigner([]types.KeyInfo{*ki})
+func winsAtEpoch(t *testing.T, epoch uint64, ticket block.Ticket, ki *crypto.KeyInfo, networkPower, numSectors, sectorSize uint64, sectorInfos ffi.SortedPublicSectorInfo) bool {
+	signer := types.NewMockSigner([]crypto.KeyInfo{*ki})
 	wAddr, err := ki.Address()
 	require.NoError(t, err)
 	em := ElectionMachine{}
@@ -263,13 +264,13 @@ func winsAtEpoch(t *testing.T, epoch uint64, ticket block.Ticket, ki *types.KeyI
 	return false
 }
 
-func losesAtEpoch(t *testing.T, epoch uint64, ticket block.Ticket, ki *types.KeyInfo, networkPower, numSectors, sectorSize uint64, sectorInfos ffi.SortedPublicSectorInfo) bool {
+func losesAtEpoch(t *testing.T, epoch uint64, ticket block.Ticket, ki *crypto.KeyInfo, networkPower, numSectors, sectorSize uint64, sectorInfos ffi.SortedPublicSectorInfo) bool {
 	return !winsAtEpoch(t, epoch, ticket, ki, networkPower, numSectors, sectorSize, sectorInfos)
 }
 
 // SeedLoserInNRounds returns a ticket that loses with a null block count of N.
-func SeedLoserInNRounds(t *testing.T, n int, ki *types.KeyInfo, networkPower, numSectors, sectorSize uint64) block.Ticket {
-	signer := types.NewMockSigner([]types.KeyInfo{*ki})
+func SeedLoserInNRounds(t *testing.T, n int, ki *crypto.KeyInfo, networkPower, numSectors, sectorSize uint64) block.Ticket {
+	signer := types.NewMockSigner([]crypto.KeyInfo{*ki})
 	wAddr, err := ki.Address()
 	require.NoError(t, err)
 	tm := TicketMachine{}

--- a/internal/pkg/crypto/crypto.go
+++ b/internal/pkg/crypto/crypto.go
@@ -1,14 +1,21 @@
 package crypto
 
 import (
-	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/rand"
 	"io"
 
-	bls "github.com/filecoin-project/filecoin-ffi"
 	secp256k1 "github.com/ipsn/go-secp256k1"
+
+	bls "github.com/filecoin-project/filecoin-ffi"
+)
+
+// These constants should be replaced with values imported from a shared signature type.
+const (
+	// SECP256K1 is a cryptosystem used to compute private keys
+	SECP256K1 = "secp256k1"
+	// BLS is a public/private key system that supports aggregate signatures
+	BLS = "bls"
 )
 
 // PrivateKeyBytes is the size of a serialized private key.
@@ -34,11 +41,6 @@ func SignBLS(sk, msg []byte) ([]byte, error) {
 	copy(privateKey[:], sk)
 	sig := bls.PrivateKeySign(privateKey, msg)
 	return sig[:], nil
-}
-
-// Equals compares two private key for equality and returns true if they are the same.
-func Equals(sk, other []byte) bool {
-	return bytes.Equal(sk, other)
 }
 
 // VerifySecp checks the given signature is a secp256k1 signature and returns true if it is valid.
@@ -80,11 +82,11 @@ func VerifyBLSAggregate(pubKeys, msgs [][]byte, signature []byte) bool {
 	return bls.Verify(&blsSig, digests, keys)
 }
 
-// GenerateKeyFromSeed generates a new key from the given reader.
-func GenerateKeyFromSeed(seed io.Reader) ([]byte, error) {
+// NewSecpKeyFromSeed generates a new key from the given reader.
+func NewSecpKeyFromSeed(seed io.Reader) (KeyInfo, error) {
 	key, err := ecdsa.GenerateKey(secp256k1.S256(), seed)
 	if err != nil {
-		return nil, err
+		return KeyInfo{}, err
 	}
 
 	privkey := make([]byte, PrivateKeyBytes)
@@ -93,15 +95,22 @@ func GenerateKeyFromSeed(seed io.Reader) ([]byte, error) {
 	// the length is guaranteed to be fixed, given the serialization rules for secp2561k curve points.
 	copy(privkey[PrivateKeyBytes-len(blob):], blob)
 
-	return privkey, nil
+	return KeyInfo{
+		PrivateKey:  privkey,
+		CryptSystem: SECP256K1,
+	}, nil
 }
 
-// GenerateKey creates a new key using secure randomness from crypto.rand.
-func GenerateKey() ([]byte, error) {
-	return GenerateKeyFromSeed(rand.Reader)
+func NewBLSKeyRandom() KeyInfo {
+	k := bls.PrivateKeyGenerate()
+	return KeyInfo{
+		PrivateKey:  k[:],
+		CryptSystem: BLS,
+	}
 }
 
 // EcRecover recovers the public key from a message, signature pair.
 func EcRecover(msg, signature []byte) ([]byte, error) {
 	return secp256k1.RecoverPubkey(msg, signature)
 }
+

--- a/internal/pkg/crypto/crypto.go
+++ b/internal/pkg/crypto/crypto.go
@@ -113,4 +113,3 @@ func NewBLSKeyRandom() KeyInfo {
 func EcRecover(msg, signature []byte) ([]byte, error) {
 	return secp256k1.RecoverPubkey(msg, signature)
 }
-

--- a/internal/pkg/crypto/crypto_test.go
+++ b/internal/pkg/crypto/crypto_test.go
@@ -1,9 +1,8 @@
 package crypto_test
 
 import (
-	"math/rand"
+	"bytes"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,10 +15,10 @@ import (
 func TestGenerateSecpKey(t *testing.T) {
 	tf.UnitTest(t)
 
-	rand.Seed(time.Now().UnixNano())
-
-	sk, err := crypto.GenerateKey()
+	token := bytes.Repeat([]byte{42}, 512)
+	ki, err := crypto.NewSecpKeyFromSeed(bytes.NewReader(token))
 	assert.NoError(t, err)
+	sk := ki.PrivateKey
 
 	assert.Equal(t, len(sk), 32)
 
@@ -42,13 +41,13 @@ func TestGenerateSecpKey(t *testing.T) {
 	// invalid signature - different message
 	msg2 := make([]byte, 32)
 	copy(msg2, msg)
-	rand.Shuffle(len(msg2), func(i, j int) { msg2[i], msg2[j] = msg2[j], msg2[i] })
+	msg2[0] = 42
 	assert.False(t, crypto.VerifySecp(pk, msg2, digest))
 
 	// invalid signature - different digest
 	digest2 := make([]byte, 65)
 	copy(digest2, digest)
-	rand.Shuffle(len(digest2), func(i, j int) { digest2[i], digest2[j] = digest2[j], digest2[i] })
+	digest2[0] = 42
 	assert.False(t, crypto.VerifySecp(pk, msg, digest2))
 
 	// invalid signature - digest too short

--- a/internal/pkg/crypto/keyinfo.go
+++ b/internal/pkg/crypto/keyinfo.go
@@ -1,4 +1,4 @@
-package types
+package crypto
 
 import (
 	"bytes"
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 
 	bls "github.com/filecoin-project/filecoin-ffi"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 )
 
@@ -75,7 +74,7 @@ func (ki *KeyInfo) PublicKey() []byte {
 		return publicKey[:]
 	}
 	if ki.CryptSystem == SECP256K1 {
-		return crypto.PublicKey(ki.PrivateKey)
+		return PublicKey(ki.PrivateKey)
 	}
 	return []byte{}
 }

--- a/internal/pkg/crypto/keyinfo_test.go
+++ b/internal/pkg/crypto/keyinfo_test.go
@@ -1,4 +1,4 @@
-package types
+package crypto_test
 
 import (
 	"testing"
@@ -12,18 +12,15 @@ import (
 func TestKeyInfoMarshal(t *testing.T) {
 	tf.UnitTest(t)
 
-	testKey, err := crypto.GenerateKey()
-	assert.NoError(t, err)
-	testType := "test_key_type"
-	ki := &KeyInfo{
-		PrivateKey:  testKey,
-		CryptSystem: testType,
+	ki := crypto.KeyInfo{
+		PrivateKey:  []byte{1, 2, 3, 4},
+		CryptSystem: crypto.SECP256K1,
 	}
 
 	marshaled, err := ki.Marshal()
 	assert.NoError(t, err)
 
-	kiBack := &KeyInfo{}
+	kiBack := &crypto.KeyInfo{}
 	err = kiBack.Unmarshal(marshaled)
 	assert.NoError(t, err)
 

--- a/internal/pkg/types/helpers.go
+++ b/internal/pkg/types/helpers.go
@@ -1,2 +1,1 @@
 package types
-

--- a/internal/pkg/types/helpers.go
+++ b/internal/pkg/types/helpers.go
@@ -1,9 +1,2 @@
 package types
 
-const (
-	// SECP256K1 is a cryptosystem used to compute private keys
-	SECP256K1 = "secp256k1"
-
-	// BLS is a public/private key system that supports aggregate signatures
-	BLS = "bls"
-)

--- a/internal/pkg/vm/testing_messages.go
+++ b/internal/pkg/vm/testing_messages.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	address "github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
 // MessageMaker creates unique, signed messages for use in tests.
@@ -20,7 +22,7 @@ type MessageMaker struct {
 }
 
 // NewMessageMaker creates a new message maker with a set of signing keys.
-func NewMessageMaker(t *testing.T, keys []types.KeyInfo) *MessageMaker {
+func NewMessageMaker(t *testing.T, keys []crypto.KeyInfo) *MessageMaker {
 	addresses := make([]address.Address, len(keys))
 	signer := types.NewMockSigner(keys)
 

--- a/internal/pkg/wallet/backend.go
+++ b/internal/pkg/wallet/backend.go
@@ -2,6 +2,8 @@ package wallet
 
 import (
 	"github.com/filecoin-project/go-address"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
@@ -19,7 +21,7 @@ type Backend interface {
 
 	// GetKeyInfo will return the keyinfo associated with address `addr`
 	// iff backend contains the addr.
-	GetKeyInfo(addr address.Address) (*types.KeyInfo, error)
+	GetKeyInfo(addr address.Address) (*crypto.KeyInfo, error)
 }
 
 // Importer is a specialization of a wallet backend that can import
@@ -28,5 +30,5 @@ type Backend interface {
 type Importer interface {
 	// ImportKey imports the key described by the given keyinfo
 	// into the backend
-	ImportKey(ki *types.KeyInfo) error
+	ImportKey(ki *crypto.KeyInfo) error
 }

--- a/internal/pkg/wallet/dsbackend.go
+++ b/internal/pkg/wallet/dsbackend.go
@@ -1,11 +1,11 @@
 package wallet
 
 import (
+	"crypto/rand"
 	"reflect"
 	"strings"
 	"sync"
 
-	bls "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-address"
 	ds "github.com/ipfs/go-datastore"
 	dsq "github.com/ipfs/go-datastore/query"
@@ -63,7 +63,7 @@ func NewDSBackend(ds repo.Datastore) (*DSBackend, error) {
 }
 
 // ImportKey loads the address in `ai` and KeyInfo `ki` into the backend
-func (backend *DSBackend) ImportKey(ki *types.KeyInfo) error {
+func (backend *DSBackend) ImportKey(ki *crypto.KeyInfo) error {
 	return backend.putKeyInfo(ki)
 }
 
@@ -103,18 +103,12 @@ func (backend *DSBackend) NewAddress(protocol address.Protocol) (address.Address
 }
 
 func (backend *DSBackend) newSecpAddress() (address.Address, error) {
-	prv, err := crypto.GenerateKey()
+	ki, err := crypto.NewSecpKeyFromSeed(rand.Reader)
 	if err != nil {
 		return address.Undef, err
 	}
 
-	// TODO: maybe the above call should just return a keyinfo?
-	ki := &types.KeyInfo{
-		PrivateKey:  prv,
-		CryptSystem: types.SECP256K1,
-	}
-
-	if err := backend.putKeyInfo(ki); err != nil {
+	if err := backend.putKeyInfo(&ki); err != nil {
 		return address.Undef, err
 	}
 
@@ -122,21 +116,14 @@ func (backend *DSBackend) newSecpAddress() (address.Address, error) {
 }
 
 func (backend *DSBackend) newBLSAddress() (address.Address, error) {
-	privateKey := bls.PrivateKeyGenerate()
-
-	ki := &types.KeyInfo{
-		PrivateKey:  privateKey[:],
-		CryptSystem: types.BLS,
-	}
-
-	if err := backend.putKeyInfo(ki); err != nil {
+	ki := crypto.NewBLSKeyRandom()
+	if err := backend.putKeyInfo(&ki); err != nil {
 		return address.Undef, err
 	}
-
 	return ki.Address()
 }
 
-func (backend *DSBackend) putKeyInfo(ki *types.KeyInfo) error {
+func (backend *DSBackend) putKeyInfo(ki *crypto.KeyInfo) error {
 	a, err := ki.Address()
 	if err != nil {
 		return err
@@ -165,7 +152,7 @@ func (backend *DSBackend) SignBytes(data []byte, addr address.Address) (types.Si
 		return nil, err
 	}
 
-	if ki.CryptSystem == types.BLS {
+	if ki.CryptSystem == crypto.BLS {
 		return crypto.SignBLS(ki.PrivateKey, data)
 	}
 
@@ -176,7 +163,7 @@ func (backend *DSBackend) SignBytes(data []byte, addr address.Address) (types.Si
 
 // GetKeyInfo will return the private & public keys associated with address `addr`
 // iff backend contains the addr.
-func (backend *DSBackend) GetKeyInfo(addr address.Address) (*types.KeyInfo, error) {
+func (backend *DSBackend) GetKeyInfo(addr address.Address) (*crypto.KeyInfo, error) {
 	if !backend.HasAddress(addr) {
 		return nil, errors.New("backend does not contain address")
 	}
@@ -187,7 +174,7 @@ func (backend *DSBackend) GetKeyInfo(addr address.Address) (*types.KeyInfo, erro
 		return nil, errors.Wrap(err, "failed to fetch private key from backend")
 	}
 
-	ki := &types.KeyInfo{}
+	ki := &crypto.KeyInfo{}
 	if err := ki.Unmarshal(kib); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal keyinfo from backend")
 	}

--- a/internal/pkg/wallet/wallet.go
+++ b/internal/pkg/wallet/wallet.go
@@ -7,12 +7,12 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/filecoin-project/specs-actors/actors/crypto"
+	acrypto "github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-address"
 
-	crypto2 "github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
@@ -110,7 +110,7 @@ func (w *Wallet) SignBytes(data []byte, addr address.Address) (types.Signature, 
 }
 
 // SignBytesV2 returns a spec-actors crypto.Signature
-func (w *Wallet) SignBytesV2(data []byte, addr address.Address) (*crypto.Signature, error) {
+func (w *Wallet) SignBytesV2(data []byte, addr address.Address) (*acrypto.Signature, error) {
 	var err error
 
 	sig, err := w.SignBytes(data, addr)
@@ -118,14 +118,14 @@ func (w *Wallet) SignBytesV2(data []byte, addr address.Address) (*crypto.Signatu
 		return nil, err
 	}
 
-	var sigType crypto.SigType
+	var sigType acrypto.SigType
 	if addr.Protocol() == address.BLS {
-		sigType = crypto.SigTypeBLS
+		sigType = acrypto.SigTypeBLS
 	} else {
-		sigType = crypto.SigTypeSecp256k1
+		sigType = acrypto.SigTypeSecp256k1
 	}
 
-	return &crypto.Signature{
+	return &acrypto.Signature{
 		Type: sigType,
 		Data: sig[:],
 	}, nil
@@ -154,30 +154,30 @@ func (w *Wallet) GetPubKeyForAddress(addr address.Address) ([]byte, error) {
 }
 
 // NewKeyInfo creates a new KeyInfo struct in the wallet backend and returns it
-func (w *Wallet) NewKeyInfo() (*crypto2.KeyInfo, error) {
+func (w *Wallet) NewKeyInfo() (*crypto.KeyInfo, error) {
 	newAddr, err := NewAddress(w, address.SECP256K1)
 	if err != nil {
-		return &crypto2.KeyInfo{}, err
+		return &crypto.KeyInfo{}, err
 	}
 
 	return w.keyInfoForAddr(newAddr)
 }
 
-func (w *Wallet) keyInfoForAddr(addr address.Address) (*crypto2.KeyInfo, error) {
+func (w *Wallet) keyInfoForAddr(addr address.Address) (*crypto.KeyInfo, error) {
 	backend, err := w.Find(addr)
 	if err != nil {
-		return &crypto2.KeyInfo{}, err
+		return &crypto.KeyInfo{}, err
 	}
 
 	info, err := backend.GetKeyInfo(addr)
 	if err != nil {
-		return &crypto2.KeyInfo{}, err
+		return &crypto.KeyInfo{}, err
 	}
 	return info, nil
 }
 
 // Import adds the given keyinfos to the wallet
-func (w *Wallet) Import(kinfos ...*crypto2.KeyInfo) ([]address.Address, error) {
+func (w *Wallet) Import(kinfos ...*crypto.KeyInfo) ([]address.Address, error) {
 	dsb := w.Backends(DSBackendType)
 	if len(dsb) != 1 {
 		return nil, fmt.Errorf("expected exactly one datastore wallet backend")
@@ -204,8 +204,8 @@ func (w *Wallet) Import(kinfos ...*crypto2.KeyInfo) ([]address.Address, error) {
 }
 
 // Export returns the KeyInfos for the given wallet addresses
-func (w *Wallet) Export(addrs []address.Address) ([]*crypto2.KeyInfo, error) {
-	out := make([]*crypto2.KeyInfo, len(addrs))
+func (w *Wallet) Export(addrs []address.Address) ([]*crypto.KeyInfo, error) {
+	out := make([]*crypto.KeyInfo, len(addrs))
 	for i, addr := range addrs {
 		bck, err := w.Find(addr)
 		if err != nil {

--- a/internal/pkg/wallet/wallet.go
+++ b/internal/pkg/wallet/wallet.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-address"
+
+	crypto2 "github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
@@ -152,30 +154,30 @@ func (w *Wallet) GetPubKeyForAddress(addr address.Address) ([]byte, error) {
 }
 
 // NewKeyInfo creates a new KeyInfo struct in the wallet backend and returns it
-func (w *Wallet) NewKeyInfo() (*types.KeyInfo, error) {
+func (w *Wallet) NewKeyInfo() (*crypto2.KeyInfo, error) {
 	newAddr, err := NewAddress(w, address.SECP256K1)
 	if err != nil {
-		return &types.KeyInfo{}, err
+		return &crypto2.KeyInfo{}, err
 	}
 
 	return w.keyInfoForAddr(newAddr)
 }
 
-func (w *Wallet) keyInfoForAddr(addr address.Address) (*types.KeyInfo, error) {
+func (w *Wallet) keyInfoForAddr(addr address.Address) (*crypto2.KeyInfo, error) {
 	backend, err := w.Find(addr)
 	if err != nil {
-		return &types.KeyInfo{}, err
+		return &crypto2.KeyInfo{}, err
 	}
 
 	info, err := backend.GetKeyInfo(addr)
 	if err != nil {
-		return &types.KeyInfo{}, err
+		return &crypto2.KeyInfo{}, err
 	}
 	return info, nil
 }
 
 // Import adds the given keyinfos to the wallet
-func (w *Wallet) Import(kinfos ...*types.KeyInfo) ([]address.Address, error) {
+func (w *Wallet) Import(kinfos ...*crypto2.KeyInfo) ([]address.Address, error) {
 	dsb := w.Backends(DSBackendType)
 	if len(dsb) != 1 {
 		return nil, fmt.Errorf("expected exactly one datastore wallet backend")
@@ -202,8 +204,8 @@ func (w *Wallet) Import(kinfos ...*types.KeyInfo) ([]address.Address, error) {
 }
 
 // Export returns the KeyInfos for the given wallet addresses
-func (w *Wallet) Export(addrs []address.Address) ([]*types.KeyInfo, error) {
-	out := make([]*types.KeyInfo, len(addrs))
+func (w *Wallet) Export(addrs []address.Address) ([]*crypto2.KeyInfo, error) {
+	out := make([]*crypto2.KeyInfo, len(addrs))
 	for i, addr := range addrs {
 		bck, err := w.Find(addr)
 		if err != nil {

--- a/internal/pkg/wallet/wallet_test.go
+++ b/internal/pkg/wallet/wallet_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"testing"
 
-	bls "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/ipfs/go-datastore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	bls "github.com/filecoin-project/filecoin-ffi"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
@@ -89,7 +91,7 @@ func TestWalletBLSKeys(t *testing.T) {
 	t.Run("key uses BLS cryptography", func(t *testing.T) {
 		ki, err := wb.GetKeyInfo(addr)
 		require.NoError(t, err)
-		assert.Equal(t, types.BLS, ki.CryptSystem)
+		assert.Equal(t, crypto.BLS, ki.CryptSystem)
 	})
 
 	t.Run("valid signatures verify", func(t *testing.T) {

--- a/tools/fast/action_wallet.go
+++ b/tools/fast/action_wallet.go
@@ -8,6 +8,7 @@ import (
 	files "github.com/ipfs/go-ipfs-files"
 
 	commands "github.com/filecoin-project/go-filecoin/cmd/go-filecoin"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
@@ -31,11 +32,11 @@ func (f *Filecoin) WalletImport(ctx context.Context, file files.File) ([]address
 }
 
 // WalletExport run the wallet export command against the filecoin process.
-func (f *Filecoin) WalletExport(ctx context.Context, addrs []address.Address) ([]*types.KeyInfo, error) {
+func (f *Filecoin) WalletExport(ctx context.Context, addrs []address.Address) ([]*crypto.KeyInfo, error) {
 	// the command returns an KeyInfoListResult
 	var klr commands.WalletSerializeResult
 	// we expect to interact with an array of KeyInfo(s)
-	var out []*types.KeyInfo
+	var out []*crypto.KeyInfo
 	var sAddrs []string
 	for _, a := range addrs {
 		sAddrs = append(sAddrs, a.String())

--- a/tools/gengen/main.go
+++ b/tools/gengen/main.go
@@ -7,11 +7,11 @@ import (
 	"os"
 
 	"github.com/filecoin-project/go-filecoin/cmd/go-filecoin"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/tools/gengen/util"
 )
 
-func writeKey(ki *types.KeyInfo, name string, jsonout bool) error {
+func writeKey(ki *crypto.KeyInfo, name string, jsonout bool) error {
 	addr, err := ki.Address()
 	if err != nil {
 		return err

--- a/tools/gengen/util/gengen.go
+++ b/tools/gengen/util/gengen.go
@@ -90,7 +90,7 @@ type GenesisCfg struct {
 // RenderedGenInfo contains information about a genesis block creation
 type RenderedGenInfo struct {
 	// Keys is the set of keys generated
-	Keys []*types.KeyInfo
+	Keys []*crypto.KeyInfo
 
 	// Miners is the list of addresses of miners created
 	Miners []RenderedMinerInfo
@@ -184,26 +184,17 @@ func GenGen(ctx context.Context, cfg *GenesisCfg, cst cbor.IpldStore, bs blockst
 	}, nil
 }
 
-func genKeys(cfgkeys int, pnrg io.Reader) ([]*types.KeyInfo, error) {
-	keys := make([]*types.KeyInfo, cfgkeys)
+func genKeys(cfgkeys int, pnrg io.Reader) ([]*crypto.KeyInfo, error) {
+	keys := make([]*crypto.KeyInfo, cfgkeys)
 	for i := 0; i < cfgkeys; i++ {
-		sk, err := crypto.GenerateKeyFromSeed(pnrg) // TODO: GenerateKey should return a KeyInfo
-		if err != nil {
-			return nil, err
-		}
-
-		ki := &types.KeyInfo{
-			PrivateKey:  sk,
-			CryptSystem: types.SECP256K1,
-		}
-
-		keys[i] = ki
+		ki := crypto.NewBLSKeyRandom() // use seed
+		keys[i] = &ki
 	}
 
 	return keys, nil
 }
 
-func setupPrealloc(ctx context.Context, vm consensus.GenesisVM, st state.Tree, keys []*types.KeyInfo, prealloc []string) error {
+func setupPrealloc(ctx context.Context, vm consensus.GenesisVM, st state.Tree, keys []*crypto.KeyInfo, prealloc []string) error {
 
 	if len(keys) < len(prealloc) {
 		return fmt.Errorf("keys do not match prealloc")
@@ -245,7 +236,7 @@ func setupPrealloc(ctx context.Context, vm consensus.GenesisVM, st state.Tree, k
 	return nil
 }
 
-func setupMiners(vm consensus.GenesisVM, st state.Tree, keys []*types.KeyInfo, miners []*CreateStorageMinerConfig, pnrg io.Reader) ([]RenderedMinerInfo, error) {
+func setupMiners(vm consensus.GenesisVM, st state.Tree, keys []*crypto.KeyInfo, miners []*CreateStorageMinerConfig, pnrg io.Reader) ([]RenderedMinerInfo, error) {
 	var minfos []RenderedMinerInfo
 
 	for _, m := range miners {

--- a/tools/gengen/util/gengen_test.go
+++ b/tools/gengen/util/gengen_test.go
@@ -65,6 +65,7 @@ func TestGenGenLoading(t *testing.T) {
 
 func TestGenGenDeterministicBetweenBuilds(t *testing.T) {
 	tf.UnitTest(t)
+	t.Skip("Non-deterministic BLS key generation https://github.com/filecoin-project/go-filecoin/issues/3781")
 
 	ctx := context.Background()
 	var info *RenderedGenInfo


### PR DESCRIPTION
### Motivation
Miner workers must use BLS keys in order to produce VRFs, and the miner actor now enforces this.

### Proposed changes
Change gengen to use BLS keys. This unfortunately causes them to be non-deterministic due to an unfriendly BLS interface in filecoin-ffi (see #3781)

I made the crypto interface a bit easier to use with some renames and returning KeyInfo from the crypto methods. This required moving some things to break a circular dependency.