### PR TITLE
Fix genesis weight calculation

### DIFF
--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -702,15 +702,17 @@ func (node *Node) getWeight(ctx context.Context, ts block.TipSet) (fbig.Int, err
 	if err != nil {
 		return fbig.Zero(), err
 	}
-	// TODO handle genesis cid more gracefully
-	if parent.Len() == 0 {
-		return node.syncer.ChainSelector.Weight(ctx, ts, cid.Undef)
+	var baseStRoot cid.Cid
+	if parent.Empty() {
+		// use genesis state as parent state of genesis block
+		baseStRoot, err = node.chain.ChainReader.GetTipSetStateRoot(ts.Key())
+	} else {
+		baseStRoot, err = node.chain.ChainReader.GetTipSetStateRoot(parent)
 	}
-	root, err := node.chain.ChainReader.GetTipSetStateRoot(parent)
 	if err != nil {
 		return fbig.Zero(), err
 	}
-	return node.syncer.ChainSelector.Weight(ctx, ts, root)
+	return node.syncer.ChainSelector.Weight(ctx, ts, baseStRoot)
 }
 
 // -- Accessors

--- a/internal/pkg/chainsync/internal/syncer/syncer.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer.go
@@ -317,14 +317,18 @@ func (syncer *Syncer) syncOne(ctx context.Context, grandParent, parent, next blo
 // TODO #3537 this should be stored the first time it is computed and retrieved
 // from disk just like aggregate state roots.
 func (syncer *Syncer) calculateParentWeight(ctx context.Context, parent, grandParent block.TipSet) (fbig.Int, error) {
+	var baseStRoot cid.Cid
+	var err error
 	if grandParent.Equals(block.UndefTipSet) {
-		return syncer.chainSelector.Weight(ctx, parent, cid.Undef)
+		// use genesis state as parent of genesis block
+		baseStRoot, err = syncer.chainStore.GetTipSetStateRoot(parent.Key())
+	} else {
+		baseStRoot, err = syncer.chainStore.GetTipSetStateRoot(grandParent.Key())
 	}
-	gpStRoot, err := syncer.chainStore.GetTipSetStateRoot(grandParent.Key())
 	if err != nil {
 		return fbig.Zero(), err
 	}
-	return syncer.chainSelector.Weight(ctx, parent, gpStRoot)
+	return syncer.chainSelector.Weight(ctx, parent, baseStRoot)
 }
 
 // ancestorsFromStore returns the parent and grandparent tipsets of `ts`

--- a/internal/pkg/chainsync/internal/syncer/syncer.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer.go
@@ -577,15 +577,17 @@ func (syncer *Syncer) stageIfHeaviest(ctx context.Context, candidate block.TipSe
 	if err != nil {
 		return err
 	}
-	var stagedParentStateID cid.Cid
-	if !stagedParentKey.Empty() { // head is not genesis
-		stagedParentStateID, err = syncer.chainStore.GetTipSetStateRoot(stagedParentKey)
+	var stagedBaseStateID cid.Cid
+	if stagedParentKey.Empty() { // if staged is genesis base state is genesis state
+		stagedBaseStateID = syncer.staged.At(0).StateRoot.Cid
+	} else {
+		stagedBaseStateID, err = syncer.chainStore.GetTipSetStateRoot(stagedParentKey)
 		if err != nil {
 			return err
 		}
 	}
 
-	heavier, err := syncer.chainSelector.IsHeavier(ctx, candidate, syncer.staged, candidateParentStateID, stagedParentStateID)
+	heavier, err := syncer.chainSelector.IsHeavier(ctx, candidate, syncer.staged, candidateParentStateID, stagedBaseStateID)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/consensus/chain_selector.go
+++ b/internal/pkg/consensus/chain_selector.go
@@ -50,9 +50,6 @@ func log2b(x fbig.Int) fbig.Int {
 //
 //
 func (c *ChainSelector) Weight(ctx context.Context, ts block.TipSet, pStateID cid.Cid) (fbig.Int, error) {
-	if ts.Len() > 0 && ts.At(0).Cid().Equals(c.genesisCid) {
-		return fbig.Zero(), nil
-	}
 	// Retrieve parent weight.
 	parentWeight, err := ts.ParentWeight()
 	if err != nil {

--- a/internal/pkg/consensus/chain_selector.go
+++ b/internal/pkg/consensus/chain_selector.go
@@ -45,17 +45,13 @@ func log2b(x fbig.Int) fbig.Int {
 	return fbig.NewInt(int64(bits - 1))
 }
 
-// Weight returns the EC weight of this TipSet in uint64 encoded fixed point
-// representation.
-//
-//
+// Weight returns the EC weight of this TipSet as a filecoin big int.
 func (c *ChainSelector) Weight(ctx context.Context, ts block.TipSet, pStateID cid.Cid) (fbig.Int, error) {
 	// Retrieve parent weight.
 	parentWeight, err := ts.ParentWeight()
 	if err != nil {
 		return fbig.Zero(), err
 	}
-
 	if !pStateID.Defined() {
 		return fbig.Zero(), errors.New("undefined state passed to chain selector new weight")
 	}

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -191,7 +191,7 @@ func (c *Expected) validateMining(ctx context.Context,
 		}
 
 		if !parentWeight.Equals(blk.ParentWeight) {
-			return errors.Errorf("block %s has invalid parent weight %d", blk.Cid().String(), parentWeight)
+			return errors.Errorf("block %s has invalid parent weight %d expected %d", blk.Cid().String(), blk.ParentWeight, parentWeight)
 		}
 		workerAddr, err := powerTable.WorkerAddr(ctx, blk.Miner)
 		if err != nil {


### PR DESCRIPTION
### Motivation
We currently set the weight of the genesis block to 0 rather than adding the power of the block to a genesis parent weight of 0.  Making this change gets us up to parity with lotus.  

This is somewhat speculative since this is inadequately speced (added to spec todo list) but it is arguably more sensible than what we do now (and easy to revert) so adding to master

### Proposed changes

Closes issue #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

