### PR TITLE
Tipset Key change

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -168,7 +168,6 @@ github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.m
 github.com/filecoin-project/specs-actors v0.0.0-20200226200336-94c9b92b2775/go.mod h1:0HAWYrvajFHDgRaKbF0rl+IybVLZL5z4gQ8koCMPhoU=
 github.com/filecoin-project/specs-actors v0.0.0-20200306000749-99e98e61e2a0 h1:n7Q8UMP2Jsj1dQkM0tRKVWUeAbrz8x2f8l1UVeB4PC4=
 github.com/filecoin-project/specs-actors v0.0.0-20200306000749-99e98e61e2a0/go.mod h1:0HAWYrvajFHDgRaKbF0rl+IybVLZL5z4gQ8koCMPhoU=
-github.com/filecoin-project/specs-actors v0.0.0-20200309172618-71390e5cd9f2 h1:ft47fZteHYLxFdscNXA+MuxY1cNiZ1sGFme3oqRjE1k=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fxamacker/cbor v1.5.0 h1:idAiyeNSq/jeG9FPbCLVZLFJjsxP+g40a3UrXFapumw=

--- a/internal/pkg/block/tipset.go
+++ b/internal/pkg/block/tipset.go
@@ -61,7 +61,6 @@ func NewTipSet(blocks ...*Block) (TipSet, error) {
 			}
 		}
 		sorted[i] = blk
-		cids[i] = blk.Cid()
 	}
 
 	// Sort blocks by ticket
@@ -73,6 +72,9 @@ func NewTipSet(blocks ...*Block) (TipSet, error) {
 		}
 		return cmp < 0
 	})
+	for i, blk := range sorted {
+		cids[i] = blk.Cid()
+	}
 	// Duplicate blocks (CIDs) are rejected here, pass that error through.
 	key, err := NewTipSetKeyFromUnique(cids...)
 	if err != nil {

--- a/internal/pkg/block/tipset_key_test.go
+++ b/internal/pkg/block/tipset_key_test.go
@@ -138,13 +138,3 @@ func TestTipSetKeyJSONRoundtrip(t *testing.T) {
 	assert.Equal(t, 3, act.Len())
 	assert.True(t, act.Equals(exp))
 }
-
-func asSlice(cids map[cid.Cid]struct{}) []cid.Cid {
-	slc := make([]cid.Cid, len(cids))
-	var i int
-	for c := range cids {
-		slc[i] = c
-		i++
-	}
-	return slc
-}

--- a/internal/pkg/block/tipset_test.go
+++ b/internal/pkg/block/tipset_test.go
@@ -88,12 +88,6 @@ func TestTipSet(t *testing.T) {
 		assert.Equal(t, 3, t3.Len())
 	})
 
-	t.Run("key", func(t *testing.T) {
-		assert.Equal(t, blk.NewTipSetKey(b1.Cid()), RequireNewTipSet(t, b1).Key())
-		assert.Equal(t, blk.NewTipSetKey(b1.Cid(), b2.Cid(), b3.Cid()),
-			RequireNewTipSet(t, b1, b2, b3).Key())
-	})
-
 	t.Run("height", func(t *testing.T) {
 		tsHeight, _ := RequireNewTipSet(t, b1).Height()
 		assert.Equal(t, b1.Height, tsHeight)

--- a/internal/pkg/block/tipset_test.go
+++ b/internal/pkg/block/tipset_test.go
@@ -88,6 +88,13 @@ func TestTipSet(t *testing.T) {
 		assert.Equal(t, 3, t3.Len())
 	})
 
+	t.Run("key", func(t *testing.T) {
+		assert.Equal(t, blk.NewTipSetKey(b1.Cid()), RequireNewTipSet(t, b1).Key())
+		// sorted ticket order is b1, b2, b3
+		assert.Equal(t, blk.NewTipSetKey(b1.Cid(), b2.Cid(), b3.Cid()),
+			RequireNewTipSet(t, b2, b3, b1).Key())
+	})
+
 	t.Run("height", func(t *testing.T) {
 		tsHeight, _ := RequireNewTipSet(t, b1).Height()
 		assert.Equal(t, b1.Height, tsHeight)


### PR DESCRIPTION
### Motivation
Get our tipset keys up to spec and ready for interop

### Proposed changes
Callers now maintain sorting convention.  I've also removed the duplicate filtering because it has low value now that callers need to be careful about what they pass in.  I have kept the constructor that errors if there are duplicates.

Closes issue #3840

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

