### PR TITLE
Order blocks by min ticket digest, rather than ticket raw VRF proof.

### DIFF
--- a/internal/pkg/block/ticket.go
+++ b/internal/pkg/block/ticket.go
@@ -1,6 +1,7 @@
 package block
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
@@ -15,12 +16,13 @@ type Ticket struct {
 	VRFProof crypto.VRFPi
 }
 
-// SortKey returns the canonical byte ordering of the ticket
-func (t Ticket) SortKey() []byte {
-	return t.VRFProof
-}
-
 // String returns the string representation of the VRFProof of the ticket
 func (t Ticket) String() string {
 	return fmt.Sprintf("%x", t.VRFProof)
+}
+
+func (t *Ticket) Compare(o *Ticket) int {
+	tDigest := t.VRFProof.Digest()
+	oDigest := o.VRFProof.Digest()
+	return bytes.Compare(tDigest[:], oDigest[:])
 }

--- a/internal/pkg/block/tipset.go
+++ b/internal/pkg/block/tipset.go
@@ -65,7 +65,7 @@ func NewTipSet(blocks ...*Block) (TipSet, error) {
 
 	// Sort blocks by ticket
 	sort.Slice(sorted, func(i, j int) bool {
-		cmp := bytes.Compare(sorted[i].Ticket.SortKey(), sorted[j].Ticket.SortKey())
+		cmp := sorted[i].Ticket.Compare(&sorted[j].Ticket)
 		if cmp == 0 {
 			// Break ticket ties with the block CIDs, which are distinct.
 			cmp = bytes.Compare(sorted[i].Cid().Bytes(), sorted[j].Cid().Bytes())


### PR DESCRIPTION
### Motivation
The ticket ordering was changed in the (not-yet-merged) https://github.com/filecoin-project/specs/pull/883/files#diff-440d67a4748619ac846e6d07011156a7

@sternhenri also changed Lotus to do this at the same time.

### Proposed changes
Order blocks by ticket digest bytes.