### PR TITLE
plumb start and end epochs for self-deal to DealProposal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.4.12 // indirect
-	github.com/Workiva/go-datastructures v1.0.50
 	github.com/cskr/pubsub v1.0.2
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v0.7.3-0.20190315170154-87d593639c77
@@ -16,7 +15,6 @@ require (
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/filecoin-project/filecoin-ffi v0.0.0-20200210194142-cb6019e08542
 	github.com/filecoin-project/go-address v0.0.1
-	github.com/filecoin-project/go-amt-ipld v1.0.0
 	github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e
 	github.com/filecoin-project/go-data-transfer v0.0.0-20191219005021-4accf56bd2ce
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
@@ -24,7 +22,7 @@ require (
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/filecoin-project/go-paramfetch v0.0.1
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200211164318-76f24b9797d4
-	github.com/filecoin-project/go-storage-miner v0.0.0-20200219183610-a3cfe4033120
+	github.com/filecoin-project/go-storage-miner v0.0.0-20200219222018-c835b9cb4fc5
 	github.com/filecoin-project/specs-actors v0.0.0-20200219204052-73c232aae190
 	github.com/fxamacker/cbor v1.5.0
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
@@ -90,7 +88,6 @@ require (
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
-	github.com/polydawn/refmt v0.0.0-20190809202753-05966cbd336a
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/common v0.7.0
 	github.com/spf13/afero v1.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/filecoin-project/go-paramfetch v0.0.1
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200211164318-76f24b9797d4
-	github.com/filecoin-project/go-storage-miner v0.0.0-20200220222105-fa36cabadc61
+	github.com/filecoin-project/go-storage-miner v0.0.0-20200220230132-20d809156265
 	github.com/filecoin-project/specs-actors v0.0.0-20200219204052-73c232aae190
 	github.com/fxamacker/cbor v1.5.0
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/filecoin-project/go-paramfetch v0.0.1
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200211164318-76f24b9797d4
-	github.com/filecoin-project/go-storage-miner v0.0.0-20200219222018-c835b9cb4fc5
+	github.com/filecoin-project/go-storage-miner v0.0.0-20200220222105-fa36cabadc61
 	github.com/filecoin-project/specs-actors v0.0.0-20200219204052-73c232aae190
 	github.com/fxamacker/cbor v1.5.0
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIi
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-storage-miner v0.0.0-20200219222018-c835b9cb4fc5 h1:fnIhdGgrxq1Jh85CXOwH8xazK68tYwitHW7XifIuyq4=
 github.com/filecoin-project/go-storage-miner v0.0.0-20200219222018-c835b9cb4fc5/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
+github.com/filecoin-project/go-storage-miner v0.0.0-20200220222105-fa36cabadc61 h1:fne6rbv9Em39yIImme/Wpu6mOgsrq1LQil+qByfHicM=
+github.com/filecoin-project/go-storage-miner v0.0.0-20200220222105-fa36cabadc61/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.0.0-20200219204052-73c232aae190 h1:tkjpVvUseIGBVEiovy01iOJ8nNi2o98VIT6xwJwBGj0=
 github.com/filecoin-project/specs-actors v0.0.0-20200219204052-73c232aae190/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=

--- a/go.sum
+++ b/go.sum
@@ -163,10 +163,10 @@ github.com/filecoin-project/go-statemachine v0.0.0-20200129214539-c78c5f7e9f9c h
 github.com/filecoin-project/go-statemachine v0.0.0-20200129214539-c78c5f7e9f9c/go.mod h1:1K7s8n65xznskrVYhwalQDO5blLMIZlf96OYQilZVJY=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
-github.com/filecoin-project/go-storage-miner v0.0.0-20200219222018-c835b9cb4fc5 h1:fnIhdGgrxq1Jh85CXOwH8xazK68tYwitHW7XifIuyq4=
-github.com/filecoin-project/go-storage-miner v0.0.0-20200219222018-c835b9cb4fc5/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
-github.com/filecoin-project/go-storage-miner v0.0.0-20200220222105-fa36cabadc61 h1:fne6rbv9Em39yIImme/Wpu6mOgsrq1LQil+qByfHicM=
-github.com/filecoin-project/go-storage-miner v0.0.0-20200220222105-fa36cabadc61/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
+github.com/filecoin-project/go-storage-miner v0.0.0-20200220225542-39e9649e8d0c h1:zbyMQVdwGjhu2v6d0fCzZsllui/Stxi6zUouhPcWV68=
+github.com/filecoin-project/go-storage-miner v0.0.0-20200220225542-39e9649e8d0c/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
+github.com/filecoin-project/go-storage-miner v0.0.0-20200220230132-20d809156265 h1:bFpRbrxwT62db3jpJ9rTrevloRVLdT5qeHehkQRIP7c=
+github.com/filecoin-project/go-storage-miner v0.0.0-20200220230132-20d809156265/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.0.0-20200219204052-73c232aae190 h1:tkjpVvUseIGBVEiovy01iOJ8nNi2o98VIT6xwJwBGj0=
 github.com/filecoin-project/specs-actors v0.0.0-20200219204052-73c232aae190/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/Stebalien/go-bitfield v0.0.1 h1:X3kbSSPUaJK60wV2hjOPZwmpljr6VGCqdq4cBLhbQBo=
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
-github.com/Workiva/go-datastructures v1.0.50 h1:slDmfW6KCHcC7U+LP3DDBbm4fqTwZGn1beOFPfGaLvo=
-github.com/Workiva/go-datastructures v1.0.50/go.mod h1:Z+F2Rca0qCsVYDS8z7bAGm8f3UkzuWYS/oBZz5a7VVA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
@@ -137,8 +135,6 @@ github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5 h1:/Mm
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-address v0.0.1 h1:P8MudT6kL/c4CUk+GgjULYEfVnJ7k1E+lE+sM14g7js=
 github.com/filecoin-project/go-address v0.0.1/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
-github.com/filecoin-project/go-amt-ipld v1.0.0 h1:jJteqdKcwFYoN9Wgs7MzDWVWvRWUfhhFo4bltJ7wrus=
-github.com/filecoin-project/go-amt-ipld v1.0.0/go.mod h1:KsFPWjF+UUYl6n9A+qbg4bjFgAOneicFZtDH/LQEX2U=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e h1:IOoff6yAZSJ5zHCPY2jzGNwQYQU6ygsRVe/cSnJrY+o=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2 h1:av5fw6wmm58FYMgJeoB/lK9XXrgdugYiTqkdxjTy9k8=
@@ -167,12 +163,11 @@ github.com/filecoin-project/go-statemachine v0.0.0-20200129214539-c78c5f7e9f9c h
 github.com/filecoin-project/go-statemachine v0.0.0-20200129214539-c78c5f7e9f9c/go.mod h1:1K7s8n65xznskrVYhwalQDO5blLMIZlf96OYQilZVJY=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
-github.com/filecoin-project/go-storage-miner v0.0.0-20200219183610-a3cfe4033120 h1:YZ3+GBp0tWXoKS4iBb7nL20xdIv5/tzpHNiJK0xp8Wg=
-github.com/filecoin-project/go-storage-miner v0.0.0-20200219183610-a3cfe4033120/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
+github.com/filecoin-project/go-storage-miner v0.0.0-20200219222018-c835b9cb4fc5 h1:fnIhdGgrxq1Jh85CXOwH8xazK68tYwitHW7XifIuyq4=
+github.com/filecoin-project/go-storage-miner v0.0.0-20200219222018-c835b9cb4fc5/go.mod h1:+/3GNVOS9uhFsj1dqTWWeuGWzaxlzofEplu3m8lVDeM=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.0.0-20200219204052-73c232aae190 h1:tkjpVvUseIGBVEiovy01iOJ8nNi2o98VIT6xwJwBGj0=
 github.com/filecoin-project/specs-actors v0.0.0-20200219204052-73c232aae190/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
-github.com/filecoin-project/specs-actors v0.0.0-20200220030330-088602fad572 h1:7WYK28dFGirTVKtS5zQmw314MN73+C3MR+YvXxyPO5A=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fxamacker/cbor v1.5.0 h1:idAiyeNSq/jeG9FPbCLVZLFJjsxP+g40a3UrXFapumw=
@@ -1102,7 +1097,6 @@ github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830 h1:8kxMKmKzXXL4Ru
 github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc h1:BCPnHtcboadS0DvysUuJXZ4lWVv5Bh5i7+tbIyi+ck4=
 github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc/go.mod h1:r45hJU7yEoA81k6MWNhpMj/kms0n14dkzkxYHoB96UM=
-github.com/whyrusleeping/cbor-gen v0.0.0-20190917003517-d78d67427694/go.mod h1:xdlJQaiqipF0HW+Mzpg7XRM3fWbGvfgFlcppuvlkIvY=
 github.com/whyrusleeping/cbor-gen v0.0.0-20191212224538-d370462a7e8a/go.mod h1:xdlJQaiqipF0HW+Mzpg7XRM3fWbGvfgFlcppuvlkIvY=
 github.com/whyrusleeping/cbor-gen v0.0.0-20191216205031-b047b6acb3c0 h1:efb/4CnrubzNGqQOeHErxyQ6rIsJb7GcgeSDF7fqWeI=
 github.com/whyrusleeping/cbor-gen v0.0.0-20191216205031-b047b6acb3c0/go.mod h1:xdlJQaiqipF0HW+Mzpg7XRM3fWbGvfgFlcppuvlkIvY=
@@ -1194,8 +1188,6 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200210222208-86ce3cb69678 h1:wCWoJcFExDgyYx2m2hpHgwz8W3+FPdfldvIgzqDIhyg=
-golang.org/x/crypto v0.0.0-20200210222208-86ce3cb69678/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1288,8 +1280,6 @@ golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 h1:gSbV7h1NRL2G1xTg/owz62CST1oJBmxy4QpMMregXVQ=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 h1:sfkvUWPNGwSV+8/fNqctR5lS2AqCSqYwXdrjCxp/dXo=
-golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200219091948-cb0a6d8edb6c h1:jceGD5YNJGgGMkJz79agzOln1K9TaZUjv5ird16qniQ=
 golang.org/x/sys v0.0.0-20200219091948-cb0a6d8edb6c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/internal/app/go-filecoin/internal/submodule/storage_mining_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/storage_mining_submodule.go
@@ -40,7 +40,10 @@ func NewStorageMiningSubmodule(minerAddr address.Address, ds datastore.Batching,
 
 	// The amount of epochs we expect the storage miner to take to replicate and
 	// prove a sector. This value should be shared with the storage miner side
-	// of go-fil-markets.
+	// of go-fil-markets. The protocol specifies a maximum sealing duration (1)
+	// which could be used to improve the accuracy of provingDelay.
+	//
+	// 1: https://github.com/filecoin-project/specs-actors/commit/fa20d55a3ff0c0134b130dc27850998ffd432580#diff-5a14038af5531003ed825ab608d0dd51R21
 	//
 	// TODO: What is the correct value for proving delay given 32GiB sectors?
 	provingDelay := abi.ChainEpoch(2 * 60 * 24)

--- a/internal/app/go-filecoin/internal/submodule/storage_mining_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/storage_mining_submodule.go
@@ -39,7 +39,10 @@ func NewStorageMiningSubmodule(minerAddr address.Address, ds datastore.Batching,
 	minerNode := storageminerconnector.NewStorageMinerNodeConnector(minerAddr, c.ChainReader, c.State, m.Outbox, mw, w.Wallet, stateViewer)
 
 	// The amount of epochs we expect the storage miner to take to replicate and
-	// prove a sector.
+	// prove a sector. This value should be shared with the storage miner side
+	// of go-fil-markets.
+	//
+	// TODO: What is the correct value for proving delay given 32GiB sectors?
 	provingDelay := abi.ChainEpoch(2 * 60 * 24)
 
 	// The quantity of epochs during which the self-deal will be valid.

--- a/internal/app/go-filecoin/porcelain/api.go
+++ b/internal/app/go-filecoin/porcelain/api.go
@@ -117,8 +117,8 @@ func (a *API) ClientListAsks(ctx context.Context) <-chan Ask {
 }
 
 // SealPieceIntoNewSector writes the provided piece into a new sector
-func (a *API) SealPieceIntoNewSector(ctx context.Context, dealID uint64, pieceSize uint64, pieceReader io.Reader) error {
-	return SealPieceIntoNewSector(ctx, a, dealID, pieceSize, pieceReader)
+func (a *API) SealPieceIntoNewSector(ctx context.Context, dealID uint64, dealStart, dealEnd abi.ChainEpoch, pieceSize uint64, pieceReader io.Reader) error {
+	return SealPieceIntoNewSector(ctx, a, dealID, dealStart, dealEnd, pieceSize, pieceReader)
 }
 
 // PingMinerWithTimeout pings a storage or retrieval miner, waiting the given

--- a/internal/app/go-filecoin/porcelain/piecemanager.go
+++ b/internal/app/go-filecoin/porcelain/piecemanager.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 
+	"github.com/filecoin-project/specs-actors/actors/abi"
+
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/piecemanager"
@@ -14,10 +16,10 @@ type pmPlumbing interface {
 }
 
 // SealPieceIntoNewSector writes the provided piece-bytes into a new sector.
-func SealPieceIntoNewSector(ctx context.Context, p pmPlumbing, dealID uint64, pieceSize uint64, pieceReader io.Reader) error {
+func SealPieceIntoNewSector(ctx context.Context, p pmPlumbing, dealID uint64, dealStart, dealEnd abi.ChainEpoch, pieceSize uint64, pieceReader io.Reader) error {
 	if p.PieceManager() == nil {
 		return errors.New("must be mining to add piece")
 	}
 
-	return p.PieceManager().SealPieceIntoNewSector(ctx, dealID, pieceSize, pieceReader)
+	return p.PieceManager().SealPieceIntoNewSector(ctx, dealID, dealStart, dealEnd, pieceSize, pieceReader)
 }

--- a/internal/app/go-filecoin/porcelain/piecemanager.go
+++ b/internal/app/go-filecoin/porcelain/piecemanager.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
-
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/piecemanager"

--- a/internal/app/go-filecoin/storage_market_connector/provider.go
+++ b/internal/app/go-filecoin/storage_market_connector/provider.go
@@ -131,7 +131,7 @@ func (s *StorageProviderNodeConnector) OnDealComplete(ctx context.Context, deal 
 	// TODO: storage provider is expecting a sector ID here. This won't work. The sector ID needs to be removed from
 	// TODO: the return value, and storage provider needs to call OnDealSectorCommitted which should add Sector ID to its
 	// TODO: callback.
-	return s.pieceManager.SealPieceIntoNewSector(ctx, deal.DealID, uint64(pieceSize), pieceReader)
+	return s.pieceManager.SealPieceIntoNewSector(ctx, deal.DealID, deal.Proposal.StartEpoch, deal.Proposal.EndEpoch, uint64(pieceSize), pieceReader)
 }
 
 // LocatePieceForDealWithinSector finds the sector, offset and length of a piece associated with the given deal id

--- a/internal/app/go-filecoin/storage_miner_connector/connector.go
+++ b/internal/app/go-filecoin/storage_miner_connector/connector.go
@@ -3,7 +3,6 @@ package storageminerconnector
 import (
 	"context"
 	"errors"
-	"math"
 
 	"github.com/filecoin-project/go-address"
 	commcid "github.com/filecoin-project/go-fil-commcid"
@@ -86,7 +85,7 @@ func (m *StorageMinerNodeConnector) handleNewTipSet(ctx context.Context, previou
 }
 
 // SendSelfDeals creates self-deals and sends them to the network.
-func (m *StorageMinerNodeConnector) SendSelfDeals(ctx context.Context, pieces ...abi.PieceInfo) (cid.Cid, error) {
+func (m *StorageMinerNodeConnector) SendSelfDeals(ctx context.Context, startEpoch, endEpoch abi.ChainEpoch, pieces ...abi.PieceInfo) (cid.Cid, error) {
 	waddr, err := m.getMinerWorkerAddress(ctx, m.chainState.Head())
 	if err != nil {
 		return cid.Undef, err
@@ -100,8 +99,8 @@ func (m *StorageMinerNodeConnector) SendSelfDeals(ctx context.Context, pieces ..
 				PieceSize:            piece.Size,
 				Client:               waddr,
 				Provider:             m.minerAddr,
-				StartEpoch:           0, // TODO: Does this have to be set to current height?
-				EndEpoch:             abi.ChainEpoch(math.MaxInt32),
+				StartEpoch:           startEpoch,
+				EndEpoch:             endEpoch,
 				StoragePricePerEpoch: abi.NewTokenAmount(0),
 				ProviderCollateral:   abi.NewTokenAmount(0),
 				ClientCollateral:     abi.NewTokenAmount(0),
@@ -316,13 +315,25 @@ func (m *StorageMinerNodeConnector) GetSealTicket(ctx context.Context, tok stora
 	}, nil
 }
 
-func (m *StorageMinerNodeConnector) GetChainHead(ctx context.Context) (storagenode.TipSetToken, error) {
-	tok, err := encoding.Encode(m.chainState.Head())
+func (m *StorageMinerNodeConnector) GetChainHead(ctx context.Context) (storagenode.TipSetToken, abi.ChainEpoch, error) {
+	tsk := m.chainState.Head()
+
+	ts, err := m.chainState.GetTipSet(tsk)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to marshal TipSetKey to CBOR byte slice for TipSetToken")
+		return nil, 0, xerrors.Errorf("failed to get tip: %w", err)
 	}
 
-	return tok, nil
+	h, err := ts.Height()
+	if err != nil {
+		return nil, 0, xerrors.Errorf("failed to get tipset height: %w")
+	}
+
+	tok, err := encoding.Encode(tsk)
+	if err != nil {
+		return nil, 0, xerrors.Errorf("failed to marshal TipSetKey to CBOR byte slice for TipSetToken: %w", err)
+	}
+
+	return tok, abi.ChainEpoch(h), nil
 }
 
 // GetSealSeed is used to acquire the seal seed for the provided pre-commit

--- a/internal/app/go-filecoin/storage_miner_connector/connector.go
+++ b/internal/app/go-filecoin/storage_miner_connector/connector.go
@@ -193,7 +193,7 @@ func (m *StorageMinerNodeConnector) WaitForSelfDeals(ctx context.Context, mcid c
 
 // SendPreCommitSector creates a pre-commit sector message and sends it to the
 // network.
-func (m *StorageMinerNodeConnector) SendPreCommitSector(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket storagenode.SealTicket, pieces ...storagenode.Piece) (cid.Cid, error) {
+func (m *StorageMinerNodeConnector) SendPreCommitSector(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket storagenode.SealTicket, pieces ...storagenode.PieceWithDealInfo) (cid.Cid, error) {
 	waddr, err := m.getMinerWorkerAddress(ctx, m.chainState.Head())
 	if err != nil {
 		return cid.Undef, err
@@ -201,7 +201,7 @@ func (m *StorageMinerNodeConnector) SendPreCommitSector(ctx context.Context, sec
 
 	dealIds := make([]abi.DealID, len(pieces))
 	for i, piece := range pieces {
-		dealIds[i] = piece.DealID
+		dealIds[i] = piece.DealInfo.DealID
 	}
 
 	params := miner.SectorPreCommitInfo{
@@ -333,7 +333,7 @@ func (m *StorageMinerNodeConnector) GetChainHead(ctx context.Context) (storageno
 		return nil, 0, xerrors.Errorf("failed to marshal TipSetKey to CBOR byte slice for TipSetToken: %w", err)
 	}
 
-	return tok, abi.ChainEpoch(h), nil
+	return tok, h, nil
 }
 
 // GetSealSeed is used to acquire the seal seed for the provided pre-commit
@@ -511,7 +511,7 @@ func (m *StorageMinerNodeConnector) GetSealedCID(ctx context.Context, tok storag
 	return preCommitInfo.Info.SealedCID, true, nil
 }
 
-func (m *StorageMinerNodeConnector) CheckPieces(ctx context.Context, sectorNum abi.SectorNumber, pieces []storagenode.Piece) *storagenode.CheckPiecesError {
+func (m *StorageMinerNodeConnector) CheckPieces(ctx context.Context, sectorNum abi.SectorNumber, pieces []storagenode.PieceWithDealInfo) *storagenode.CheckPiecesError {
 	return nil
 }
 

--- a/internal/pkg/piecemanager/interface.go
+++ b/internal/pkg/piecemanager/interface.go
@@ -3,6 +3,8 @@ package piecemanager
 import (
 	"context"
 	"io"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
 )
 
 // PieceManager is responsible for sealing pieces into sectors and progressing
@@ -16,13 +18,12 @@ type PieceManager interface {
 	// errors encountered during the pre-commit or commit flows (including
 	// message creation) are recorded in StorageMining metadata but not exposed
 	// through this API.
-	SealPieceIntoNewSector(ctx context.Context, dealID uint64, pieceSize uint64, pieceReader io.Reader) error
+	SealPieceIntoNewSector(ctx context.Context, dealID uint64, dealStart, dealEnd abi.ChainEpoch, pieceSize uint64, pieceReader io.Reader) error
 
 	// PledgeSector behaves similarly to SealPieceIntoNewSector, but differs in
 	// that it does not require a deal having been made on-chain beforehand. It
-	// provisions a new sector, fills it with self-deal junk, and seals. Like
-	// SealPieceIntoNewSector, this method is fire-and-forget.
-	PledgeSector() error
+	// provisions a new sector, fills it with self-deal junk, and seals.
+	PledgeSector(ctx context.Context) error
 
 	// UnsealSector produces a reader to the unsealed bytes associated with the
 	// provided sector id, or an error if no such sealed sector exists. The


### PR DESCRIPTION
### Motivation

Today, the self-deal start and end epochs are set to constants - and the wrong constants, at that.

### Proposed changes

This changeset pushes the choice of self-deal start and end-epochs into go-storage-miner, who uses existing deal information to choose self-deal start and end epochs (in the event that a to-be-sealed sector contains client data) or the provided "proving delay" and "duration" values otherwise.