### PR TITLE
Move actor state head update to end of transaction rather than end of message send.

### DIFF
--- a/internal/pkg/vm/internal/vmcontext/actor_state_handle.go
+++ b/internal/pkg/vm/internal/vmcontext/actor_state_handle.go
@@ -1,15 +1,15 @@
 package vmcontext
 
 import (
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/runtime"
 	specsruntime "github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/runtime"
 )
 
 type actorStateHandle struct {
-	ctx  actorStateHandleContext
-	head cid.Cid
+	ctx actorStateHandleContext
 	// validations is a list of validations that the vm will execute after the actor code finishes.
 	//
 	// Any validation failure will result in the execution getting aborted.
@@ -22,38 +22,23 @@ type actorStateHandle struct {
 type validateFn = func() bool
 
 type actorStateHandleContext interface {
-	Store() specsruntime.Store
 	AllowSideEffects(bool)
+	Create(obj specsruntime.CBORMarshaler) cid.Cid
+	Load(obj specsruntime.CBORUnmarshaler) cid.Cid
+	Replace(expected cid.Cid, obj specsruntime.CBORMarshaler) cid.Cid
 }
-
-type readonlyContextWrapper struct {
-	store specsruntime.Store
-}
-
-func (w readonlyContextWrapper) Store() specsruntime.Store {
-	return w.store
-}
-
-func (readonlyContextWrapper) AllowSideEffects(bool) {}
 
 // NewActorStateHandle returns a new `ActorStateHandle`
 //
 // Note: just visible for testing.
-func NewActorStateHandle(ctx actorStateHandleContext, head cid.Cid) specsruntime.StateHandle {
-	aux := newActorStateHandle(ctx, head)
+func NewActorStateHandle(ctx actorStateHandleContext) specsruntime.StateHandle {
+	aux := newActorStateHandle(ctx)
 	return &aux
 }
 
-// NewReadonlyStateHandle returns a new reaadonly `ActorStateHandle`
-func NewReadonlyStateHandle(store specsruntime.Store, head cid.Cid) specsruntime.StateHandle {
-	aux := newActorStateHandle(readonlyContextWrapper{store: store}, head)
-	return &aux
-}
-
-func newActorStateHandle(ctx actorStateHandleContext, head cid.Cid) actorStateHandle {
+func newActorStateHandle(ctx actorStateHandleContext) actorStateHandle {
 	return actorStateHandle{
 		ctx:         ctx,
-		head:        head,
 		validations: []validateFn{},
 		usedObjs:    map[interface{}]cid.Cid{},
 	}
@@ -62,32 +47,18 @@ func newActorStateHandle(ctx actorStateHandleContext, head cid.Cid) actorStateHa
 var _ specsruntime.StateHandle = (*actorStateHandle)(nil)
 
 func (h *actorStateHandle) Create(obj specsruntime.CBORMarshaler) {
-	if h.head != cid.Undef {
-		runtime.Abortf(exitcode.SysErrorIllegalActor, "Actor state already initialized")
-	}
-
-	// store state
-	h.head = h.ctx.Store().Put(obj)
-
-	// update internal ref to state
-	h.usedObjs[obj] = h.head
+	// Store the new state.
+	c := h.ctx.Create(obj)
+	// Store the expected CID of obj.
+	h.usedObjs[obj] = c
 }
 
 // Readonly is the implementation of the ActorStateHandle interface.
 func (h *actorStateHandle) Readonly(obj specsruntime.CBORUnmarshaler) {
-	// load state from storage
-	// Note: we copy the head over to `readonlyHead` in case it gets modified afterwards via `Transaction()`.
-	readonlyHead := h.head
-
-	if readonlyHead == cid.Undef {
-		runtime.Abortf(exitcode.SysErrorIllegalActor, "Nil state can not be accessed via Readonly(), use Transaction() instead")
-	}
-
-	// track the variable used by the caller
-	h.usedObjs[obj] = h.head
-
-	// load it to obj
-	h.ctx.Store().Get(readonlyHead, obj)
+	// Load state to obj.
+	c := h.ctx.Load(obj)
+	// Track the state and expected CID used by the caller.
+	h.usedObjs[obj] = c
 }
 
 // Transaction is the implementation of the ActorStateHandle interface.
@@ -96,27 +67,19 @@ func (h *actorStateHandle) Transaction(obj specsruntime.CBORer, f func() interfa
 		runtime.Abortf(exitcode.SysErrorIllegalActor, "Must not pass nil to Transaction()")
 	}
 
-	oldcid := h.head
+	// Load state to obj.
+	prior := h.ctx.Load(obj)
 
-	// load state only if it already exists
-	if h.head != cid.Undef {
-		h.ctx.Store().Get(oldcid, obj)
-	}
-
-	// call user code allowing mutation but not side-effects
+	// Call user code allowing mutation but not side-effects
 	h.ctx.AllowSideEffects(false)
 	out := f()
 	h.ctx.AllowSideEffects(true)
 
-	// store the new state
-	newcid := h.ctx.Store().Put(obj)
+	// Store the new state
+	newCid := h.ctx.Replace(prior, obj)
 
-	// update head
-	h.head = newcid
-
-	// track the variable used by the caller
-	h.usedObjs[obj] = h.head
-
+	// Record the expected state of obj
+	h.usedObjs[obj] = newCid
 	return out
 }
 

--- a/internal/pkg/vm/internal/vmcontext/invocation_context.go
+++ b/internal/pkg/vm/internal/vmcontext/invocation_context.go
@@ -67,12 +67,67 @@ func newInvocationContext(rt *VM, topLevel *topLevelContext, msg internalMessage
 
 type stateHandleContext invocationContext
 
-func (ctx *stateHandleContext) AllowSideEffects(allow bool) {
-	ctx.allowSideEffects = allow
+func (shc *stateHandleContext) AllowSideEffects(allow bool) {
+	shc.allowSideEffects = allow
 }
 
-func (ctx *stateHandleContext) Store() specsruntime.Store {
-	return ((*invocationContext)(ctx)).Store()
+func (shc *stateHandleContext) Create(obj specsruntime.CBORMarshaler) cid.Cid {
+	actr := shc.loadActor()
+	if actr.Head.Cid.Defined() {
+		runtime.Abortf(exitcode.SysErrorIllegalActor, "failed to construct actor state: already initialized")
+	}
+	c := shc.store().Put(obj)
+	actr.Head = e.NewCid(c)
+	shc.storeActor(actr)
+	return c
+}
+
+func (shc *stateHandleContext) Load(obj specsruntime.CBORUnmarshaler) cid.Cid {
+	// The actor must be loaded from store every time since the state may have changed via a different state handle
+	// (e.g. in a recursive call).
+	actr := shc.loadActor()
+	c := actr.Head.Cid
+	if !c.Defined() {
+		runtime.Abortf(exitcode.SysErrorIllegalActor, "failed to load undefined state, must construct first")
+	}
+	found := shc.store().Get(c, obj)
+	if !found {
+		panic(fmt.Errorf("failed to load state for actor %s, CID %s", shc.msg.to, c))
+	}
+	return c
+}
+
+func (shc *stateHandleContext) Replace(expected cid.Cid, obj specsruntime.CBORMarshaler) cid.Cid {
+	actr := shc.loadActor()
+	if !actr.Head.Cid.Equals(expected) {
+		panic(fmt.Errorf("unexpected prior state %s for actor %s, expected %s", actr.Head, shc.msg.to, expected))
+	}
+	c := shc.store().Put(obj)
+	actr.Head = e.NewCid(c)
+	shc.storeActor(actr)
+	return c
+}
+
+func (shc *stateHandleContext) store() specsruntime.Store {
+	return ((*invocationContext)(shc)).Store()
+}
+
+func (shc *stateHandleContext) loadActor() *actor.Actor {
+	actr, found, err := shc.rt.state.GetActor(shc.rt.context, shc.msg.to)
+	if err != nil {
+		panic(err)
+	}
+	if !found {
+		panic(fmt.Errorf("failed to find actor %s for state", shc.msg.to))
+	}
+	return actr
+}
+
+func (shc *stateHandleContext) storeActor(actr *actor.Actor) {
+	err := shc.rt.state.SetActor(shc.rt.context, shc.msg.to, actr)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // runtime aborts are trapped by invoke, it will always return an exit code.
@@ -140,7 +195,7 @@ func (ctx *invocationContext) invoke() (ret returnWrapper, errcode exitcode.Exit
 	actorImpl := ctx.rt.getActorImpl(ctx.toActor.Code.Cid)
 
 	// 6. create target state handle
-	stateHandle := newActorStateHandle((*stateHandleContext)(ctx), ctx.toActor.Head.Cid)
+	stateHandle := newActorStateHandle((*stateHandleContext)(ctx))
 	ctx.stateHandle = &stateHandle
 
 	// dispatch
@@ -166,7 +221,6 @@ func (ctx *invocationContext) invoke() (ret returnWrapper, errcode exitcode.Exit
 	// post-dispatch
 	// 1. check caller was validated
 	// 2. check state manipulation was valid
-	// 3. update actor state
 	// 4. success!
 
 	// 1. check caller was validated
@@ -183,24 +237,11 @@ func (ctx *invocationContext) invoke() (ret returnWrapper, errcode exitcode.Exit
 		return id
 	})
 
-	// 3. update actor state
-	// we need to load the actor back up in case something changed during execution
-	var found bool
-	ctx.toActor, found, err = ctx.rt.state.GetActor(ctx.rt.context, ctx.msg.to)
-	if err != nil {
-		panic(err)
-	}
-	if !found {
-		// Note: this is ok, it means the actor was deleted during the execution of the message
-		return ret, exitcode.Ok
-	}
-	// update the head and save it
-	ctx.toActor.Head = e.NewCid(stateHandle.head)
-	if err := ctx.rt.state.SetActor(ctx.rt.context, ctx.msg.to, ctx.toActor); err != nil {
-		panic(err)
-	}
+	// Reset to pre-invocation state
+	ctx.toActor = nil
+	ctx.stateHandle = nil
 
-	// 4. success!
+	// 3. success!
 	return ret, exitcode.Ok
 }
 
@@ -323,7 +364,7 @@ func (ctx *invocationContext) ValidateCaller(pattern runtime.CallerPattern) {
 		runtime.Abortf(exitcode.SysErrorIllegalActor, "Method must validate caller identity exactly once")
 	}
 	if !pattern.IsMatch((*patternContext2)(ctx)) {
-		runtime.Abortf(exitcode.SysErrorIllegalActor, "Method invoked by incorrect caller")
+		runtime.Abortf(exitcode.SysErrForbidden, "Method invoked by incorrect caller")
 	}
 	ctx.isCallerValidated = true
 }
@@ -445,11 +486,11 @@ func (ctx *invocationContext) NewActorAddress() address.Address {
 // CreateActor implements runtime.ExtendedInvocationContext.
 func (ctx *invocationContext) CreateActor(codeID cid.Cid, addr address.Address) {
 	if !builtin.IsBuiltinActor(codeID) {
-		runtime.Abortf(exitcode.ErrIllegalArgument, "Can only create built-in actors.")
+		runtime.Abortf(exitcode.SysErrorIllegalArgument, "Can only create built-in actors.")
 	}
 
 	if builtin.IsSingletonActor(codeID) {
-		runtime.Abortf(exitcode.ErrIllegalArgument, "Can only have one instance of singleton actors.")
+		runtime.Abortf(exitcode.SysErrorIllegalArgument, "Can only have one instance of singleton actors.")
 	}
 
 	ctx.gasTank.Charge(ctx.rt.pricelist.OnCreateActor())
@@ -462,7 +503,7 @@ func (ctx *invocationContext) CreateActor(codeID cid.Cid, addr address.Address) 
 		panic(err)
 	}
 	if found {
-		runtime.Abortf(exitcode.ErrIllegalArgument, "Actor address already exists")
+		runtime.Abortf(exitcode.SysErrorIllegalArgument, "Actor address already exists")
 	}
 	newActor := &actor.Actor{
 		// make this the right 'type' of actor


### PR DESCRIPTION
### Motivation
A nested call must observe state changes from prior transactions, including from outer calls in order to build on them. An outer call cannot track the state head in a variable, but must load it each time in case an inner call changed it.

This change lets us pass the test proposed in https://github.com/filecoin-project/chain-validation/pull/122

### Proposed changes
Remove in-memory tracking of actor head state CID, loading it from storage every time. Update the head on every transaction.
