### PR TITLE
Change per-message gas transfer to go direct to reward actor rather than staging in burnt funds.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/docker/docker v0.7.3-0.20190315170154-87d593639c77
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.3.3 // indirect
-	github.com/filecoin-project/chain-validation v0.0.6-0.20200328000747-ec656cae21a7
+	github.com/filecoin-project/chain-validation v0.0.6-0.20200331022407-01536f38ec18
 	github.com/filecoin-project/filecoin-ffi v0.0.0-20200304181354-4446ff8a1bb9
 	github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be
 	github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/filecoin-project/chain-validation v0.0.6-0.20200326223048-633bbb557c3
 github.com/filecoin-project/chain-validation v0.0.6-0.20200326223048-633bbb557c30/go.mod h1:mXiAviXMZ2WVGmWNtjGr0JPMpNCNsPU774DawKZCzzM=
 github.com/filecoin-project/chain-validation v0.0.6-0.20200328000747-ec656cae21a7 h1:6GY4GJMfk9vbJLyEUHHrwYKXHUdga5WM1+vo6pJzzmY=
 github.com/filecoin-project/chain-validation v0.0.6-0.20200328000747-ec656cae21a7/go.mod h1:mXiAviXMZ2WVGmWNtjGr0JPMpNCNsPU774DawKZCzzM=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200331022407-01536f38ec18 h1:CdAzU3tlW//HMjikqxz/kvMLmXSD7og5Gxoj2ZgtERM=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200331022407-01536f38ec18/go.mod h1:mXiAviXMZ2WVGmWNtjGr0JPMpNCNsPU774DawKZCzzM=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5 h1:/MmWluswvDIbuPvBct4q6HeQgVm62O2DzWYTB38kt4A=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be h1:TooKBwR/g8jG0hZ3lqe9S5sy2vTUcLOZLlz3M5wGn2E=

--- a/internal/pkg/vm/internal/vmcontext/vmcontext.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext.go
@@ -256,9 +256,6 @@ func (vm *VM) ApplyTipSetMessages(blocks []interpreter.BlockMessagesInfo, head b
 			seenMsgs[mcid] = struct{}{}
 		}
 
-		// transfer gas reward from BurntFundsActor to RewardActor
-		vm.transfer(builtin.BurntFundsActorAddr, builtin.RewardActorAddr, minerGasRewardTotal)
-
 		// Pay block reward.
 		// Dragons: missing final protocol design on if/how to determine the nominal power
 		rewardMessage := makeBlockRewardMessage(blk.Miner, minerPenaltyTotal, minerGasRewardTotal, blk.TicketCount)
@@ -418,8 +415,8 @@ func (vm *VM) applyMessage(msg *types.UnsignedMessage, onChainMsgSize int, rnd c
 
 	// 6. Deduct gas limit funds from sender first
 	// Note: this should always succeed, due to the sender balance check above
-	// Note: after this point, we nede to return this funds back before exiting
-	vm.transfer(msg.From, builtin.BurntFundsActorAddr, gasLimitCost)
+	// Note: after this point, we need to return this funds back before exiting
+	vm.transfer(msg.From, builtin.RewardActorAddr, gasLimitCost)
 
 	// reload from actor
 	// Note: balance might have changed
@@ -513,7 +510,7 @@ func (vm *VM) applyMessage(msg *types.UnsignedMessage, onChainMsgSize int, rnd c
 	// 2. settle gas money around (unused_gas -> sender)
 	receipt.GasUsed = gasTank.GasConsumed()
 	refundGas := msg.GasLimit - receipt.GasUsed
-	vm.transfer(builtin.BurntFundsActorAddr, msg.From, refundGas.ToTokens(msg.GasPrice))
+	vm.transfer(builtin.RewardActorAddr, msg.From, refundGas.ToTokens(msg.GasPrice))
 
 	// 3. Success!
 	return receipt, big.Zero(), gasTank.GasConsumed().ToTokens(msg.GasPrice)


### PR DESCRIPTION
### Motivation
We implemented this correctly from the spec but Lotus took this latter approach. It shouldn't matter in the final state, but per-message chain validation tests inspect this state so the difference caused tests to fail.

Transferring direct to the reward actor saves a transfer per block.

### Proposed changes
Stage gas prepayments in the reward actor rather than the burnt funds actor.

- [x] Pull in corresponding chain validation expectations: https://github.com/filecoin-project/chain-validation/pull/152