### PR TITLE
Include message CIDs in block pubsub payloads.

### DIFF
--- a/internal/app/go-filecoin/node/block.go
+++ b/internal/app/go-filecoin/node/block.go
@@ -7,8 +7,10 @@ import (
 	"go.opencensus.io/trace"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/metrics/tracing"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/mining"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/net/blocksub"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/net/pubsub"
 )
 
@@ -27,18 +29,25 @@ func (node *Node) AddNewBlock(ctx context.Context, o mining.Output) (err error) 
 		return errors.Wrap(err, "could not add new block to online storage")
 	}
 
-	log.Debugf("syncing new block: %s", b.Cid().String())
+	// Publish blocksub message
+	log.Debugf("publishing new block: %s", b.Cid().String())
 	go func() {
-		err = node.syncer.BlockTopic.Publish(ctx, b.ToNode().RawData())
+		payload, err := blocksub.MakePayload(o.Header, o.BLSMessages, o.SECPMessages)
 		if err != nil {
-			log.Errorf("error publishing new block on block topic %s", err)
+			log.Errorf("failed to create blocksub payload: %s", err)
+		}
+		err = node.syncer.BlockTopic.Publish(ctx, payload)
+		if err != nil {
+			log.Errorf("failed to publish on blocksub: %s", err)
 		}
 	}()
+
+	log.Debugf("syncing new block: %s", b.Cid().String())
 	ci := block.NewChainInfo(node.Host().ID(), node.Host().ID(), block.NewTipSetKey(blkCid), b.Height)
 	return node.syncer.ChainSyncManager.BlockProposer().SendOwnBlock(ci)
 }
 
-func (node *Node) processBlock(ctx context.Context, msg pubsub.Message) (err error) {
+func (node *Node) handleBlockSub(ctx context.Context, msg pubsub.Message) (err error) {
 	sender := msg.GetSender()
 	source := msg.GetSource()
 	// ignore messages from self
@@ -46,18 +55,19 @@ func (node *Node) processBlock(ctx context.Context, msg pubsub.Message) (err err
 		return nil
 	}
 
-	ctx, span := trace.StartSpan(ctx, "Node.processBlock")
+	ctx, span := trace.StartSpan(ctx, "Node.handleBlockSub")
 	defer tracing.AddErrorEndSpan(ctx, span, &err)
 
-	blk, err := block.DecodeBlock(msg.GetData())
+	var payload blocksub.Payload
+	err = encoding.Decode(msg.GetData(), &payload)
 	if err != nil {
-		return errors.Wrapf(err, "bad block data from source: %s, sender: %s", source, sender)
+		return errors.Wrapf(err, "failed to decode blocksub payload from source: %s, sender: %s", source, sender)
 	}
 
-	span.AddAttributes(trace.StringAttribute("block", blk.Cid().String()))
-
-	log.Infof("Received new block %s from peer %s", blk.Cid(), sender)
-	log.Debugf("Received new block sender: %s source: %s, %s", sender, source, blk)
+	header := &payload.Header
+	span.AddAttributes(trace.StringAttribute("block", header.Cid().String()))
+	log.Infof("Received new block %s from peer %s", header.Cid(), sender)
+	log.Debugf("Received new block sender: %s source: %s, %s", sender, source, header)
 
 	// The block we went to all that effort decoding is dropped on the floor!
 	// Don't be too quick to change that, though: the syncer re-fetching the block
@@ -65,9 +75,10 @@ func (node *Node) processBlock(ctx context.Context, msg pubsub.Message) (err err
 	// See https://github.com/filecoin-project/go-filecoin/issues/2962
 	// TODO Implement principled trusting of ChainInfo's
 	// to address in #2674
-	err = node.syncer.ChainSyncManager.BlockProposer().SendGossipBlock(block.NewChainInfo(source, sender, block.NewTipSetKey(blk.Cid()), blk.Height))
+	chainInfo := block.NewChainInfo(source, sender, block.NewTipSetKey(header.Cid()), header.Height)
+	err = node.syncer.ChainSyncManager.BlockProposer().SendGossipBlock(chainInfo)
 	if err != nil {
-		return errors.Wrapf(err, "failed to notify syncer of new block, block: %s", blk.Cid())
+		return errors.Wrapf(err, "failed to notify syncer of new block, block: %s", header.Cid())
 	}
 
 	return nil

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -146,7 +146,7 @@ func (node *Node) Start(ctx context.Context) error {
 	if !node.OfflineMode {
 
 		// Subscribe to block pubsub topic to learn about new chain heads.
-		node.syncer.BlockSub, err = node.pubsubscribe(syncCtx, node.syncer.BlockTopic, node.processBlock)
+		node.syncer.BlockSub, err = node.pubsubscribe(syncCtx, node.syncer.BlockTopic, node.handleBlockSub)
 		if err != nil {
 			log.Error(err)
 		}

--- a/internal/pkg/net/blocksub/topic.go
+++ b/internal/pkg/net/blocksub/topic.go
@@ -2,6 +2,13 @@ package blocksub
 
 import (
 	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	e "github.com/filecoin-project/go-filecoin/internal/pkg/enccid"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
 // BlockTopic returns the network pubsub topic identifier on which new blocks are announced.
@@ -9,10 +16,34 @@ func Topic(networkName string) string {
 	return fmt.Sprintf("/fil/blocks/%s", networkName)
 }
 
-// Coming soon:
-//type Message struct {
-//	_           struct{} `cbor:",toarray"`
-//	Header      block.Block
-//	BLSMsgCids  []e.Cid
-//	SECPMsgCids []e.Cid
-//}
+type Payload struct {
+	_           struct{} `cbor:",toarray"`
+	Header      block.Block
+	BLSMsgCids  []e.Cid
+	SECPMsgCids []e.Cid
+}
+
+func MakePayload(header *block.Block, BLSMessages, SECPMessages []*types.SignedMessage) ([]byte, error) {
+	blsCIDs := make([]e.Cid, len(BLSMessages))
+	for i, m := range BLSMessages {
+		c, err := m.Message.Cid() // CID of the unsigned message
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create blocksub payload for BLS msg %s", m)
+		}
+		blsCIDs[i] = e.NewCid(c)
+	}
+	secpCIDs := make([]e.Cid, len(SECPMessages))
+	for i, m := range SECPMessages {
+		c, err := m.Cid() // CID of the signed message
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create blocksub payload for SECP msg %s", m)
+		}
+		secpCIDs[i] = e.NewCid(c)
+	}
+	payload := Payload{
+		Header:      *header,
+		BLSMsgCids:  blsCIDs,
+		SECPMsgCids: secpCIDs,
+	}
+	return encoding.Encode(payload)
+}


### PR DESCRIPTION
### Motivation
Issue #3882 calls for including the included message CIDs in the block-pubsub ("blocksub") message payload. 

### Proposed changes
This hooks up the encoding and decoding of the message CID lists in the publisher, subscriber, and validator. The CID lists are not validated (since we ignore them), #3903.

- [x] Land #3901 and rebase

Closes #3882.

