### PR TITLE
parameterize sectorsize when importing presealed sectors

### DIFF
--- a/cmd/go-filecoin/init.go
+++ b/cmd/go-filecoin/init.go
@@ -10,9 +10,8 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
-
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-car"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	cmdkit "github.com/ipfs/go-ipfs-cmdkit"

--- a/cmd/go-filecoin/init_daemon_test.go
+++ b/cmd/go-filecoin/init_daemon_test.go
@@ -70,6 +70,7 @@ func TestImportPresealedSectors(t *testing.T) {
 	td := th.NewDaemon(t, th.InitArgs(
 		"--presealed-sectordir",
 		project.Root("fixtures/genesis-sectors"),
+		"--presealed-sector-size", "2048",
 		"--symlink-imported-sectors",
 	)).Start()
 

--- a/cmd/go-filecoin/main.go
+++ b/cmd/go-filecoin/main.go
@@ -34,6 +34,9 @@ const (
 	// OptionPresealedSectorDir is the name of the option for specifying the directory from which presealed sectors should be pulled when initializing.
 	OptionPresealedSectorDir = "presealed-sectordir"
 
+	// OptionPresealedSectorSize is the name of the option for specifying the size of presealed sectors
+	OptionPresealedSectorSize = "presealed-sector-size"
+
 	// OptionSymlinkImportedSectors is the name of the option for specifying whether imported sectors should be copied or symlinked.
 	OptionSymlinkImportedSectors = "symlink-imported-sectors"
 

--- a/functional-tests/mining_chain_test.go
+++ b/functional-tests/mining_chain_test.go
@@ -41,7 +41,7 @@ func TestSingleMiner(t *testing.T) {
 	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, fakeClock)
 
 	nd := makeNode(ctx, t, seed, chainClock)
-	minerAddr, _, err := initNodeGenesisMiner(t, nd, seed, genCfg.Miners[0].Owner, presealPath)
+	minerAddr, _, err := initNodeGenesisMiner(t, nd, seed, genCfg.Miners[0].Owner, presealPath, genCfg.Miners[0].SectorSize)
 	require.NoError(t, err)
 
 	err = nd.Start(ctx)
@@ -97,7 +97,7 @@ func TestSyncFromSingleMiner(t *testing.T) {
 	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, fakeClock)
 
 	ndMiner := makeNode(ctx, t, seed, chainClock)
-	_, _, err := initNodeGenesisMiner(t, ndMiner, seed, genCfg.Miners[0].Owner, presealPath)
+	_, _, err := initNodeGenesisMiner(t, ndMiner, seed, genCfg.Miners[0].Owner, presealPath, genCfg.Miners[0].SectorSize)
 	require.NoError(t, err)
 
 	ndValidator := makeNode(ctx, t, seed, chainClock)
@@ -152,11 +152,11 @@ func makeNode(ctx context.Context, t *testing.T, seed *node.ChainSeed, chainCloc
 		Build(ctx)
 }
 
-func initNodeGenesisMiner(t *testing.T, nd *node.Node, seed *node.ChainSeed, minerIdx int, presealPath string) (address.Address, address.Address, error) {
+func initNodeGenesisMiner(t *testing.T, nd *node.Node, seed *node.ChainSeed, minerIdx int, presealPath string, sectorSize abi.SectorSize) (address.Address, address.Address, error) {
 	seed.GiveKey(t, nd, minerIdx)
 	miner, owner := seed.GiveMiner(t, nd, 0)
 
-	err := node.ImportPresealedSectors(nd.Repo, presealPath, true)
+	err := node.ImportPresealedSectors(nd.Repo, presealPath, sectorSize, true)
 	require.NoError(t, err)
 	return miner, owner, err
 }

--- a/internal/app/go-filecoin/node/init.go
+++ b/internal/app/go-filecoin/node/init.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"path/filepath"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
-
 	"github.com/filecoin-project/go-sectorbuilder"
+	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
 	badger "github.com/ipfs/go-ds-badger2"


### PR DESCRIPTION
### Motivation

We currently have no way to specify proof types for sectorbuilder when importing presealed sectors. Registered proof types can be derived from sector size, but we also do not have the sector size. In functional tests, we can easily get the default miner's sectors size from genesis. Unfortunately this is rather complicated in the init command so we'll need to supply a new command option.

### Proposed changes

* Add a sector size parameter when calling `ImportPresealedSectors`.
* Add a parameter to the init command to specify sectors size.
* Use `miner.SectorSize` to import sectors in functional tests.

Closes issue #3876

