### PR TITLE
Rename EPoStInfo.PoStRandomness to VRFProof

### DIFF
--- a/internal/pkg/block/block_test.go
+++ b/internal/pkg/block/block_test.go
@@ -395,10 +395,10 @@ func TestSignatureData(t *testing.T) {
 	func() {
 		before := b.SignatureData()
 
-		cpy := b.EPoStInfo.PoStRandomness
-		defer func() { b.EPoStInfo.PoStRandomness = cpy }()
+		cpy := b.EPoStInfo.VRFProof
+		defer func() { b.EPoStInfo.VRFProof = cpy }()
 
-		b.EPoStInfo.PoStRandomness = diff.EPoStInfo.PoStRandomness
+		b.EPoStInfo.VRFProof = diff.EPoStInfo.VRFProof
 		after := b.SignatureData()
 		assert.False(t, bytes.Equal(before, after))
 	}()

--- a/internal/pkg/block/epost_info.go
+++ b/internal/pkg/block/epost_info.go
@@ -6,10 +6,10 @@ import (
 
 // EPoStInfo wraps all data needed to verify an election post proof
 type EPoStInfo struct {
-	_              struct{} `cbor:",toarray"`
-	PoStProofs     []EPoStProof
-	PoStRandomness abi.PoStRandomness
-	Winners        []EPoStCandidate
+	_          struct{} `cbor:",toarray"`
+	PoStProofs []EPoStProof
+	VRFProof   abi.PoStRandomness
+	Winners    []EPoStCandidate
 }
 
 // EPoStCandidate wraps the input data needed to verify an election PoSt
@@ -38,9 +38,9 @@ func NewEPoStCandidate(sID uint64, pt []byte, sci int64) EPoStCandidate {
 // NewEPoStInfo constructs an epost info from data
 func NewEPoStInfo(proofs []EPoStProof, rand abi.PoStRandomness, winners ...EPoStCandidate) EPoStInfo {
 	return EPoStInfo{
-		Winners:        winners,
-		PoStProofs:     proofs,
-		PoStRandomness: rand,
+		PoStProofs: proofs,
+		VRFProof:   rand,
+		Winners:    winners,
 	}
 }
 

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -216,7 +216,7 @@ func (c *Expected) validateMining(ctx context.Context,
 		}
 
 		// Verify EPoSt VRF proof ("PoSt randomness")
-		if err := c.VerifyEPoStVrfProof(ctx, blk.Parents, blk.Height, blk.Miner, workerSignerAddr, blk.EPoStInfo.PoStRandomness); err != nil {
+		if err := c.VerifyEPoStVrfProof(ctx, blk.Parents, blk.Height, blk.Miner, workerSignerAddr, blk.EPoStInfo.VRFProof); err != nil {
 			return errors.Wrapf(err, "failed to verify EPoSt VRF proof (PoSt randomness) in block %s", blk.Cid())
 		}
 
@@ -257,7 +257,7 @@ func (c *Expected) validateMining(ctx context.Context,
 		if err != nil {
 			return errors.Wrapf(err, "failed to read sector infos from power table")
 		}
-		vrfDigest := crypto.VRFPi(blk.EPoStInfo.PoStRandomness).Digest()
+		vrfDigest := crypto.VRFPi(blk.EPoStInfo.VRFProof).Digest()
 		valid, err := c.VerifyPoSt(c.postVerifier, allSectorInfos, vrfDigest[:],
 			blk.EPoStInfo.PoStProofs, blk.EPoStInfo.Winners, blk.Miner)
 		if err != nil {

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -97,7 +97,7 @@ func TestLookbackElection(t *testing.T) {
 		assert.NoError(t, r.Err)
 
 		expectedVrfProof := makeExpectedEPoStVRFProof(ctx, t, rnd, mockSigner, head, miner.PoStLookback, minerAddr, minerOwnerAddr)
-		assert.Equal(t, expectedVrfProof, r.NewBlock.EPoStInfo.PoStRandomness)
+		assert.Equal(t, expectedVrfProof, r.NewBlock.EPoStInfo.VRFProof)
 
 		expectedTicket := makeExpectedTicket(ctx, t, rnd, mockSigner, head, miner.PoStLookback, minerAddr, minerOwnerAddr)
 		assert.Equal(t, expectedTicket, r.NewBlock.Ticket)
@@ -156,7 +156,7 @@ func Test_Mine(t *testing.T) {
 		assert.NoError(t, r.Err)
 
 		expectedVrfProof := makeExpectedEPoStVRFProof(ctx, t, rnd, mockSigner, tipSet, miner.PoStLookback, minerAddr, minerOwnerAddr)
-		assert.Equal(t, expectedVrfProof, r.NewBlock.EPoStInfo.PoStRandomness)
+		assert.Equal(t, expectedVrfProof, r.NewBlock.EPoStInfo.VRFProof)
 
 		expectedTicket := makeExpectedTicket(ctx, t, rnd, mockSigner, tipSet, miner.PoStLookback, minerAddr, minerOwnerAddr)
 		assert.Equal(t, expectedTicket, r.NewBlock.Ticket)

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -31,8 +31,8 @@ func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, sta
 		Data: (*bls.Aggregate([]bls.Signature{}))[:],
 	}
 	winner := block.NewEPoStCandidate(0, []byte{0xe}, 0)
-	postRandomness := []byte{0xff}
-	postInfo := block.NewEPoStInfo(electionProof, postRandomness, winner)
+	vrfProof := []byte{0xff}
+	postInfo := block.NewEPoStInfo(electionProof, vrfProof, winner)
 
 	b := &block.Block{
 		Miner:           minerAddr,


### PR DESCRIPTION
This is slightly less confusing.

This changes the JSON representation, but I'm not too concerned about that right now. Lotus has different names anyway.