### PR TITLE
Fill out genesis block header, especially setting miner to system address.

### DIFF
--- a/functional-tests/mining_sync_test.go
+++ b/functional-tests/mining_sync_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -56,7 +58,10 @@ func TestBootstrapMineOnce(t *testing.T) {
 	var blocks []block.Block
 	node0.MustRunCmdJSON(ctx, &blocks, "go-filecoin", "chain", "ls")
 	require.Equal(t, 1, len(blocks))
-	assert.Equal(t, address.Undef, blocks[0].Miner)
+	assert.Equal(t, abi.ChainEpoch(0), blocks[0].Height)
+	assert.Equal(t, big.Zero(), blocks[0].ParentWeight)
+	assert.True(t, blocks[0].Parents.Equals(block.NewTipSetKey()))
+	assert.Equal(t, builtin.SystemActorAddr, blocks[0].Miner)
 
 	// Mine once
 	node0.MustRunCmd(ctx, "go-filecoin", "mining", "once")

--- a/internal/pkg/consensus/genesis.go
+++ b/internal/pkg/consensus/genesis.go
@@ -5,10 +5,11 @@ import (
 	cbor "github.com/ipfs/go-ipld-cbor"
 
 	address "github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 )
 
 // GenesisInitFunc is the signature for function that is used to create a genesis block.
@@ -17,7 +18,12 @@ type GenesisInitFunc func(cst cbor.IpldStore, bs blockstore.Blockstore) (*block.
 // GenesisTicket is the ticket to place in the genesis block header (which can't be derived from a prior ticket),
 // used in the evaluation of the messages in the genesis block,
 // and *also* the ticket value used when computing the genesis state (the parent state of the genesis block).
-var GenesisTicket = block.Ticket{VRFProof: []byte{0xec}}
+var GenesisTicket = block.Ticket{
+	VRFProof: []byte{
+		0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec,
+		0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec, 0xec,
+	},
+}
 
 // GenesisVM is the view into the VM used during genesis block creation.
 type GenesisVM interface {


### PR DESCRIPTION
### Motivation
Apparently undefined addresses are not supposed to be serializable, so Lotus can't parse our block header. Also filled out all the other block header fields to be explicit.

This header should pass block validation as specified, except that the spec requires >0 EPoSt candidates, which should change to accept 0 when height = 0.

### Proposed changes
Set genesis miner to the System actor address. Add explicit zero/empty values for other fields.

FYI @whyrusleeping 