### PR TITLE
point to master branch of go-storage-miner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200302221106-550933c78345
-	github.com/filecoin-project/go-storage-miner v0.0.0-20200302230949-017cf17356ed
+	github.com/filecoin-project/go-storage-miner v0.0.0-20200304180041-509864323ca9
 	github.com/filecoin-project/specs-actors v0.0.0-20200226233436-635911a01775
 	github.com/fxamacker/cbor v1.5.0
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9 h
 github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
-github.com/filecoin-project/go-storage-miner v0.0.0-20200302230949-017cf17356ed h1:XnSQLIGRZ2b24cqoMW5nV5cAuDjD9hQuVSLwvNB4QHM=
-github.com/filecoin-project/go-storage-miner v0.0.0-20200302230949-017cf17356ed/go.mod h1:WOQZChiZ44xz9e3DU9mN3jLT3Cylff8mra/8FFy3W5I=
+github.com/filecoin-project/go-storage-miner v0.0.0-20200304180041-509864323ca9 h1:q8w3XH4N2DDhglSRG0mjE2MCdfXonOa+MTAMwTwzhL8=
+github.com/filecoin-project/go-storage-miner v0.0.0-20200304180041-509864323ca9/go.mod h1:WOQZChiZ44xz9e3DU9mN3jLT3Cylff8mra/8FFy3W5I=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.0.0-20200226200336-94c9b92b2775/go.mod h1:0HAWYrvajFHDgRaKbF0rl+IybVLZL5z4gQ8koCMPhoU=
 github.com/filecoin-project/specs-actors v0.0.0-20200226225703-1fa643f1847f h1:qeUmau+W9eoS487mxjwG8sTT1SOMjpzUDH5hs0OwHTw=


### PR DESCRIPTION
### Motivation

Due to my oversight, the go-storage-miner Git SHA which appears in our go.mod file corresponds to the head of a (now-merged) feature branch in go-storage-miner.

### Proposed changes

This changeset updates go.mod to consume the head of the master branch in go-storage-miner (which contains the now-merged go-storage-miner SHA previously referenced in go-filecoin's go.mod).
