### PR TITLE
Change PR template so that auto-closed issue will work

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 
 ### Proposed changes
 
-Closes issue #
+Closes #
 
 <!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->
 


### PR DESCRIPTION
The word "issue" between "closes" and the number stops GitHub actually closing it.