### PR TITLE
Hook up new randomness to seals and proofs

### DIFF
--- a/internal/app/go-filecoin/internal/submodule/chain_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/chain_submodule.go
@@ -57,19 +57,15 @@ func NewChainSubmodule(config chainConfig, repo chainRepo, blockstore *Blockstor
 	chainStatusReporter := chain.NewStatusReporter()
 	chainStore := chain.NewStore(repo.ChainDatastore(), blockstore.CborStore, state.NewTreeLoader(), chainStatusReporter, config.GenesisCid())
 
-	// set up processor
-	sampler := chain.NewSampler(chainStore)
-	processor := consensus.NewDefaultProcessor(sampler)
-
 	actorState := appstate.NewTipSetStateViewer(chainStore, blockstore.CborStore)
 	messageStore := chain.NewMessageStore(blockstore.Blockstore)
 	chainState := cst.NewChainStateReadWriter(chainStore, messageStore, blockstore.Blockstore, builtin.DefaultActors)
+	processor := consensus.NewDefaultProcessor(chainState)
 
 	return ChainSubmodule{
 		ChainReader:  chainStore,
 		MessageStore: messageStore,
 		// HeaviestTipSetCh nil
-		Sampler:        sampler,
 		ActorState:     actorState,
 		State:          chainState,
 		Processor:      processor,

--- a/internal/app/go-filecoin/plumbing/api.go
+++ b/internal/app/go-filecoin/plumbing/api.go
@@ -168,13 +168,6 @@ func (api *API) ChainLs(ctx context.Context) (*chain.TipsetIterator, error) {
 	return api.chain.Ls(ctx)
 }
 
-// ChainSampleRandomness produces a slice of random bytes sampled from a TipSet
-// in the blockchain at a given height, useful for things like PoSt challenge seed
-// generation.
-func (api *API) ChainSampleRandomness(ctx context.Context, sampleHeight abi.ChainEpoch) ([]byte, error) {
-	return api.chain.SampleRandomness(ctx, sampleHeight)
-}
-
 // SyncerStatus returns the current status of the active or last active chain sync operation.
 func (api *API) SyncerStatus() status.Status {
 	return api.syncer.Status()

--- a/internal/app/go-filecoin/storage_miner_connector/connector.go
+++ b/internal/app/go-filecoin/storage_miner_connector/connector.go
@@ -10,6 +10,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	"github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
 
@@ -25,8 +26,8 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/wallet"
 )
 
-type randomnessSampler interface {
-	SampleRandomness(ctx context.Context, sampleHeight abi.ChainEpoch) ([]byte, error)
+type chainReader interface {
+	SampleChainRandomness(ctx context.Context, head block.TipSetKey, tag crypto.DomainSeparationTag, sampleHeight abi.ChainEpoch, entropy []byte) (abi.Randomness, error)
 	GetTipSetStateRoot(ctx context.Context, tipKey block.TipSetKey) (cid.Cid, error)
 	GetTipSet(key block.TipSetKey) (block.TipSet, error)
 	Head() block.TipSetKey
@@ -40,8 +41,7 @@ type StorageMinerNodeConnector struct {
 
 	chainHeightScheduler *chainsampler.HeightThresholdScheduler
 
-	chainStore *chain.Store
-	chainState randomnessSampler
+	chainState chainReader
 	outbox     *message.Outbox
 	waiter     *msg.Waiter
 	wallet     *wallet.Wallet
@@ -54,11 +54,10 @@ var _ storagenode.Interface = new(StorageMinerNodeConnector)
 // NewStorageMinerNodeConnector produces a StorageMinerNodeConnector, which adapts
 // types in this codebase to the interface representing "the node" which is
 // expected by the go-storage-miner project.
-func NewStorageMinerNodeConnector(minerAddress address.Address, chainStore *chain.Store, chainState randomnessSampler, outbox *message.Outbox, waiter *msg.Waiter, wallet *wallet.Wallet, stateViewer *appstate.Viewer) *StorageMinerNodeConnector {
+func NewStorageMinerNodeConnector(minerAddress address.Address, chainStore *chain.Store, chainState chainReader, outbox *message.Outbox, waiter *msg.Waiter, wallet *wallet.Wallet, stateViewer *appstate.Viewer) *StorageMinerNodeConnector {
 	return &StorageMinerNodeConnector{
 		minerAddr:            minerAddress,
 		chainHeightScheduler: chainsampler.NewHeightThresholdScheduler(chainStore),
-		chainStore:           chainStore,
 		chainState:           chainState,
 		outbox:               outbox,
 		waiter:               waiter,
@@ -293,7 +292,7 @@ func (m *StorageMinerNodeConnector) GetSealTicket(ctx context.Context, tok stora
 		return storagenode.SealTicket{}, xerrors.Errorf("failed to marshal TipSetToken into a TipSetKey: %w", err)
 	}
 
-	ts, err := m.chainStore.GetTipSet(tsk)
+	ts, err := m.chainState.GetTipSet(tsk)
 	if err != nil {
 		return storagenode.SealTicket{}, xerrors.Errorf("getting head ts for SealTicket failed: %w", err)
 	}
@@ -303,7 +302,7 @@ func (m *StorageMinerNodeConnector) GetSealTicket(ctx context.Context, tok stora
 		return storagenode.SealTicket{}, err
 	}
 
-	r, err := m.chainState.SampleRandomness(ctx, h-miner.ChainFinalityish)
+	r, err := m.chainState.SampleChainRandomness(ctx, tsk, crypto.DomainSeparationTag_SealRandomness, h-miner.ChainFinalityish, nil)
 	if err != nil {
 		return storagenode.SealTicket{}, xerrors.Errorf("getting randomness for SealTicket failed: %w", err)
 	}
@@ -377,7 +376,7 @@ func (m *StorageMinerNodeConnector) GetSealSeed(ctx context.Context, preCommitMs
 					break
 				}
 
-				randomness, err := m.chainState.SampleRandomness(ctx, tsHeight)
+				randomness, err := m.chainState.SampleChainRandomness(ctx, key, crypto.DomainSeparationTag_InteractiveSealChallengeSeed, tsHeight, nil)
 				if err != nil {
 					ec <- storagenode.NewGetSealSeedError(err, storagenode.GetSealSeedFatalError)
 					break

--- a/internal/pkg/chain/sampler_test.go
+++ b/internal/pkg/chain/sampler_test.go
@@ -21,10 +21,11 @@ import (
 func TestSamplingChainRandomness(t *testing.T) {
 	tf.UnitTest(t)
 	ctx := context.Background()
+	genesisTicket := block.Ticket{VRFProof: []byte{1, 2, 3, 4}}
 
 	makeSample := func(targetEpoch, sampleEpoch int) crypto.RandomSeed {
 		buf := bytes.Buffer{}
-		var vrfProof []byte
+		vrfProof := genesisTicket.VRFProof
 		if sampleEpoch >= 0 {
 			vrfProof = []byte(strconv.Itoa(sampleEpoch))
 		}
@@ -38,7 +39,7 @@ func TestSamplingChainRandomness(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		builder, ch := makeChain(t, 21)
 		head := ch[0].Key()
-		sampler := chain.NewSampler(builder)
+		sampler := chain.NewSampler(builder, genesisTicket)
 
 		r, err := sampler.Sample(ctx, head, abi.ChainEpoch(20))
 		assert.NoError(t, err)
@@ -56,7 +57,7 @@ func TestSamplingChainRandomness(t *testing.T) {
 	t.Run("skips missing tipsets", func(t *testing.T) {
 		builder, ch := makeChain(t, 21)
 		head := ch[0].Key()
-		sampler := chain.NewSampler(builder)
+		sampler := chain.NewSampler(builder, genesisTicket)
 
 		// Sample height after the head falls back to the head.
 		headParent := ch[1].Key()
@@ -86,7 +87,7 @@ func TestSamplingChainRandomness(t *testing.T) {
 		builder, ch := makeChain(t, 6)
 		head := ch[0].Key()
 		gen := (ch[len(ch)-1]).Key()
-		sampler := chain.NewSampler(builder)
+		sampler := chain.NewSampler(builder, genesisTicket)
 
 		// Sample genesis from longer chain.
 		r, err := sampler.Sample(ctx, head, abi.ChainEpoch(0))

--- a/internal/pkg/chain/sampler_test.go
+++ b/internal/pkg/chain/sampler_test.go
@@ -1,0 +1,131 @@
+package chain_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"strconv"
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/minio/blake2b-simd"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
+	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
+)
+
+func TestSamplingChainRandomness(t *testing.T) {
+	tf.UnitTest(t)
+	ctx := context.Background()
+
+	makeSample := func(targetEpoch, sampleEpoch int) crypto.RandomSeed {
+		buf := bytes.Buffer{}
+		var vrfProof []byte
+		if sampleEpoch >= 0 {
+			vrfProof = []byte(strconv.Itoa(sampleEpoch))
+		}
+		vrfDigest := blake2b.Sum256(vrfProof)
+		buf.Write(vrfDigest[:])
+		_ = binary.Write(&buf, binary.BigEndian, abi.ChainEpoch(targetEpoch))
+		bufHash := blake2b.Sum256(buf.Bytes())
+		return bufHash[:]
+	}
+
+	t.Run("happy path", func(t *testing.T) {
+		builder, ch := makeChain(t, 21)
+		head := ch[0].Key()
+		sampler := chain.NewSampler(builder)
+
+		r, err := sampler.Sample(ctx, head, abi.ChainEpoch(20))
+		assert.NoError(t, err)
+		assert.Equal(t, makeSample(20, 20), r)
+
+		r, err = sampler.Sample(ctx, head, abi.ChainEpoch(3))
+		assert.NoError(t, err)
+		assert.Equal(t, makeSample(3, 3), r)
+
+		r, err = sampler.Sample(ctx, head, abi.ChainEpoch(0))
+		assert.NoError(t, err)
+		assert.Equal(t, makeSample(0, 0), r)
+	})
+
+	t.Run("skips missing tipsets", func(t *testing.T) {
+		builder, ch := makeChain(t, 21)
+		head := ch[0].Key()
+		sampler := chain.NewSampler(builder)
+
+		// Sample height after the head falls back to the head.
+		headParent := ch[1].Key()
+		r, err := sampler.Sample(ctx, headParent, abi.ChainEpoch(20))
+		assert.NoError(t, err)
+		assert.Equal(t, makeSample(20, 19), r)
+
+		// Another way of the same thing, sample > head.
+		r, err = sampler.Sample(ctx, head, abi.ChainEpoch(21))
+		assert.NoError(t, err)
+		assert.Equal(t, makeSample(21, 20), r)
+
+		// Add new head so as to produce null blocks between 20 and 25
+		// i.e.: 25 20 19 18 ... 0
+		headAfterNulls := builder.BuildOneOn(ch[0], func(b *chain.BlockBuilder) {
+			b.IncHeight(4)
+			b.SetTicket([]byte(strconv.Itoa(25)))
+		})
+
+		// Sampling in the nulls falls back to the last non-null
+		r, err = sampler.Sample(ctx, headAfterNulls.Key(), abi.ChainEpoch(24))
+		assert.NoError(t, err)
+		assert.Equal(t, makeSample(24, 20), r)
+	})
+
+	t.Run("genesis", func(t *testing.T) {
+		builder, ch := makeChain(t, 6)
+		head := ch[0].Key()
+		gen := (ch[len(ch)-1]).Key()
+		sampler := chain.NewSampler(builder)
+
+		// Sample genesis from longer chain.
+		r, err := sampler.Sample(ctx, head, abi.ChainEpoch(0))
+		assert.NoError(t, err)
+		assert.Equal(t, makeSample(0, 0), r)
+
+		// Sample before genesis from longer chain.
+		r, err = sampler.Sample(ctx, head, abi.ChainEpoch(-1))
+		assert.NoError(t, err)
+		assert.Equal(t, makeSample(-1, 0), r)
+
+		// Sample genesis from genesis-only chain.
+		r, err = sampler.Sample(ctx, gen, abi.ChainEpoch(0))
+		assert.NoError(t, err)
+		assert.Equal(t, makeSample(0, 0), r)
+
+		// Sample before genesis from genesis-only chain.
+		r, err = sampler.Sample(ctx, gen, abi.ChainEpoch(-1))
+		assert.NoError(t, err)
+		assert.Equal(t, makeSample(-1, 0), r)
+
+		// Sample empty chain.
+		r, err = sampler.Sample(ctx, block.NewTipSetKey(), abi.ChainEpoch(0))
+		assert.NoError(t, err)
+		assert.Equal(t, makeSample(0, -1), r)
+		r, err = sampler.Sample(ctx, block.NewTipSetKey(), abi.ChainEpoch(-1))
+		assert.NoError(t, err)
+		assert.Equal(t, makeSample(-1, -1), r)
+	})
+}
+
+// Builds a chain of single-block tips, returned in descending height order.
+// Each block's ticket is its stringified height (as bytes).
+func makeChain(t *testing.T, length int) (*chain.Builder, []block.TipSet) {
+	b := chain.NewBuilder(t, address.Undef)
+	height := 0
+	head := b.BuildManyOn(length, block.UndefTipSet, func(b *chain.BlockBuilder) {
+		b.SetTicket([]byte(strconv.Itoa(height)))
+		height++
+	})
+	return b, b.RequireTipSets(head.Key(), length)
+}

--- a/internal/pkg/consensus/genesis.go
+++ b/internal/pkg/consensus/genesis.go
@@ -36,8 +36,10 @@ import (
 // GenesisInitFunc is the signature for function that is used to create a genesis block.
 type GenesisInitFunc func(cst cbor.IpldStore, bs blockstore.Blockstore) (*block.Block, error)
 
+// GenesisTicket is the ticket to place in the genesis block header (which can't be derived from a prior ticket),
+// used in the evaluation of the messages in the genesis block,
+// and *also* the ticket value used when computing the genesis state (the parent state of the genesis block).
 var GenesisTicket = block.Ticket{VRFProof: []byte{0xec}}
-
 
 var (
 	defaultAccounts map[address.Address]abi.TokenAmount

--- a/internal/pkg/consensus/processor.go
+++ b/internal/pkg/consensus/processor.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/crypto"
 	"go.opencensus.io/trace"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/metrics/tracing"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
@@ -28,31 +28,31 @@ type ApplyMessageResult struct {
 	FailureIsPermanent bool  // Whether failure is permanent, has no chance of succeeding later.
 }
 
-type chainSampler interface {
-	Sample(ctx context.Context, head block.TipSetKey, epoch abi.ChainEpoch) (crypto.RandomSeed, error)
+type chainRandomness interface {
+	SampleChainRandomness(ctx context.Context, head block.TipSetKey, tag crypto.DomainSeparationTag, epoch abi.ChainEpoch, entropy []byte) (abi.Randomness, error)
 }
 
 // DefaultProcessor handles all block processing.
 type DefaultProcessor struct {
-	actors  vm.ActorCodeLoader
-	sampler chainSampler
+	actors vm.ActorCodeLoader
+	rnd    chainRandomness
 }
 
 var _ Processor = (*DefaultProcessor)(nil)
 
 // NewDefaultProcessor creates a default processor from the given state tree and vms.
-func NewDefaultProcessor(sampler chainSampler) *DefaultProcessor {
+func NewDefaultProcessor(rnd chainRandomness) *DefaultProcessor {
 	return &DefaultProcessor{
-		actors:  vm.DefaultActors,
-		sampler: sampler,
+		actors: vm.DefaultActors,
+		rnd:    rnd,
 	}
 }
 
 // NewConfiguredProcessor creates a default processor with custom validation and rewards.
-func NewConfiguredProcessor(actors vm.ActorCodeLoader, sampler chainSampler) *DefaultProcessor {
+func NewConfiguredProcessor(actors vm.ActorCodeLoader, rnd chainRandomness) *DefaultProcessor {
 	return &DefaultProcessor{
-		actors:  actors,
-		sampler: sampler,
+		actors: actors,
+		rnd:    rnd,
 	}
 }
 
@@ -72,23 +72,21 @@ func (p *DefaultProcessor) ProcessTipSet(ctx context.Context, st state.Tree, vms
 		return nil, err
 	}
 
-	rnd := crypto.ChainRandomnessSource{Sampler: &headChainSampler{
-		ctx:     ctx,
-		sampler: p.sampler,
-		head:    parent,
-	}}
+	rnd := headRandomness{
+		chain: p.rnd,
+		head:  parent,
+	}
 	v := vm.NewVM(st, &vms)
 
 	return v.ApplyTipSetMessages(msgs, epoch, &rnd)
 }
 
-// A chain sampler with a specific head tipset key.
-type headChainSampler struct {
-	ctx     context.Context
-	sampler chainSampler
-	head    block.TipSetKey
+// A chain randomness source with a fixed head tipset key.
+type headRandomness struct {
+	chain chainRandomness
+	head  block.TipSetKey
 }
 
-func (s *headChainSampler) Sample(epoch abi.ChainEpoch) (crypto.RandomSeed, error) {
-	return s.sampler.Sample(s.ctx, s.head, epoch)
+func (h *headRandomness) Randomness(ctx context.Context, tag crypto.DomainSeparationTag, epoch abi.ChainEpoch, entropy []byte) (abi.Randomness, error) {
+	return h.chain.SampleChainRandomness(ctx, h.head, tag, epoch, entropy)
 }

--- a/internal/pkg/consensus/testing.go
+++ b/internal/pkg/consensus/testing.go
@@ -5,9 +5,9 @@ import (
 	"encoding/binary"
 	"testing"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
-
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	acrypto "github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 
@@ -360,9 +360,9 @@ func (mem *MockElectionMachine) VerifyPoStRandomness(rand block.VRFPi, ticket bl
 ///// Sampler /////
 
 type FakeSampler struct {
-	Value crypto.RandomSeed
+	Value abi.Randomness
 }
 
-func (s *FakeSampler) Sample(_ context.Context, _ block.TipSetKey, _ abi.ChainEpoch) (crypto.RandomSeed, error) {
+func (s *FakeSampler) SampleChainRandomness(_ context.Context, _ block.TipSetKey, _ acrypto.DomainSeparationTag, _ abi.ChainEpoch, _ []byte) (abi.Randomness, error) {
 	return s.Value, nil
 }

--- a/internal/pkg/crypto/randomness.go
+++ b/internal/pkg/crypto/randomness.go
@@ -35,6 +35,8 @@ func (g *GenesisSampler) Sample(_ context.Context, epoch abi.ChainEpoch) (Random
 
 // Computes a random seed from raw ticket bytes and the epoch from which the ticket was requested
 // (which may not match the epoch it actually came from).
+// A randomness seed is the black2b hash of the VRF digest of the minimum ticket of the tipset at or before
+// the requested epoch, concatenated with the big endian bytes of the epoch value.
 func MakeRandomSeed(rawTicket []byte, epoch abi.ChainEpoch) (RandomSeed, error) {
 	buf := bytes.Buffer{}
 	vrfDigest := blake2b.Sum256(rawTicket)

--- a/internal/pkg/sampling/chain_randomness.go
+++ b/internal/pkg/sampling/chain_randomness.go
@@ -1,7 +1,6 @@
 package sampling
 
 import (
-	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
@@ -29,47 +28,4 @@ func SampleNthTicket(n int, tipSetsDescending []block.TipSet) (block.Ticket, err
 	}
 
 	return tipSetsDescending[n].MinTicket()
-}
-
-// SampleChainRandomness produces a slice of bytes (a ticket) sampled from the highest tipset with
-// height less than or equal to `sampleHeight`.
-// The tipset slice must be sorted by descending block height.
-func SampleChainRandomness(sampleHeight abi.ChainEpoch, tipSetsDescending []block.TipSet) ([]byte, error) {
-	if sampleHeight < 0 {
-		return nil, errors.Errorf("can't sample chain at negative height %d", sampleHeight)
-	}
-	if len(tipSetsDescending) == 0 {
-		return nil, errors.New("can't sample empty chain segment")
-	}
-	// Find the first (highest) tipset with height less than or equal to sampleHeight.
-	// This is more complex than necessary: https://github.com/filecoin-project/go-filecoin/issues/3025
-	sampleIndex := -1
-	for i, tip := range tipSetsDescending {
-		height, err := tip.Height()
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed sampling chain segment")
-		}
-
-		if height <= sampleHeight {
-			sampleIndex = i
-			break
-		}
-	}
-
-	// Produce an error if the slice does not include any tipsets at least as low as `sampleHeight`.
-	if sampleIndex == -1 {
-		lastIdx := len(tipSetsDescending) - 1
-		lowestAvailableHeight, err := tipSetsDescending[lastIdx].Height()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to read chain segment height")
-		}
-
-		return nil, errors.Errorf("sample height %d out of range %d...", sampleHeight, lowestAvailableHeight)
-	}
-
-	ticket, err := tipSetsDescending[sampleIndex].MinTicket()
-	if err != nil {
-		return nil, err
-	}
-	return ticket.SortKey(), nil
 }

--- a/internal/pkg/sampling/chain_randomness_test.go
+++ b/internal/pkg/sampling/chain_randomness_test.go
@@ -5,86 +5,12 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/sampling"
-	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 )
-
-func TestSamplingChainRandomness(t *testing.T) {
-	tf.UnitTest(t)
-
-	t.Run("happy path", func(t *testing.T) {
-		_, ch := makeChain(t, 21)
-		r, err := sampling.SampleChainRandomness(abi.ChainEpoch(uint64(20)), ch)
-		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(20)), r)
-
-		r, err = sampling.SampleChainRandomness(abi.ChainEpoch(uint64(3)), ch)
-		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(3)), r)
-
-		r, err = sampling.SampleChainRandomness(abi.ChainEpoch(uint64(0)), ch)
-		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(0)), r)
-	})
-
-	t.Run("skips missing tipsets", func(t *testing.T) {
-		builder, ch := makeChain(t, 21)
-
-		// Sample height after the head falls back to the head
-		r, err := sampling.SampleChainRandomness(abi.ChainEpoch(uint64(25)), ch)
-		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(20)), r)
-
-		// Add new head so as to produce null blocks between 20 and 25
-		// i.e.: 25 20 19 18 ... 0
-		headAfterNulls := builder.BuildOneOn(ch[0], func(b *chain.BlockBuilder) {
-			b.IncHeight(4)
-			b.SetTicket([]byte(strconv.Itoa(25)))
-		})
-		ch = append([]block.TipSet{headAfterNulls}, ch...)
-
-		// Sampling in the nulls falls back to the last non-null
-		r, err = sampling.SampleChainRandomness(abi.ChainEpoch(uint64(24)), ch)
-		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(20)), r)
-
-		// When sampling immediately after the nulls, the look-back skips the nulls (not counting them).
-		r, err = sampling.SampleChainRandomness(abi.ChainEpoch(uint64(25)), ch)
-		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(25)), r)
-	})
-
-	t.Run("fails when chain insufficient", func(t *testing.T) {
-		// Chain: 20, 19, 18, 17, 16
-		// The final tipset is not of height zero (genesis)
-		_, ch := makeChain(t, 21)
-		ch = ch[:5]
-
-		// Sample is out of range
-		_, err := sampling.SampleChainRandomness(abi.ChainEpoch(uint64(15)), ch)
-		assert.Error(t, err)
-
-		// Ok when the chain is just sufficiently long.
-		r, err := sampling.SampleChainRandomness(abi.ChainEpoch(uint64(16)), ch)
-		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(16)), r)
-	})
-
-	t.Run("falls back to genesis block", func(t *testing.T) {
-		_, ch := makeChain(t, 6)
-
-		// Sample height can be zero.
-		r, err := sampling.SampleChainRandomness(abi.ChainEpoch(uint64(0)), ch)
-		assert.NoError(t, err)
-		assert.Equal(t, []byte(strconv.Itoa(0)), r)
-	})
-}
 
 func TestSampleNthTicket(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {

--- a/internal/pkg/vm/internal/vmcontext/runtime_adapter.go
+++ b/internal/pkg/vm/internal/vmcontext/runtime_adapter.go
@@ -71,7 +71,7 @@ func (a *runtimeAdapter) GetActorCodeCID(addr address.Address) (ret cid.Cid, ok 
 
 // GetRandomness implements Runtime.
 func (a *runtimeAdapter) GetRandomness(tag crypto.DomainSeparationTag, epoch abi.ChainEpoch, entropy []byte) abi.Randomness {
-	randomness, err := a.ctx.randSource.Randomness(tag, epoch, entropy)
+	randomness, err := a.ctx.randSource.Randomness(a.Context(), tag, epoch, entropy)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/gengen/util/gengen.go
+++ b/tools/gengen/util/gengen.go
@@ -120,13 +120,12 @@ func GenGen(ctx context.Context, cfg *GenesisCfg, cst cbor.IpldStore, bs blockst
 	if err != nil {
 		return nil, err
 	}
-
 	st := state.NewTree(cst)
 	store := vm.NewStorage(bs)
 	vm := vm.NewVM(st, &store).(consensus.GenesisVM)
-	rnd := crypto.GenesisRandomnessSource{}
+	rnd := crypto.ChainRandomnessSource{Sampler: &crypto.GenesisSampler{TicketBytes: consensus.GenesisTicket.VRFProof}}
 
-	if err := consensus.SetupDefaultActors(ctx, vm, &store, st, cfg.ProofsMode, cfg.Network); err != nil {
+	if err := consensus.SetupDefaultActors(ctx, vm, &store, st, &rnd, cfg.Network); err != nil {
 		return nil, err
 	}
 
@@ -169,7 +168,7 @@ func GenGen(ctx context.Context, cfg *GenesisCfg, cst cbor.IpldStore, bs blockst
 			Type: crypto.SigTypeBLS,
 			Data: emptyBLSSignature[:],
 		},
-		Ticket:    block.Ticket{VRFProof: []byte{0xec}},
+		Ticket:    consensus.GenesisTicket,
 		Timestamp: cfg.Time,
 	}
 


### PR DESCRIPTION
### Motivation
The new specced randomness generation routines should replace our prior chain sampling mechanisms.

### Proposed changes
Replace all uses of `sampling/SampleChainRandomness` with new randomness. Along the way changed the interface to randomness consumed by the processor to enable sharing implementation.

Note that the election ticket generation is done differently and still needs to be reconciled with this approach.