### PR TITLE
Move VRFPi type from block to crypto package

### DIFF
--- a/internal/pkg/block/epost_info.go
+++ b/internal/pkg/block/epost_info.go
@@ -36,11 +36,11 @@ func NewEPoStCandidate(sID uint64, pt []byte, sci int64) EPoStCandidate {
 }
 
 // NewEPoStInfo constructs an epost info from data
-func NewEPoStInfo(proofs []EPoStProof, rand []byte, winners ...EPoStCandidate) EPoStInfo {
+func NewEPoStInfo(proofs []EPoStProof, rand abi.PoStRandomness, winners ...EPoStCandidate) EPoStInfo {
 	return EPoStInfo{
 		Winners:        winners,
 		PoStProofs:     proofs,
-		PoStRandomness: abi.PoStRandomness(rand),
+		PoStRandomness: rand,
 	}
 }
 

--- a/internal/pkg/block/ticket.go
+++ b/internal/pkg/block/ticket.go
@@ -3,7 +3,7 @@ package block
 import (
 	"fmt"
 
-	"github.com/minio/blake2b-simd"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 )
 
 // A Ticket is a marker of a tick of the blockchain's clock.  It is the source
@@ -12,7 +12,7 @@ import (
 type Ticket struct {
 	_ struct{} `cbor:",toarray"`
 	// A proof output by running a VRF on the VRFProof of the parent ticket
-	VRFProof VRFPi
+	VRFProof crypto.VRFPi
 }
 
 // SortKey returns the canonical byte ordering of the ticket
@@ -23,13 +23,4 @@ func (t Ticket) SortKey() []byte {
 // String returns the string representation of the VRFProof of the ticket
 func (t Ticket) String() string {
 	return fmt.Sprintf("%x", t.VRFProof)
-}
-
-// VRFPi is the proof output from running a VRF.
-type VRFPi []byte
-
-// Digest returns the digest (hash) of a proof, for use generating challenges etc.
-func (p VRFPi) Digest() [32]byte {
-	proofDigest := blake2b.Sum256(p)
-	return proofDigest
 }

--- a/internal/pkg/chain/sampler_test.go
+++ b/internal/pkg/chain/sampler_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/minio/blake2b-simd"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
@@ -26,7 +25,7 @@ func TestSamplingChainRandomness(t *testing.T) {
 		if sampleEpoch >= 0 {
 			vrfProof = []byte(strconv.Itoa(sampleEpoch))
 		}
-		vrfDigest := blake2b.Sum256(vrfProof)
+		vrfDigest := vrfProof.Digest()
 		return vrfDigest[:]
 	}
 

--- a/internal/pkg/chain/testing.go
+++ b/internal/pkg/chain/testing.go
@@ -194,7 +194,7 @@ func (f *Builder) Build(parent block.TipSet, width int, build func(b *BlockBuild
 	}
 	for i := 0; i < width; i++ {
 		ticket := block.Ticket{}
-		ticket.VRFProof = block.VRFPi(make([]byte, binary.Size(f.seq)))
+		ticket.VRFProof = make([]byte, binary.Size(f.seq))
 		binary.BigEndian.PutUint64(ticket.VRFProof, f.seq)
 		f.seq++
 
@@ -301,7 +301,7 @@ type BlockBuilder struct {
 
 // SetTicket sets the block's ticket.
 func (bb *BlockBuilder) SetTicket(raw []byte) {
-	bb.block.Ticket = block.Ticket{VRFProof: block.VRFPi(raw)}
+	bb.block.Ticket = block.Ticket{VRFProof: crypto.VRFPi(raw)}
 }
 
 // SetTimestamp sets the block's timestamp.

--- a/internal/pkg/chainsync/fetcher/graphsync_helpers_test.go
+++ b/internal/pkg/chainsync/fetcher/graphsync_helpers_test.go
@@ -368,7 +368,7 @@ func simpleBlock() *block.Block {
 func requireSimpleValidBlock(t *testing.T, nonce uint64, miner address.Address) *block.Block {
 	b := simpleBlock()
 	ticket := block.Ticket{}
-	ticket.VRFProof = block.VRFPi(make([]byte, binary.Size(nonce)))
+	ticket.VRFProof = make([]byte, binary.Size(nonce))
 	binary.BigEndian.PutUint64(ticket.VRFProof, nonce)
 	b.Ticket = ticket
 	bytes, err := cbor.DumpObject("null")

--- a/internal/pkg/consensus/election.go
+++ b/internal/pkg/consensus/election.go
@@ -29,7 +29,7 @@ func NewElectionMachine(chain ChainRandomness) *ElectionMachine {
 
 // GenerateEPoStVrfProof computes the Election PoSt challenge seed for a target epoch after a base tipset.
 func (em ElectionMachine) GenerateEPoStVrfProof(ctx context.Context, base block.TipSetKey,
-	epoch abi.ChainEpoch, miner address.Address, worker address.Address, signer types.Signer) (block.VRFPi, error) {
+	epoch abi.ChainEpoch, miner address.Address, worker address.Address, signer types.Signer) (crypto.VRFPi, error) {
 	return sampleChainAndComputeVrf(ctx, em.chain, base, epoch, acrypto.DomainSeparationTag_ElectionPoStChallengeSeed, miner, signer, worker)
 }
 
@@ -56,8 +56,7 @@ func (em ElectionMachine) GenerateEPoSt(allSectorInfos []abi.SectorInfo, challen
 
 // VerifyEPoStVrfProof verifies that the PoSt randomness is the result of the
 // candidate signing the ticket.
-func (em ElectionMachine) VerifyEPoStVrfProof(ctx context.Context, base block.TipSetKey,
-	epoch abi.ChainEpoch, miner address.Address, worker address.Address, vrfProof block.VRFPi) error {
+func (em ElectionMachine) VerifyEPoStVrfProof(ctx context.Context, base block.TipSetKey, epoch abi.ChainEpoch, miner address.Address, worker address.Address, vrfProof abi.PoStRandomness) error {
 	entropy, err := encoding.Encode(miner)
 	if err != nil {
 		return errors.Wrapf(err, "failed to encode entropy")
@@ -177,7 +176,7 @@ func (tm TicketMachine) IsValidTicket(ctx context.Context, base block.TipSetKey,
 }
 
 func sampleChainAndComputeVrf(ctx context.Context, chain ChainRandomness, base block.TipSetKey, epoch abi.ChainEpoch, tag acrypto.DomainSeparationTag,
-	miner address.Address, signer types.Signer, worker address.Address) (block.VRFPi, error) {
+	miner address.Address, signer types.Signer, worker address.Address) (crypto.VRFPi, error) {
 	entropy, err := encoding.Encode(miner)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to encode entropy")

--- a/internal/pkg/crypto/randomness.go
+++ b/internal/pkg/crypto/randomness.go
@@ -23,7 +23,7 @@ type ChainSampler interface {
 // A sampler for use when computing genesis state (the state that the genesis block points to as parent state).
 // There is no chain to sample a seed from.
 type GenesisSampler struct {
-	VRFProof []byte
+	VRFProof VRFPi
 }
 
 func (g *GenesisSampler) Sample(_ context.Context, epoch abi.ChainEpoch) (RandomSeed, error) {
@@ -35,8 +35,8 @@ func (g *GenesisSampler) Sample(_ context.Context, epoch abi.ChainEpoch) (Random
 
 // Computes a random seed from raw ticket bytes.
 // A randomness seed is the VRF digest of the minimum ticket of the tipset at or before the requested epoch
-func MakeRandomSeed(rawVRFProof []byte) (RandomSeed, error) {
-	digest := blake2b.Sum256(rawVRFProof)
+func MakeRandomSeed(rawVRFProof VRFPi) (RandomSeed, error) {
+	digest := rawVRFProof.Digest()
 	return digest[:], nil
 }
 

--- a/internal/pkg/crypto/vrf.go
+++ b/internal/pkg/crypto/vrf.go
@@ -1,0 +1,12 @@
+package crypto
+
+import "github.com/minio/blake2b-simd"
+
+// VRFPi is the proof output from running a VRF.
+type VRFPi []byte
+
+// Digest returns the digest (hash) of a proof, for use generating challenges etc.
+func (p VRFPi) Digest() [32]byte {
+	proofDigest := blake2b.Sum256(p)
+	return proofDigest
+}

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -20,6 +20,7 @@ import (
 
 	bls "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vmsupport"
 
@@ -253,7 +254,7 @@ func sharedSetup(t *testing.T, mockSigner types.MockSigner) (
 }
 
 func makeExpectedEPoStVRFProof(ctx context.Context, t *testing.T, rnd *consensus.FakeChainRandomness, mockSigner *types.MockSigner,
-	head block.TipSet, lookback abi.ChainEpoch, minerAddr address.Address, minerOwnerAddr address.Address) block.VRFPi {
+	head block.TipSet, lookback abi.ChainEpoch, minerAddr address.Address, minerOwnerAddr address.Address) crypto.VRFPi {
 	height, err := head.Height()
 	require.NoError(t, err)
 	entropy, err := encoding.Encode(minerAddr)


### PR DESCRIPTION
### Motivation
Moving the type here allows using it for better safety in the crypto randomness methods.

Note: we can probably move types.signer here too later.