### PR TITLE
Feat/mining message filter

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1244,8 +1244,6 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 h1:Ao/3l156eZf2AW5wK8a7/smtodRU+gha3+BeqJ69lRk=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191101175033-0deb6923b6d9 h1:DPz9iiH3YoKiKhX/ijjoZvT0VFwK2c6CWYWQ7Zyr8TU=
-golang.org/x/net v0.0.0-20191101175033-0deb6923b6d9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/internal/app/go-filecoin/internal/submodule/messaging_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/messaging_submodule.go
@@ -9,6 +9,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/message"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/net"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/net/pubsub"
+	"github.com/pkg/errors"
 )
 
 // MessagingSubmodule enhances the `Node` with internal messaging capabilities.
@@ -23,7 +24,8 @@ type MessagingSubmodule struct {
 	MessageTopic *pubsub.Topic
 	MessageSub   pubsub.Subscription
 
-	MsgPool *message.Pool
+	MsgPool   *message.Pool
+	MsgSigVal *consensus.MessageSignatureValidator
 }
 
 type messagingConfig interface {
@@ -36,10 +38,17 @@ type messagingRepo interface {
 
 // NewMessagingSubmodule creates a new discovery submodule.
 func NewMessagingSubmodule(ctx context.Context, config messagingConfig, repo messagingRepo, network *NetworkSubmodule, chain *ChainSubmodule, wallet *WalletSubmodule) (MessagingSubmodule, error) {
-	msgPool := message.NewPool(repo.Config().Mpool, consensus.NewIngestionValidator(chain.State, repo.Config().Mpool))
+	msgSyntaxValidator := consensus.NewMessageSyntaxValidator()
+	msgSignatureValidator := consensus.NewMessageSignatureValidator(chain.State)
+	msgPool := message.NewPool(repo.Config().Mpool, msgSyntaxValidator)
 	inbox := message.NewInbox(msgPool, message.InboxMaxAgeTipsets, chain.ChainReader, chain.MessageStore)
 
 	// setup messaging topic.
+	// register block validation on pubsub
+	mtv := net.NewMessageTopicValidator(msgSyntaxValidator, msgSignatureValidator)
+	if err := network.pubsub.RegisterTopicValidator(mtv.Topic(network.NetworkName), mtv.Validator(), mtv.Opts()...); err != nil {
+		return MessagingSubmodule{}, errors.Wrap(err, "failed to register message validator")
+	}
 	topic, err := network.pubsub.Join(net.MessageTopic(network.NetworkName))
 	if err != nil {
 		return MessagingSubmodule{}, err
@@ -49,13 +58,14 @@ func NewMessagingSubmodule(ctx context.Context, config messagingConfig, repo mes
 	outboxPolicy := message.NewMessageQueuePolicy(chain.MessageStore, message.OutboxMaxAgeRounds)
 	msgPublisher := message.NewDefaultPublisher(pubsub.NewTopic(topic), msgPool)
 	signer := wallet.Wallet
-	outbox := message.NewOutbox(signer, consensus.NewOutboundMessageValidator(), msgQueue, msgPublisher, outboxPolicy, chain.ChainReader, chain.State, config.Journal().Topic("outbox"))
+	outbox := message.NewOutbox(signer, msgSyntaxValidator, msgQueue, msgPublisher, outboxPolicy, chain.ChainReader, chain.State, config.Journal().Topic("outbox"))
 
 	return MessagingSubmodule{
 		Inbox:        inbox,
 		Outbox:       outbox,
 		MessageTopic: pubsub.NewTopic(topic),
 		// MessageSub: nil,
-		MsgPool: msgPool,
+		MsgPool:   msgPool,
+		MsgSigVal: msgSignatureValidator,
 	}, nil
 }

--- a/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
@@ -52,7 +52,7 @@ func NewSyncerSubmodule(ctx context.Context, config syncerConfig, blockstore *Bl
 	// TODO when #2961 is resolved do the needful here.
 	blkValid := consensus.NewDefaultBlockValidator(config.ChainClock())
 
-	// register block validation on floodsub
+	// register block validation on pubsub
 	btv := net.NewBlockTopicValidator(blkValid)
 	if err := network.pubsub.RegisterTopicValidator(btv.Topic(network.NetworkName), btv.Validator(), btv.Opts()...); err != nil {
 		return SyncerSubmodule{}, errors.Wrap(err, "failed to register block validator")

--- a/internal/app/go-filecoin/node/message.go
+++ b/internal/app/go-filecoin/node/message.go
@@ -19,6 +19,12 @@ func (node *Node) processMessage(ctx context.Context, pubSubMsg pubsub.Message) 
 	if err := unmarshaled.Unmarshal(pubSubMsg.GetData()); err != nil {
 		return err
 	}
+	// TODO #3566 This is redundant with pubsub repeater validation.
+	// We should do this in one call, maybe by waiting on pool add in repeater?
+	err = node.Messaging.MsgSigVal.Validate(ctx, unmarshaled)
+	if err != nil {
+		return err
+	}
 
 	log.Debugf("Received new message %s from peer %s", unmarshaled, pubSubMsg.GetSender())
 

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -687,7 +687,7 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (*mining.DefaultWorker
 
 		MessageSource: node.Messaging.Inbox.Pool(),
 		MessageStore:  node.chain.MessageStore,
-		Processor:     node.Chain().Processor,
+		PenaltyChecker: consensus.NewMessagePenaltyChecker(node.Chain().State),
 		Blockstore:    node.Blockstore.Blockstore,
 		Clock:         node.ChainClock,
 		Poster:        node.StorageMining.PoStGenerator,

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -685,12 +685,12 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (*mining.DefaultWorker
 		TicketGen:      consensus.NewTicketMachine(node.PorcelainAPI),
 		TipSetMetadata: node.chain.ChainReader,
 
-		MessageSource:  node.Messaging.Inbox.Pool(),
-		MessageStore:   node.chain.MessageStore,
-		PenaltyChecker: consensus.NewMessagePenaltyChecker(node.Chain().State),
-		Blockstore:     node.Blockstore.Blockstore,
-		Clock:          node.ChainClock,
-		Poster:         node.StorageMining.PoStGenerator,
+		MessageSource:    node.Messaging.Inbox.Pool(),
+		MessageStore:     node.chain.MessageStore,
+		MessageQualifier: consensus.NewMessagePenaltyChecker(node.Chain().State),
+		Blockstore:       node.Blockstore.Blockstore,
+		Clock:            node.ChainClock,
+		Poster:           node.StorageMining.PoStGenerator,
 	}), nil
 }
 

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -685,12 +685,12 @@ func (node *Node) CreateMiningWorker(ctx context.Context) (*mining.DefaultWorker
 		TicketGen:      consensus.NewTicketMachine(node.PorcelainAPI),
 		TipSetMetadata: node.chain.ChainReader,
 
-		MessageSource: node.Messaging.Inbox.Pool(),
-		MessageStore:  node.chain.MessageStore,
+		MessageSource:  node.Messaging.Inbox.Pool(),
+		MessageStore:   node.chain.MessageStore,
 		PenaltyChecker: consensus.NewMessagePenaltyChecker(node.Chain().State),
-		Blockstore:    node.Blockstore.Blockstore,
-		Clock:         node.ChainClock,
-		Poster:        node.StorageMining.PoStGenerator,
+		Blockstore:     node.Blockstore.Blockstore,
+		Clock:          node.ChainClock,
+		Poster:         node.StorageMining.PoStGenerator,
 	}), nil
 }
 

--- a/internal/pkg/chainsync/fetcher/graphsync_fetcher.go
+++ b/internal/pkg/chainsync/fetcher/graphsync_fetcher.go
@@ -408,9 +408,6 @@ func (gsf *GraphSyncFetcher) loadAndVerifyFullBlock(ctx context.Context, key blo
 				return err
 			}
 
-			if err := gsf.validator.ValidateMessagesSyntax(ctx, messages); err != nil {
-				return errors.Wrapf(err, "invalid messages for for message collection (cid %s)", rawBlock.Cid())
-			}
 			return nil
 		})
 	if err != nil {
@@ -436,9 +433,6 @@ func (gsf *GraphSyncFetcher) loadAndVerifyFullBlock(ctx context.Context, key blo
 				return err
 			}
 
-			if err := gsf.validator.ValidateUnsignedMessagesSyntax(ctx, messages); err != nil {
-				return errors.Wrapf(err, "invalid messages for for message collection (cid %s)", rawBlock.Cid())
-			}
 			return nil
 		})
 	if err != nil {

--- a/internal/pkg/chainsync/fetcher/graphsync_fetcher.go
+++ b/internal/pkg/chainsync/fetcher/graphsync_fetcher.go
@@ -435,6 +435,7 @@ func (gsf *GraphSyncFetcher) loadAndVerifyFullBlock(ctx context.Context, key blo
 
 			return nil
 		})
