### PR TITLE
Serialize signable block data with proper dummy value for signature 

### DIFF
--- a/internal/pkg/block/block.go
+++ b/internal/pkg/block/block.go
@@ -61,7 +61,7 @@ type Block struct {
 	Timestamp uint64 `json:"timestamp"`
 
 	// The signature of the miner's worker key over the block
-	BlockSig crypto.Signature `json:"blocksig"`
+	BlockSig *crypto.Signature `json:"blocksig"`
 
 	// ForkSignaling is extra data used by miners to communicate
 	ForkSignaling uint64
@@ -147,8 +147,8 @@ func (b *Block) Equals(other *Block) bool {
 	return b.Cid().Equals(other.Cid())
 }
 
-// SignatureData returns the cid bytes of the block's bytes without the
-// blocksig for signature creation and verification
+// SignatureData returns the block's bytes with a null signature field for
+// signature creation and verification
 func (b *Block) SignatureData() []byte {
 	tmp := &Block{
 		Miner:           b.Miner,

--- a/internal/pkg/block/block.go
+++ b/internal/pkg/block/block.go
@@ -147,8 +147,8 @@ func (b *Block) Equals(other *Block) bool {
 	return b.Cid().Equals(other.Cid())
 }
 
-// SignatureData returns the block's bytes without the blocksig for signature
-// creating and verification
+// SignatureData returns the cid bytes of the block's bytes without the
+// blocksig for signature creation and verification
 func (b *Block) SignatureData() []byte {
 	tmp := &Block{
 		Miner:           b.Miner,

--- a/internal/pkg/block/block_test.go
+++ b/internal/pkg/block/block_test.go
@@ -56,7 +56,7 @@ func TestTriangleEncoding(t *testing.T) {
 	}
 	t.Run("encoding block with zero fields works", func(t *testing.T) {
 		testRoundTrip(t, &blk.Block{
-			BlockSig:        crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
+			BlockSig:        &crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
 			BLSAggregateSig: crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
 		})
 	})
@@ -77,7 +77,7 @@ func TestTriangleEncoding(t *testing.T) {
 			ParentWeight:    fbig.NewInt(1000),
 			StateRoot:       e.NewCid(types.CidFromString(t, "somecid")),
 			Timestamp:       1,
-			BlockSig: crypto.Signature{
+			BlockSig: &crypto.Signature{
 				Type: crypto.SigTypeBLS,
 				Data: []byte{0x3},
 			},
@@ -129,7 +129,7 @@ func TestDecodeBlock(t *testing.T) {
 			Messages:        e.NewCid(cM),
 			StateRoot:       e.NewCid(c2),
 			MessageReceipts: e.NewCid(cR),
-			BlockSig:        crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
+			BlockSig:        &crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
 			BLSAggregateSig: crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
 		}
 
@@ -239,7 +239,7 @@ func TestSignatureData(t *testing.T) {
 		StateRoot:       e.NewCid(types.CidFromString(t, "somecid")),
 		Timestamp:       1,
 		EPoStInfo:       postInfo,
-		BlockSig: crypto.Signature{
+		BlockSig: &crypto.Signature{
 			Type: crypto.SigTypeBLS,
 			Data: []byte{0x3},
 		},
@@ -261,7 +261,7 @@ func TestSignatureData(t *testing.T) {
 		StateRoot:       e.NewCid(types.CidFromString(t, "someothercid")),
 		Timestamp:       4,
 		EPoStInfo:       diffPoStInfo,
-		BlockSig: crypto.Signature{
+		BlockSig: &crypto.Signature{
 			Type: crypto.SigTypeBLS,
 			Data: []byte{0x4},
 		},

--- a/internal/pkg/chain/testing.go
+++ b/internal/pkg/chain/testing.go
@@ -212,7 +212,7 @@ func (f *Builder) Build(parent block.TipSet, width int, build func(b *BlockBuild
 			//EPoStInfo:       ePoStInfo,
 			//ForkSignaling:   forkSig,
 			Timestamp: f.stamper.Stamp(height),
-			BlockSig:  crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
+			BlockSig:  &crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
 		}
 
 		if build != nil {

--- a/internal/pkg/chainsync/fetcher/graphsync_helpers_test.go
+++ b/internal/pkg/chainsync/fetcher/graphsync_helpers_test.go
@@ -358,7 +358,7 @@ func simpleBlock() *block.Block {
 		StateRoot:       e.NewCid(types.EmptyMessagesCID),
 		Messages:        e.NewCid(types.EmptyTxMetaCID),
 		MessageReceipts: e.NewCid(types.EmptyReceiptsCID),
-		BlockSig:        crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
+		BlockSig:        &crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
 		BLSAggregateSig: crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
 	}
 }

--- a/internal/pkg/consensus/block_validation.go
+++ b/internal/pkg/consensus/block_validation.go
@@ -105,13 +105,16 @@ func (dv *DefaultBlockValidator) ValidateSyntax(ctx context.Context, blk *block.
 		return err
 	}
 	if !blk.StateRoot.Defined() {
-		return fmt.Errorf("block %s has nil StateRoot", blk.Cid().String())
+		return fmt.Errorf("block %s has nil StateRoot", blk.Cid())
 	}
 	if blk.Miner.Empty() {
-		return fmt.Errorf("block %s has nil miner address", blk.Cid().String())
+		return fmt.Errorf("block %s has nil miner address", blk.Cid())
 	}
 	if len(blk.Ticket.VRFProof) == 0 {
-		return fmt.Errorf("block %s has nil ticket", blk.Cid().String())
+		return fmt.Errorf("block %s has nil ticket", blk.Cid())
+	}
+	if blk.BlockSig == nil {
+		return fmt.Errorf("block %s has nil signature", blk.Cid())
 	}
 
 	return nil

--- a/internal/pkg/consensus/block_validation_test.go
+++ b/internal/pkg/consensus/block_validation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	e "github.com/filecoin-project/go-filecoin/internal/pkg/enccid"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
@@ -112,6 +113,10 @@ func TestBlockValidSyntax(t *testing.T) {
 		Height:    1,
 
 		EPoStInfo: validPoStInfo,
+		BlockSig: &crypto.Signature{
+			Type: crypto.SigTypeBLS,
+			Data: []byte{0x3},
+		},
 	}
 	require.NoError(t, validator.ValidateSyntax(ctx, blk))
 

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -2,7 +2,6 @@ package consensus
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"time"
 
@@ -203,8 +202,9 @@ func (c *Expected) validateMining(ctx context.Context,
 			return errors.Wrapf(err, "failed to convert address, %s, to a signing address", workerAddr.String())
 		}
 		// Validate block signature
-		sigData := blk.SignatureData()
-		fmt.Printf("sigData: %x\n", sigData)
+		if blk.BlockSig == nil {
+			return errors.Errorf("invalid nil block signature")
+		}
 		if err := crypto.ValidateSignature(blk.SignatureData(), workerSignerAddr, *blk.BlockSig); err != nil {
 			return errors.Wrap(err, "block signature invalid")
 		}

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -202,6 +203,8 @@ func (c *Expected) validateMining(ctx context.Context,
 			return errors.Wrapf(err, "failed to convert address, %s, to a signing address", workerAddr.String())
 		}
 		// Validate block signature
+		sigData := blk.SignatureData()
+		fmt.Printf("sigData: %x\n", sigData)
 		if err := crypto.ValidateSignature(blk.SignatureData(), workerSignerAddr, blk.BlockSig); err != nil {
 			return errors.Wrap(err, "block signature invalid")
 		}

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -205,7 +205,7 @@ func (c *Expected) validateMining(ctx context.Context,
 		// Validate block signature
 		sigData := blk.SignatureData()
 		fmt.Printf("sigData: %x\n", sigData)
-		if err := crypto.ValidateSignature(blk.SignatureData(), workerSignerAddr, blk.BlockSig); err != nil {
+		if err := crypto.ValidateSignature(blk.SignatureData(), workerSignerAddr, *blk.BlockSig); err != nil {
 			return errors.Wrap(err, "block signature invalid")
 		}
 

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -119,10 +119,11 @@ func (w *DefaultWorker) Generate(
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to convert worker address to signing address")
 	}
-	next.BlockSig, err = w.workerSigner.SignBytes(next.SignatureData(), workerSigningAddr)
+	blockSig, err := w.workerSigner.SignBytes(next.SignatureData(), workerSigningAddr)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to sign block")
 	}
+	next.BlockSig = &blockSig
 
 	return next, nil
 }

--- a/internal/pkg/net/validators_test.go
+++ b/internal/pkg/net/validators_test.go
@@ -97,7 +97,7 @@ func TestBlockPubSubValidation(t *testing.T) {
 		StateRoot:       e.NewCid(types.NewCidForTestGetter()()),
 		Miner:           miner,
 		Ticket:          block.Ticket{VRFProof: []byte{0}},
-		BlockSig:        crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
+		BlockSig:        &crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
 		BLSAggregateSig: crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
 	}
 	// publish the invalid block
@@ -115,7 +115,7 @@ func TestBlockPubSubValidation(t *testing.T) {
 		StateRoot:       e.NewCid(types.NewCidForTestGetter()()),
 		Miner:           miner,
 		Ticket:          block.Ticket{VRFProof: []byte{0}},
-		BlockSig:        crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
+		BlockSig:        &crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
 		BLSAggregateSig: crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
 	}
 	// publish the invalid block

--- a/internal/pkg/slashing/check.go
+++ b/internal/pkg/slashing/check.go
@@ -130,7 +130,7 @@ func verifyBlockSignature(ctx context.Context, view FaultStateView, blk block.Bl
 	if err != nil {
 		panic(errors.Wrapf(err, "failed to inspect miner addresses"))
 	}
-	err = state.NewSignatureValidator(view).ValidateSignature(ctx, blk.SignatureData(), worker, blk.BlockSig)
+	err = state.NewSignatureValidator(view).ValidateSignature(ctx, blk.SignatureData(), worker, *blk.BlockSig)
 	if err != nil {
 		return errors.Wrapf(err, "no consensus fault: block %s signature invalid", blk.Cid())
 	}

--- a/internal/pkg/slashing/check.go
+++ b/internal/pkg/slashing/check.go
@@ -130,6 +130,9 @@ func verifyBlockSignature(ctx context.Context, view FaultStateView, blk block.Bl
 	if err != nil {
 		panic(errors.Wrapf(err, "failed to inspect miner addresses"))
 	}
+	if blk.BlockSig == nil {
+		return errors.Errorf("no consensus fault: block %s has nil signature", blk.Cid())
+	}
 	err = state.NewSignatureValidator(view).ValidateSignature(ctx, blk.SignatureData(), worker, *blk.BlockSig)
 	if err != nil {
 		return errors.Wrapf(err, "no consensus fault: block %s signature invalid", blk.Cid())

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -47,7 +47,7 @@ func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, sta
 	}
 	sig, err := signer.SignBytes(b.SignatureData(), minerWorker)
 	require.NoError(t, err)
-	b.BlockSig = sig
+	b.BlockSig = &sig
 
 	return b
 }

--- a/tools/gengen/util/generator.go
+++ b/tools/gengen/util/generator.go
@@ -298,7 +298,7 @@ func (g *GenesisGenerator) genBlock(ctx context.Context) (cid.Cid, error) {
 		},
 		Ticket:    consensus.GenesisTicket,
 		Timestamp: g.cfg.Time,
-		BlockSig:  crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
+		BlockSig:  &crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
 	}
 
 	return g.cst.Put(ctx, geneblk)


### PR DESCRIPTION
### Motivation
To interop with lotus we need to sign and verify consistent block bytes.

There is some unspecced (issue forthcoming) ambiguity in how to serialize the bytes for signing and verifying.  We are adopting lotus's strategy of serializing sig field as null because it makes a bit more sense than our current strategy

### Proposed changes
- Turn sig field into pointer so that we can use the block datastructure to get this encoding automatically (could use a different structure if reviewers prefer)
- Add non-nil sig validation to syntax val to prevent users from crashing nodes

Closes issue #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

