### PR TITLE
Fix tricky BLS bug

### DIFF
--- a/internal/pkg/crypto/crypto.go
+++ b/internal/pkg/crypto/crypto.go
@@ -70,6 +70,7 @@ func VerifyBLSAggregate(pubKeys, msgs [][]byte, signature []byte) bool {
 	for _, pubKey := range pubKeys {
 		var blsPubKey bls.PublicKey
 		copy(blsPubKey[:], pubKey)
+		keys = append(keys, blsPubKey)
 	}
 
 	var blsSig bls.Signature


### PR DESCRIPTION
### Motivation
Found this bug causing all bls aggregate sigs to be invalid during integration testing.  Since that effort is uncovering other issues and this bug will block the devnet from sending bls messages I'm PRing this independently.


<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

