### PR TITLE
Move DefaultGenesis from testhelpers/core to gengen

### DIFF
--- a/internal/app/go-filecoin/node/node_test.go
+++ b/internal/app/go-filecoin/node/node_test.go
@@ -16,15 +16,15 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/config"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/proofs"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
-	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/tools/gengen/util"
 )
 
 func TestNodeConstruct(t *testing.T) {
 	tf.UnitTest(t)
 	ctx := context.Background()
 	builder := test.NewNodeBuilder(t)
-	builder.WithGenesisInit(th.DefaultGenesis)
+	builder.WithGenesisInit(gengen.DefaultGenesis)
 	builder.WithBuilderOpt(node.FakeProofVerifierBuilderOpts()...)
 	nd := builder.Build(ctx)
 	assert.NotNil(t, nd.Host)
@@ -37,7 +37,7 @@ func TestNodeNetworking(t *testing.T) {
 
 	ctx := context.Background()
 	builder := test.NewNodeBuilder(t)
-	builder.WithGenesisInit(th.DefaultGenesis)
+	builder.WithGenesisInit(gengen.DefaultGenesis)
 	builder.WithBuilderOpt(node.FakeProofVerifierBuilderOpts()...)
 	nds := builder.BuildMany(ctx, 2)
 	nd1, nd2 := nds[0], nds[1]
@@ -63,7 +63,7 @@ func TestConnectsToBootstrapNodes(t *testing.T) {
 		r := repo.NewInMemoryRepo()
 		r.Config().Swarm.Address = "/ip4/0.0.0.0/tcp/0"
 
-		require.NoError(t, node.Init(ctx, r, th.DefaultGenesis))
+		require.NoError(t, node.Init(ctx, r, gengen.DefaultGenesis))
 		r.Config().Bootstrap.Addresses = []string{}
 		opts, err := node.OptionsFromRepo(r)
 		require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestConnectsToBootstrapNodes(t *testing.T) {
 
 		// These are two bootstrap nodes we'll connect to.
 		builder := test.NewNodeBuilder(t)
-		builder.WithGenesisInit(th.DefaultGenesis)
+		builder.WithGenesisInit(gengen.DefaultGenesis)
 		builder.WithBuilderOpt(node.FakeProofVerifierBuilderOpts()...)
 		nds := builder.BuildMany(ctx, 2)
 		node.StartNodes(t, nds)
@@ -93,7 +93,7 @@ func TestConnectsToBootstrapNodes(t *testing.T) {
 		r := repo.NewInMemoryRepo()
 		r.Config().Swarm.Address = "/ip4/0.0.0.0/tcp/0"
 
-		require.NoError(t, node.Init(ctx, r, th.DefaultGenesis))
+		require.NoError(t, node.Init(ctx, r, gengen.DefaultGenesis))
 		r.Config().Bootstrap.Addresses = []string{peer1, peer2}
 
 		opts, err := node.OptionsFromRepo(r)
@@ -128,7 +128,7 @@ func TestNodeInit(t *testing.T) {
 
 	ctx := context.Background()
 	builder := test.NewNodeBuilder(t)
-	builder.WithGenesisInit(th.DefaultGenesis)
+	builder.WithGenesisInit(gengen.DefaultGenesis)
 	builder.WithBuilderOpt(node.FakeProofVerifierBuilderOpts()...)
 	builder.WithBuilderOpt(node.OfflineMode(true))
 
@@ -182,7 +182,7 @@ func TestOptionWithError(t *testing.T) {
 
 	ctx := context.Background()
 	r := repo.NewInMemoryRepo()
-	assert.NoError(t, node.Init(ctx, r, th.DefaultGenesis))
+	assert.NoError(t, node.Init(ctx, r, gengen.DefaultGenesis))
 
 	opts, err := node.OptionsFromRepo(r)
 	assert.NoError(t, err)
@@ -217,7 +217,7 @@ func TestNodeConfig(t *testing.T) {
 	initOpts := []node.InitOpt{}
 
 	builder := test.NewNodeBuilder(t)
-	builder.WithGenesisInit(th.DefaultGenesis)
+	builder.WithGenesisInit(gengen.DefaultGenesis)
 	builder.WithInitOpt(initOpts...)
 	builder.WithBuilderOpt(builderOptions...)
 	builder.WithBuilderOpt(node.OfflineMode(true))

--- a/internal/app/go-filecoin/plumbing/msg/waiter_test.go
+++ b/internal/app/go-filecoin/plumbing/msg/waiter_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
+	"github.com/filecoin-project/go-filecoin/tools/gengen/util"
+
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
@@ -17,7 +19,6 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
 	e "github.com/filecoin-project/go-filecoin/internal/pkg/enccid"
-	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
@@ -49,7 +50,7 @@ type smsgs []*types.SignedMessage
 type smsgsSet [][]*types.SignedMessage
 
 func setupTest(t *testing.T) (cbor.IpldStore, *chain.Store, *chain.MessageStore, *Waiter) {
-	d := requiredCommonDeps(t, th.DefaultGenesis)
+	d := requiredCommonDeps(t, gengen.DefaultGenesis)
 	return d.cst, d.chainStore, d.messages, NewWaiter(d.chainStore, d.messages, d.blockstore, d.cst)
 }
 

--- a/internal/pkg/consensus/expected_test.go
+++ b/internal/pkg/consensus/expected_test.go
@@ -28,6 +28,7 @@ import (
 	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vmsupport"
+	"github.com/filecoin-project/go-filecoin/tools/gengen/util"
 )
 
 // TestExpected_RunStateTransition_validateMining is concerned only with validateMining behavior.
@@ -43,7 +44,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 	t.Run("passes the validateMining section when given valid mining blocks", func(t *testing.T) {
 		cistore, bstore := setupCborBlockstore()
-		genesisBlock, err := th.DefaultGenesis(cistore, bstore)
+		genesisBlock, err := gengen.DefaultGenesis(cistore, bstore)
 		require.NoError(t, err)
 
 		//Set miner actor
@@ -66,7 +67,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 	t.Run("returns nil + mining error when election proof validation fails", func(t *testing.T) {
 		cistore, bstore := setupCborBlockstore()
-		genesisBlock, err := th.DefaultGenesis(cistore, bstore)
+		genesisBlock, err := gengen.DefaultGenesis(cistore, bstore)
 		require.NoError(t, err)
 
 		pTipSet := th.RequireNewTipSet(t, genesisBlock)
@@ -90,7 +91,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 	t.Run("fails when bls signature is not valid across bls messages", func(t *testing.T) {
 		cistore, bstore := setupCborBlockstore()
-		genesisBlock, err := th.DefaultGenesis(cistore, bstore)
+		genesisBlock, err := gengen.DefaultGenesis(cistore, bstore)
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
@@ -119,7 +120,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 	t.Run("fails when secp message has invalid signature", func(t *testing.T) {
 		cistore, bstore := setupCborBlockstore()
-		genesisBlock, err := th.DefaultGenesis(cistore, bstore)
+		genesisBlock, err := gengen.DefaultGenesis(cistore, bstore)
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
@@ -155,7 +156,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 	t.Run("returns nil + mining error when ticket validation fails", func(t *testing.T) {
 		cistore, bstore := setupCborBlockstore()
-		genesisBlock, err := th.DefaultGenesis(cistore, bstore)
+		genesisBlock, err := gengen.DefaultGenesis(cistore, bstore)
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
@@ -175,7 +176,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 	t.Run("returns nil + mining error when signature is invalid", func(t *testing.T) {
 		cistore, bstore := setupCborBlockstore()
-		genesisBlock, err := th.DefaultGenesis(cistore, bstore)
+		genesisBlock, err := gengen.DefaultGenesis(cistore, bstore)
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
@@ -197,7 +198,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 
 	t.Run("returns nil + error when parent weight invalid", func(t *testing.T) {
 		cistore, bstore := setupCborBlockstore()
-		genesisBlock, err := th.DefaultGenesis(cistore, bstore)
+		genesisBlock, err := gengen.DefaultGenesis(cistore, bstore)
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)

--- a/internal/pkg/testhelpers/core.go
+++ b/internal/pkg/testhelpers/core.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
@@ -14,14 +13,10 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/cborutil"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/version"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
-	gengen "github.com/filecoin-project/go-filecoin/tools/gengen/util"
 )
 
 // RequireMakeStateTree takes a map of addresses to actors and stores them on
@@ -215,46 +210,4 @@ func RequireInitAccountActor(ctx context.Context, t *testing.T, st state.Tree, v
 	// return act, idAddr
 
 	return nil, address.Undef
-}
-
-// GetTotalPower get total miner power from storage market
-func GetTotalPower(t *testing.T, st state.Tree, vms vm.Storage) abi.StoragePower {
-	// Dragons: re-write using direct state access
-	panic("re-write")
-	// res, err := CreateAndApplyTestMessage(t, st, vms, vmaddr.StorageMarketAddress, 0, 0, storagemarket.GetTotalStorage, nil)
-	// require.NoError(t, err)
-	// require.NoError(t, res.ExecutionError)
-	// require.Equal(t, uint8(0), res.Receipt.ExitCode)
-	// return types.NewBytesAmountFromBytes(ßres.Receipt.ReturnValue)
-}
-
-// RequireGetNonce returns the next nonce of the actor at address a within
-// state tree st, failing on error.
-func RequireGetNonce(t *testing.T, st state.Tree, vms vm.Storage, a address.Address) uint64 {
-	ctx := context.Background()
-	actr, _ := RequireLookupActor(ctx, t, st, vms, a)
-	nonce, err := actor.NextNonce(actr)
-	require.NoError(t, err)
-	return nonce
-}
-
-// RequireCreateStorages creates an empty state tree and storage map.
-func RequireCreateStorages(ctx context.Context, t *testing.T) (*state.State, vm.Storage) {
-	d := datastore.NewMapDatastore()
-	bs := blockstore.NewBlockstore(d)
-	cst := cborutil.NewIpldStore(bs)
-	blk, err := DefaultGenesis(cst, bs)
-	require.NoError(t, err)
-
-	st, err := state.LoadState(ctx, cst, blk.StateRoot.Cid)
-	require.NoError(t, err)
-
-	vms := vm.NewStorage(bs)
-
-	return st, vms
-}
-
-// DefaultGenesis creates a test network genesis block with default accounts and actors installed.
-func DefaultGenesis(cst cbor.IpldStore, bs blockstore.Blockstore) (*block.Block, error) {
-	return gengen.MakeGenesisFunc(gengen.NetworkName(version.TEST))(cst, bs)
 }

--- a/tools/gengen/util/testing.go
+++ b/tools/gengen/util/testing.go
@@ -3,7 +3,12 @@ package gengen
 import (
 	"fmt"
 
+	"github.com/ipfs/go-ipfs-blockstore"
+	"github.com/ipfs/go-ipld-cbor"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/constants"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/version"
 )
 
 // MakeCommitCfgs creates n gengen commit configs, casting strings to cids.
@@ -37,4 +42,9 @@ func MakeCommitCfgs(n int) ([]*CommitConfig, error) {
 		}
 	}
 	return cfgs, nil
+}
+
+// DefaultGenesis creates a test network genesis block with default accounts and actors installed.
+func DefaultGenesis(cst cbornode.IpldStore, bs blockstore.Blockstore) (*block.Block, error) {
+	return MakeGenesisFunc(NetworkName(version.TEST))(cst, bs)
 }


### PR DESCRIPTION
### Motivation
Testhelpers is an ugly dumping ground and causing circular dependency problems. 

### Proposed changes
I've moved one thing out of it to reduce the number of unwanted deps that come from using some of the more primitive things in the package.