### PR TITLE
TxMeta Order

### DIFF
--- a/internal/pkg/types/message.go
+++ b/internal/pkg/types/message.go
@@ -191,8 +191,8 @@ func NewGasPrice(price int64) AttoFIL {
 // TxMeta tracks the merkleroots of both secp and bls messages separately
 type TxMeta struct {
 	_        struct{} `cbor:",toarray"`
-	SecpRoot e.Cid    `json:"secpRoot"`
 	BLSRoot  e.Cid    `json:"blsRoot"`
+	SecpRoot e.Cid    `json:"secpRoot"`
 }
 
 // String returns a readable printing string of TxMeta


### PR DESCRIPTION
### Motivation
Data format up to spec.  This was preventing full block sync.  It was so small it was worth just PRing and not spinning off into an issue

### Proposed changes
Flip field order in txmeta

Closes issue #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