+	// TODO #3312 we should validate these messages in the same way we validate blocks
 	if err != nil {
 		return block.UndefTipSet, nil, err
 	}

--- a/internal/pkg/consensus/block_validation.go
+++ b/internal/pkg/consensus/block_validation.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 )
 
 // BlockValidator defines an interface used to validate a blocks syntax and
@@ -21,7 +19,6 @@ type BlockValidator interface {
 // syntax of constituent messages
 type SyntaxValidator interface {
 	BlockSyntaxValidator
-	MessageSyntaxValidator
 }
 
 // BlockSemanticValidator defines an interface used to validate a blocks
@@ -34,15 +31,6 @@ type BlockSemanticValidator interface {
 // syntax.
 type BlockSyntaxValidator interface {
 	ValidateSyntax(ctx context.Context, blk *block.Block) error
-}
-
-// MessageSyntaxValidator defines an interface used to validate collections
-// of messages and receipts syntax
-type MessageSyntaxValidator interface {
-	ValidateMessagesSyntax(ctx context.Context, messages []*types.SignedMessage) error
-	ValidateUnsignedMessagesSyntax(ctx context.Context, messages []*types.UnsignedMessage) error
-	// TODO: Remove receipt validation when they're no longer fetched, #3489
-	ValidateReceiptsSyntax(ctx context.Context, receipts []vm.MessageReceipt) error
 }
 
 // DefaultBlockValidator implements the BlockValidator interface.
@@ -126,26 +114,5 @@ func (dv *DefaultBlockValidator) ValidateSyntax(ctx context.Context, blk *block.
 		return fmt.Errorf("block %s has nil ticket", blk.Cid().String())
 	}
 
-	return nil
-}
-
-// ValidateMessagesSyntax validates a set of messages are correctly formed.
-// TODO: Create a real implementation
-// See: https://github.com/filecoin-project/go-filecoin/issues/3312
-func (dv *DefaultBlockValidator) ValidateMessagesSyntax(ctx context.Context, messages []*types.SignedMessage) error {
-	return nil
-}
-
-// ValidateUnsignedMessagesSyntax validates a set of messages are correctly formed.
-// TODO: Create a real implementation
-// See: https://github.com/filecoin-project/go-filecoin/issues/3312
-func (dv *DefaultBlockValidator) ValidateUnsignedMessagesSyntax(ctx context.Context, messages []*types.UnsignedMessage) error {
-	return nil
-}
-
-// ValidateReceiptsSyntax validates a set of receipts are correctly formed.
-// TODO: Create a real implementation
-// See: https://github.com/filecoin-project/go-filecoin/issues/3312
-func (dv *DefaultBlockValidator) ValidateReceiptsSyntax(ctx context.Context, receipts []vm.MessageReceipt) error {
 	return nil
 }

--- a/internal/pkg/consensus/validation.go
+++ b/internal/pkg/consensus/validation.go
@@ -34,9 +34,7 @@ var (
 	errNegativeValue      = fmt.Errorf("negative value")
 	errInsufficientGas    = fmt.Errorf("balance insufficient to cover transfer+gas")
 	errInvalidSignature   = fmt.Errorf("invalid signature by sender over message data")
-	// TODO we'll eventually handle sending to self.
-	errSelfSend    = fmt.Errorf("cannot send to self")
-	errEmptySender = fmt.Errorf("message sends from empty actor")
+	errEmptySender        = fmt.Errorf("message sends from empty actor")
 )
 
 func init() {
@@ -76,8 +74,7 @@ func (v *MessagePenaltyChecker) PenaltyCheck(ctx context.Context, msg *types.Uns
 		return errEmptySender
 	}
 
-	// Sender must be an account actor, or an empty actor which will be upgraded to an account actor
-	// when the message is processed.
+	// Sender must be an account actor.
 	if !(builtin.AccountActorCodeID.Equals(fromActor.Code.Cid)) {
 		return errNonAccountActor
 	}
@@ -134,10 +131,6 @@ func (v *MessageSyntaxValidator) Validate(ctx context.Context, smsg *types.Signe
 		log.Debugf("Cannot transfer negative value: %s from actor: %s", msg.Value, msg.From)
 		errNegativeValueCt.Inc(ctx, 1)
 		return errNegativeValue
-	}
-
-	if msg.From == msg.To {
-		return errSelfSend
 	}
 
 	if msg.GasPrice.LessThanEqual(types.ZeroAttoFIL) {

--- a/internal/pkg/consensus/validation_test.go
+++ b/internal/pkg/consensus/validation_test.go
@@ -123,10 +123,10 @@ func TestMessageSyntaxValidator(t *testing.T) {
 		assert.NoError(t, validator.Validate(ctx, msg))
 	})
 
-	t.Run("self send fails", func(t *testing.T) {
+	t.Run("self send passes", func(t *testing.T) {
 		msg, err := types.NewSignedMessage(*newMessage(t, alice, alice, 100, 5, 1, 0), signer)
 		require.NoError(t, err)
-		assert.Errorf(t, validator.Validate(ctx, msg), "self")
+		assert.NoError(t, validator.Validate(ctx, msg), "self")
 	})
 
 	t.Run("negative value fails", func(t *testing.T) {

--- a/internal/pkg/consensus/validation_test.go
+++ b/internal/pkg/consensus/validation_test.go
@@ -11,7 +11,6 @@ import (
 
 	bls "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/config"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	e "github.com/filecoin-project/go-filecoin/internal/pkg/enccid"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/state"
@@ -35,59 +34,51 @@ func init() {
 	}
 }
 
-func TestMessageValidator(t *testing.T) {
+func TestMessagePenaltyChecker(t *testing.T) {
 	tf.UnitTest(t)
 
 	alice := addresses[0]
 	bob := addresses[1]
 	actor := newActor(t, 1000, 100)
+	api := NewMockIngestionValidatorAPI()
+	api.ActorAddr = alice
+	api.Actor = actor
 
-	validator := consensus.NewDefaultMessageValidator()
+	checker := consensus.NewMessagePenaltyChecker(api)
 	ctx := context.Background()
 
 	t.Run("valid", func(t *testing.T) {
 		msg := newMessage(t, alice, bob, 100, 5, 1, 0)
-		assert.NoError(t, validator.Validate(ctx, msg, actor))
-	})
-
-	t.Run("self send fails", func(t *testing.T) {
-		msg := newMessage(t, alice, alice, 100, 5, 1, 0)
-		assert.Errorf(t, validator.Validate(ctx, msg, actor), "self")
+		assert.NoError(t, checker.PenaltyCheck(ctx, msg))
 	})
 
 	t.Run("non-account actor fails", func(t *testing.T) {
 		badActor := newActor(t, 1000, 100)
 		badActor.Code = e.NewCid(types.CidFromString(t, "somecid"))
 		msg := newMessage(t, alice, bob, 100, 5, 1, 0)
-		assert.Errorf(t, validator.Validate(ctx, msg, badActor), "account")
-	})
-
-	t.Run("negative value fails", func(t *testing.T) {
-		msg := newMessage(t, alice, alice, 100, -5, 1, 0)
-		assert.Errorf(t, validator.Validate(ctx, msg, actor), "negative")
-	})
-
-	t.Run("block gas limit fails", func(t *testing.T) {
-		msg := newMessage(t, alice, bob, 100, 5, 1, uint64(types.BlockGasLimit)+1)
-		assert.Errorf(t, validator.Validate(ctx, msg, actor), "block limit")
+		api := NewMockIngestionValidatorAPI()
+		api.ActorAddr = alice
+		api.Actor = badActor
+		checker := consensus.NewMessagePenaltyChecker(api)
+		assert.Errorf(t, checker.PenaltyCheck(ctx, msg), "account")
 	})
 
 	t.Run("can't cover value", func(t *testing.T) {
 		msg := newMessage(t, alice, bob, 100, 2000, 1, 0) // lots of value
-		assert.Errorf(t, validator.Validate(ctx, msg, actor), "funds")
+		assert.Errorf(t, checker.PenaltyCheck(ctx, msg), "funds")
 
 		msg = newMessage(t, alice, bob, 100, 5, 100000, 200) // lots of expensive gas
-		assert.Errorf(t, validator.Validate(ctx, msg, actor), "funds")
+		assert.Errorf(t, checker.PenaltyCheck(ctx, msg), "funds")
 	})
 
 	t.Run("low nonce", func(t *testing.T) {
 		msg := newMessage(t, alice, bob, 99, 5, 1, 0)
-		assert.Errorf(t, validator.Validate(ctx, msg, actor), "too low")
+		assert.Errorf(t, checker.PenaltyCheck(ctx, msg), "too low")
 	})
 
 	t.Run("high nonce", func(t *testing.T) {
 		msg := newMessage(t, alice, bob, 101, 5, 1, 0)
-		assert.Errorf(t, validator.Validate(ctx, msg, actor), "too high")
+		assert.Errorf(t, checker.PenaltyCheck(ctx, msg), "too high")
 	})
 }
 
@@ -104,13 +95,12 @@ func TestBLSSignatureValidationConfiguration(t *testing.T) {
 	unsigned := &types.SignedMessage{Message: *msg}
 	actor := newActor(t, 1000, 0)
 
-	t.Run("ingestion validator does not ignore missing signature", func(t *testing.T) {
+	t.Run("syntax validator does not ignore missing signature", func(t *testing.T) {
 		api := NewMockIngestionValidatorAPI()
 		api.ActorAddr = from
 		api.Actor = actor
 
-		mpoolCfg := config.NewDefaultConfig().Mpool
-		validator := consensus.NewIngestionValidator(api, mpoolCfg)
+		validator := consensus.NewMessageSignatureValidator(api)
 
 		err := validator.Validate(ctx, unsigned)
 		require.Error(t, err)
@@ -118,51 +108,14 @@ func TestBLSSignatureValidationConfiguration(t *testing.T) {
 	})
 }
 
-func TestOutboundMessageValidator(t *testing.T) {
-	tf.UnitTest(t)
-
-	alice := addresses[0]
-	bob := addresses[1]
-	actor := newActor(t, 1000, 100)
-
-	validator := consensus.NewOutboundMessageValidator()
-	ctx := context.Background()
-
-	t.Run("allows high nonce", func(t *testing.T) {
-		msg := newMessage(t, alice, bob, 100, 5, 1, 0)
-		assert.NoError(t, validator.Validate(ctx, msg, actor))
-		msg = newMessage(t, alice, bob, 101, 5, 1, 0)
-		assert.NoError(t, validator.Validate(ctx, msg, actor))
-	})
-}
-
-func TestIngestionValidator(t *testing.T) {
+func TestMessageSyntaxValidator(t *testing.T) {
 	tf.UnitTest(t)
 	var signer = types.NewMockSigner(keys)
-
 	alice := addresses[0]
 	bob := addresses[1]
-	act := newActor(t, 1000, 53)
-	api := NewMockIngestionValidatorAPI()
-	api.ActorAddr = alice
-	api.Actor = act
 
-	mpoolCfg := config.NewDefaultConfig().Mpool
-	validator := consensus.NewIngestionValidator(api, mpoolCfg)
+	validator := consensus.NewMessageSyntaxValidator()
 	ctx := context.Background()
-
-	t.Run("Validates extreme nonce gaps", func(t *testing.T) {
-		msg, err := types.NewSignedMessage(*newMessage(t, alice, bob, 100, 5, 1, 0), signer)
-		require.NoError(t, err)
-		assert.NoError(t, validator.Validate(ctx, msg))
-
-		highNonce := act.CallSeqNum + mpoolCfg.MaxNonceGap + 10
-		msg, err = types.NewSignedMessage(*newMessage(t, alice, bob, highNonce, 5, 1, 0), signer)
-		require.NoError(t, err)
-		err = validator.Validate(ctx, msg)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "too much greater than actor nonce")
-	})
 
 	t.Run("Actor not found is not an error", func(t *testing.T) {
 		msg, err := types.NewSignedMessage(*newMessage(t, bob, alice, 0, 0, 1, 0), signer)
@@ -170,19 +123,24 @@ func TestIngestionValidator(t *testing.T) {
 		assert.NoError(t, validator.Validate(ctx, msg))
 	})
 
-	t.Run("ingestion validator does not ignore missing signature", func(t *testing.T) {
-		// create bls address
-		pubKey := bls.PrivateKeyPublicKey(bls.PrivateKeyGenerate())
-		from, err := address.NewBLSAddress(pubKey[:])
+	t.Run("self send fails", func(t *testing.T) {
+		msg, err := types.NewSignedMessage(*newMessage(t, alice, alice, 100, 5, 1, 0), signer)
 		require.NoError(t, err)
-
-		msg := newMessage(t, from, addresses[1], 0, 0, 1, 300)
-		unsigned := &types.SignedMessage{Message: *msg}
-
-		err = validator.Validate(ctx, unsigned)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid signature")
+		assert.Errorf(t, validator.Validate(ctx, msg), "self")
 	})
+
+	t.Run("negative value fails", func(t *testing.T) {
+		msg, err := types.NewSignedMessage(*newMessage(t, alice, alice, 100, -5, 1, 0), signer)
+		require.NoError(t, err)
+		assert.Errorf(t, validator.Validate(ctx, msg), "negative")
+	})
+
+	t.Run("block gas limit fails", func(t *testing.T) {
+		msg, err := types.NewSignedMessage(*newMessage(t, alice, bob, 100, 5, 1, uint64(types.BlockGasLimit)+1), signer)
+		require.NoError(t, err)
+		assert.Errorf(t, validator.Validate(ctx, msg), "block limit")
+	})
+
 }
 
 func newActor(t *testing.T, balanceAF int, nonce uint64) *actor.Actor {

--- a/internal/pkg/message/outbox.go
+++ b/internal/pkg/message/outbox.go
@@ -46,7 +46,7 @@ type Outbox struct {
 
 type messageValidator interface {
 	// Validate checks a message for validity.
-	Validate(ctx context.Context, msg *types.UnsignedMessage, fromActor *actor.Actor) error
+	Validate(ctx context.Context, msg *types.SignedMessage) error
 }
 
 type actorProvider interface {
@@ -124,7 +124,7 @@ func (ob *Outbox) Send(ctx context.Context, from, to address.Address, value type
 
 	// Slightly awkward: it would be better validate before signing but the MeteredMessage construction
 	// is hidden inside NewSignedMessage.
-	err = ob.validator.Validate(ctx, &signed.Message, fromActor)
+	err = ob.validator.Validate(ctx, signed)
 	if err != nil {
 		return cid.Undef, nil, errors.Wrap(err, "invalid message")
 	}

--- a/internal/pkg/message/testing.go
+++ b/internal/pkg/message/testing.go
@@ -92,7 +92,7 @@ type FakeValidator struct {
 }
 
 // Validate returns an error only if `RejectMessages` is true.
-func (v FakeValidator) Validate(ctx context.Context, msg *types.UnsignedMessage, fromActor *actor.Actor) error {
+func (v FakeValidator) Validate(ctx context.Context, msg *types.SignedMessage) error {
 	if v.RejectMessages {
 		return errors.New("rejected for testing")
 	}

--- a/internal/pkg/mining/scheduler_test.go
+++ b/internal/pkg/mining/scheduler_test.go
@@ -71,12 +71,12 @@ func TestMineOnce10Null(t *testing.T) {
 		Election:       consensus.NewElectionMachine(rnd),
 		TicketGen:      consensus.NewTicketMachine(rnd),
 
-		MessageSource:  pool,
-		PenaltyChecker: &NoPenaltyChecker{},
-		Blockstore:     bs,
-		MessageStore:   messages,
-		Clock:          chainClock,
-		Poster:         &consensus.TestElectionPoster{},
+		MessageSource:    pool,
+		MessageQualifier: &NoMessageQualifier{},
+		Blockstore:       bs,
+		MessageStore:     messages,
+		Clock:            chainClock,
+		Poster:           &consensus.TestElectionPoster{},
 	})
 
 	result, err := MineOnce(context.Background(), *worker, baseTs, chainClock)
@@ -134,12 +134,12 @@ func TestMineOneEpoch10Null(t *testing.T) {
 		Election:       consensus.NewElectionMachine(rnd),
 		TicketGen:      consensus.NewTicketMachine(rnd),
 
-		MessageSource:  pool,
-		PenaltyChecker: &NoPenaltyChecker{},
-		Blockstore:     bs,
-		MessageStore:   messages,
-		Clock:          chainClock,
-		Poster:         &consensus.TestElectionPoster{},
+		MessageSource:    pool,
+		MessageQualifier: &NoMessageQualifier{},
+		Blockstore:       bs,
+		MessageStore:     messages,
+		Clock:            chainClock,
+		Poster:           &consensus.TestElectionPoster{},
 	})
 
 	for i := 0; i < 10; i++ {

--- a/internal/pkg/mining/scheduler_test.go
+++ b/internal/pkg/mining/scheduler_test.go
@@ -71,12 +71,12 @@ func TestMineOnce10Null(t *testing.T) {
 		Election:       consensus.NewElectionMachine(rnd),
 		TicketGen:      consensus.NewTicketMachine(rnd),
 
-		MessageSource: pool,
-		Processor:     th.NewFakeProcessor(),
-		Blockstore:    bs,
-		MessageStore:  messages,
-		Clock:         chainClock,
-		Poster:        &consensus.TestElectionPoster{},
+		MessageSource:  pool,
+		PenaltyChecker: &NoPenaltyChecker{},
+		Blockstore:     bs,
+		MessageStore:   messages,
+		Clock:          chainClock,
+		Poster:         &consensus.TestElectionPoster{},
 	})
 
 	result, err := MineOnce(context.Background(), *worker, baseTs, chainClock)
@@ -134,12 +134,12 @@ func TestMineOneEpoch10Null(t *testing.T) {
 		Election:       consensus.NewElectionMachine(rnd),
 		TicketGen:      consensus.NewTicketMachine(rnd),
 
-		MessageSource: pool,
-		Processor:     th.NewFakeProcessor(),
-		Blockstore:    bs,
-		MessageStore:  messages,
-		Clock:         chainClock,
-		Poster:        &consensus.TestElectionPoster{},
+		MessageSource:  pool,
+		PenaltyChecker: &NoPenaltyChecker{},
+		Blockstore:     bs,
+		MessageStore:   messages,
+		Clock:          chainClock,
+		Poster:         &consensus.TestElectionPoster{},
 	})
 
 	for i := 0; i < 10; i++ {

--- a/internal/pkg/mining/testing.go
+++ b/internal/pkg/mining/testing.go
@@ -53,9 +53,9 @@ func NthTicket(i uint8) block.Ticket {
 	return block.Ticket{VRFProof: []byte{i}}
 }
 
-// NoPenaltyChecker always returns no error
-type NoPenaltyChecker struct{}
+// NoMessageQualifier always returns no error
+type NoMessageQualifier struct{}
 
-func (npc *NoPenaltyChecker) PenaltyCheck(_ context.Context, _ *types.UnsignedMessage) error {
+func (npc *NoMessageQualifier) PenaltyCheck(_ context.Context, _ *types.UnsignedMessage) error {
 	return nil
 }

--- a/internal/pkg/mining/testing.go
+++ b/internal/pkg/mining/testing.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,4 +51,11 @@ func MakeEchoMine(t *testing.T) func(context.Context, block.TipSet, uint64, chan
 // the input uint8 value.
 func NthTicket(i uint8) block.Ticket {
 	return block.Ticket{VRFProof: []byte{i}}
+}
+
+// NoPenaltyChecker always returns no error
+type NoPenaltyChecker struct{}
+
+func (npc *NoPenaltyChecker) PenaltyCheck(_ context.Context, _ *types.UnsignedMessage) error {
+	return nil
 }

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -93,7 +93,7 @@ type tipSetMetadata interface {
 	GetTipSetReceiptsRoot(key block.TipSetKey) (cid.Cid, error)
 }
 
-type messagePenaltyChecker interface {
+type messageMessageQualifier interface {
 	PenaltyCheck(ctx context.Context, msg *types.UnsignedMessage) error
 }
 
@@ -111,7 +111,7 @@ type DefaultWorker struct {
 	election       electionUtil
 	ticketGen      ticketGenerator
 	messageSource  MessageSource
-	penaltyChecker messagePenaltyChecker
+	penaltyChecker messageMessageQualifier
 	messageStore   chain.MessageWriter // nolint: structcheck
 	blockstore     blockstore.Blockstore
 	clock          clock.Clock
@@ -127,12 +127,12 @@ type WorkerParameters struct {
 	WorkerSigner   types.Signer
 
 	// consensus things
-	TipSetMetadata tipSetMetadata
-	GetStateTree   GetStateTree
-	PenaltyChecker messagePenaltyChecker
-	GetWeight      GetWeight
-	Election       electionUtil
-	TicketGen      ticketGenerator
+	TipSetMetadata   tipSetMetadata
+	GetStateTree     GetStateTree
+	MessageQualifier messageMessageQualifier
+	GetWeight        GetWeight
+	Election         electionUtil
+	TicketGen        ticketGenerator
 
 	// core filecoin things
 	MessageSource MessageSource
@@ -150,7 +150,7 @@ func NewDefaultWorker(parameters WorkerParameters) *DefaultWorker {
 		getWeight:      parameters.GetWeight,
 		messageSource:  parameters.MessageSource,
 		messageStore:   parameters.MessageStore,
-		penaltyChecker: parameters.PenaltyChecker,
+		penaltyChecker: parameters.MessageQualifier,
 		blockstore:     parameters.Blockstore,
 		minerAddr:      parameters.MinerAddr,
 		minerOwnerAddr: parameters.MinerOwnerAddr,

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -82,11 +82,11 @@ func TestLookbackElection(t *testing.T) {
 			Election:       consensus.NewElectionMachine(rnd),
 			TicketGen:      consensus.NewTicketMachine(rnd),
 
-			MessageSource:  pool,
-			PenaltyChecker: &mining.NoPenaltyChecker{},
-			Blockstore:     bs,
-			MessageStore:   messages,
-			Clock:          clock.NewSystemClock(),
+			MessageSource:    pool,
+			MessageQualifier: &mining.NoMessageQualifier{},
+			Blockstore:       bs,
+			MessageStore:     messages,
+			Clock:            clock.NewSystemClock(),
 		})
 
 		go worker.Mine(ctx, head, 0, outCh)
@@ -141,11 +141,11 @@ func Test_Mine(t *testing.T) {
 			Election:       consensus.NewElectionMachine(rnd),
 			TicketGen:      consensus.NewTicketMachine(rnd),
 
-			MessageSource:  pool,
-			PenaltyChecker: &mining.NoPenaltyChecker{},
-			Blockstore:     bs,
-			MessageStore:   messages,
-			Clock:          clock.NewSystemClock(),
+			MessageSource:    pool,
+			MessageQualifier: &mining.NoMessageQualifier{},
+			Blockstore:       bs,
+			MessageStore:     messages,
+			Clock:            clock.NewSystemClock(),
 		})
 
 		go worker.Mine(ctx, tipSet, 0, outCh)
@@ -175,11 +175,11 @@ func Test_Mine(t *testing.T) {
 			Election:       consensus.NewElectionMachine(rnd),
 			TicketGen:      consensus.NewTicketMachine(rnd),
 
-			MessageSource:  pool,
-			PenaltyChecker: &mining.NoPenaltyChecker{},
-			Blockstore:     bs,
-			MessageStore:   messages,
-			Clock:          clock.NewSystemClock(),
+			MessageSource:    pool,
+			MessageQualifier: &mining.NoMessageQualifier{},
+			Blockstore:       bs,
+			MessageStore:     messages,
+			Clock:            clock.NewSystemClock(),
 		})
 		outCh := make(chan mining.Output)
 
@@ -205,11 +205,11 @@ func Test_Mine(t *testing.T) {
 			Election:       consensus.NewElectionMachine(rnd),
 			TicketGen:      consensus.NewTicketMachine(rnd),
 
-			MessageSource:  pool,
-			PenaltyChecker: &mining.NoPenaltyChecker{},
-			Blockstore:     bs,
-			MessageStore:   messages,
-			Clock:          clock.NewSystemClock(),
+			MessageSource:    pool,
+			MessageQualifier: &mining.NoMessageQualifier{},
+			Blockstore:       bs,
+			MessageStore:     messages,
+			Clock:            clock.NewSystemClock(),
 		})
 		input := block.TipSet{}
 		outCh := make(chan mining.Output)
@@ -380,11 +380,11 @@ func TestApplyBLSMessages(t *testing.T) {
 		Election:       &consensus.FakeElectionMachine{},
 		TicketGen:      &consensus.FakeTicketMachine{},
 
-		MessageSource:  pool,
-		PenaltyChecker: &mining.NoPenaltyChecker{},
-		Blockstore:     bs,
-		MessageStore:   msgStore,
-		Clock:          clock.NewSystemClock(),
+		MessageSource:    pool,
+		MessageQualifier: &mining.NoMessageQualifier{},
+		Blockstore:       bs,
+		MessageStore:     msgStore,
+		Clock:            clock.NewSystemClock(),
 	})
 
 	outCh := make(chan mining.Output)
@@ -478,11 +478,11 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 		Election:       &consensus.FakeElectionMachine{},
 		TicketGen:      &consensus.FakeTicketMachine{},
 
-		MessageSource:  pool,
-		PenaltyChecker: &mining.NoPenaltyChecker{},
-		Blockstore:     bs,
-		MessageStore:   messages,
-		Clock:          th.NewFakeClock(time.Unix(1234567890, 0)),
+		MessageSource:    pool,
+		MessageQualifier: &mining.NoMessageQualifier{},
+		Blockstore:       bs,
+		MessageStore:     messages,
+		Clock:            th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	builder := chain.NewBuilder(t, address.Undef)
@@ -543,11 +543,11 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		Election:       &consensus.FakeElectionMachine{},
 		TicketGen:      &consensus.FakeTicketMachine{},
 
-		MessageSource:  pool,
-		PenaltyChecker: &mining.NoPenaltyChecker{},
-		Blockstore:     bs,
-		MessageStore:   messages,
-		Clock:          th.NewFakeClock(time.Unix(1234567890, 0)),
+		MessageSource:    pool,
+		MessageQualifier: &mining.NoMessageQualifier{},
+		Blockstore:       bs,
+		MessageStore:     messages,
+		Clock:            th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	// addr3 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
@@ -648,11 +648,11 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 		Election:       &consensus.FakeElectionMachine{},
 		TicketGen:      &consensus.FakeTicketMachine{},
 
-		MessageSource:  pool,
-		PenaltyChecker: &mining.NoPenaltyChecker{},
-		Blockstore:     bs,
-		MessageStore:   messages,
-		Clock:          th.NewFakeClock(time.Unix(1234567890, 0)),
+		MessageSource:    pool,
+		MessageQualifier: &mining.NoMessageQualifier{},
+		Blockstore:       bs,
+		MessageStore:     messages,
+		Clock:            th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	h := abi.ChainEpoch(100)
@@ -708,11 +708,11 @@ func TestGenerateWithoutMessages(t *testing.T) {
 		Election:       &consensus.FakeElectionMachine{},
 		TicketGen:      &consensus.FakeTicketMachine{},
 
-		MessageSource:  pool,
-		PenaltyChecker: &mining.NoPenaltyChecker{},
-		Blockstore:     bs,
-		MessageStore:   messages,
-		Clock:          th.NewFakeClock(time.Unix(1234567890, 0)),
+		MessageSource:    pool,
+		MessageQualifier: &mining.NoMessageQualifier{},
+		Blockstore:       bs,
+		MessageStore:     messages,
+		Clock:            th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	assert.Len(t, pool.Pending(), 0)
@@ -762,11 +762,11 @@ func TestGenerateError(t *testing.T) {
 		Election:       &consensus.FakeElectionMachine{},
 		TicketGen:      &consensus.FakeTicketMachine{},
 
-		MessageSource:  pool,
-		PenaltyChecker: &mining.NoPenaltyChecker{},
-		Blockstore:     bs,
-		MessageStore:   messages,
-		Clock:          th.NewFakeClock(time.Unix(1234567890, 0)),
+		MessageSource:    pool,
+		MessageQualifier: &mining.NoMessageQualifier{},
+		Blockstore:       bs,
+		MessageStore:     messages,
+		Clock:            th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	// This is actually okay and should result in a receipt

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -82,11 +82,11 @@ func TestLookbackElection(t *testing.T) {
 			Election:       consensus.NewElectionMachine(rnd),
 			TicketGen:      consensus.NewTicketMachine(rnd),
 
-			MessageSource: pool,
-			Processor:     th.NewFakeProcessor(),
-			Blockstore:    bs,
-			MessageStore:  messages,
-			Clock:         clock.NewSystemClock(),
+			MessageSource:  pool,
+			PenaltyChecker: &mining.NoPenaltyChecker{},
+			Blockstore:     bs,
+			MessageStore:   messages,
+			Clock:          clock.NewSystemClock(),
 		})
 
 		go worker.Mine(ctx, head, 0, outCh)
@@ -141,11 +141,11 @@ func Test_Mine(t *testing.T) {
 			Election:       consensus.NewElectionMachine(rnd),
 			TicketGen:      consensus.NewTicketMachine(rnd),
 
-			MessageSource: pool,
-			Processor:     th.NewFakeProcessor(),
-			Blockstore:    bs,
-			MessageStore:  messages,
-			Clock:         clock.NewSystemClock(),
+			MessageSource:  pool,
+			PenaltyChecker: &mining.NoPenaltyChecker{},
+			Blockstore:     bs,
+			MessageStore:   messages,
+			Clock:          clock.NewSystemClock(),
 		})
 
 		go worker.Mine(ctx, tipSet, 0, outCh)
@@ -175,11 +175,11 @@ func Test_Mine(t *testing.T) {
 			Election:       consensus.NewElectionMachine(rnd),
 			TicketGen:      consensus.NewTicketMachine(rnd),
 
-			MessageSource: pool,
-			Processor:     th.NewFakeProcessor(),
-			Blockstore:    bs,
-			MessageStore:  messages,
-			Clock:         clock.NewSystemClock(),
+			MessageSource:  pool,
+			PenaltyChecker: &mining.NoPenaltyChecker{},
+			Blockstore:     bs,
+			MessageStore:   messages,
+			Clock:          clock.NewSystemClock(),
 		})
 		outCh := make(chan mining.Output)
 
@@ -205,11 +205,11 @@ func Test_Mine(t *testing.T) {
 			Election:       consensus.NewElectionMachine(rnd),
 			TicketGen:      consensus.NewTicketMachine(rnd),
 
-			MessageSource: pool,
-			Processor:     th.NewFakeProcessor(),
-			Blockstore:    bs,
-			MessageStore:  messages,
-			Clock:         clock.NewSystemClock(),
+			MessageSource:  pool,
+			PenaltyChecker: &mining.NoPenaltyChecker{},
+			Blockstore:     bs,
+			MessageStore:   messages,
+			Clock:          clock.NewSystemClock(),
 		})
 		input := block.TipSet{}
 		outCh := make(chan mining.Output)
@@ -380,11 +380,11 @@ func TestApplyBLSMessages(t *testing.T) {
 		Election:       &consensus.FakeElectionMachine{},
 		TicketGen:      &consensus.FakeTicketMachine{},
 
-		MessageSource: pool,
-		Processor:     th.NewFakeProcessor(),
-		Blockstore:    bs,
-		MessageStore:  msgStore,
-		Clock:         clock.NewSystemClock(),
+		MessageSource:  pool,
+		PenaltyChecker: &mining.NoPenaltyChecker{},
+		Blockstore:     bs,
+		MessageStore:   msgStore,
+		Clock:          clock.NewSystemClock(),
 	})
 
 	outCh := make(chan mining.Output)
@@ -478,11 +478,11 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 		Election:       &consensus.FakeElectionMachine{},
 		TicketGen:      &consensus.FakeTicketMachine{},
 
-		MessageSource: pool,
-		Processor:     th.NewFakeProcessor(),
-		Blockstore:    bs,
-		MessageStore:  messages,
-		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
+		MessageSource:  pool,
+		PenaltyChecker: &mining.NoPenaltyChecker{},
+		Blockstore:     bs,
+		MessageStore:   messages,
+		Clock:          th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	builder := chain.NewBuilder(t, address.Undef)
@@ -528,7 +528,6 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		return st, nil
 	}
 	rnd := &consensus.FakeChainRandomness{Seed: 0}
-	syscalls := &vm.FakeSyscalls{}
 	messages := chain.NewMessageStore(bs)
 
 	worker := mining.NewDefaultWorker(mining.WorkerParameters{
@@ -544,11 +543,11 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		Election:       &consensus.FakeElectionMachine{},
 		TicketGen:      &consensus.FakeTicketMachine{},
 
-		MessageSource: pool,
-		Processor:     consensus.NewDefaultProcessor(syscalls, rnd),
-		Blockstore:    bs,
-		MessageStore:  messages,
-		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
+		MessageSource:  pool,
+		PenaltyChecker: &mining.NoPenaltyChecker{},
+		Blockstore:     bs,
+		MessageStore:   messages,
+		Clock:          th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	// addr3 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
@@ -630,7 +629,6 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 		return st, nil
 	}
 	rnd := &consensus.FakeChainRandomness{Seed: 0}
-	syscalls := &vm.FakeSyscalls{}
 	minerAddr := addrs[3]
 	th.RequireInitAccountActor(ctx, t, st, vm.NewStorage(bs), addrs[4], types.ZeroAttoFIL)
 	minerOwnerAddr := addrs[4]
@@ -650,11 +648,11 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 		Election:       &consensus.FakeElectionMachine{},
 		TicketGen:      &consensus.FakeTicketMachine{},
 
-		MessageSource: pool,
-		Processor:     consensus.NewDefaultProcessor(syscalls, rnd),
-		Blockstore:    bs,
-		MessageStore:  messages,
-		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
+		MessageSource:  pool,
+		PenaltyChecker: &mining.NoPenaltyChecker{},
+		Blockstore:     bs,
+		MessageStore:   messages,
+		Clock:          th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	h := abi.ChainEpoch(100)
@@ -695,7 +693,6 @@ func TestGenerateWithoutMessages(t *testing.T) {
 		return st, nil
 	}
 	rnd := &consensus.FakeChainRandomness{Seed: 0}
-	syscalls := &vm.FakeSyscalls{}
 	messages := chain.NewMessageStore(bs)
 
 	worker := mining.NewDefaultWorker(mining.WorkerParameters{
@@ -711,11 +708,11 @@ func TestGenerateWithoutMessages(t *testing.T) {
 		Election:       &consensus.FakeElectionMachine{},
 		TicketGen:      &consensus.FakeTicketMachine{},
 
-		MessageSource: pool,
-		Processor:     consensus.NewDefaultProcessor(syscalls, rnd),
-		Blockstore:    bs,
-		MessageStore:  messages,
-		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
+		MessageSource:  pool,
+		PenaltyChecker: &mining.NoPenaltyChecker{},
+		Blockstore:     bs,
+		MessageStore:   messages,
+		Clock:          th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	assert.Len(t, pool.Pending(), 0)
@@ -751,7 +748,6 @@ func TestGenerateError(t *testing.T) {
 		return st, nil
 	}
 	rnd := &consensus.FakeChainRandomness{Seed: 0}
-	syscalls := &vm.FakeSyscalls{}
 	messages := chain.NewMessageStore(bs)
 	worker := mining.NewDefaultWorker(mining.WorkerParameters{
 		API: th.NewDefaultFakeWorkerPorcelainAPI(blockSignerAddr, rnd),
@@ -766,11 +762,11 @@ func TestGenerateError(t *testing.T) {
 		Election:       &consensus.FakeElectionMachine{},
 		TicketGen:      &consensus.FakeTicketMachine{},
 
-		MessageSource: pool,
-		Processor:     consensus.NewDefaultProcessor(syscalls, rnd),
-		Blockstore:    bs,
-		MessageStore:  messages,
-		Clock:         th.NewFakeClock(time.Unix(1234567890, 0)),
+		MessageSource:  pool,
+		PenaltyChecker: &mining.NoPenaltyChecker{},
+		Blockstore:     bs,
+		MessageStore:   messages,
+		Clock:          th.NewFakeClock(time.Unix(1234567890, 0)),
 	})
 
 	// This is actually okay and should result in a receipt

--- a/internal/pkg/net/validators.go
+++ b/internal/pkg/net/validators.go
@@ -70,8 +70,8 @@ type MessageTopicValidator struct {
 	opts      []pubsub.ValidatorOpt
 }
 
-// NewMessageTopicValidator returns a MessageTopicValidator using `mv` for
-// message validation
+// NewMessageTopicValidator returns a MessageTopicValidator using the input
+// signature and syntax validators.
 func NewMessageTopicValidator(syntaxVal *consensus.MessageSyntaxValidator, sigVal *consensus.MessageSignatureValidator, opts ...pubsub.ValidatorOpt) *MessageTopicValidator {
 	return &MessageTopicValidator{
 		opts: opts,


### PR DESCRIPTION
### Motivation
We want to prevent blocks mined from including messages that will penalize the miner.

### Proposed changes
1) Reorganize message validation rules into 
  a) syntax validation -- checks that can be done without any actor state   
  b) signature validation
  c) penalty checks -- checks that reference actor state and are marked as causing miner penalty in the spec

2) Reorganize where validation is called.  Mpool Add, pubsub replay and inbox add do syntax validation.  Signature validation is now out of mpool / inbox add and only in pubsub message topic receipt and pubsub message topic replay.  Unfortunately there is still duplication in these two validations. Removing duplication here would have required veering far from the intention of this PR. So #3566 is still open.  Finally we now do message penalty checking validation in the mining worker to filter messages included in blocks.

This omits new tests to get this out the door as errors related to the new penalty checking feature should be non-critical and fairly easy to track down.  But I'll write a mining worker test or an integration mining once test showing we filter out bad messages if that's preferred.

Closes issue #3839

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

