### PR TITLE
Feat/empty blsaggregatesig serializes to null

### DIFF
--- a/internal/pkg/block/block.go
+++ b/internal/pkg/block/block.go
@@ -55,7 +55,7 @@ type Block struct {
 	Messages e.Cid `json:"messages,omitempty"`
 
 	// The aggregate signature of all BLS signed messages in the block
-	BLSAggregateSig crypto.Signature `json:"blsAggregateSig"`
+	BLSAggregateSig *crypto.Signature `json:"blsAggregateSig"`
 
 	// The timestamp, in seconds since the Unix epoch, at which this block was created.
 	Timestamp uint64 `json:"timestamp"`

--- a/internal/pkg/block/block_test.go
+++ b/internal/pkg/block/block_test.go
@@ -57,7 +57,7 @@ func TestTriangleEncoding(t *testing.T) {
 	t.Run("encoding block with zero fields works", func(t *testing.T) {
 		testRoundTrip(t, &blk.Block{
 			BlockSig:        &crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
-			BLSAggregateSig: crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
+			BLSAggregateSig: &crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
 		})
 	})
 
@@ -81,7 +81,7 @@ func TestTriangleEncoding(t *testing.T) {
 				Type: crypto.SigTypeBLS,
 				Data: []byte{0x3},
 			},
-			BLSAggregateSig: crypto.Signature{
+			BLSAggregateSig: &crypto.Signature{
 				Type: crypto.SigTypeBLS,
 				Data: []byte{0x3},
 			},
@@ -130,7 +130,7 @@ func TestDecodeBlock(t *testing.T) {
 			StateRoot:       e.NewCid(c2),
 			MessageReceipts: e.NewCid(cR),
 			BlockSig:        &crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
-			BLSAggregateSig: crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
+			BLSAggregateSig: &crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
 		}
 
 		after, err := blk.DecodeBlock(before.ToNode().RawData())

--- a/internal/pkg/block/block_test.go
+++ b/internal/pkg/block/block_test.go
@@ -55,10 +55,7 @@ func TestTriangleEncoding(t *testing.T) {
 		types.AssertHaveSameCid(t, exp, &cborJSONRoundTrip)
 	}
 	t.Run("encoding block with zero fields works", func(t *testing.T) {
-		testRoundTrip(t, &blk.Block{
-			BlockSig:        &crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
-			BLSAggregateSig: &crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
-		})
+		testRoundTrip(t, &blk.Block{})
 	})
 
 	t.Run("encoding block with nonzero fields works", func(t *testing.T) {

--- a/internal/pkg/chain/testing.go
+++ b/internal/pkg/chain/testing.go
@@ -206,7 +206,7 @@ func (f *Builder) Build(parent block.TipSet, width int, build func(b *BlockBuild
 			Height:          height,
 			Messages:        e.NewCid(types.EmptyTxMetaCID),
 			MessageReceipts: e.NewCid(types.EmptyReceiptsCID),
-			BLSAggregateSig: emptyBLSSig,
+			BLSAggregateSig: &emptyBLSSig,
 			// Omitted fields below
 			//StateRoot:       stateRoot,
 			//EPoStInfo:       ePoStInfo,

--- a/internal/pkg/chainsync/fetcher/graphsync_helpers_test.go
+++ b/internal/pkg/chainsync/fetcher/graphsync_helpers_test.go
@@ -359,7 +359,7 @@ func simpleBlock() *block.Block {
 		Messages:        e.NewCid(types.EmptyTxMetaCID),
 		MessageReceipts: e.NewCid(types.EmptyReceiptsCID),
 		BlockSig:        &crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
-		BLSAggregateSig: crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
+		BLSAggregateSig: &crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
 	}
 }
 

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -105,7 +105,7 @@ func (w *DefaultWorker) Generate(
 		StateRoot:       e.NewCid(baseStateRoot),
 		Ticket:          ticket,
 		Timestamp:       uint64(midEpoch.Unix()),
-		BLSAggregateSig: blsAggregateSig,
+		BLSAggregateSig: &blsAggregateSig,
 	}
 
 	view, err := w.api.PowerStateView(baseTipSet.Key())

--- a/internal/pkg/net/blocksub/validator_test.go
+++ b/internal/pkg/net/blocksub/validator_test.go
@@ -99,7 +99,7 @@ func TestBlockPubSubValidation(t *testing.T) {
 		Miner:           miner,
 		Ticket:          block.Ticket{VRFProof: []byte{0}},
 		BlockSig:        &crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
-		BLSAggregateSig: crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
+		BLSAggregateSig: &crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
 	}
 	// publish the invalid block
 	payload := blocksub.Payload{
@@ -124,7 +124,7 @@ func TestBlockPubSubValidation(t *testing.T) {
 		Miner:           miner,
 		Ticket:          block.Ticket{VRFProof: []byte{0}},
 		BlockSig:        &crypto.Signature{Type: crypto.SigTypeSecp256k1, Data: []byte{}},
-		BLSAggregateSig: crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
+		BLSAggregateSig: &crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
 	}
 	// publish the invalid block
 	payload = blocksub.Payload{

--- a/internal/pkg/state/sigval.go
+++ b/internal/pkg/state/sigval.go
@@ -42,7 +42,13 @@ func (v *SignatureValidator) ValidateMessageSignature(ctx context.Context, msg *
 	return v.ValidateSignature(ctx, mCid.Bytes(), msg.Message.From, msg.Signature)
 }
 
-func (v *SignatureValidator) ValidateBLSMessageAggregate(ctx context.Context, msgs []*types.UnsignedMessage, sig crypto.Signature) error {
+func (v *SignatureValidator) ValidateBLSMessageAggregate(ctx context.Context, msgs []*types.UnsignedMessage, sig *crypto.Signature) error {
+	if sig == nil {
+		if len(msgs) > 0 {
+			return errors.New("Invalid empty BLS sig over messages")
+		}
+		return nil
+	}
 	pubKeys := [][]byte{}
 	encodedMsgCids := [][]byte{}
 	for _, msg := range msgs {

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -42,7 +42,7 @@ func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, sta
 		Height:          height,
 		StateRoot:       e.NewCid(stateRootCid),
 		MessageReceipts: e.NewCid(receiptRootCid),
-		BLSAggregateSig: emptyBLSSig,
+		BLSAggregateSig: &emptyBLSSig,
 		EPoStInfo:       postInfo,
 	}
 	sig, err := signer.SignBytes(context.TODO(), b.SignatureData(), minerWorker)

--- a/tools/gengen/util/generator.go
+++ b/tools/gengen/util/generator.go
@@ -299,8 +299,8 @@ func (g *GenesisGenerator) genBlock(ctx context.Context) (cid.Cid, error) {
 		StateRoot:       e.NewCid(stateRoot),
 		MessageReceipts: e.NewCid(emptyAMTCid),
 		Messages:        e.NewCid(metaCid),
-		Timestamp:     g.cfg.Time,
-		ForkSignaling: 0,
+		Timestamp:       g.cfg.Time,
+		ForkSignaling:   0,
 	}
 
 	return g.cst.Put(ctx, geneblk)

--- a/tools/gengen/util/generator.go
+++ b/tools/gengen/util/generator.go
@@ -300,7 +300,7 @@ func (g *GenesisGenerator) genBlock(ctx context.Context) (cid.Cid, error) {
 		StateRoot:       e.NewCid(stateRoot),
 		MessageReceipts: e.NewCid(emptyAMTCid),
 		Messages:        e.NewCid(metaCid),
-		BLSAggregateSig: crypto.Signature{
+		BLSAggregateSig: &crypto.Signature{
 			Type: crypto.SigTypeBLS,
 			Data: bls.Aggregate(nil)[:],
 		},

--- a/tools/gengen/util/generator.go
+++ b/tools/gengen/util/generator.go
@@ -26,7 +26,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	mh "github.com/multiformats/go-multihash"
 
-	bls "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/cborutil"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
@@ -300,12 +299,7 @@ func (g *GenesisGenerator) genBlock(ctx context.Context) (cid.Cid, error) {
 		StateRoot:       e.NewCid(stateRoot),
 		MessageReceipts: e.NewCid(emptyAMTCid),
 		Messages:        e.NewCid(metaCid),
-		BLSAggregateSig: &crypto.Signature{
-			Type: crypto.SigTypeBLS,
-			Data: bls.Aggregate(nil)[:],
-		},
 		Timestamp:     g.cfg.Time,
-		BlockSig:      &crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{}},
 		ForkSignaling: 0,
 	}
 


### PR DESCRIPTION
### Motivation
Get bls agg sig up to spec

### Proposed changes
Give the field a pointer value like the block sig so that we serialize it as cbor null

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

