### PR TITLE
Update chain validation tests. Enable gas validation on message (but not tipset) tests.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/docker/docker v0.7.3-0.20190315170154-87d593639c77
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.3.3 // indirect
-	github.com/filecoin-project/chain-validation v0.0.6-0.20200320180300-770c56e63e5a
+	github.com/filecoin-project/chain-validation v0.0.6-0.20200321221401-2be15be01942
 	github.com/filecoin-project/filecoin-ffi v0.0.0-20200304181354-4446ff8a1bb9
 	github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be
 	github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/filecoin-project/chain-validation v0.0.6-0.20200320032143-61b8abee564
 github.com/filecoin-project/chain-validation v0.0.6-0.20200320032143-61b8abee564f/go.mod h1:YTLxUr6gOZpkUaXzLe7OZ4s1dpfJGp2FY/J2/K5DJqc=
 github.com/filecoin-project/chain-validation v0.0.6-0.20200320180300-770c56e63e5a h1:hSi8idqR6SX8XOf6/JBua0a/xvT8swBRGQ1j6oznUIE=
 github.com/filecoin-project/chain-validation v0.0.6-0.20200320180300-770c56e63e5a/go.mod h1:YTLxUr6gOZpkUaXzLe7OZ4s1dpfJGp2FY/J2/K5DJqc=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200321221401-2be15be01942 h1:9IADU7hQKe7z176piOBouA+m5shk5/a6aq4Kc5L2Km8=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200321221401-2be15be01942/go.mod h1:YTLxUr6gOZpkUaXzLe7OZ4s1dpfJGp2FY/J2/K5DJqc=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5 h1:/MmWluswvDIbuPvBct4q6HeQgVm62O2DzWYTB38kt4A=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be h1:TooKBwR/g8jG0hZ3lqe9S5sy2vTUcLOZLlz3M5wGn2E=

--- a/internal/pkg/vm/internal/vmcontext/testing.go
+++ b/internal/pkg/vm/internal/vmcontext/testing.go
@@ -42,10 +42,11 @@ var _ vstate.KeyManager = (*KeyManager)(nil)
 
 type Factories struct {
 	vstate.Applier
+	config *ValidationConfig
 }
 
-func NewFactories() *Factories {
-	factory := &Factories{&ValidationApplier{}}
+func NewFactories(config *ValidationConfig) *Factories {
+	factory := &Factories{&ValidationApplier{}, config}
 	return factory
 }
 
@@ -69,12 +70,7 @@ func (f *Factories) NewRandomnessSource() vstate.RandomnessSource {
 }
 
 func (f *Factories) NewValidationConfig() vstate.ValidationConfig {
-	return &ValidationConfig{
-		// TODO enable this when ready https://github.com/filecoin-project/go-filecoin/issues/3801
-		trackGas:         false,
-		checkExitCode:    true,
-		checkReturnValue: true,
-	}
+	return f.config
 }
 
 //
@@ -107,7 +103,7 @@ type specialSyscallWrapper struct {
 	internal *vdriver.ChainValidationSyscalls
 }
 
-func (s specialSyscallWrapper) VerifySignature(ctx context.Context, view SyscallsStateView, signature gfcrypto.Signature, signer address.Address, plaintext []byte) error {
+func (s specialSyscallWrapper) VerifySignature(_ context.Context, _ SyscallsStateView, signature gfcrypto.Signature, signer address.Address, plaintext []byte) error {
 	return s.internal.VerifySignature(signature, signer, plaintext)
 }
 
@@ -115,19 +111,19 @@ func (s specialSyscallWrapper) HashBlake2b(data []byte) [32]byte {
 	return s.internal.HashBlake2b(data)
 }
 
-func (s specialSyscallWrapper) ComputeUnsealedSectorCID(ctx context.Context, proof abi.RegisteredProof, pieces []abi.PieceInfo) (cid.Cid, error) {
+func (s specialSyscallWrapper) ComputeUnsealedSectorCID(_ context.Context, proof abi.RegisteredProof, pieces []abi.PieceInfo) (cid.Cid, error) {
 	return s.internal.ComputeUnsealedSectorCID(proof, pieces)
 }
 
-func (s specialSyscallWrapper) VerifySeal(ctx context.Context, info abi.SealVerifyInfo) error {
+func (s specialSyscallWrapper) VerifySeal(_ context.Context, info abi.SealVerifyInfo) error {
 	return s.internal.VerifySeal(info)
 }
 
-func (s specialSyscallWrapper) VerifyPoSt(ctx context.Context, info abi.PoStVerifyInfo) error {
+func (s specialSyscallWrapper) VerifyPoSt(_ context.Context, info abi.PoStVerifyInfo) error {
 	return s.internal.VerifyPoSt(info)
 }
 
-func (s specialSyscallWrapper) VerifyConsensusFault(ctx context.Context, h1, h2, extra []byte, head block.TipSetKey, view SyscallsStateView, earliest abi.ChainEpoch) (*runtime.ConsensusFault, error) {
+func (s specialSyscallWrapper) VerifyConsensusFault(_ context.Context, h1, h2, extra []byte, _ block.TipSetKey, _ SyscallsStateView, earliest abi.ChainEpoch) (*runtime.ConsensusFault, error) {
 	return s.internal.VerifyConsensusFault(h1, h2, extra, earliest)
 }
 

--- a/internal/pkg/vm/internal/vmcontext/validation_test.go
+++ b/internal/pkg/vm/internal/vmcontext/validation_test.go
@@ -34,18 +34,20 @@ var TestSuiteSkipper TestSkipper
 func init() {
 	// initialize the test skipper with tests being skipped
 	TestSuiteSkipper = TestSkipper{testSkips: []suites.TestCase{
-		// Skipping since multisig address resolution breaks tests
-		// https://github.com/filecoin-project/specs-actors/issues/184
-		message.TestMultiSigActor,
+		// Incorrect behavior on self-send.
+		message.TestValueTransferAdvance,
 		// Skipping for unknown reason.
 		tipset.TestInternalMessageApplicationFailure,
 	}}
 }
 
 func TestChainValidationMessageSuite(t *testing.T) {
-	f := NewFactories()
+	f := NewFactories(&ValidationConfig{
+		trackGas:         true,
+		checkExitCode:    true,
+		checkReturnValue: true,
+	})
 	for _, testCase := range suites.MessageTestCases() {
-		// All skipped due to gas accounting causing divergent balance calculations.
 		if TestSuiteSkipper.Skip(testCase) {
 			continue
 		}
@@ -56,9 +58,13 @@ func TestChainValidationMessageSuite(t *testing.T) {
 }
 
 func TestChainValidationTipSetSuite(t *testing.T) {
-	f := NewFactories()
+	f := NewFactories(&ValidationConfig{
+		// TODO: enable gas when tests read gas expectations from fixture. https://github.com/filecoin-project/go-filecoin/issues/3801
+		trackGas:         false,
+		checkExitCode:    true,
+		checkReturnValue: true,
+	})
 	for _, testCase := range suites.TipSetTestCases() {
-		// All skipped due to VM state incorrectly throws illegal actor state error.
 		if TestSuiteSkipper.Skip(testCase) {
 			continue
 		}


### PR DESCRIPTION
The tipset tests still use hardcoded and out-of-date gas expectations.