### PR TITLE
enable go-log debug logs for chainval tests

### DIFF
--- a/internal/pkg/vm/internal/vmcontext/validation_test.go
+++ b/internal/pkg/vm/internal/vmcontext/validation_test.go
@@ -7,9 +7,15 @@ import (
 	"strings"
 	"testing"
 
+	logging "github.com/ipfs/go-log"
+
 	"github.com/filecoin-project/chain-validation/suites"
 	"github.com/filecoin-project/chain-validation/suites/message"
 )
+
+func init() {
+	logging.SetAllLoggers(logging.LevelDebug)
+}
 
 // TestSkipper contains a list of test cases skipped by the implementation.
 type TestSkipper struct {


### PR DESCRIPTION
@icorderi this change will cause go-filecoin to produce log messages while chain-validation is running. Leaving as a draft as I don't know if we want this merged.

