### PR TITLE
Upgrade go-sectorbuilder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/filecoin-project/chain-validation v0.0.6-0.20200227010210-ab4704e894ef
-	github.com/filecoin-project/filecoin-ffi v0.0.0-20200226205820-4da0bccccefb
+	github.com/filecoin-project/filecoin-ffi v0.0.0-20200304181354-4446ff8a1bb9
 	github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be
 	github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
@@ -22,7 +22,7 @@ require (
 	github.com/filecoin-project/go-fil-markets v0.0.0-20200301210355-399fb545b7ae
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663
-	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200302221106-550933c78345
+	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200306003553-541b1e74104d
 	github.com/filecoin-project/go-storage-miner v0.0.0-20200304180041-509864323ca9
 	github.com/filecoin-project/specs-actors v0.0.0-20200226233436-635911a01775
 	github.com/fxamacker/cbor v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663/g
 github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200226210935-4739f8749f56/go.mod h1:tzTc9BxxSbjlIzhFwm5h9oBkXKkRuLxeiWspntwnKyw=
 github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200302221106-550933c78345 h1:v/xtxdxmW/tP0/iIW9Ug27Zb9TSnaJU5ApQvN2bXttY=
 github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200302221106-550933c78345/go.mod h1:7457bcGT+BbIU90ey3ZZpEqssA4OQ4MgEptoTp5978s=
+github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200306003553-541b1e74104d h1:FRUaOxLQvPcyOrI1J/ZiGThohyoMimf5mpyH/ZF7b7o=
+github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200306003553-541b1e74104d/go.mod h1:xAd/X905Ncgj8kkHsP2pmQUf6MQT2qJTDcOEfkwCjYc=
 github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9 h1:k9qVR9ItcziSB2rxtlkN/MDWNlbsI6yzec+zjUatLW0=
 github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=


### PR DESCRIPTION
### Motivation
I want this for https://github.com/filecoin-project/go-sectorbuilder/pull/86

### Proposed changes
Upgrade to master (and the dependent ffi comes with it).

FYI @laser @icorderi 