### PR TITLE
Add interface for external injection of VM syscall implementations

### DIFF
--- a/internal/app/go-filecoin/internal/submodule/chain_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/chain_submodule.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
 	appstate "github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vmsupport"
 )
 
 // ChainSubmodule enhances the `Node` with chain capabilities.
@@ -59,7 +60,8 @@ func NewChainSubmodule(config chainConfig, repo chainRepo, blockstore *Blockstor
 	actorState := appstate.NewTipSetStateViewer(chainStore, blockstore.CborStore)
 	messageStore := chain.NewMessageStore(blockstore.Blockstore)
 	chainState := cst.NewChainStateReadWriter(chainStore, messageStore, blockstore.Blockstore, builtin.DefaultActors)
-	processor := consensus.NewDefaultProcessor(chainState)
+	syscalls := vmsupport.NewSyscalls()
+	processor := consensus.NewDefaultProcessor(syscalls, chainState)
 
 	return ChainSubmodule{
 		ChainReader:  chainStore,

--- a/internal/pkg/consensus/expected_test.go
+++ b/internal/pkg/consensus/expected_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vmsupport"
 )
 
 // TestExpected_RunStateTransition_validateMining is concerned only with validateMining behavior.
@@ -73,7 +74,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
 		views := consensus.AsPowerStateViewer(appstate.NewViewer(cistore))
-		exp := consensus.NewExpected(cistore, bstore, consensus.NewDefaultProcessor(&consensus.FakeChainRandomness{}), &views, th.BlockTimeTest,
+		exp := consensus.NewExpected(cistore, bstore, consensus.NewDefaultProcessor(&vmsupport.FakeSyscalls{}, &consensus.FakeChainRandomness{}), &views, th.BlockTimeTest,
 			&consensus.FailingElectionValidator{}, &consensus.FakeTicketMachine{}, &proofs.ElectionPoster{})
 
 		nextBlocks := requireMakeNBlocks(t, 3, pTipSet, genesisBlock.StateRoot.Cid, types.EmptyReceiptsCID, miners, minerToWorker, mockSigner)

--- a/internal/pkg/consensus/genesis.go
+++ b/internal/pkg/consensus/genesis.go
@@ -31,6 +31,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vmsupport"
 )
 
 // GenesisInitFunc is the signature for function that is used to create a genesis block.
@@ -182,7 +183,7 @@ func MakeGenesisFunc(opts ...GenOption) GenesisInitFunc {
 		ctx := context.Background()
 		st := state.NewState(cst)
 		store := vm.NewStorage(bs)
-		vm := vm.NewVM(st, &store).(GenesisVM)
+		vm := vm.NewVM(st, &store, vmsupport.NewSyscalls()).(GenesisVM)
 		rnd := crypto.ChainRandomnessSource{Sampler: &crypto.GenesisSampler{VRFProof: GenesisTicket.VRFProof}}
 
 		genCfg := NewEmptyConfig()

--- a/internal/pkg/consensus/processor.go
+++ b/internal/pkg/consensus/processor.go
@@ -34,25 +34,24 @@ type ChainRandomness interface {
 
 // DefaultProcessor handles all block processing.
 type DefaultProcessor struct {
-	actors vm.ActorCodeLoader
-	rnd    ChainRandomness
+	actors   vm.ActorCodeLoader
+	syscalls vm.SyscallsImpl
+	rnd      ChainRandomness
 }
 
 var _ Processor = (*DefaultProcessor)(nil)
 
 // NewDefaultProcessor creates a default processor from the given state tree and vms.
-func NewDefaultProcessor(rnd ChainRandomness) *DefaultProcessor {
-	return &DefaultProcessor{
-		actors: vm.DefaultActors,
-		rnd:    rnd,
-	}
+func NewDefaultProcessor(syscalls vm.SyscallsImpl, rnd ChainRandomness) *DefaultProcessor {
+	return NewConfiguredProcessor(vm.DefaultActors, syscalls, rnd)
 }
 
 // NewConfiguredProcessor creates a default processor with custom validation and rewards.
-func NewConfiguredProcessor(actors vm.ActorCodeLoader, rnd ChainRandomness) *DefaultProcessor {
+func NewConfiguredProcessor(actors vm.ActorCodeLoader, syscalls vm.SyscallsImpl, rnd ChainRandomness) *DefaultProcessor {
 	return &DefaultProcessor{
-		actors: actors,
-		rnd:    rnd,
+		actors:   actors,
+		syscalls: syscalls,
+		rnd:      rnd,
 	}
 }
 
@@ -76,7 +75,7 @@ func (p *DefaultProcessor) ProcessTipSet(ctx context.Context, st state.Tree, vms
 		chain: p.rnd,
 		head:  parent,
 	}
-	v := vm.NewVM(st, &vms)
+	v := vm.NewVM(st, &vms, p.syscalls)
 
 	return v.ApplyTipSetMessages(msgs, epoch, &rnd)
 }

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -21,6 +21,7 @@ import (
 	bls "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vmsupport"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -529,6 +530,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		return st, nil
 	}
 	rnd := &consensus.FakeChainRandomness{Seed: 0}
+	syscalls := &vmsupport.FakeSyscalls{}
 	messages := chain.NewMessageStore(bs)
 
 	worker := mining.NewDefaultWorker(mining.WorkerParameters{
@@ -545,7 +547,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		TicketGen:      &consensus.FakeTicketMachine{},
 
 		MessageSource: pool,
-		Processor:     consensus.NewDefaultProcessor(rnd),
+		Processor:     consensus.NewDefaultProcessor(syscalls, rnd),
 		Blockstore:    bs,
 		MessageStore:  messages,
 		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
@@ -630,6 +632,7 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 		return st, nil
 	}
 	rnd := &consensus.FakeChainRandomness{Seed: 0}
+	syscalls := &vmsupport.FakeSyscalls{}
 	minerAddr := addrs[3]
 	th.RequireInitAccountActor(ctx, t, st, vm.NewStorage(bs), addrs[4], types.ZeroAttoFIL)
 	minerOwnerAddr := addrs[4]
@@ -650,7 +653,7 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 		TicketGen:      &consensus.FakeTicketMachine{},
 
 		MessageSource: pool,
-		Processor:     consensus.NewDefaultProcessor(rnd),
+		Processor:     consensus.NewDefaultProcessor(syscalls, rnd),
 		Blockstore:    bs,
 		MessageStore:  messages,
 		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
@@ -694,6 +697,7 @@ func TestGenerateWithoutMessages(t *testing.T) {
 		return st, nil
 	}
 	rnd := &consensus.FakeChainRandomness{Seed: 0}
+	syscalls := &vmsupport.FakeSyscalls{}
 	messages := chain.NewMessageStore(bs)
 
 	worker := mining.NewDefaultWorker(mining.WorkerParameters{
@@ -710,7 +714,7 @@ func TestGenerateWithoutMessages(t *testing.T) {
 		TicketGen:      &consensus.FakeTicketMachine{},
 
 		MessageSource: pool,
-		Processor:     consensus.NewDefaultProcessor(rnd),
+		Processor:     consensus.NewDefaultProcessor(syscalls, rnd),
 		Blockstore:    bs,
 		MessageStore:  messages,
 		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
@@ -749,6 +753,7 @@ func TestGenerateError(t *testing.T) {
 		return st, nil
 	}
 	rnd := &consensus.FakeChainRandomness{Seed: 0}
+	syscalls := &vmsupport.FakeSyscalls{}
 	messages := chain.NewMessageStore(bs)
 	worker := mining.NewDefaultWorker(mining.WorkerParameters{
 		API: th.NewDefaultFakeWorkerPorcelainAPI(blockSignerAddr, rnd),
@@ -764,7 +769,7 @@ func TestGenerateError(t *testing.T) {
 		TicketGen:      &consensus.FakeTicketMachine{},
 
 		MessageSource: pool,
-		Processor:     consensus.NewDefaultProcessor(rnd),
+		Processor:     consensus.NewDefaultProcessor(syscalls, rnd),
 		Blockstore:    bs,
 		MessageStore:  messages,
 		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vmsupport"
 )
 
 // RequireSignedTestBlockFromTipSet creates a block with a valid signature by
@@ -123,7 +124,7 @@ func (mbv *StubBlockValidator) StubSemanticValidationForBlock(child *block.Block
 
 // NewFakeProcessor creates a processor with a test validator and test rewarder
 func NewFakeProcessor() *consensus.DefaultProcessor {
-	return consensus.NewConfiguredProcessor(vm.DefaultActors, &consensus.FakeChainRandomness{})
+	return consensus.NewConfiguredProcessor(vm.DefaultActors, &vmsupport.FakeSyscalls{}, &consensus.FakeChainRandomness{})
 }
 
 // ApplyTestMessage sends a message directly to the vm, bypassing message
@@ -139,7 +140,7 @@ func ApplyTestMessageWithActors(actors vm.ActorCodeLoader, st state.Tree, store 
 
 // ApplyTestMessageWithGas uses the FakeBlockRewarder but the default SignedMessageValidator
 func ApplyTestMessageWithGas(actors vm.ActorCodeLoader, st state.Tree, store vm.Storage, msg *types.UnsignedMessage, bh abi.ChainEpoch, minerOwner address.Address) (*consensus.ApplicationResult, error) {
-	applier := consensus.NewConfiguredProcessor(actors, &consensus.FakeChainRandomness{})
+	applier := consensus.NewConfiguredProcessor(actors, &vmsupport.FakeSyscalls{}, &consensus.FakeChainRandomness{})
 	return newMessageApplier(msg, applier, st, store, bh, minerOwner, nil)
 }
 
@@ -192,5 +193,5 @@ func applyTestMessageWithAncestors(actors vm.ActorCodeLoader, st state.Tree, sto
 }
 
 func newTestApplier(actors vm.ActorCodeLoader) *consensus.DefaultProcessor {
-	return consensus.NewConfiguredProcessor(actors, &consensus.FakeChainRandomness{})
+	return consensus.NewConfiguredProcessor(actors, &vmsupport.FakeSyscalls{}, &consensus.FakeChainRandomness{})
 }

--- a/internal/pkg/vm/internal/vmcontext/runtime_adapter.go
+++ b/internal/pkg/vm/internal/vmcontext/runtime_adapter.go
@@ -120,9 +120,14 @@ func (a *runtimeAdapter) DeleteActor() {
 	a.ctx.DeleteActor()
 }
 
-// Syscalls implements Runtime.
+// SyscallsImpl implements Runtime.
 func (a *runtimeAdapter) Syscalls() specsruntime.Syscalls {
-	return &syscalls{gasTank: a.ctx.gasTank}
+	return &syscalls{
+		impl:      a.ctx.rt.syscalls,
+		gasTank:   a.ctx.gasTank,
+		pricelist: a.ctx.rt.pricelist,
+		epoch:     a.ctx.Runtime().CurrentEpoch(),
+	}
 }
 
 // Context implements Runtime.

--- a/internal/pkg/vm/internal/vmcontext/syscalls.go
+++ b/internal/pkg/vm/internal/vmcontext/syscalls.go
@@ -2,62 +2,60 @@ package vmcontext
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/gascost"
 	"github.com/filecoin-project/specs-actors/actors/abi"
-	specscrypto "github.com/filecoin-project/specs-actors/actors/crypto"
 	specsruntime "github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/ipfs/go-cid"
-	"github.com/minio/blake2b-simd"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/gascost"
 )
 
+// Syscall implementation interface.
+// These methods take the chain epoch and other context that is implicit in the runtime as explicit parameters.
+type SyscallsImpl interface {
+	VerifySignature(epoch abi.ChainEpoch, signature crypto.Signature, signer address.Address, plaintext []byte) error
+	HashBlake2b(data []byte) [32]byte
+	ComputeUnsealedSectorCID(proof abi.RegisteredProof, pieces []abi.PieceInfo) (cid.Cid, error)
+	VerifySeal(epoch abi.ChainEpoch, info abi.SealVerifyInfo) error
+	VerifyPoSt(epoch abi.ChainEpoch, info abi.PoStVerifyInfo) error
+	VerifyConsensusFault(epoch abi.ChainEpoch, h1, h2 []byte) error
+}
+
 type syscalls struct {
+	impl      SyscallsImpl
 	gasTank   *GasTracker
 	pricelist gascost.Pricelist
+	epoch     abi.ChainEpoch
 }
 
 var _ specsruntime.Syscalls = (*syscalls)(nil)
 
-// VerifySignature implements Syscalls.
-func (sys syscalls) VerifySignature(signature specscrypto.Signature, signer address.Address, plaintext []byte) error {
-	// Dragons: this lets all id addresses off the hook -- we need to remove this
-	// once market actor code actually checks proposal signature.  Depending on how
-	// that works we may want to do id address to pubkey address lookup here or we
-	// might defer that to VM
-	if signer.Protocol() == address.ID {
-		return nil
-	}
+func (sys syscalls) VerifySignature(signature crypto.Signature, signer address.Address, plaintext []byte) error {
 	sys.gasTank.Charge(sys.pricelist.OnVerifySignature(signature.Type, len(plaintext)))
-	return crypto.ValidateSignature(plaintext, signer, signature)
+	return sys.impl.VerifySignature(sys.epoch, signature, signer, plaintext)
 }
 
-// HashBlake2b implements Syscalls.
 func (sys syscalls) HashBlake2b(data []byte) [32]byte {
 	sys.gasTank.Charge(sys.pricelist.OnHashing(len(data)))
-	return blake2b.Sum256(data)
+	return sys.impl.HashBlake2b(data)
 }
 
-// ComputeUnsealedSectorCID implements Syscalls.
-// Review: why is this returning an error instead of aborting? is this failing recoverable by actors?
 func (sys syscalls) ComputeUnsealedSectorCID(proof abi.RegisteredProof, pieces []abi.PieceInfo) (cid.Cid, error) {
 	sys.gasTank.Charge(sys.pricelist.OnComputeUnsealedSectorCid(proof, &pieces))
-	panic("TODO")
+	return sys.impl.ComputeUnsealedSectorCID(proof, pieces)
 }
 
-// VerifySeal implements Syscalls.
 func (sys syscalls) VerifySeal(info abi.SealVerifyInfo) error {
 	sys.gasTank.Charge(sys.pricelist.OnVerifySeal(info))
-	panic("TODO")
+	return sys.impl.VerifySeal(sys.epoch, info)
 }
 
-// VerifyPoSt implements Syscalls.
 func (sys syscalls) VerifyPoSt(info abi.PoStVerifyInfo) error {
 	sys.gasTank.Charge(sys.pricelist.OnVerifyPost(info))
-	panic("TODO")
+	return sys.impl.VerifyPoSt(sys.epoch, info)
 }
 
-// VerifyConsensusFault implements Syscalls.
 func (sys syscalls) VerifyConsensusFault(h1, h2 []byte) error {
 	sys.gasTank.Charge(sys.pricelist.OnVerifyConsensusFault())
-	panic("TODO")
+	return sys.impl.VerifyConsensusFault(sys.epoch, h1, h2)
 }

--- a/internal/pkg/vm/internal/vmcontext/testing.go
+++ b/internal/pkg/vm/internal/vmcontext/testing.go
@@ -5,14 +5,10 @@ import (
 	"fmt"
 	"math/rand"
 
+	vtypes "github.com/filecoin-project/chain-validation/chain/types"
+	vstate "github.com/filecoin-project/chain-validation/state"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-crypto"
-	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-datastore"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
-
-	ffi "github.com/filecoin-project/filecoin-ffi"
-
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
@@ -20,10 +16,11 @@ import (
 	acrypto "github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
 
-	vtypes "github.com/filecoin-project/chain-validation/chain/types"
-	vstate "github.com/filecoin-project/chain-validation/state"
-
+	ffi "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/cborutil"
 	gfcrypto "github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/enccid"
@@ -34,6 +31,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/interpreter"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/storage"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vmsupport"
 )
 
 var _ vstate.Factories = &Factories{}
@@ -108,7 +106,7 @@ func NewState() *ValidationVMWrapper {
 	bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
 	cst := cborutil.NewIpldStore(bs)
 	vmstrg := storage.NewStorage(bs)
-	vm := NewVM(gfbuiltin.DefaultActors, &vmstrg, state.NewState(cst))
+	vm := NewVM(gfbuiltin.DefaultActors, &vmstrg, state.NewState(cst), &vmsupport.FakeSyscalls{})
 	return &ValidationVMWrapper{
 		vm: &vm,
 	}

--- a/internal/pkg/vm/internal/vmcontext/vmcontext.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext.go
@@ -38,6 +38,7 @@ type VM struct {
 	actorImpls   ActorImplLookup
 	store        *storage.VMStorage
 	state        state.Tree
+	syscalls     SyscallsImpl
 	currentEpoch abi.ChainEpoch
 	pricelist    gascost.Pricelist
 }
@@ -62,15 +63,15 @@ type internalMessage struct {
 
 // NewVM creates a new runtime for executing messages.
 // Dragons: change to take a root and the store, build the tree internally
-func NewVM(actorImpls ActorImplLookup, store *storage.VMStorage, st state.Tree) VM {
+func NewVM(actorImpls ActorImplLookup, store *storage.VMStorage, st state.Tree, syscalls SyscallsImpl) VM {
 	return VM{
+		context:    context.Background(),
 		actorImpls: actorImpls,
 		store:      store,
 		state:      st,
-		context:    context.Background(),
+		syscalls:   syscalls,
 		// loaded during execution
 		// currentEpoch: ..,
-		// rnd: ..,
 	}
 }
 

--- a/internal/pkg/vm/vm.go
+++ b/internal/pkg/vm/vm.go
@@ -20,6 +20,8 @@ type Interpreter = interpreter.VMInterpreter
 // Storage is the raw storage for the VM.
 type Storage = storage.VMStorage
 
+type SyscallsImpl = vmcontext.SyscallsImpl
+
 // BlockMessagesInfo contains messages for one block in a tipset.
 type BlockMessagesInfo = interpreter.BlockMessagesInfo
 
@@ -27,8 +29,8 @@ type BlockMessagesInfo = interpreter.BlockMessagesInfo
 type MessageReceipt = message.Receipt
 
 // NewVM creates a new VM interpreter.
-func NewVM(st state.Tree, store *storage.VMStorage) Interpreter {
-	vm := vmcontext.NewVM(builtin.DefaultActors, store, st)
+func NewVM(st state.Tree, store *storage.VMStorage, syscalls SyscallsImpl) Interpreter {
+	vm := vmcontext.NewVM(builtin.DefaultActors, store, st, syscalls)
 	return &vm
 }
 

--- a/internal/pkg/vmsupport/syscalls.go
+++ b/internal/pkg/vmsupport/syscalls.go
@@ -1,0 +1,49 @@
+package vmsupport
+
+import (
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/ipfs/go-cid"
+	"github.com/minio/blake2b-simd"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
+)
+
+type Syscalls struct {
+	// Dependencies on chain state and proofs coming here soon.
+}
+
+func NewSyscalls() *Syscalls {
+	return &Syscalls{}
+}
+
+func (s Syscalls) VerifySignature(epoch abi.ChainEpoch, signature crypto.Signature, signer address.Address, plaintext []byte) error {
+	// Dragons: this lets all id addresses off the hook -- we need to remove this
+	// once market actor code actually checks proposal signature.  Depending on how
+	// that works we may want to do id address to pubkey address lookup here or we
+	// might defer that to VM
+	if signer.Protocol() == address.ID {
+		return nil
+	}
+	return crypto.ValidateSignature(plaintext, signer, signature)
+}
+
+func (s Syscalls) HashBlake2b(data []byte) [32]byte {
+	return blake2b.Sum256(data)
+}
+
+func (s Syscalls) ComputeUnsealedSectorCID(proof abi.RegisteredProof, pieces []abi.PieceInfo) (cid.Cid, error) {
+	panic("implement me")
+}
+
+func (s Syscalls) VerifySeal(epoch abi.ChainEpoch, info abi.SealVerifyInfo) error {
+	panic("implement me")
+}
+
+func (s Syscalls) VerifyPoSt(epoch abi.ChainEpoch, info abi.PoStVerifyInfo) error {
+	panic("implement me")
+}
+
+func (s Syscalls) VerifyConsensusFault(epoch abi.ChainEpoch, h1, h2 []byte) error {
+	panic("implement me")
+}

--- a/internal/pkg/vmsupport/testing.go
+++ b/internal/pkg/vmsupport/testing.go
@@ -1,0 +1,38 @@
+package vmsupport
+
+import (
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/ipfs/go-cid"
+	"github.com/minio/blake2b-simd"
+
+	gfcrypto "github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
+)
+
+type FakeSyscalls struct {
+}
+
+func (f FakeSyscalls) VerifySignature(epoch abi.ChainEpoch, signature gfcrypto.Signature, signer address.Address, plaintext []byte) error {
+	// This doesn't resolve account ID addresses to their signing addresses (but should).
+	return gfcrypto.ValidateSignature(plaintext, signer, signature)
+}
+
+func (f FakeSyscalls) HashBlake2b(data []byte) [32]byte {
+	return blake2b.Sum256(data)
+}
+
+func (f FakeSyscalls) ComputeUnsealedSectorCID(proof abi.RegisteredProof, pieces []abi.PieceInfo) (cid.Cid, error) {
+	panic("implement me")
+}
+
+func (f FakeSyscalls) VerifySeal(epoch abi.ChainEpoch, info abi.SealVerifyInfo) error {
+	panic("implement me")
+}
+
+func (f FakeSyscalls) VerifyPoSt(epoch abi.ChainEpoch, info abi.PoStVerifyInfo) error {
+	panic("implement me")
+}
+
+func (f FakeSyscalls) VerifyConsensusFault(epoch abi.ChainEpoch, h1, h2 []byte) error {
+	panic("implement me")
+}

--- a/tools/gengen/util/generator.go
+++ b/tools/gengen/util/generator.go
@@ -37,6 +37,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vmsupport"
 )
 
 type cstore struct {
@@ -77,7 +78,7 @@ func NewGenesisGenerator(bs blockstore.Blockstore) *GenesisGenerator {
 	g := GenesisGenerator{}
 	g.stateTree = state.NewState(cst)
 	g.store = vm.NewStorage(bs)
-	g.vm = vm.NewVM(g.stateTree, &g.store).(consensus.GenesisVM)
+	g.vm = vm.NewVM(g.stateTree, &g.store, vmsupport.NewSyscalls()).(consensus.GenesisVM)
 	g.cst = cst
 
 	g.chainRand = crypto.ChainRandomnessSource{Sampler: &crypto.GenesisSampler{VRFProof: consensus.GenesisTicket.VRFProof}}


### PR DESCRIPTION
### Motivation
Some syscall implementations depend on chain state (to resolve addresses), the blockchain itself (consensus fault slashing) etc. Rather than expose the VM to all of these, the syscall implementations are abstracted behind an interface. This also allows the syscalls to be faked for testing (@frrist you'll need this).

### Proposed changes
The VM defines a new interface as a parameter to `NewVM` which abstracts the actual syscall implementations. The new interface has additional parameters such as the current epoch, which are implicit in the Runtime interface called by actors.

Follow-up PRs will actually implement them.

Question:
- I put this in a new `vmsupport` package so that the `vm` package as a whole doesn't need new imports. Is there anywhere better?
- Any better names than I've chosen?