### PR TITLE
Test/drand for test

### DIFF
--- a/internal/pkg/drand/testing.go
+++ b/internal/pkg/drand/testing.go
@@ -1,0 +1,32 @@
+package drand
+
+import (
+	"context"
+	"encoding/binary"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
+
+	ffi "github.com/filecoin-project/filecoin-ffi"
+)
+
+// Fake is a fake drand utility that reads and validates entries as specified below
+type Fake struct{}
+
+// ReadEntry immediately returns a drand entry with a signature equal to the
+// round number
+func (d *Fake) ReadEntry(ctx context.Context, drandRound Round) (*Entry, error) {
+	fakeSigData := make([]byte, ffi.SignatureBytes)
+	binary.PutUvarint(fakeSigData, uint64(drandRound))
+	return &Entry{
+		Round: drandRound,
+		Signature: crypto.Signature{
+			Type: crypto.SigTypeBLS,
+			Data: fakeSigData,
+		},
+	}, nil
+}
+
+// VerifyEntry always returns true without error
+func (d *Fake) VerifyEntry(parent, child *Entry) (bool, error) {
+	return true, nil
+}


### PR DESCRIPTION
### Motivation
We want something very simple we can plug into the consensus and mining modules for testing out those changes. 

This is not the last drand fake we'll do.  We'll want a more sophisticated fake soon to give us more confidence in integration tests.  We might be able to run the drand protocol with 1 or 2 peers in memory and lazy load the chain based on the read calls we get for example.  It would then be pretty simple to put this behind an http api and provide a little local service for functional tests.

### Proposed changes

Closes #3943 

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

