### PR TITLE
Fix VMContext transfer to persist debit when receiver is sender.

### DIFF
--- a/internal/pkg/vm/internal/vmcontext/validation_test.go
+++ b/internal/pkg/vm/internal/vmcontext/validation_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/chain-validation/suites"
-	"github.com/filecoin-project/chain-validation/suites/message"
 	"github.com/filecoin-project/chain-validation/suites/tipset"
 )
 
@@ -34,8 +33,6 @@ var TestSuiteSkipper TestSkipper
 func init() {
 	// initialize the test skipper with tests being skipped
 	TestSuiteSkipper = TestSkipper{testSkips: []suites.TestCase{
-		// Incorrect behavior on self-send.
-		message.TestValueTransferAdvance,
 		// Skipping for unknown reason.
 		tipset.TestInternalMessageApplicationFailure,
 	}}


### PR DESCRIPTION
### Motivation
Sending to self shouldn't magically create money!

- [x] Land #3917 and rebase PR

### Proposed changes
Persist the debit account before loading the credit account, in case they are the same actor.
