### PR TITLE
Feat/network protocol interop

### DIFF
--- a/cmd/go-filecoin/main.go
+++ b/cmd/go-filecoin/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/paths"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 const (
@@ -354,29 +355,29 @@ var priceOption = cmdkit.StringOption("gas-price", "Price (FIL e.g. 0.00013) to 
 var limitOption = cmdkit.Uint64Option("gas-limit", "Maximum GasUnits this message is allowed to consume")
 var previewOption = cmdkit.BoolOption("preview", "Preview the Gas cost of this command without actually executing it")
 
-func parseGasOptions(req *cmds.Request) (types.AttoFIL, types.GasUnits, bool, error) {
+func parseGasOptions(req *cmds.Request) (types.AttoFIL, gas.Unit, bool, error) {
 	priceOption := req.Options["gas-price"]
 	if priceOption == nil {
-		return types.ZeroAttoFIL, types.GasUnits(0), false, errors.New("gas-price option is required")
+		return types.ZeroAttoFIL, gas.NewGas(0), false, errors.New("gas-price option is required")
 	}
 
 	price, ok := types.NewAttoFILFromFILString(priceOption.(string))
 	if !ok {
-		return types.ZeroAttoFIL, types.GasUnits(0), false, errors.New("invalid gas price (specify FIL as a decimal number)")
+		return types.ZeroAttoFIL, gas.NewGas(0), false, errors.New("invalid gas price (specify FIL as a decimal number)")
 	}
 
 	limitOption := req.Options["gas-limit"]
 	if limitOption == nil {
-		return types.ZeroAttoFIL, types.GasUnits(0), false, errors.New("gas-limit option is required")
+		return types.ZeroAttoFIL, gas.NewGas(0), false, errors.New("gas-limit option is required")
 	}
 
-	gasLimitInt, ok := limitOption.(uint64)
+	gasLimitInt, ok := limitOption.(int64)
 	if !ok {
 		msg := fmt.Sprintf("invalid gas limit: %s", limitOption)
-		return types.ZeroAttoFIL, types.GasUnits(0), false, errors.New(msg)
+		return types.ZeroAttoFIL, gas.NewGas(0), false, errors.New(msg)
 	}
 
 	preview, _ := req.Options["preview"].(bool)
 
-	return price, types.GasUnits(gasLimitInt), preview, nil
+	return price, gas.NewGas(gasLimitInt), preview, nil
 }

--- a/cmd/go-filecoin/main.go
+++ b/cmd/go-filecoin/main.go
@@ -358,7 +358,7 @@ var previewOption = cmdkit.BoolOption("preview", "Preview the Gas cost of this c
 func parseGasOptions(req *cmds.Request) (types.AttoFIL, gas.Unit, bool, error) {
 	priceOption := req.Options["gas-price"]
 	if priceOption == nil {
-		return types.ZeroAttoFIL, gas.NewGas(0), false, errors.New("gas-price option is required")
+		return types.ZeroAttoFIL, gas.Zero, false, errors.New("gas-price option is required")
 	}
 
 	price, ok := types.NewAttoFILFromFILString(priceOption.(string))

--- a/cmd/go-filecoin/message.go
+++ b/cmd/go-filecoin/message.go
@@ -24,6 +24,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/plumbing/msg"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/message"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 var msgCmd = &cmds.Command{
@@ -41,7 +42,7 @@ var msgCmd = &cmds.Command{
 // MessageSendResult is the return type for message send command
 type MessageSendResult struct {
 	Cid     cid.Cid
-	GasUsed types.GasUnits
+	GasUsed gas.Unit
 	Preview bool
 }
 
@@ -125,7 +126,7 @@ var msgSendCmd = &cmds.Command{
 
 		return re.Emit(&MessageSendResult{
 			Cid:     c,
-			GasUsed: types.GasUnits(0),
+			GasUsed: gas.NewGas(0),
 			Preview: false,
 		})
 	},
@@ -173,7 +174,7 @@ var signedMsgSendCmd = &cmds.Command{
 
 		return re.Emit(&MessageSendResult{
 			Cid:     c,
-			GasUsed: types.GasUnits(0),
+			GasUsed: gas.NewGas(0),
 			Preview: false,
 		})
 	},

--- a/cmd/go-filecoin/miner.go
+++ b/cmd/go-filecoin/miner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/constants"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 var minerCmd = &cmds.Command{
@@ -36,7 +37,7 @@ var minerCmd = &cmds.Command{
 // MinerCreateResult is the type returned when creating a miner.
 type MinerCreateResult struct {
 	Address address.Address
-	GasUsed types.GasUnits
+	GasUsed gas.Unit
 	Preview bool
 }
 
@@ -127,7 +128,7 @@ additional sectors.`,
 
 		return re.Emit(&MinerCreateResult{
 			Address: *addr,
-			GasUsed: types.GasUnits(0),
+			GasUsed: gas.NewGas(0),
 			Preview: false,
 		})
 	},
@@ -221,7 +222,7 @@ This command waits for the ask to be mined.`,
 // MinerUpdatePeerIDResult is the return type for miner update-peerid command
 type MinerUpdatePeerIDResult struct {
 	Cid     cid.Cid
-	GasUsed types.GasUnits
+	GasUsed gas.Unit
 	Preview bool
 }
 
@@ -298,7 +299,7 @@ var minerUpdatePeerIDCmd = &cmds.Command{
 
 		return re.Emit(&MinerUpdatePeerIDResult{
 			Cid:     c,
-			GasUsed: types.GasUnits(0),
+			GasUsed: gas.NewGas(0),
 			Preview: false,
 		})
 	},

--- a/internal/app/go-filecoin/connectors/storage_market/common.go
+++ b/internal/app/go-filecoin/connectors/storage_market/common.go
@@ -27,6 +27,7 @@ import (
 	appstate "github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/wallet"
 )
 
@@ -95,7 +96,7 @@ func (c *connectorCommon) addFunds(ctx context.Context, fromAddr address.Address
 		builtin.StorageMarketActorAddr,
 		types.NewAttoFIL(amount.Int),
 		types.NewGasPrice(1),
-		types.GasUnits(300),
+		gas.NewGas(300),
 		true,
 		builtin.MethodsMarket.AddBalance,
 		&addr,

--- a/internal/app/go-filecoin/connectors/storage_market/provider.go
+++ b/internal/app/go-filecoin/connectors/storage_market/provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	appstate "github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/wallet"
 )
 
@@ -96,7 +97,7 @@ func (s *StorageProviderNodeConnector) PublishDeals(ctx context.Context, deal st
 		builtin.StorageMarketActorAddr,
 		types.ZeroAttoFIL,
 		types.NewGasPrice(1),
-		types.GasUnits(300),
+		gas.NewGas(300),
 		true,
 		builtin.MethodsMarket.PublishStorageDeals,
 		params,

--- a/internal/app/go-filecoin/connectors/storage_miner/connector.go
+++ b/internal/app/go-filecoin/connectors/storage_miner/connector.go
@@ -25,6 +25,7 @@ import (
 	appstate "github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/wallet"
 )
 
@@ -127,7 +128,7 @@ func (m *StorageMinerNodeConnector) SendSelfDeals(ctx context.Context, startEpoc
 		builtin.StorageMarketActorAddr,
 		types.ZeroAttoFIL,
 		types.NewGasPrice(1),
-		types.GasUnits(300),
+		gas.NewGas(300),
 		true,
 		builtin.MethodsMarket.PublishStorageDeals,
 		&params,
@@ -218,7 +219,7 @@ func (m *StorageMinerNodeConnector) SendPreCommitSector(ctx context.Context, sec
 		m.minerAddr,
 		types.ZeroAttoFIL,
 		types.NewGasPrice(1),
-		types.GasUnits(300),
+		gas.NewGas(300),
 		true,
 		builtin.MethodsMiner.PreCommitSector,
 		&params,
@@ -261,7 +262,7 @@ func (m *StorageMinerNodeConnector) SendProveCommitSector(ctx context.Context, s
 		m.minerAddr,
 		types.ZeroAttoFIL,
 		types.NewGasPrice(1),
-		types.GasUnits(300),
+		gas.NewGas(300),
 		true,
 		builtin.MethodsMiner.ProveCommitSector,
 		&params,
@@ -463,7 +464,7 @@ func (m *StorageMinerNodeConnector) SendReportFaults(ctx context.Context, sector
 		m.minerAddr,
 		types.ZeroAttoFIL,
 		types.NewGasPrice(1),
-		types.GasUnits(300),
+		gas.NewGas(300),
 		true,
 		builtin.MethodsMiner.DeclareTemporaryFaults,
 		&params,

--- a/internal/app/go-filecoin/internal/submodule/network_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/network_submodule.go
@@ -2,7 +2,6 @@ package submodule
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/ipfs/go-bitswap"
@@ -83,7 +82,6 @@ func NewNetworkSubmodule(ctx context.Context, config networkConfig, repo network
 	if err != nil {
 		return NetworkSubmodule{}, err
 	}
-	networkName = "interop"
 
 	// set up host
 	var peerHost host.Host
@@ -146,7 +144,6 @@ func NewNetworkSubmodule(ctx context.Context, config networkConfig, repo network
 
 	// build network
 	network := net.New(peerHost, net.NewRouter(router), bandwidthTracker, net.NewPinger(peerHost, pingService))
-	fmt.Printf("network name: <%s>\n", networkName)
 	// build the network submdule
 	return NetworkSubmodule{
 		NetworkName:   networkName,

--- a/internal/app/go-filecoin/internal/submodule/network_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/network_submodule.go
@@ -2,6 +2,7 @@ package submodule
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ipfs/go-bitswap"
@@ -82,6 +83,7 @@ func NewNetworkSubmodule(ctx context.Context, config networkConfig, repo network
 	if err != nil {
 		return NetworkSubmodule{}, err
 	}
+	networkName = "interop"
 
 	// set up host
 	var peerHost host.Host
@@ -144,7 +146,7 @@ func NewNetworkSubmodule(ctx context.Context, config networkConfig, repo network
 
 	// build network
 	network := net.New(peerHost, net.NewRouter(router), bandwidthTracker, net.NewPinger(peerHost, pingService))
-
+	fmt.Printf("network name: <%s>\n", networkName)
 	// build the network submdule
 	return NetworkSubmodule{
 		NetworkName:   networkName,

--- a/internal/app/go-filecoin/node/block_propagate_test.go
+++ b/internal/app/go-filecoin/node/block_propagate_test.go
@@ -156,7 +156,7 @@ func TestChainSyncWithMessages(t *testing.T) {
 	receiverStart, err := nodeReceive.PorcelainAPI.WalletBalance(ctx, receiverAddress)
 	require.NoError(t, err)
 	gasPrice := types.NewGasPrice(1)
-	expGasCost := gas.NewGas(244).ToTokens(gasPrice) // DRAGONS -- this is brittle need a better way to predict this.
+	expGasCost := gas.NewGas(242).ToTokens(gasPrice) // DRAGONS -- this is brittle need a better way to predict this.
 
 	/* send message from SendNode */
 	sendVal := specsbig.NewInt(100)

--- a/internal/app/go-filecoin/node/block_propagate_test.go
+++ b/internal/app/go-filecoin/node/block_propagate_test.go
@@ -156,7 +156,7 @@ func TestChainSyncWithMessages(t *testing.T) {
 	receiverStart, err := nodeReceive.PorcelainAPI.WalletBalance(ctx, receiverAddress)
 	require.NoError(t, err)
 	gasPrice := types.NewGasPrice(1)
-	expGasCost := gas.NewGas(242).ToTokens(gasPrice) // DRAGONS -- this is brittle need a better way to predict this.
+	expGasCost := gas.NewGas(244).ToTokens(gasPrice) // DRAGONS -- this is brittle need a better way to predict this.
 
 	/* send message from SendNode */
 	sendVal := specsbig.NewInt(100)
@@ -166,7 +166,7 @@ func TestChainSyncWithMessages(t *testing.T) {
 		receiverAddress,
 		sendVal,
 		gasPrice,
-		types.GasUnits(1000),
+		gas.NewGas(1000),
 		builtin.MethodSend,
 		&adt.EmptyValue{},
 	)

--- a/internal/app/go-filecoin/node/message_propagate_test.go
+++ b/internal/app/go-filecoin/node/message_propagate_test.go
@@ -15,13 +15,13 @@ import (
 	. "github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/proofs"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/version"
-	gengen "github.com/filecoin-project/go-filecoin/tools/gengen/util"
-	specsbig "github.com/filecoin-project/specs-actors/actors/abi/big"
-
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/version"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
+	gengen "github.com/filecoin-project/go-filecoin/tools/gengen/util"
+	specsbig "github.com/filecoin-project/specs-actors/actors/abi/big"
 )
 
 // TestMessagePropagation is a high level check that messages are propagated between message
@@ -78,7 +78,7 @@ func TestMessagePropagation(t *testing.T) {
 			builtin.InitActorAddr,
 			specsbig.NewInt(100),
 			types.NewGasPrice(1),
-			types.GasUnits(0),
+			gas.NewGas(0),
 			fooMethod,
 			&adt.EmptyValue{},
 		)

--- a/internal/app/go-filecoin/paymentchannel/fake_mgr_api.go
+++ b/internal/app/go-filecoin/paymentchannel/fake_mgr_api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 // FakePaymentChannelAPI mocks some needed APIs for a payment channel manager
@@ -73,7 +74,7 @@ func (f *FakePaymentChannelAPI) Send(_ context.Context,
 	from, to address.Address,
 	value types.AttoFIL,
 	gasPrice types.AttoFIL,
-	gasLimit types.GasUnits,
+	gasLimit gas.Unit,
 	bcast bool,
 	method abi.MethodNum,
 	params interface{}) (out cid.Cid, pubErrCh chan error, err error) {

--- a/internal/app/go-filecoin/paymentchannel/manager.go
+++ b/internal/app/go-filecoin/paymentchannel/manager.go
@@ -21,10 +21,11 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 var defaultGasPrice = types.NewAttoFILFromFIL(actor.DefaultGasCost)
-var defaultGasLimit = types.GasUnits(300)
+var defaultGasLimit = gas.NewGas(300)
 var zeroAmt = abi.NewTokenAmount(0)
 
 // Manager manages payment channel actor and the data paymentChannels operations.
@@ -52,7 +53,7 @@ type MsgSender interface {
 		from, to address.Address,
 		value types.AttoFIL,
 		gasPrice types.AttoFIL,
-		gasLimit types.GasUnits,
+		gasLimit gas.Unit,
 		bcast bool,
 		method abi.MethodNum,
 		params interface{}) (out cid.Cid, pubErrCh chan error, err error)

--- a/internal/app/go-filecoin/plumbing/api.go
+++ b/internal/app/go-filecoin/plumbing/api.go
@@ -32,6 +32,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/wallet"
 )
@@ -223,7 +224,7 @@ func (api *API) MessagePoolRemove(cid cid.Cid) {
 
 // MessagePreview previews the Gas cost of a message by running it locally on the client and
 // recording the amount of Gas used.
-func (api *API) MessagePreview(ctx context.Context, from, to address.Address, method abi.MethodNum, params ...interface{}) (types.GasUnits, error) {
+func (api *API) MessagePreview(ctx context.Context, from, to address.Address, method abi.MethodNum, params ...interface{}) (gas.Unit, error) {
 	return api.msgPreviewer.Preview(ctx, from, to, method, params...)
 }
 
@@ -238,7 +239,7 @@ func (api *API) StateView(baseKey block.TipSetKey) (*appstate.View, error) {
 // message to go on chain. Note that no default from address is provided.  The error
 // channel returned receives either nil or an error and is immediately closed after
 // the message is published to the network to signal that the publish is complete.
-func (api *API) MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method abi.MethodNum, params interface{}) (cid.Cid, chan error, error) {
+func (api *API) MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit gas.Unit, method abi.MethodNum, params interface{}) (cid.Cid, chan error, error) {
 	return api.outbox.Send(ctx, from, to, value, gasPrice, gasLimit, true, method, params)
 }
 

--- a/internal/app/go-filecoin/plumbing/msg/previewer.go
+++ b/internal/app/go-filecoin/plumbing/msg/previewer.go
@@ -9,7 +9,7 @@ import (
 	cbor "github.com/ipfs/go-ipld-cbor"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
 )
 
@@ -42,33 +42,33 @@ func NewPreviewer(chainReader previewerChainReader, cst cbor.IpldStore, bs bstor
 }
 
 // Preview sends a read-only message to an actor.
-func (p *Previewer) Preview(ctx context.Context, optFrom, to address.Address, method abi.MethodNum, params ...interface{}) (types.GasUnits, error) {
+func (p *Previewer) Preview(ctx context.Context, optFrom, to address.Address, method abi.MethodNum, params ...interface{}) (gas.Unit, error) {
 	// Dragons: delete
 
 	// encodedParams, err := abi.ToEncodedValues(params...)
 	// if err != nil {
-	// 	return types.GasUnits(0), errors.Wrap(err, "failed to encode message params")
+	// 	return gas.Unit(0), errors.Wrap(err, "failed to encode message params")
 	// }
 
 	// st, err := p.chainReader.GetTipSetState(ctx, p.chainReader.GetHead())
 	// if err != nil {
-	// 	return types.GasUnits(0), errors.Wrap(err, "failed to load tree for latest state root")
+	// 	return gas.Unit(0), errors.Wrap(err, "failed to load tree for latest state root")
 	// }
 	// head, err := p.chainReader.GetTipSet(p.chainReader.GetHead())
 	// if err != nil {
-	// 	return types.GasUnits(0), errors.Wrap(err, "failed to get head tipset ")
+	// 	return gas.Unit(0), errors.Wrap(err, "failed to get head tipset ")
 	// }
 	// h, err := head.Height()
 	// if err != nil {
-	// 	return types.GasUnits(0), errors.Wrap(err, "failed to get head tipset height")
+	// 	return gas.Unit(0), errors.Wrap(err, "failed to get head tipset height")
 	// }
 
 	// vms := vm.NewStorageMap(p.bs)
 	// usedGas, err := p.processor.PreviewQueryMethod(ctx, st, vms, to, method, encodedParams, optFrom, abi.ChainEpoch(h))
 	// if err != nil {
-	// 	return types.GasUnits(0), errors.Wrap(err, "query method returned an error")
+	// 	return gas.Unit(0), errors.Wrap(err, "query method returned an error")
 	// }
 	// return usedGas, nil
 
-	return types.GasUnits(0), nil
+	return gas.NewGas(0), nil
 }

--- a/internal/app/go-filecoin/porcelain/api.go
+++ b/internal/app/go-filecoin/porcelain/api.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 // API is the porcelain implementation, a set of convenience calls written on the
@@ -67,7 +68,7 @@ func (a *API) MinerCreate(
 	ctx context.Context,
 	accountAddr address.Address,
 	gasPrice types.AttoFIL,
-	gasLimit types.GasUnits,
+	gasLimit gas.Unit,
 	sectorSize abi.SectorSize,
 	pid peer.ID,
 	collateral types.AttoFIL,
@@ -81,7 +82,7 @@ func (a *API) MinerPreviewCreate(
 	fromAddr address.Address,
 	sectorSize abi.SectorSize,
 	pid peer.ID,
-) (usedGas types.GasUnits, err error) {
+) (usedGas gas.Unit, err error) {
 	return MinerPreviewCreate(ctx, a, fromAddr, sectorSize, pid)
 }
 
@@ -91,7 +92,7 @@ func (a *API) MinerGetStatus(ctx context.Context, minerAddr address.Address, bas
 }
 
 // MinerSetPrice configures the price of storage. See implementation for details.
-func (a *API) MinerSetPrice(ctx context.Context, from address.Address, miner address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, price types.AttoFIL, expiry *big.Int) (MinerSetPriceResponse, error) {
+func (a *API) MinerSetPrice(ctx context.Context, from address.Address, miner address.Address, gasPrice types.AttoFIL, gasLimit gas.Unit, price types.AttoFIL, expiry *big.Int) (MinerSetPriceResponse, error) {
 	panic("implement me in terms of the storage market module")
 }
 
@@ -132,7 +133,7 @@ func (a *API) PingMinerWithTimeout(
 }
 
 // MinerSetWorkerAddress sets the miner worker address to the provided address
-func (a *API) MinerSetWorkerAddress(ctx context.Context, toAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits) (cid.Cid, error) {
+func (a *API) MinerSetWorkerAddress(ctx context.Context, toAddr address.Address, gasPrice types.AttoFIL, gasLimit gas.Unit) (cid.Cid, error) {
 	return MinerSetWorkerAddress(ctx, a, toAddr, gasPrice, gasLimit)
 }
 

--- a/internal/app/go-filecoin/porcelain/miner_test.go
+++ b/internal/app/go-filecoin/porcelain/miner_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/wallet"
 )
 
@@ -56,7 +57,7 @@ func (mpc *minerCreate) ConfigSet(dottedPath string, paramJSON string) error {
 	return mpc.config.Set(dottedPath, paramJSON)
 }
 
-func (mpc *minerCreate) MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method abi.MethodNum, params interface{}) (cid.Cid, chan error, error) {
+func (mpc *minerCreate) MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit gas.Unit, method abi.MethodNum, params interface{}) (cid.Cid, chan error, error) {
 	if mpc.msgFail {
 		return cid.Cid{}, nil, errors.New("test Error")
 	}
@@ -92,7 +93,7 @@ func TestMinerCreate(t *testing.T) {
 			plumbing,
 			address.Address{},
 			types.NewGasPrice(0),
-			types.GasUnits(100),
+			gas.NewGas(100),
 			constants.DevSectorSize,
 			"",
 			collateral,
@@ -111,7 +112,7 @@ func TestMinerCreate(t *testing.T) {
 			plumbing,
 			address.Address{},
 			types.NewGasPrice(0),
-			types.GasUnits(100),
+			gas.NewGas(100),
 			constants.DevSectorSize,
 			"",
 			collateral,
@@ -182,7 +183,7 @@ func (p *mSetWorkerPlumbing) MinerStateView(baseKey block.TipSetKey) (MinerState
 	}, nil
 }
 
-func (p *mSetWorkerPlumbing) MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method abi.MethodNum, params interface{}) (cid.Cid, chan error, error) {
+func (p *mSetWorkerPlumbing) MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit gas.Unit, method abi.MethodNum, params interface{}) (cid.Cid, chan error, error) {
 
 	if p.msgFail {
 		return cid.Cid{}, nil, errors.New("MsgFail")
@@ -214,7 +215,7 @@ func TestMinerSetWorkerAddress(t *testing.T) {
 	minerAddr := vmaddr.RequireIDAddress(t, 101)
 	workerAddr := vmaddr.RequireIDAddress(t, 102)
 	gprice := types.ZeroAttoFIL
-	glimit := types.GasUnits(0)
+	glimit := gas.NewGas(0)
 
 	t.Run("Calling set worker address sets address", func(t *testing.T) {
 		plumbing := &mSetWorkerPlumbing{

--- a/internal/pkg/consensus/processor_test.go
+++ b/internal/pkg/consensus/processor_test.go
@@ -66,7 +66,7 @@ package consensus_test
 
 // 	stCid, _, minerAddr := mustCreateStorageMiner(ctx, t, st, vms, minerOwner)
 
-// 	msg1 := types.NewMeteredMessage(fromAddr1, toAddr, 0, types.NewAttoFILFromFIL(550), types.SendMethodID, nil, types.NewGasPrice(1), types.GasUnits(300))
+// 	msg1 := types.NewMeteredMessage(fromAddr1, toAddr, 0, types.NewAttoFILFromFIL(550), types.SendMethodID, nil, types.NewGasPrice(1), gas.Unit(300))
 // 	msgs1 := []*types.UnsignedMessage{msg1}
 // 	cidGetter := types.NewCidForTestGetter()
 // 	blk1 := &block.Block{
@@ -78,7 +78,7 @@ package consensus_test
 // 	}
 
 // 	msgs2 := []*types.UnsignedMessage{types.NewMeteredMessage(fromAddr2, toAddr, 0,
-// 		types.NewAttoFILFromFIL(50), types.SendMethodID, nil, types.NewGasPrice(1), types.GasUnits(300))}
+// 		types.NewAttoFILFromFIL(50), types.SendMethodID, nil, types.NewGasPrice(1), gas.Unit(300))}
 // 	blk2 := &block.Block{
 // 		Height:    20,
 // 		StateRoot: stCid,
@@ -121,7 +121,7 @@ package consensus_test
 // 	stCid, _, minerAddr := mustCreateStorageMiner(ctx, t, st, vms, minerOwner)
 
 // 	msgs1 := []*types.UnsignedMessage{types.NewMeteredMessage(fromAddr, toAddr, 0,
-// 		types.NewAttoFILFromFIL(501), types.SendMethodID, nil, types.NewGasPrice(1), types.GasUnits(0))}
+// 		types.NewAttoFILFromFIL(501), types.SendMethodID, nil, types.NewGasPrice(1), gas.Unit(0))}
 // 	blk1 := &block.Block{
 // 		Height:    20,
 // 		StateRoot: stCid,
@@ -130,7 +130,7 @@ package consensus_test
 // 	}
 
 // 	msgs2 := []*types.UnsignedMessage{types.NewMeteredMessage(fromAddr, toAddr, 0,
-// 		types.NewAttoFILFromFIL(502), types.SendMethodID, nil, types.NewGasPrice(1), types.GasUnits(0))}
+// 		types.NewAttoFILFromFIL(502), types.SendMethodID, nil, types.NewGasPrice(1), gas.Unit(0))}
 // 	blk2 := &block.Block{
 // 		Height:    20,
 // 		StateRoot: stCid,
@@ -223,7 +223,7 @@ package consensus_test
 // 	stCid, _, minerAddr := mustCreateStorageMiner(ctx, t, st, vms, minerOwnerAddr)
 
 // 	msgs := [][]*types.UnsignedMessage{{types.NewMeteredMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(1000),
-// 		actor.ReturnRevertErrorID, nil, types.NewGasPrice(1), types.GasUnits(0))}}
+// 		actor.ReturnRevertErrorID, nil, types.NewGasPrice(1), gas.Unit(0))}}
 // 	blk := &block.Block{
 // 		Height:    20,
 // 		StateRoot: stCid,
@@ -311,7 +311,7 @@ package consensus_test
 // 		_, st := requireMakeStateTree(t, cst, map[address.Address]*actor.Actor{})
 // 		th.RequireInitAccountActor(ctx, t, st, vms, addr1, types.NewAttoFILFromFIL(1000))
 // 		_, addr2 := th.RequireNewMinerActor(ctx, t, st, vms, addr1, 10, th.RequireRandomPeerID(t), types.NewAttoFILFromFIL(10000))
-// 		msg := types.NewMeteredMessage(addr1, addr2, 5, types.NewAttoFILFromFIL(550), types.SendMethodID, []byte{}, types.NewGasPrice(1), types.GasUnits(0))
+// 		msg := types.NewMeteredMessage(addr1, addr2, 5, types.NewAttoFILFromFIL(550), types.SendMethodID, []byte{}, types.NewGasPrice(1), gas.Unit(0))
 
 // 		_, err := NewDefaultProcessor().ApplyMessage(ctx, st, vms, msg, addr2, abi.ChainEpoch(0), vm.NewLegacyGasTracker(), nil)
 // 		assert.Error(t, err)
@@ -331,7 +331,7 @@ package consensus_test
 // 		require.NoError(t, st.SetActor(ctx, idAddr, act1))
 
 // 		_, addr2 := th.RequireNewMinerActor(ctx, t, st, vms, addr1, uint64(10), th.RequireRandomPeerID(t), types.NewAttoFILFromFIL(10000))
-// 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(550), types.SendMethodID, []byte{}, types.NewGasPrice(1), types.GasUnits(0))
+// 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(550), types.SendMethodID, []byte{}, types.NewGasPrice(1), gas.Unit(0))
 
 // 		_, err := NewDefaultProcessor().ApplyMessage(ctx, st, vms, msg, addr2, abi.ChainEpoch(0), vm.NewLegacyGasTracker(), nil)
 // 		assert.Error(t, err)
@@ -340,7 +340,7 @@ package consensus_test
 
 // 	t.Run("errors when specifying a gas limit in excess of balance", func(t *testing.T) {
 // 		addr1, _, addr2, _, st, vms, _ := mustSetup2Actors(t, types.NewAttoFILFromFIL(1000), types.NewAttoFILFromFIL(10000))
-// 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(550), types.SendMethodID, []byte{}, types.NewAttoFILFromFIL(10), types.GasUnits(50))
+// 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(550), types.SendMethodID, []byte{}, types.NewAttoFILFromFIL(10), gas.Unit(50))
 
 // 		// the maximum gas charge (10*50 = 500) is greater than the sender balance minus the message value (1000-550 = 450)
 // 		_, err := NewDefaultProcessor().ApplyMessage(context.Background(), st, vms, msg, addr2, abi.ChainEpoch(0), vm.NewLegacyGasTracker(), nil)
@@ -357,7 +357,7 @@ package consensus_test
 // 		ctx := context.Background()
 // 		require.NoError(t, st.SetActor(ctx, addr1, act1))
 
-// 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.ZeroAttoFIL, types.SendMethodID, []byte{}, types.NewAttoFILFromFIL(10), types.GasUnits(50))
+// 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.ZeroAttoFIL, types.SendMethodID, []byte{}, types.NewAttoFILFromFIL(10), gas.Unit(50))
 
 // 		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, vms, msg, addr2, abi.ChainEpoch(0), vm.NewLegacyGasTracker(), nil)
 // 		require.Error(t, err)
@@ -375,7 +375,7 @@ package consensus_test
 // 		_, st := requireMakeStateTree(t, cst, map[address.Address]*actor.Actor{})
 // 		_, addr2 := th.RequireNewMinerActor(ctx, t, st, vms, addr1, 10, th.RequireRandomPeerID(t), types.NewAttoFILFromFIL(1000))
 
-// 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.ZeroAttoFIL, types.SendMethodID, []byte{}, types.NewAttoFILFromFIL(10), types.GasUnits(50))
+// 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.ZeroAttoFIL, types.SendMethodID, []byte{}, types.NewAttoFILFromFIL(10), gas.Unit(50))
 
 // 		_, err := NewDefaultProcessor().ApplyMessage(context.Background(), st, vms, msg, addr2,
 // 			abi.ChainEpoch(0), vm.NewLegacyGasTracker(), nil)
@@ -398,7 +398,7 @@ package consensus_test
 // 		someval, ok := types.NewAttoFILFromString("-500", 10)
 // 		require.True(t, ok)
 
-// 		msg := types.NewMeteredMessage(addr1, addr2, 0, someval, types.SendMethodID, []byte{}, types.NewGasPrice(1), types.GasUnits(0))
+// 		msg := types.NewMeteredMessage(addr1, addr2, 0, someval, types.SendMethodID, []byte{}, types.NewGasPrice(1), gas.Unit(0))
 
 // 		_, err := NewDefaultProcessor().ApplyMessage(ctx, st, vms, msg, addr2, abi.ChainEpoch(0), vm.NewLegacyGasTracker(), nil)
 // 		assert.Error(t, err)
@@ -407,7 +407,7 @@ package consensus_test
 
 // 	t.Run("errors when attempting to send to self", func(t *testing.T) {
 // 		addr1, _, addr2, _, st, vms, _ := mustSetup2Actors(t, types.NewAttoFILFromFIL(1000), types.NewAttoFILFromFIL(10000))
-// 		msg := types.NewMeteredMessage(addr1, addr1, 0, types.NewAttoFILFromFIL(550), types.SendMethodID, []byte{}, types.NewAttoFILFromFIL(10), types.GasUnits(0))
+// 		msg := types.NewMeteredMessage(addr1, addr1, 0, types.NewAttoFILFromFIL(550), types.SendMethodID, []byte{}, types.NewAttoFILFromFIL(10), gas.Unit(0))
 
 // 		// the maximum gas charge (10*50 = 500) is greater than the sender balance minus the message value (1000-550 = 450)
 // 		_, err := NewDefaultProcessor().ApplyMessage(context.Background(), st, vms, msg, addr2, abi.ChainEpoch(0), vm.NewLegacyGasTracker(), nil)
@@ -417,7 +417,7 @@ package consensus_test
 
 // 	t.Run("errors when specifying a gas limit in excess of balance", func(t *testing.T) {
 // 		addr1, _, addr2, _, st, vms, _ := mustSetup2Actors(t, types.NewAttoFILFromFIL(1000), types.NewAttoFILFromFIL(10000))
-// 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(550), types.SendMethodID, []byte{}, types.NewAttoFILFromFIL(10), types.GasUnits(50))
+// 		msg := types.NewMeteredMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(550), types.SendMethodID, []byte{}, types.NewAttoFILFromFIL(10), gas.Unit(50))
 
 // 		// the maximum gas charge (10*50 = 500) is greater than the sender balance minus the message value (1000-550 = 450)
 // 		_, err := NewDefaultProcessor().ApplyMessage(context.Background(), st, vms, msg, address.Undef, abi.ChainEpoch(0), vm.NewLegacyGasTracker(), nil)
@@ -547,7 +547,7 @@ package consensus_test
 // 	_, addr1ID := th.RequireInitAccountActor(ctx, t, st, vms, addr1, types.NewAttoFILFromFIL(1000))
 
 // 	// send 500 from addr1 to addr2
-// 	msg := types.NewMeteredMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(500), types.SendMethodID, []byte{}, types.NewGasPrice(1), types.GasUnits(0))
+// 	msg := types.NewMeteredMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(500), types.SendMethodID, []byte{}, types.NewGasPrice(1), gas.Unit(0))
 // 	_, err := NewDefaultProcessor().ApplyMessage(ctx, st, vms, msg, addr4, abi.ChainEpoch(0), vm.NewLegacyGasTracker(), nil)
 // 	require.NoError(t, err)
 
@@ -558,7 +558,7 @@ package consensus_test
 // 	require.NoError(t, err)
 
 // 	// send 250 along from addr2 to addr3
-// 	msg = types.NewMeteredMessage(addr2, addr3, 0, types.NewAttoFILFromFIL(300), types.SendMethodID, []byte{}, types.NewGasPrice(1), types.GasUnits(0))
+// 	msg = types.NewMeteredMessage(addr2, addr3, 0, types.NewAttoFILFromFIL(300), types.SendMethodID, []byte{}, types.NewGasPrice(1), gas.Unit(0))
 // 	_, err = NewDefaultProcessor().ApplyMessage(ctx, st, vms, msg, addr4, abi.ChainEpoch(0), vm.NewLegacyGasTracker(), nil)
 // 	require.NoError(t, err)
 
@@ -649,7 +649,7 @@ package consensus_test
 // 		minerAddr := addresses[2]
 
 // 		gasPrice := types.NewAttoFILFromFIL(uint64(3))
-// 		gasLimit := types.GasUnits(200)
+// 		gasLimit := gas.Unit(200)
 // 		msg := types.NewMeteredMessage(addr0, addr1, 0, types.ZeroAttoFIL, actor.HasReturnValueID, nil, gasPrice, gasLimit)
 
 // 		appResult, err := th.ApplyTestMessageWithGas(actors, st, vms, msg, abi.ChainEpoch(0), minerAddr)
@@ -673,7 +673,7 @@ package consensus_test
 // 		minerAddr := addresses[2]
 
 // 		gasPrice := types.NewAttoFILFromFIL(uint64(3))
-// 		gasLimit := types.GasUnits(200)
+// 		gasLimit := gas.Unit(200)
 // 		msg := types.NewMeteredMessage(addr0, addr1, 0, types.ZeroAttoFIL, actor.ChargeGasAndRevertErrorID, nil, gasPrice, gasLimit)
 
 // 		appResult, err := th.ApplyTestMessageWithGas(actors, st, vms, msg, abi.ChainEpoch(0), minerAddr)
@@ -699,7 +699,7 @@ package consensus_test
 // 		minerAddr := addresses[2]
 
 // 		gasPrice := types.NewAttoFILFromFIL(uint64(3))
-// 		gasLimit := types.GasUnits(50)
+// 		gasLimit := gas.Unit(50)
 // 		msg := types.NewMeteredMessage(addr0, addr1, 0, types.ZeroAttoFIL, actor.HasReturnValueID, nil, gasPrice, gasLimit)
 
 // 		appResult, err := th.ApplyTestMessageWithGas(actors, st, vms, msg, abi.ChainEpoch(0), minerAddr)
@@ -729,7 +729,7 @@ package consensus_test
 // 		require.NoError(t, err)
 
 // 		gasPrice := types.NewAttoFILFromFIL(uint64(3))
-// 		gasLimit := types.GasUnits(600)
+// 		gasLimit := gas.Unit(600)
 // 		msg := types.NewMeteredMessage(addr0, addr1, 0, types.ZeroAttoFIL, actor.RunsAnotherMessageID, params, gasPrice, gasLimit)
 
 // 		appResult, err := th.ApplyTestMessageWithGas(actors, st, vms, msg, abi.ChainEpoch(0), minerAddr)
@@ -760,7 +760,7 @@ package consensus_test
 // 		require.NoError(t, err)
 
 // 		gasPrice := types.NewAttoFILFromFIL(uint64(3))
-// 		gasLimit := types.GasUnits(50)
+// 		gasLimit := gas.Unit(50)
 // 		msg := types.NewMeteredMessage(addr0, addr1, 0, types.ZeroAttoFIL, actor.RunsAnotherMessageID, params, gasPrice, gasLimit)
 
 // 		appResult, err := th.ApplyTestMessageWithGas(actors, st, vms, msg, abi.ChainEpoch(0), minerAddr)

--- a/internal/pkg/consensus/validation_test.go
+++ b/internal/pkg/consensus/validation_test.go
@@ -137,7 +137,7 @@ func TestMessageSyntaxValidator(t *testing.T) {
 	})
 
 	t.Run("block gas limit fails", func(t *testing.T) {
-		msg, err := types.NewSignedMessage(*newMessage(t, alice, bob, 100, 5, 1, int64(types.BlockGasLimit)+1), signer)
+		msg, err := types.NewSignedMessage(*newMessage(t, alice, bob, 100, 5, 1, types.BlockGasLimit+1), signer)
 		require.NoError(t, err)
 		assert.Errorf(t, validator.Validate(ctx, msg), "block limit")
 	})
@@ -151,7 +151,7 @@ func newActor(t *testing.T, balanceAF int, nonce uint64) *actor.Actor {
 }
 
 func newMessage(t *testing.T, from, to address.Address, nonce uint64, valueAF int,
-	gasPrice int64, gasLimit int64) *types.UnsignedMessage {
+	gasPrice int64, gasLimit gas.Unit) *types.UnsignedMessage {
 	val, ok := types.NewAttoFILFromString(fmt.Sprintf("%d", valueAF), 10)
 	require.True(t, ok, "invalid attofil")
 	return types.NewMeteredMessage(
@@ -162,7 +162,7 @@ func newMessage(t *testing.T, from, to address.Address, nonce uint64, valueAF in
 		methodID,
 		[]byte("params"),
 		types.NewGasPrice(gasPrice),
-		gas.NewGas(gasLimit),
+		gasLimit,
 	)
 }
 

--- a/internal/pkg/consensus/validation_test.go
+++ b/internal/pkg/consensus/validation_test.go
@@ -17,6 +17,7 @@ import (
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -91,7 +92,7 @@ func TestBLSSignatureValidationConfiguration(t *testing.T) {
 	from, err := address.NewBLSAddress(pubKey[:])
 	require.NoError(t, err)
 
-	msg := types.NewMeteredMessage(from, addresses[1], 0, types.ZeroAttoFIL, methodID, []byte("params"), types.NewGasPrice(1), types.GasUnits(300))
+	msg := types.NewMeteredMessage(from, addresses[1], 0, types.ZeroAttoFIL, methodID, []byte("params"), types.NewGasPrice(1), gas.NewGas(300))
 	unsigned := &types.SignedMessage{Message: *msg}
 	actor := newActor(t, 1000, 0)
 
@@ -136,7 +137,7 @@ func TestMessageSyntaxValidator(t *testing.T) {
 	})
 
 	t.Run("block gas limit fails", func(t *testing.T) {
-		msg, err := types.NewSignedMessage(*newMessage(t, alice, bob, 100, 5, 1, uint64(types.BlockGasLimit)+1), signer)
+		msg, err := types.NewSignedMessage(*newMessage(t, alice, bob, 100, 5, 1, int64(types.BlockGasLimit)+1), signer)
 		require.NoError(t, err)
 		assert.Errorf(t, validator.Validate(ctx, msg), "block limit")
 	})
@@ -150,7 +151,7 @@ func newActor(t *testing.T, balanceAF int, nonce uint64) *actor.Actor {
 }
 
 func newMessage(t *testing.T, from, to address.Address, nonce uint64, valueAF int,
-	gasPrice int64, gasLimit uint64) *types.UnsignedMessage {
+	gasPrice int64, gasLimit int64) *types.UnsignedMessage {
 	val, ok := types.NewAttoFILFromString(fmt.Sprintf("%d", valueAF), 10)
 	require.True(t, ok, "invalid attofil")
 	return types.NewMeteredMessage(
@@ -161,7 +162,7 @@ func newMessage(t *testing.T, from, to address.Address, nonce uint64, valueAF in
 		methodID,
 		[]byte("params"),
 		types.NewGasPrice(gasPrice),
-		types.GasUnits(gasLimit),
+		gas.NewGas(gasLimit),
 	)
 }
 

--- a/internal/pkg/discovery/hello_protocol.go
+++ b/internal/pkg/discovery/hello_protocol.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/cborutil"
+	e "github.com/filecoin-project/go-filecoin/internal/pkg/enccid"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/metrics"
 )
@@ -31,17 +32,17 @@ var helloMsgErrCt = metrics.NewInt64Counter("hello_message_error", "Number of er
 
 // HelloMessage is the data structure of a single message in the hello protocol.
 type HelloMessage struct {
-	_                    struct{}
+	_                    struct{} `cbor:",toarray"`
 	HeaviestTipSetCids   block.TipSetKey
 	HeaviestTipSetHeight abi.ChainEpoch
 	HeaviestTipSetWeight fbig.Int
-	GenesisHash          cid.Cid
+	GenesisHash          e.Cid
 }
 
 // LatencyMessage is written in response to a hello message for measuring peer
 // latency.
 type LatencyMessage struct {
-	_        struct{}
+	_        struct{} `cbor:",toarray"`
 	TArrival int64
 	TSent    int64
 }
@@ -164,7 +165,7 @@ func (h *HelloProtocolHandler) getOurHelloMessage() (*HelloMessage, error) {
 	}
 
 	return &HelloMessage{
-		GenesisHash:          h.genesis,
+		GenesisHash:          e.NewCid(h.genesis),
 		HeaviestTipSetCids:   heaviest.Key(),
 		HeaviestTipSetHeight: height,
 		HeaviestTipSetWeight: weight,

--- a/internal/pkg/message/handler_integration_test.go
+++ b/internal/pkg/message/handler_integration_test.go
@@ -21,6 +21,7 @@ import (
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 // TestNewHeadHandlerIntegration tests inbox and outbox policy consistency.
@@ -37,7 +38,7 @@ func TestNewHeadHandlerIntegration(t *testing.T) {
 	// accepted.
 	maxAge := uint(10)
 	gasPrice := types.NewGasPrice(1)
-	gasUnits := types.GasUnits(1000)
+	gasUnits := gas.NewGas(1000)
 
 	makeHandler := func(provider *message.FakeProvider, root block.TipSet) *message.HeadHandler {
 		mpool := message.NewPool(config.NewDefaultConfig().Mpool, th.NewMockMessagePoolValidator())

--- a/internal/pkg/message/outbox.go
+++ b/internal/pkg/message/outbox.go
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/metrics"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 // Outbox validates and marshals messages for sending and maintains the outbound message queue.
@@ -83,7 +84,7 @@ func (ob *Outbox) Queue() *Queue {
 // Send marshals and sends a message, retaining it in the outbound message queue.
 // If bcast is true, the publisher broadcasts the message to the network at the current block height.
 func (ob *Outbox) Send(ctx context.Context, from, to address.Address, value types.AttoFIL,
-	gasPrice types.AttoFIL, gasLimit types.GasUnits, bcast bool, method abi.MethodNum, params interface{}) (out cid.Cid, pubErrCh chan error, err error) {
+	gasPrice types.AttoFIL, gasLimit gas.Unit, bcast bool, method abi.MethodNum, params interface{}) (out cid.Cid, pubErrCh chan error, err error) {
 	defer func() {
 		if err != nil {
 			msgSendErrCt.Inc(ctx, 1)

--- a/internal/pkg/message/outbox_test.go
+++ b/internal/pkg/message/outbox_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 func newOutboxTestJournal(t *testing.T) journal.Writer {
@@ -41,7 +42,7 @@ func TestOutbox(t *testing.T) {
 		ob := message.NewOutbox(w, message.FakeValidator{RejectMessages: true}, queue, publisher,
 			message.NullPolicy{}, provider, provider, newOutboxTestJournal(t))
 
-		cid, _, err := ob.Send(context.Background(), sender, sender, types.NewAttoFILFromFIL(2), types.NewGasPrice(0), types.GasUnits(0), bcast, builtin.MethodSend, &adt.EmptyValue{})
+		cid, _, err := ob.Send(context.Background(), sender, sender, types.NewAttoFILFromFIL(2), types.NewGasPrice(0), gas.NewGas(0), bcast, builtin.MethodSend, &adt.EmptyValue{})
 		assert.Errorf(t, err, "for testing")
 		assert.False(t, cid.Defined())
 	})
@@ -72,7 +73,7 @@ func TestOutbox(t *testing.T) {
 		}{{true, actr.CallSeqNum, 1000}, {false, actr.CallSeqNum + 1, 1000}}
 
 		for _, test := range testCases {
-			_, pubDone, err := ob.Send(context.Background(), sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), types.GasUnits(0), test.bcast, builtin.MethodSend, &adt.EmptyValue{})
+			_, pubDone, err := ob.Send(context.Background(), sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), gas.NewGas(0), test.bcast, builtin.MethodSend, &adt.EmptyValue{})
 			require.NoError(t, err)
 			assert.Equal(t, uint64(test.height), queue.List(sender)[0].Stamp)
 			require.NotNil(t, pubDone)
@@ -112,7 +113,7 @@ func TestOutbox(t *testing.T) {
 			defer wg.Done()
 			for i := 0; i < msgCount; i++ {
 				method := abi.MethodNum(batch*10000 + i)
-				_, _, err := s.Send(ctx, sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), types.GasUnits(0), bcast, method, []byte{})
+				_, _, err := s.Send(ctx, sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), gas.NewGas(0), bcast, method, []byte{})
 				require.NoError(t, err)
 			}
 		}
@@ -156,7 +157,7 @@ func TestOutbox(t *testing.T) {
 
 		ob := message.NewOutbox(w, message.FakeValidator{}, queue, publisher, message.NullPolicy{}, provider, provider, newOutboxTestJournal(t))
 
-		_, _, err := ob.Send(context.Background(), sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), types.GasUnits(0), true, builtin.MethodSend, &adt.EmptyValue{})
+		_, _, err := ob.Send(context.Background(), sender, toAddr, types.ZeroAttoFIL, types.NewGasPrice(0), gas.NewGas(0), true, builtin.MethodSend, &adt.EmptyValue{})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "account or empty")
 	})

--- a/internal/pkg/mining/mqueue_test.go
+++ b/internal/pkg/mining/mqueue_test.go
@@ -9,6 +9,7 @@ import (
 
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 func TestMessageQueueOrder(t *testing.T) {
@@ -28,7 +29,7 @@ func TestMessageQueueOrder(t *testing.T) {
 			To:         to,
 			CallSeqNum: nonce,
 			GasPrice:   types.NewGasPrice(price),
-			GasLimit:   types.GasUnits(units),
+			GasLimit:   gas.NewGas(int64(units)),
 		}
 		s, err := types.NewSignedMessage(msg, &mockSigner)
 		require.NoError(t, err)

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
 )
 
@@ -298,14 +299,14 @@ func TestApplyMessagesForSuccessTempAndPermFailures(t *testing.T) {
 	// // If a given message's category changes in the future, it needs to be replaced here in tests by another so we fully
 	// // exercise the categorization.
 	// // addr2 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
-	// msg0 := types.NewMeteredMessage(addr2, addr1, 0, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), types.GasUnits(0))
+	// msg0 := types.NewMeteredMessage(addr2, addr1, 0, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), gas.Unit(0))
 
 	// // This is actually okay and should result in a receipt
-	// msg1 := types.NewMeteredMessage(addr1, addr2, 0, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), types.GasUnits(0))
+	// msg1 := types.NewMeteredMessage(addr1, addr2, 0, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), gas.Unit(0))
 
 	// // The following two are sending to self -- errSelfSend, a permanent error.
-	// msg2 := types.NewMeteredMessage(addr1, addr1, 1, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), types.GasUnits(0))
-	// msg3 := types.NewMeteredMessage(addr2, addr2, 1, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), types.GasUnits(0))
+	// msg2 := types.NewMeteredMessage(addr1, addr1, 1, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), gas.Unit(0))
+	// msg3 := types.NewMeteredMessage(addr2, addr2, 1, types.ZeroAttoFIL, types.SendMethodID, nil, types.NewGasPrice(1), gas.Unit(0))
 
 	// messages := []*types.UnsignedMessage{msg0, msg1, msg2, msg3}
 
@@ -551,21 +552,21 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 	})
 
 	// addr3 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
-	msg1 := types.NewMeteredMessage(addrs[2], addrs[0], 0, types.ZeroAttoFIL, builtin.MethodSend, nil, types.NewGasPrice(1), types.GasUnits(0))
+	msg1 := types.NewMeteredMessage(addrs[2], addrs[0], 0, types.ZeroAttoFIL, builtin.MethodSend, nil, types.NewGasPrice(1), gas.NewGas(0))
 	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner)
 	require.NoError(t, err)
 
 	// This is actually okay and should result in a receipt
-	msg2 := types.NewMeteredMessage(addrs[0], addrs[1], 0, types.ZeroAttoFIL, builtin.MethodSend, nil, types.NewGasPrice(1), types.GasUnits(0))
+	msg2 := types.NewMeteredMessage(addrs[0], addrs[1], 0, types.ZeroAttoFIL, builtin.MethodSend, nil, types.NewGasPrice(1), gas.NewGas(0))
 	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner)
 	require.NoError(t, err)
 
 	// add the following and then increment the actor nonce at addrs[1], nonceTooLow, a permanent error.
-	msg3 := types.NewMeteredMessage(addrs[1], addrs[0], 0, types.ZeroAttoFIL, builtin.MethodSend, nil, types.NewGasPrice(1), types.GasUnits(0))
+	msg3 := types.NewMeteredMessage(addrs[1], addrs[0], 0, types.ZeroAttoFIL, builtin.MethodSend, nil, types.NewGasPrice(1), gas.NewGas(0))
 	smsg3, err := types.NewSignedMessage(*msg3, &mockSigner)
 	require.NoError(t, err)
 
-	msg4 := types.NewMeteredMessage(addrs[1], addrs[2], 1, types.ZeroAttoFIL, builtin.MethodSend, nil, types.NewGasPrice(1), types.GasUnits(0))
+	msg4 := types.NewMeteredMessage(addrs[1], addrs[2], 1, types.ZeroAttoFIL, builtin.MethodSend, nil, types.NewGasPrice(1), gas.NewGas(0))
 	smsg4, err := types.NewSignedMessage(*msg4, &mockSigner)
 	require.NoError(t, err)
 
@@ -770,7 +771,7 @@ func TestGenerateError(t *testing.T) {
 	})
 
 	// This is actually okay and should result in a receipt
-	msg := types.NewMeteredMessage(addrs[0], addrs[1], 0, types.ZeroAttoFIL, builtin.MethodSend, nil, types.NewGasPrice(0), types.GasUnits(0))
+	msg := types.NewMeteredMessage(addrs[0], addrs[1], 0, types.ZeroAttoFIL, builtin.MethodSend, nil, types.NewGasPrice(0), gas.Unit(0))
 	smsg, err := types.NewSignedMessage(*msg, &mockSigner)
 	require.NoError(t, err)
 	_, err = pool.Add(ctx, smsg, 0)

--- a/internal/pkg/poster/poster.go
+++ b/internal/pkg/poster/poster.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/message"
 	appstate "github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 // Poster listens for changes to the chain head and generates and submits a PoSt if one is required.
@@ -166,7 +167,7 @@ func (p *Poster) sendPoSt(ctx context.Context, stateView *appstate.View, candida
 		p.minerAddr,
 		types.ZeroAttoFIL,
 		types.NewGasPrice(1),
-		types.GasUnits(300),
+		gas.NewGas(300),
 		true,
 		builtin.MethodsMiner.SubmitWindowedPoSt,
 		windowedPost,

--- a/internal/pkg/state/sigval_test.go
+++ b/internal/pkg/state/sigval_test.go
@@ -13,6 +13,7 @@ import (
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 type fakeStateView struct {
@@ -82,7 +83,7 @@ func TestBadFrom(t *testing.T) {
 		v := NewSignatureValidator(&fakeStateView{})
 
 		// Can't use NewSignedMessage constructor as it always signs with msg.From.
-		msg := types.NewMeteredMessage(keyAddr, keyAddr, 1, types.ZeroAttoFIL, builtin.MethodSend, nil, types.NewGasPrice(0), types.GasUnits(0))
+		msg := types.NewMeteredMessage(keyAddr, keyAddr, 1, types.ZeroAttoFIL, builtin.MethodSend, nil, types.NewGasPrice(0), gas.NewGas(0))
 		bmsg, err := msg.Marshal()
 		require.NoError(t, err)
 		sig, err := signer.SignBytes(bmsg, otherAddr) // sign with addr != msg.From
@@ -102,7 +103,7 @@ func TestBadFrom(t *testing.T) {
 		v := NewSignatureValidator(state)
 
 		// Can't use NewSignedMessage constructor as it always signs with msg.From.
-		msg := types.NewMeteredMessage(idAddress, idAddress, 1, types.ZeroAttoFIL, builtin.MethodSend, nil, types.NewGasPrice(0), types.GasUnits(0))
+		msg := types.NewMeteredMessage(idAddress, idAddress, 1, types.ZeroAttoFIL, builtin.MethodSend, nil, types.NewGasPrice(0), gas.NewGas(0))
 		bmsg, err := msg.Marshal()
 		require.NoError(t, err)
 		sig, err := signer.SignBytes(bmsg, otherAddr) // sign with addr != msg.From (resolved)

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -17,6 +17,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
 )
 
@@ -185,7 +186,7 @@ func CreateAndApplyTestMessage(t *testing.T, st state.Tree, vms vm.Storage, to a
 
 func applyTestMessageWithAncestors(actors vm.ActorCodeLoader, st state.Tree, store vm.Storage, msg *types.UnsignedMessage, bh abi.ChainEpoch, ancestors []block.TipSet) (*consensus.ApplicationResult, error) {
 	msg.GasPrice = types.NewGasPrice(1)
-	msg.GasLimit = types.GasUnits(300)
+	msg.GasLimit = gas.NewGas(300)
 
 	ta := newTestApplier(actors)
 	return newMessageApplier(msg, ta, st, store, bh, address.Undef, ancestors)

--- a/internal/pkg/testhelpers/core.go
+++ b/internal/pkg/testhelpers/core.go
@@ -48,7 +48,7 @@ func RequireNewMinerActor(ctx context.Context, t *testing.T, st state.Tree, vms 
 	// require.NoError(t, err)
 
 	// gt := vm.NewLegacyGasTracker()
-	// gt.MsgGasLimit = types.GasUnits(10000)
+	// gt.MsgGasLimit = gas.Unit(10000)
 	// // we are required to have a message in the context even though it will not be used.
 	// dummyMessage := types.NewUnsignedMessage(address.TestAddress, address.TestAddress2, 0, types.ZeroAttoFIL, types.SendMethodID, []byte{})
 	// vmctx := vm.NewVMContext(vm.NewContextParams{

--- a/internal/pkg/types/message.go
+++ b/internal/pkg/types/message.go
@@ -67,11 +67,11 @@ type UnsignedMessage struct {
 
 	Value AttoFIL `json:"value"`
 
-	Method abi.MethodNum `json:"method"`
-	Params []byte        `json:"params"`
-
 	GasPrice AttoFIL  `json:"gasPrice"`
 	GasLimit gas.Unit `json:"gasLimit"`
+
+	Method abi.MethodNum `json:"method"`
+	Params []byte        `json:"params"`
 	// Pay attention to Equals() if updating this struct.
 }
 

--- a/internal/pkg/types/message_test.go
+++ b/internal/pkg/types/message_test.go
@@ -10,6 +10,7 @@ import (
 
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 func TestMessageMarshal(t *testing.T) {
@@ -28,7 +29,7 @@ func TestMessageMarshal(t *testing.T) {
 		builtin.MethodSend,
 		[]byte("foobar"),
 		NewAttoFILFromFIL(3),
-		GasUnits(4),
+		gas.NewGas(4),
 	)
 
 	// This check requests that you add a non-zero value for new fields above,

--- a/internal/pkg/types/signed_message_test.go
+++ b/internal/pkg/types/signed_message_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 var mockSigner = NewMockSigner(MustGenerateKeyInfo(1, 42))
@@ -86,7 +87,7 @@ func makeMessage(t *testing.T, signer MockSigner, nonce uint64) *SignedMessage {
 		abi.MethodNum(2352),
 		[]byte("params"),
 		NewGasPrice(1000),
-		GasUnits(100))
+		gas.NewGas(100))
 	smsg, err := NewSignedMessage(*msg, &signer)
 	require.NoError(t, err)
 

--- a/internal/pkg/types/testing.go
+++ b/internal/pkg/types/testing.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/constants"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 // MockSigner implements the Signer interface
@@ -149,7 +150,8 @@ func NewSignedMessageForTestGetter(ms MockSigner) func() *SignedMessage {
 			builtin.MethodSend,
 			[]byte("params"),
 			ZeroAttoFIL,
-			GasUnits(0))
+			gas.Zero,
+		)
 		smsg, err := NewSignedMessage(*msg, &ms)
 		if err != nil {
 			panic(err)
@@ -235,7 +237,7 @@ func NewSignedMsgs(n uint, ms MockSigner) []*SignedMessage {
 		msg.From = ms.Addresses[0]
 		msg.CallSeqNum = uint64(i)
 		msg.GasPrice = ZeroAttoFIL // NewGasPrice(1)
-		msg.GasLimit = GasUnits(0)
+		msg.GasLimit = gas.NewGas(0)
 		smsgs[i], err = NewSignedMessage(*msg, ms)
 		if err != nil {
 			panic(err)

--- a/internal/pkg/version/protocol_versions.go
+++ b/internal/pkg/version/protocol_versions.go
@@ -7,8 +7,8 @@ import (
 // USER is the user network
 const USER = "alpha2"
 
-// DEVNET4 is the network name of devnet
-const DEVNET4 = "interop"
+// INTEROP is the network name of an interop net
+const INTEROP = "interop"
 
 // LOCALNET is the network name of localnet
 const LOCALNET = "localnet"
@@ -19,19 +19,14 @@ const TEST = "gfctest"
 // Protocol0 is the first protocol version
 const Protocol0 = 0
 
-// Protocol1 is the weight upgrade
-const Protocol1 = 1
-
 // ConfigureProtocolVersions configures all protocol upgrades for all known networks.
 // TODO: support arbitrary network names at "latest" protocol version so that only coordinated
 // network upgrades need to be represented here. See #3491.
 func ConfigureProtocolVersions(network string) (*ProtocolVersionTable, error) {
 	return NewProtocolVersionTableBuilder(network).
 		Add(USER, Protocol0, abi.ChainEpoch(0)).
-		Add(USER, Protocol1, abi.ChainEpoch(43000)).
-		Add(DEVNET4, Protocol0, abi.ChainEpoch(0)).
-		Add(DEVNET4, Protocol1, abi.ChainEpoch(300)).
-		Add(LOCALNET, Protocol1, abi.ChainEpoch(0)).
-		Add(TEST, Protocol1, abi.ChainEpoch(0)).
+		Add(INTEROP, Protocol0, abi.ChainEpoch(0)).
+		Add(LOCALNET, Protocol0, abi.ChainEpoch(0)).
+		Add(TEST, Protocol0, abi.ChainEpoch(0)).
 		Build()
 }

--- a/internal/pkg/version/protocol_versions.go
+++ b/internal/pkg/version/protocol_versions.go
@@ -8,7 +8,7 @@ import (
 const USER = "alpha2"
 
 // DEVNET4 is the network name of devnet
-const DEVNET4 = "devnet4"
+const DEVNET4 = "interop"
 
 // LOCALNET is the network name of localnet
 const LOCALNET = "localnet"

--- a/internal/pkg/vm/gas/gas.go
+++ b/internal/pkg/vm/gas/gas.go
@@ -1,13 +1,12 @@
 package gas
 
 import (
-	"errors"
-
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 )
 
 // Unit is the unit of gas.
+// This type is signed by design; it is possible for operations to consume negative gas.
 type Unit int64
 
 // Zero is the zero value for Gas.
@@ -30,24 +29,4 @@ func (gas Unit) AsBigInt() big.Int {
 func (gas Unit) ToTokens(price abi.TokenAmount) abi.TokenAmount {
 	// cost = gas * price
 	return big.Mul(gas.AsBigInt(), price)
-}
-
-// MarshalBinary ensures that gas.Unit is serialized as a byte array
-func (gas *Unit) MarshalBinary() ([]byte, error) {
-	bi := big.NewInt(int64(*gas))
-	return bi.MarshalBinary()
-}
-
-func (gas *Unit) UnmarshalBinary(bs []byte) error {
-	bi := big.Zero()
-	err := bi.UnmarshalBinary(bs)
-	if err != nil {
-		return err
-	}
-
-	if !bi.IsInt64() {
-		return errors.New("serialized units too big for int64")
-	}
-	*gas = Unit(bi.Int64())
-	return nil
 }

--- a/internal/pkg/vm/internal/vmcontext/testing.go
+++ b/internal/pkg/vm/internal/vmcontext/testing.go
@@ -29,6 +29,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	gfbuiltin "github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/gascost"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/interpreter"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/storage"
@@ -308,7 +309,7 @@ func (a *ValidationApplier) ApplyMessage(context *vtypes.ExecutionContext, state
 		Method:     msg.Method,
 		Params:     msg.Params,
 		GasPrice:   msg.GasPrice,
-		GasLimit:   types.GasUnits(msg.GasLimit),
+		GasLimit:   gas.Unit(msg.GasLimit),
 	}
 
 	// invoke vm
@@ -344,7 +345,7 @@ func toOurBlockMessageInfoType(theirs []vtypes.BlockMessagesInfo) []interpreter.
 				Method:     blsMsg.Method,
 				Params:     blsMsg.Params,
 				GasPrice:   blsMsg.GasPrice,
-				GasLimit:   types.GasUnits(blsMsg.GasLimit),
+				GasLimit:   gas.Unit(blsMsg.GasLimit),
 			}
 			ours[i].BLSMessages = append(ours[i].BLSMessages, ourbls)
 		}
@@ -358,7 +359,7 @@ func toOurBlockMessageInfoType(theirs []vtypes.BlockMessagesInfo) []interpreter.
 					Method:     secpMsg.Message.Method,
 					Params:     secpMsg.Message.Params,
 					GasPrice:   secpMsg.Message.GasPrice,
-					GasLimit:   types.GasUnits(secpMsg.Message.GasLimit),
+					GasLimit:   gas.Unit(secpMsg.Message.GasLimit),
 				},
 				Signature: secpMsg.Signature,
 			}

--- a/internal/pkg/vm/internal/vmcontext/vmcontext.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext.go
@@ -329,14 +329,12 @@ func (vm *VM) applyImplicitMessage(imsg internalMessage, rnd crypto.RandomnessSo
 
 // applyMessage applies the message to the current state.
 func (vm *VM) applyMessage(msg *types.UnsignedMessage, onChainMsgSize int, rnd crypto.RandomnessSource) (message.Receipt, minerPenaltyFIL, gasRewardFIL) {
-	// Dragons: temp until we remove legacy types
-	var msgGasLimit gas.Unit = msg.GasLimit
 	// This method does not actually execute the message itself,
 	// but rather deals with the pre/post processing of a message.
 	// (see: `invocationContext.invoke()` for the dispatch and execution)
 
 	// initiate gas tracking
-	gasTank := NewGasTracker(msgGasLimit)
+	gasTank := NewGasTracker(msg.GasLimit)
 
 	// pre-send
 	// 1. charge for message existence
@@ -377,7 +375,7 @@ func (vm *VM) applyMessage(msg *types.UnsignedMessage, onChainMsgSize int, rnd c
 	}
 
 	// 4. Check sender balance (gas + value being sent)
-	gasLimitCost := msgGasLimit.ToTokens(msg.GasPrice)
+	gasLimitCost := msg.GasLimit.ToTokens(msg.GasPrice)
 	totalCost := big.Add(msg.Value, gasLimitCost)
 	if fromActor.Balance.LessThan(totalCost) {
 		// Execution error; sender does not have sufficient funds to pay for the gas limit.
@@ -469,7 +467,7 @@ func (vm *VM) applyMessage(msg *types.UnsignedMessage, onChainMsgSize int, rnd c
 
 	// 2. settle gas money around (unused_gas -> sender)
 	receipt.GasUsed = gasTank.GasConsumed()
-	refundGas := msgGasLimit - receipt.GasUsed
+	refundGas := msg.GasLimit - receipt.GasUsed
 	vm.transfer(builtin.BurntFundsActorAddr, msg.From, refundGas.ToTokens(msg.GasPrice))
 
 	// 3. Success!

--- a/internal/pkg/vm/internal/vmcontext/vmcontext.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext.go
@@ -330,7 +330,7 @@ func (vm *VM) applyImplicitMessage(imsg internalMessage, rnd crypto.RandomnessSo
 // applyMessage applies the message to the current state.
 func (vm *VM) applyMessage(msg *types.UnsignedMessage, onChainMsgSize int, rnd crypto.RandomnessSource) (message.Receipt, minerPenaltyFIL, gasRewardFIL) {
 	// Dragons: temp until we remove legacy types
-	var msgGasLimit gas.Unit = gas.Unit(msg.GasLimit)
+	var msgGasLimit gas.Unit = msg.GasLimit
 	// This method does not actually execute the message itself,
 	// but rather deals with the pre/post processing of a message.
 	// (see: `invocationContext.invoke()` for the dispatch and execution)

--- a/internal/pkg/vm/testing_messages.go
+++ b/internal/pkg/vm/testing_messages.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
 
 // MessageMaker creates unique, signed messages for use in tests.
 type MessageMaker struct {
 	DefaultGasPrice types.AttoFIL
-	DefaultGasUnits types.GasUnits
+	DefaultGasUnits gas.Unit
 
 	signer *types.MockSigner
 	seq    uint
@@ -32,7 +33,7 @@ func NewMessageMaker(t *testing.T, keys []crypto.KeyInfo) *MessageMaker {
 		addresses[i] = addr
 	}
 
-	return &MessageMaker{types.ZeroAttoFIL, types.GasUnits(0), &signer, 0, t}
+	return &MessageMaker{types.ZeroAttoFIL, gas.Unit(0), &signer, 0, t}
 }
 
 // Addresses returns the addresses for which this maker can sign messages.


### PR DESCRIPTION
### Motivation
Interop with lotus on message data over the wire

### Proposed changes
- Tag hello protocol structures properly so we can de/encode them and speak hello
- Reorder message fields to match new spec PR / lotus
- Change gas units serialization to that of big int instead of int64 to match lotus / spec.  We keep the internal representation of int64 which should be good (@icorderi @anorth could use your help confirming this doesn't put is in hot water with the spec)
- Remove deprecated gas unit type and use the new one everywhere

Note that you need to do a bit more hacking (specifically using a hardcoded network name different than that in gen block) to actually speak pubsub enough to see this working.

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

