### PR TITLE
Resolve signer address in VM signature verification syscall.

### DIFF
--- a/internal/pkg/vm/internal/vmcontext/runtime_adapter.go
+++ b/internal/pkg/vm/internal/vmcontext/runtime_adapter.go
@@ -123,11 +123,11 @@ func (a *runtimeAdapter) DeleteActor() {
 // SyscallsImpl implements Runtime.
 func (a *runtimeAdapter) Syscalls() specsruntime.Syscalls {
 	return &syscalls{
-		impl:      a.ctx.rt.syscalls,
-		ctx:       a.ctx.rt.context,
-		gasTank:   a.ctx.gasTank,
-		pricelist: a.ctx.rt.pricelist,
-		epoch:     a.ctx.Runtime().CurrentEpoch(),
+		impl:        a.ctx.rt.syscalls,
+		ctx:         a.ctx.rt.context,
+		gasTank:     a.ctx.gasTank,
+		pricelist:   a.ctx.rt.pricelist,
+		sigResolver: a.ctx.rt,
 	}
 }
 

--- a/internal/pkg/vmsupport/syscalls.go
+++ b/internal/pkg/vmsupport/syscalls.go
@@ -24,13 +24,10 @@ func NewSyscalls(verifier sectorbuilder.Verifier) *Syscalls {
 	}
 }
 
-func (s Syscalls) VerifySignature(epoch abi.ChainEpoch, signature crypto.Signature, signer address.Address, plaintext []byte) error {
-	// Dragons: this lets all id addresses off the hook -- we need to remove this
-	// once market actor code actually checks proposal signature.  Depending on how
-	// that works we may want to do id address to pubkey address lookup here or we
-	// might defer that to VM
-	if signer.Protocol() == address.ID {
-		return nil
+func (s Syscalls) VerifySignature(signature crypto.Signature, signer address.Address, plaintext []byte) error {
+	if signer.Protocol() != address.SECP256K1 && signer.Protocol() != address.BLS {
+		// This is a programmer error: callers must resolve the address in state first.
+		return fmt.Errorf("unresolved signer address")
 	}
 	return crypto.ValidateSignature(plaintext, signer, signature)
 }

--- a/internal/pkg/vmsupport/testing.go
+++ b/internal/pkg/vmsupport/testing.go
@@ -15,8 +15,8 @@ import (
 type FakeSyscalls struct {
 }
 
-func (f FakeSyscalls) VerifySignature(epoch abi.ChainEpoch, signature gfcrypto.Signature, signer address.Address, plaintext []byte) error {
-	// This doesn't resolve account ID addresses to their signing addresses (but should).
+func (f FakeSyscalls) VerifySignature(signature gfcrypto.Signature, signer address.Address, plaintext []byte) error {
+	// The signer is assumed to be already resolved to a pubkey address.
 	return gfcrypto.ValidateSignature(plaintext, signer, signature)
 }
 

--- a/tools/gengen/util/generator.go
+++ b/tools/gengen/util/generator.go
@@ -484,7 +484,7 @@ func (g *GenesisGenerator) commitDeals(ctx context.Context, addr, mIDAddr addres
 			ProviderCollateral:   specsbig.Zero(), // collateral should actually be good
 			ClientCollateral:     specsbig.Zero(),
 		}
-		proposalBytes, err := encoding.Encode(proposal)
+		proposalBytes, err := encoding.Encode(&proposal)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Motivation
The signature verification syscall must resolve account actor ID addresses to their signing keys. This lookup needs to be done in the state at the time of the call, which might be mid-tipset. 

### Proposed changes
Implement an account resolution method on the runtime itself, which can inspect the current state, and provide it to the syscall wrapper.

An alternative, which I first tried, is providing a state view from the outside, keyed by epoch or tipset key or something, but that cannot reference state that hasn't been committed to storage yet (which happens only at the end of tipset processing).

The tests will pass after updating specs-actors to include https://github.com/filecoin-project/specs-actors/pull/232
- [x] prereq: merge https://github.com/filecoin-project/go-filecoin/pull/3833

We'll need a different mechanism for verifying block and message signatures, probably state-view based.