### PR TITLE
add tipset identifier to more chain-querying methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,3 +121,5 @@ require (
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./vendors/filecoin-ffi
+
+replace github.com/filecoin-project/go-fil-markets => /Users/erinswenson-healey/dev/go-fil-markets

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v0.0.0-20191219005021-4accf56bd2ce
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
-	github.com/filecoin-project/go-fil-markets v0.0.0-20200316155113-06e2b48c8232
+	github.com/filecoin-project/go-fil-markets v0.0.0-20200317195437-9176aecee576
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200311224656-7d83652bdbed
@@ -121,5 +121,3 @@ require (
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./vendors/filecoin-ffi
-
-replace github.com/filecoin-project/go-fil-markets => /Users/erinswenson-healey/dev/go-fil-markets

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v0.0.0-20191219005021-4accf56bd2ce
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
-	github.com/filecoin-project/go-fil-markets v0.0.0-20200317195437-9176aecee576
+	github.com/filecoin-project/go-fil-markets v0.0.0-20200318012938-6403a5bda668
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200311224656-7d83652bdbed

--- a/go.sum
+++ b/go.sum
@@ -502,6 +502,8 @@ github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
 github.com/ipfs/iptb v1.3.8-0.20190401234037-98ccf4228a73 h1:aVEkLO+VpBjWcEh6XuhRus91Pd2Wj4p6cgcq/gS0er8=
 github.com/ipfs/iptb v1.3.8-0.20190401234037-98ccf4228a73/go.mod h1:1rzHpCYtNp87/+hTxG5TfCVn/yMY3dKnLn8tBiMfdmg=
+github.com/ipld/go-car v0.0.5-0.20200316204026-3e2cf7af0fab h1:+3Y6Jb3IBmG3t6e3r6TItnuciOaMOuGW7QIVEUa5vy4=
+github.com/ipld/go-car v0.0.5-0.20200316204026-3e2cf7af0fab/go.mod h1:yR5AsJ38xTwwgwGpbh60ICtdLPp5lGfuH28PAAzaEhM=
 github.com/ipld/go-ipld-prime v0.0.2-0.20191108012745-28a82f04c785 h1:fASnkvtR+SmB2y453RxmDD3Uvd4LonVUgFGk9JoDaZs=
 github.com/ipld/go-ipld-prime v0.0.2-0.20191108012745-28a82f04c785/go.mod h1:bDDSvVz7vaK12FNvMeRYnpRFkSUPNQOiCYQezMD/P3w=
 github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5 h1:lSip43rAdyGA+yRQuy6ju0ucZkWpYc1F2CTQtZTVW/4=

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200316155113-06e2b48c8232 h1:Pd3N9ibBJe8CWoN6Ypuohswtt6Tn15JPMYxz4/BI5wc=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200316155113-06e2b48c8232/go.mod h1:8NJk7Wp/tOL7NIS/PNDear6VD7UCINhvfnvqAhlcMEY=
+github.com/filecoin-project/go-fil-markets v0.0.0-20200317195437-9176aecee576 h1:te2pkYAQL7q9cWXvtrlx8ATMwmkFBl5tgG2XF5vr6Vg=
+github.com/filecoin-project/go-fil-markets v0.0.0-20200317195437-9176aecee576/go.mod h1:7EGCMycMpwICVzckXUfNL44HfIxG7pwoAVeOuZFGX/4=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543 h1:aMJGfgqe1QDhAVwxRg5fjCRF533xHidiKsugk7Vvzug=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543/go.mod h1:mjrHv1cDGJWDlGmC0eDc1E5VJr8DmL9XMUcaFwiuKg8=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:92PET+sx1Hb4W/8CgFwGuxaKbttwY+UNspYZTvXY0vs=

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/filecoin-project/go-fil-markets v0.0.0-20200316155113-06e2b48c8232 h1
 github.com/filecoin-project/go-fil-markets v0.0.0-20200316155113-06e2b48c8232/go.mod h1:8NJk7Wp/tOL7NIS/PNDear6VD7UCINhvfnvqAhlcMEY=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200317195437-9176aecee576 h1:te2pkYAQL7q9cWXvtrlx8ATMwmkFBl5tgG2XF5vr6Vg=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200317195437-9176aecee576/go.mod h1:7EGCMycMpwICVzckXUfNL44HfIxG7pwoAVeOuZFGX/4=
+github.com/filecoin-project/go-fil-markets v0.0.0-20200318012938-6403a5bda668 h1:856ZUIBb2K8+C5nepxi4FQ/yeTSWdr4mWbjs1JbByGU=
+github.com/filecoin-project/go-fil-markets v0.0.0-20200318012938-6403a5bda668/go.mod h1:7EGCMycMpwICVzckXUfNL44HfIxG7pwoAVeOuZFGX/4=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543 h1:aMJGfgqe1QDhAVwxRg5fjCRF533xHidiKsugk7Vvzug=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543/go.mod h1:mjrHv1cDGJWDlGmC0eDc1E5VJr8DmL9XMUcaFwiuKg8=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:92PET+sx1Hb4W/8CgFwGuxaKbttwY+UNspYZTvXY0vs=

--- a/go.sum
+++ b/go.sum
@@ -147,10 +147,6 @@ github.com/filecoin-project/go-data-transfer v0.0.0-20191219005021-4accf56bd2ce 
 github.com/filecoin-project/go-data-transfer v0.0.0-20191219005021-4accf56bd2ce/go.mod h1:b14UWxhxVCAjrQUYvVGrQRRsjAh79wXYejw9RbUcAww=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1:yvQJCW9mmi9zy+51xA01Ea2X7/dL7r8eKDPuGUjRmbo=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
-github.com/filecoin-project/go-fil-markets v0.0.0-20200316155113-06e2b48c8232 h1:Pd3N9ibBJe8CWoN6Ypuohswtt6Tn15JPMYxz4/BI5wc=
-github.com/filecoin-project/go-fil-markets v0.0.0-20200316155113-06e2b48c8232/go.mod h1:8NJk7Wp/tOL7NIS/PNDear6VD7UCINhvfnvqAhlcMEY=
-github.com/filecoin-project/go-fil-markets v0.0.0-20200317195437-9176aecee576 h1:te2pkYAQL7q9cWXvtrlx8ATMwmkFBl5tgG2XF5vr6Vg=
-github.com/filecoin-project/go-fil-markets v0.0.0-20200317195437-9176aecee576/go.mod h1:7EGCMycMpwICVzckXUfNL44HfIxG7pwoAVeOuZFGX/4=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200318012938-6403a5bda668 h1:856ZUIBb2K8+C5nepxi4FQ/yeTSWdr4mWbjs1JbByGU=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200318012938-6403a5bda668/go.mod h1:7EGCMycMpwICVzckXUfNL44HfIxG7pwoAVeOuZFGX/4=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543 h1:aMJGfgqe1QDhAVwxRg5fjCRF533xHidiKsugk7Vvzug=
@@ -371,8 +367,6 @@ github.com/ipfs/go-blockservice v0.0.1/go.mod h1:2Ao89U7jV1KIqqNk5EdhSTBG/Pgc1vM
 github.com/ipfs/go-blockservice v0.1.0/go.mod h1:hzmMScl1kXHg3M2BjTymbVPjv627N7sYcvYaKbop39M=
 github.com/ipfs/go-blockservice v0.1.3-0.20190908200855-f22eea50656c h1:lN5IQA07VtLiTLAp/Scezp1ljFhXErC6yq4O1cu+yJ0=
 github.com/ipfs/go-blockservice v0.1.3-0.20190908200855-f22eea50656c/go.mod h1:t+411r7psEUhLueM8C7aPA7cxCclv4O3VsUVxt9kz2I=
-github.com/ipfs/go-car v0.0.3-0.20200131220434-3f68f6ebd093 h1:mYq7vJKGUzxIkkYfqXfO0uEO8gOmV9F38Tcpvi/p8P8=
-github.com/ipfs/go-car v0.0.3-0.20200131220434-3f68f6ebd093/go.mod h1:rEkw0S1sHd5kHL3rUSGEhwNanYqTwwNhjtpp0rwjrr4=
 github.com/ipfs/go-car v0.0.3-0.20200221191037-3762780fa84e h1:+wPt/tQHMOl00ekuf+5+ekWpyGQ6JOnF9vzEXjW7LtA=
 github.com/ipfs/go-car v0.0.3-0.20200221191037-3762780fa84e/go.mod h1:rEkw0S1sHd5kHL3rUSGEhwNanYqTwwNhjtpp0rwjrr4=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=

--- a/internal/app/go-filecoin/connectors/retrieval_market/client.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	paychActor "github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
@@ -28,6 +29,8 @@ type RetrievalClientConnector struct {
 	cs       ChainReaderAPI
 }
 
+var _ retrievalmarket.RetrievalClientNode = new(RetrievalClientConnector)
+
 // NewRetrievalClientConnector creates a new RetrievalClientConnector
 func NewRetrievalClientConnector(
 	bs blockstore.Blockstore,
@@ -48,8 +51,7 @@ func (r *RetrievalClientConnector) SetRetrievalClient(client retrievalmarket.Ret
 }
 
 // GetOrCreatePaymentChannel gets or creates a payment channel and posts to chain
-func (r *RetrievalClientConnector) GetOrCreatePaymentChannel(ctx context.Context, clientAddress address.Address, minerAddress address.Address, clientFundsAvailable abi.TokenAmount) (address.Address, error) {
-
+func (r *RetrievalClientConnector) GetOrCreatePaymentChannel(ctx context.Context, clientAddress address.Address, minerAddress address.Address, clientFundsAvailable abi.TokenAmount, tok shared.TipSetToken) (address.Address, error) {
 	if clientAddress == address.Undef || minerAddress == address.Undef {
 		return address.Undef, errors.New("empty address")
 	}
@@ -59,7 +61,7 @@ func (r *RetrievalClientConnector) GetOrCreatePaymentChannel(ctx context.Context
 	}
 	if chinfo.IsZero() {
 		// create the payment channel
-		bal, err := r.getBalance(ctx, clientAddress)
+		bal, err := r.getBalance(ctx, clientAddress, tok)
 		if err != nil {
 			return address.Undef, err
 		}
@@ -80,13 +82,13 @@ func (r *RetrievalClientConnector) AllocateLane(paymentChannel address.Address) 
 }
 
 // CreatePaymentVoucher creates a payment voucher for the retrieval client.
-func (r *RetrievalClientConnector) CreatePaymentVoucher(ctx context.Context, paychAddr address.Address, amount abi.TokenAmount, lane uint64) (*paychActor.SignedVoucher, error) {
-	height, err := r.getBlockHeight()
+func (r *RetrievalClientConnector) CreatePaymentVoucher(ctx context.Context, paychAddr address.Address, amount abi.TokenAmount, lane uint64, tok shared.TipSetToken) (*paychActor.SignedVoucher, error) {
+	height, err := r.getBlockHeight(tok)
 	if err != nil {
 		return nil, err
 	}
 
-	bal, err := r.getBalance(ctx, paychAddr)
+	bal, err := r.getBalance(ctx, paychAddr, tok)
 	if err != nil {
 		return nil, err
 	}
@@ -127,16 +129,16 @@ func (r *RetrievalClientConnector) CreatePaymentVoucher(ctx context.Context, pay
 	return &v, nil
 }
 
-func (r *RetrievalClientConnector) getBlockHeight() (abi.ChainEpoch, error) {
-	ts, err := r.getHeadTipSet()
+func (r *RetrievalClientConnector) getBlockHeight(tok shared.TipSetToken) (abi.ChainEpoch, error) {
+	ts, err := r.getTipSet(tok)
 	if err != nil {
 		return 0, err
 	}
 	return ts.Height()
 }
 
-func (r *RetrievalClientConnector) getBalance(ctx context.Context, account address.Address) (types.AttoFIL, error) {
-	ts, err := r.getHeadTipSet()
+func (r *RetrievalClientConnector) getBalance(ctx context.Context, account address.Address, tok shared.TipSetToken) (types.AttoFIL, error) {
+	ts, err := r.getTipSet(tok)
 	if err != nil {
 		return types.ZeroAttoFIL, err
 	}
@@ -149,11 +151,20 @@ func (r *RetrievalClientConnector) getBalance(ctx context.Context, account addre
 	return actor.Balance, nil
 }
 
-func (r *RetrievalClientConnector) getHeadTipSet() (block.TipSet, error) {
-	head := r.cs.Head()
-	ts, err := r.cs.GetTipSet(head)
+func (r *RetrievalClientConnector) GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error) {
+	panic("wombat")
+}
+
+func (r *RetrievalClientConnector) getTipSet(tok shared.TipSetToken) (block.TipSet, error) {
+	var tsk block.TipSetKey
+	if err := tsk.UnmarshalCBOR(tok); err != nil {
+		return block.TipSet{}, err
+	}
+
+	ts, err := r.cs.GetTipSet(tsk)
 	if err != nil {
 		return block.TipSet{}, err
 	}
+
 	return ts, nil
 }

--- a/internal/app/go-filecoin/connectors/retrieval_market/client.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/client.go
@@ -13,6 +13,7 @@ import (
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	xerrors "github.com/pkg/errors"
 
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/connectors"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
@@ -152,7 +153,7 @@ func (r *RetrievalClientConnector) getBalance(ctx context.Context, account addre
 }
 
 func (r *RetrievalClientConnector) GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error) {
-	panic("wombat")
+	return connectors.GetChainHead(r.cs)
 }
 
 func (r *RetrievalClientConnector) getTipSet(tok shared.TipSetToken) (block.TipSet, error) {

--- a/internal/app/go-filecoin/connectors/retrieval_market/client_test.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/client_test.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	. "github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/connectors/retrieval_market"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/shared_testutil"
@@ -24,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	. "github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/connectors/retrieval_market"
 	pch "github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/paymentchannel"
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/plumbing/cst"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"

--- a/internal/app/go-filecoin/connectors/retrieval_market/common.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/common.go
@@ -3,6 +3,8 @@ package retrievalmarketconnector
 import (
 	"context"
 
+	"github.com/filecoin-project/go-fil-markets/shared"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -31,7 +33,7 @@ type RetrievalSigner interface {
 type PaychMgrAPI interface {
 	AllocateLane(paychAddr address.Address) (uint64, error)
 	ChannelExists(paychAddr address.Address) (bool, error)
-	GetMinerWorker(ctx context.Context, miner address.Address) (address.Address, error)
+	GetMinerWorkerAddress(ctx context.Context, miner address.Address, tok shared.TipSetToken) (address.Address, error)
 	GetPaymentChannelInfo(paychAddr address.Address) (*paymentchannel.ChannelInfo, error)
 	GetPaymentChannelByAccounts(payer, payee address.Address) (*paymentchannel.ChannelInfo, error)
 	CreatePaymentChannel(payer, payee address.Address, amt abi.TokenAmount) (address.Address, error)

--- a/internal/app/go-filecoin/connectors/retrieval_market/common.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/common.go
@@ -38,5 +38,5 @@ type PaychMgrAPI interface {
 	GetPaymentChannelByAccounts(payer, payee address.Address) (*paymentchannel.ChannelInfo, error)
 	CreatePaymentChannel(payer, payee address.Address, amt abi.TokenAmount) (address.Address, error)
 	AddVoucherToChannel(paychAddr address.Address, voucher *paychActor.SignedVoucher) error
-	AddVoucher(paychAddr address.Address, voucher *paychActor.SignedVoucher, proof []byte, expected big.Int) (abi.TokenAmount, error)
+	AddVoucher(paychAddr address.Address, voucher *paychActor.SignedVoucher, proof []byte, expected big.Int, tok shared.TipSetToken) (abi.TokenAmount, error)
 }

--- a/internal/app/go-filecoin/connectors/retrieval_market/common.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/common.go
@@ -3,9 +3,8 @@ package retrievalmarketconnector
 import (
 	"context"
 
-	"github.com/filecoin-project/go-fil-markets/shared"
-
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	paychActor "github.com/filecoin-project/specs-actors/actors/builtin/paych"

--- a/internal/app/go-filecoin/connectors/retrieval_market/provider.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/provider.go
@@ -115,12 +115,10 @@ func (r *RetrievalProviderConnector) SavePaymentVoucher(_ context.Context, payme
 	return actual, nil
 }
 
-// GetMinerWorker produces the worker address for the provided storage miner
-// address at the chain head.
-func (r *RetrievalProviderConnector) GetMinerWorker(ctx context.Context, miner address.Address) (address.Address, error) {
-	// TODO: This should be passed a tipset key. See the getMinerWorkerAddress
-	// method on StorageMinerNodeConnector for an example.
-	return r.paychMgr.GetMinerWorker(ctx, miner)
+// GetMinerWorkerAddress produces the worker address for the provided storage
+// miner address from the tipset for the provided token.
+func (r *RetrievalProviderConnector) GetMinerWorkerAddress(ctx context.Context, miner address.Address, tok shared.TipSetToken) (address.Address, error) {
+	return r.paychMgr.GetMinerWorkerAddress(ctx, miner, tok)
 }
 
 func (r *RetrievalProviderConnector) GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error) {

--- a/internal/app/go-filecoin/connectors/retrieval_market/provider.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/provider.go
@@ -105,8 +105,7 @@ func (wrc limitedOffsetReadCloser) Close() error {
 // SavePaymentVoucher stores the provided payment voucher with the payment channel actor
 // Returns actual amount available to be redeemed by voucher?
 func (r *RetrievalProviderConnector) SavePaymentVoucher(_ context.Context, paymentChannel address.Address, voucher *paych.SignedVoucher, proof []byte, expected abi.TokenAmount) (actual abi.TokenAmount, err error) {
-
-	actual, err = r.paychMgr.AddVoucher(paymentChannel, voucher, proof, expected)
+	actual, err = r.paychMgr.AddVoucher(paymentChannel, voucher, proof, expected, shared.TipSetToken{})
 
 	if err != nil {
 		return abi.NewTokenAmount(0), err

--- a/internal/app/go-filecoin/connectors/retrieval_market/provider.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/provider.go
@@ -104,8 +104,8 @@ func (wrc limitedOffsetReadCloser) Close() error {
 
 // SavePaymentVoucher stores the provided payment voucher with the payment channel actor
 // Returns actual amount available to be redeemed by voucher?
-func (r *RetrievalProviderConnector) SavePaymentVoucher(_ context.Context, paymentChannel address.Address, voucher *paych.SignedVoucher, proof []byte, expected abi.TokenAmount) (actual abi.TokenAmount, err error) {
-	actual, err = r.paychMgr.AddVoucher(paymentChannel, voucher, proof, expected, shared.TipSetToken{})
+func (r *RetrievalProviderConnector) SavePaymentVoucher(_ context.Context, paymentChannel address.Address, voucher *paych.SignedVoucher, proof []byte, expected abi.TokenAmount, tok shared.TipSetToken) (actual abi.TokenAmount, err error) {
+	actual, err = r.paychMgr.AddVoucher(paymentChannel, voucher, proof, expected, tok)
 
 	if err != nil {
 		return abi.NewTokenAmount(0), err

--- a/internal/app/go-filecoin/connectors/storage_market/client.go
+++ b/internal/app/go-filecoin/connectors/storage_market/client.go
@@ -3,6 +3,8 @@ package storagemarketconnector
 import (
 	"context"
 
+	appstate "github.com/filecoin-project/go-filecoin/internal/pkg/state"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
@@ -43,9 +45,10 @@ func NewStorageClientNodeConnector(
 	wlt *wallet.Wallet,
 	ob *message.Outbox,
 	ca address.Address,
+	sv *appstate.Viewer,
 ) *StorageClientNodeConnector {
 	return &StorageClientNodeConnector{
-		connectorCommon: connectorCommon{cs, w, wlt, ob},
+		connectorCommon: connectorCommon{cs, sv, w, wlt, ob},
 		cborStore:       cbor,
 		clientAddr:      ca,
 	}
@@ -137,7 +140,7 @@ func (s *StorageClientNodeConnector) ValidatePublishedDeal(ctx context.Context, 
 
 	unsigned := chnMsg.Message.Message
 
-	minerWorker, err := s.GetMinerWorker(ctx, deal.Proposal.Provider)
+	minerWorker, err := s.GetMinerWorkerAddress(ctx, deal.Proposal.Provider, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/app/go-filecoin/connectors/storage_market/client.go
+++ b/internal/app/go-filecoin/connectors/storage_market/client.go
@@ -3,8 +3,6 @@ package storagemarketconnector
 import (
 	"context"
 
-	appstate "github.com/filecoin-project/go-filecoin/internal/pkg/state"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
@@ -23,6 +21,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/plumbing/msg"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/message"
+	appstate "github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/wallet"
 )

--- a/internal/app/go-filecoin/connectors/storage_market/provider.go
+++ b/internal/app/go-filecoin/connectors/storage_market/provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/message"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/piecemanager"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/state"
+	appstate "github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/wallet"
 )
@@ -44,9 +45,10 @@ func NewStorageProviderNodeConnector(ma address.Address,
 	w *msg.Waiter,
 	pm piecemanager.PieceManager,
 	wlt *wallet.Wallet,
+	sv *appstate.Viewer,
 ) *StorageProviderNodeConnector {
 	return &StorageProviderNodeConnector{
-		connectorCommon: connectorCommon{cs, w, wlt, ob},
+		connectorCommon: connectorCommon{cs, sv, w, wlt, ob},
 		chainStore:      cs,
 		minerAddr:       ma,
 		outbox:          ob,
@@ -56,7 +58,7 @@ func NewStorageProviderNodeConnector(ma address.Address,
 
 // AddFunds sends a message to add storage market collateral for the given address
 func (s *StorageProviderNodeConnector) AddFunds(ctx context.Context, addr address.Address, amount abi.TokenAmount) error {
-	workerAddr, err := s.GetMinerWorker(ctx, s.minerAddr)
+	workerAddr, err := s.GetMinerWorkerAddress(ctx, s.minerAddr, nil)
 	if err != nil {
 		return err
 	}
@@ -83,7 +85,7 @@ func (s *StorageProviderNodeConnector) EnsureFunds(ctx context.Context, addr, wa
 func (s *StorageProviderNodeConnector) PublishDeals(ctx context.Context, deal storagemarket.MinerDeal) (abi.DealID, cid.Cid, error) {
 	params := market.PublishStorageDealsParams{Deals: []market.ClientDealProposal{deal.ClientDealProposal}}
 
-	workerAddr, err := s.GetMinerWorker(ctx, s.minerAddr)
+	workerAddr, err := s.GetMinerWorkerAddress(ctx, s.minerAddr, nil)
 	if err != nil {
 		return 0, cid.Undef, err
 	}

--- a/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 
+	appstate "github.com/filecoin-project/go-filecoin/internal/pkg/state"
+
 	"github.com/ipfs/go-graphsync"
 
 	"github.com/filecoin-project/go-address"
@@ -50,11 +52,10 @@ func NewStorageProtocolSubmodule(
 	gsync graphsync.GraphExchange,
 	repoPath string,
 	sealProofType abi.RegisteredProof,
-
+	stateViewer *appstate.Viewer,
 ) (*StorageProtocolSubmodule, error) {
-
-	pnode := storagemarketconnector.NewStorageProviderNodeConnector(minerAddr, c.State, m.Outbox, mw, pm, wlt)
-	cnode := storagemarketconnector.NewStorageClientNodeConnector(cborutil.NewIpldStore(bs), c.State, mw, wlt, m.Outbox, clientAddr)
+	pnode := storagemarketconnector.NewStorageProviderNodeConnector(minerAddr, c.State, m.Outbox, mw, pm, wlt, stateViewer)
+	cnode := storagemarketconnector.NewStorageClientNodeConnector(cborutil.NewIpldStore(bs), c.State, mw, wlt, m.Outbox, clientAddr, stateViewer)
 
 	pieceStagingPath, err := paths.PieceStagingDir(repoPath)
 	if err != nil {

--- a/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"os"
 
-	appstate "github.com/filecoin-project/go-filecoin/internal/pkg/state"
-
-	"github.com/ipfs/go-graphsync"
-
 	"github.com/filecoin-project/go-address"
 	graphsyncimpl "github.com/filecoin-project/go-data-transfer/impl/graphsync"
 	"github.com/filecoin-project/go-fil-markets/filestore"
@@ -17,6 +13,7 @@ import (
 	smnetwork "github.com/filecoin-project/go-fil-markets/storagemarket/network"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-graphsync"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/pkg/errors"
@@ -26,6 +23,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/plumbing/msg"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/cborutil"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/piecemanager"
+	appstate "github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/wallet"
 )
 

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -7,8 +7,6 @@ import (
 	"reflect"
 	"runtime"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/constants"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-sectorbuilder"
 	"github.com/filecoin-project/go-sectorbuilder/fs"
@@ -32,6 +30,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/config"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/constants"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/message"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/metrics"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/mining"

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -466,8 +466,10 @@ func (node *Node) setupStorageMining(ctx context.Context) error {
 	waiter := msg.NewWaiter(node.chain.ChainReader, node.chain.MessageStore, node.Blockstore.Blockstore, cborStore)
 
 	// TODO: rework these modules so they can be at least partially constructed during the building phase #3738
+	stateViewer := state.NewViewer(cborStore)
+
 	node.StorageMining, err = submodule.NewStorageMiningSubmodule(minerAddr, node.Repo.Datastore(),
-		sectorBuilder, &node.chain, &node.Messaging, waiter, &node.Wallet, state.NewViewer(cborStore), node.BlockMining.PoStGenerator)
+		sectorBuilder, &node.chain, &node.Messaging, waiter, &node.Wallet, stateViewer, node.BlockMining.PoStGenerator)
 	if err != nil {
 		return err
 	}
@@ -487,6 +489,7 @@ func (node *Node) setupStorageMining(ctx context.Context) error {
 		node.network.GraphExchange,
 		repoPath,
 		sectorBuilder.SealProofType(),
+		stateViewer,
 	)
 	if err != nil {
 		return errors.Wrap(err, "error initializing storage protocol")

--- a/internal/app/go-filecoin/paymentchannel/manager.go
+++ b/internal/app/go-filecoin/paymentchannel/manager.go
@@ -3,6 +3,8 @@ package paymentchannel
 import (
 	"context"
 
+	"github.com/filecoin-project/go-fil-markets/shared"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-statestore"
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -309,15 +311,6 @@ func (pm *Manager) saveNewVoucher(paychAddr address.Address, voucher *paychActor
 }
 
 // GetMinerWorker mocks getting a miner worker address from the miner address
-func (pm *Manager) GetMinerWorker(ctx context.Context, miner address.Address) (address.Address, error) {
-	sv, err := pm.getStateView()
-	if err != nil {
-		return address.Undef, err
-	}
-	_, workerAddr, err := sv.MinerControlAddresses(ctx, miner)
-	if err != nil {
-		return address.Undef, err
-	}
-
-	return workerAddr, nil
+func (pm *Manager) GetMinerWorkerAddress(ctx context.Context, miner address.Address, tok shared.TipSetToken) (address.Address, error) {
+	panic("wombat")
 }

--- a/internal/app/go-filecoin/paymentchannel/manager.go
+++ b/internal/app/go-filecoin/paymentchannel/manager.go
@@ -3,9 +3,8 @@ package paymentchannel
 import (
 	"context"
 
-	"github.com/filecoin-project/go-fil-markets/shared"
-
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-statestore"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"

--- a/internal/app/go-filecoin/paymentchannel/manager_test.go
+++ b/internal/app/go-filecoin/paymentchannel/manager_test.go
@@ -7,6 +7,8 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/filecoin-project/go-fil-markets/shared"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/shared_testutil"
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -312,7 +314,7 @@ func TestManager_GetMinerWorker(t *testing.T) {
 
 	t.Run("happy path", func(t *testing.T) {
 		viewer.Views[root].AddMinerWithState(minerAddr, minerWorkerAddr)
-		res, err := manager.GetMinerWorker(ctx, minerAddr)
+		res, err := manager.GetMinerWorkerAddress(ctx, minerAddr, shared.TipSetToken{})
 		assert.NoError(t, err)
 		assert.Equal(t, minerWorkerAddr, res)
 	})
@@ -320,14 +322,14 @@ func TestManager_GetMinerWorker(t *testing.T) {
 	t.Run("returns error if getting control addr fails", func(t *testing.T) {
 		viewer.Views[root].AddMinerWithState(minerAddr, minerWorkerAddr)
 		viewer.Views[root].MinerControlErr = errors.New("boom")
-		_, err := manager.GetMinerWorker(ctx, minerAddr)
+		_, err := manager.GetMinerWorkerAddress(ctx, minerAddr, shared.TipSetToken{})
 		assert.EqualError(t, err, "boom")
 	})
 
 	t.Run("returns error if getting state view fails", func(t *testing.T) {
 		viewer.Views[root].AddMinerWithState(minerAddr, minerWorkerAddr)
 		cr.GetTSErr = errors.New("boom")
-		_, err := manager.GetMinerWorker(ctx, minerAddr)
+		_, err := manager.GetMinerWorkerAddress(ctx, minerAddr, shared.TipSetToken{})
 		assert.EqualError(t, err, "boom")
 	})
 }

--- a/internal/app/go-filecoin/paymentchannel/manager_test.go
+++ b/internal/app/go-filecoin/paymentchannel/manager_test.go
@@ -229,7 +229,7 @@ func TestManager_AddVoucher(t *testing.T) {
 		for i := 0; i < numVouchers; i++ {
 			newV := v
 			newV.Amount = abi.NewTokenAmount(increment * int64(i+1))
-			resAmt, err := manager.AddVoucher(paychAddr, &newV, proof, abi.NewTokenAmount(increment))
+			resAmt, err := manager.AddVoucher(paychAddr, &newV, proof, abi.NewTokenAmount(increment), shared.TipSetToken{})
 			require.NoError(t, err)
 			assert.True(t, resAmt.Equals(abi.NewTokenAmount(increment)))
 		}
@@ -246,11 +246,11 @@ func TestManager_AddVoucher(t *testing.T) {
 	t.Run("returns error if we try to save the same voucher", func(t *testing.T) {
 		viewer, manager := setupViewerManager(ctx, t, root, cr)
 		viewer.Views[root].AddActorWithState(paychAddr, clientAddr, minerAddr, paychIDAddr)
-		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1))
+		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1), shared.TipSetToken{})
 		require.NoError(t, err)
 		assert.Equal(t, amt, resAmt)
 
-		resAmt, err = manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1))
+		resAmt, err = manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1), shared.TipSetToken{})
 		assert.EqualError(t, err, "voucher already saved")
 		assert.Equal(t, abi.NewTokenAmount(0), resAmt)
 	})
@@ -258,7 +258,7 @@ func TestManager_AddVoucher(t *testing.T) {
 	t.Run("returns error if marshaling fails", func(t *testing.T) {
 		viewer, manager := setupViewerManager(ctx, t, root, cr)
 		viewer.Views[root].AddActorWithState(paychAddr, clientAddr, address.Undef, address.Undef)
-		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("applesauce"), abi.NewTokenAmount(1))
+		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("applesauce"), abi.NewTokenAmount(1), shared.TipSetToken{})
 		assert.EqualError(t, err, "cannot marshal undefined address")
 		assert.Equal(t, abi.NewTokenAmount(0), resAmt)
 	})
@@ -267,7 +267,7 @@ func TestManager_AddVoucher(t *testing.T) {
 		viewer, manager := setupViewerManager(ctx, t, root, cr)
 		viewer.Views[root].AddActorWithState(paychAddr, clientAddr, minerAddr, paychIDAddr)
 		viewer.Views[root].PaychActorPartiesErr = errors.New("boom")
-		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1))
+		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1), shared.TipSetToken{})
 		assert.EqualError(t, err, "boom")
 		assert.Equal(t, abi.NewTokenAmount(0), resAmt)
 	})
@@ -277,7 +277,7 @@ func TestManager_AddVoucher(t *testing.T) {
 		cr2.GetTSErr = errors.New("kaboom")
 		viewer, manager := setupViewerManager(ctx, t, root, cr2)
 		viewer.Views[root].AddActorWithState(paychAddr, clientAddr, minerAddr, paychIDAddr)
-		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("applesauce"), abi.NewTokenAmount(1))
+		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("applesauce"), abi.NewTokenAmount(1), shared.TipSetToken{})
 		assert.EqualError(t, err, "kaboom")
 		assert.Equal(t, abi.NewTokenAmount(0), resAmt)
 	})
@@ -286,7 +286,7 @@ func TestManager_AddVoucher(t *testing.T) {
 		viewer, manager := setupViewerManager(ctx, t, root, cr)
 
 		viewer.Views[root].AddActorWithState(paychAddr, clientAddr, minerAddr, paychIDAddr)
-		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1))
+		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1), shared.TipSetToken{})
 		require.NoError(t, err)
 		_, err = manager.AllocateLane(paychAddr)
 		require.NoError(t, err)
@@ -296,7 +296,7 @@ func TestManager_AddVoucher(t *testing.T) {
 		for _, amt := range amounts {
 			newV := v
 			newV.Amount = types.NewAttoFILFromFIL(amt)
-			resAmt, err = manager.AddVoucher(paychAddr, &newV, []byte("porkchops"), abi.NewTokenAmount(1))
+			resAmt, err = manager.AddVoucher(paychAddr, &newV, []byte("porkchops"), abi.NewTokenAmount(1), shared.TipSetToken{})
 			assert.EqualError(t, err, "voucher amount insufficient")
 			assert.Equal(t, abi.NewTokenAmount(0), resAmt)
 		}

--- a/internal/app/go-filecoin/paymentchannel/manager_test.go
+++ b/internal/app/go-filecoin/paymentchannel/manager_test.go
@@ -7,8 +7,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/filecoin-project/go-fil-markets/shared"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/shared_testutil"
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -26,6 +24,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/plumbing/cst"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
@@ -216,6 +215,10 @@ func TestManager_AddVoucher(t *testing.T) {
 		SecretPreimage: []uint8{},
 	}
 
+	tsk := block.NewTipSetKey(root)
+	tok, err := encoding.Encode(tsk)
+	require.NoError(t, err)
+
 	t.Run("Adding a valid voucher creates a payment channel info and saves the voucher", func(t *testing.T) {
 		testAPI := NewFakePaymentChannelAPI(ctx, t)
 		ds := dss.MutexWrap(datastore.NewMapDatastore())
@@ -229,7 +232,7 @@ func TestManager_AddVoucher(t *testing.T) {
 		for i := 0; i < numVouchers; i++ {
 			newV := v
 			newV.Amount = abi.NewTokenAmount(increment * int64(i+1))
-			resAmt, err := manager.AddVoucher(paychAddr, &newV, proof, abi.NewTokenAmount(increment), shared.TipSetToken{})
+			resAmt, err := manager.AddVoucher(paychAddr, &newV, proof, abi.NewTokenAmount(increment), tok)
 			require.NoError(t, err)
 			assert.True(t, resAmt.Equals(abi.NewTokenAmount(increment)))
 		}
@@ -246,11 +249,11 @@ func TestManager_AddVoucher(t *testing.T) {
 	t.Run("returns error if we try to save the same voucher", func(t *testing.T) {
 		viewer, manager := setupViewerManager(ctx, t, root, cr)
 		viewer.Views[root].AddActorWithState(paychAddr, clientAddr, minerAddr, paychIDAddr)
-		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1), shared.TipSetToken{})
+		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1), tok)
 		require.NoError(t, err)
 		assert.Equal(t, amt, resAmt)
 
-		resAmt, err = manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1), shared.TipSetToken{})
+		resAmt, err = manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1), tok)
 		assert.EqualError(t, err, "voucher already saved")
 		assert.Equal(t, abi.NewTokenAmount(0), resAmt)
 	})
@@ -258,7 +261,7 @@ func TestManager_AddVoucher(t *testing.T) {
 	t.Run("returns error if marshaling fails", func(t *testing.T) {
 		viewer, manager := setupViewerManager(ctx, t, root, cr)
 		viewer.Views[root].AddActorWithState(paychAddr, clientAddr, address.Undef, address.Undef)
-		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("applesauce"), abi.NewTokenAmount(1), shared.TipSetToken{})
+		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("applesauce"), abi.NewTokenAmount(1), tok)
 		assert.EqualError(t, err, "cannot marshal undefined address")
 		assert.Equal(t, abi.NewTokenAmount(0), resAmt)
 	})
@@ -267,7 +270,7 @@ func TestManager_AddVoucher(t *testing.T) {
 		viewer, manager := setupViewerManager(ctx, t, root, cr)
 		viewer.Views[root].AddActorWithState(paychAddr, clientAddr, minerAddr, paychIDAddr)
 		viewer.Views[root].PaychActorPartiesErr = errors.New("boom")
-		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1), shared.TipSetToken{})
+		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1), tok)
 		assert.EqualError(t, err, "boom")
 		assert.Equal(t, abi.NewTokenAmount(0), resAmt)
 	})
@@ -277,7 +280,7 @@ func TestManager_AddVoucher(t *testing.T) {
 		cr2.GetTSErr = errors.New("kaboom")
 		viewer, manager := setupViewerManager(ctx, t, root, cr2)
 		viewer.Views[root].AddActorWithState(paychAddr, clientAddr, minerAddr, paychIDAddr)
-		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("applesauce"), abi.NewTokenAmount(1), shared.TipSetToken{})
+		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("applesauce"), abi.NewTokenAmount(1), tok)
 		assert.EqualError(t, err, "kaboom")
 		assert.Equal(t, abi.NewTokenAmount(0), resAmt)
 	})
@@ -286,7 +289,7 @@ func TestManager_AddVoucher(t *testing.T) {
 		viewer, manager := setupViewerManager(ctx, t, root, cr)
 
 		viewer.Views[root].AddActorWithState(paychAddr, clientAddr, minerAddr, paychIDAddr)
-		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1), shared.TipSetToken{})
+		resAmt, err := manager.AddVoucher(paychAddr, &v, []byte("porkchops"), abi.NewTokenAmount(1), tok)
 		require.NoError(t, err)
 		_, err = manager.AllocateLane(paychAddr)
 		require.NoError(t, err)
@@ -296,7 +299,7 @@ func TestManager_AddVoucher(t *testing.T) {
 		for _, amt := range amounts {
 			newV := v
 			newV.Amount = types.NewAttoFILFromFIL(amt)
-			resAmt, err = manager.AddVoucher(paychAddr, &newV, []byte("porkchops"), abi.NewTokenAmount(1), shared.TipSetToken{})
+			resAmt, err = manager.AddVoucher(paychAddr, &newV, []byte("porkchops"), abi.NewTokenAmount(1), tok)
 			assert.EqualError(t, err, "voucher amount insufficient")
 			assert.Equal(t, abi.NewTokenAmount(0), resAmt)
 		}
@@ -312,9 +315,13 @@ func TestManager_GetMinerWorker(t *testing.T) {
 	cr := NewFakeChainReader(block.NewTipSetKey(root))
 	viewer, manager := setupViewerManager(ctx, t, root, cr)
 
+	tsk := block.NewTipSetKey(root)
+	tok, err := encoding.Encode(tsk)
+	require.NoError(t, err)
+
 	t.Run("happy path", func(t *testing.T) {
 		viewer.Views[root].AddMinerWithState(minerAddr, minerWorkerAddr)
-		res, err := manager.GetMinerWorkerAddress(ctx, minerAddr, shared.TipSetToken{})
+		res, err := manager.GetMinerWorkerAddress(ctx, minerAddr, tok)
 		assert.NoError(t, err)
 		assert.Equal(t, minerWorkerAddr, res)
 	})
@@ -322,15 +329,15 @@ func TestManager_GetMinerWorker(t *testing.T) {
 	t.Run("returns error if getting control addr fails", func(t *testing.T) {
 		viewer.Views[root].AddMinerWithState(minerAddr, minerWorkerAddr)
 		viewer.Views[root].MinerControlErr = errors.New("boom")
-		_, err := manager.GetMinerWorkerAddress(ctx, minerAddr, shared.TipSetToken{})
+		_, err := manager.GetMinerWorkerAddress(ctx, minerAddr, tok)
 		assert.EqualError(t, err, "boom")
 	})
 
 	t.Run("returns error if getting state view fails", func(t *testing.T) {
 		viewer.Views[root].AddMinerWithState(minerAddr, minerWorkerAddr)
 		cr.GetTSErr = errors.New("boom")
-		_, err := manager.GetMinerWorkerAddress(ctx, minerAddr, shared.TipSetToken{})
-		assert.EqualError(t, err, "boom")
+		_, err := manager.GetMinerWorkerAddress(ctx, minerAddr, tok)
+		assert.Contains(t, err.Error(), "boom")
 	})
 }
 


### PR DESCRIPTION
### Motivation

We need to provide a tipset identifier to chain-querying methods to ensure a consistent view of the chain across queries.

### Proposed changes

This PR updates go-fil-markets to use the latest and greatest, which also necessitates a few tipset token changes.