### PR TITLE
Fix genesis reward actor initial balance, interpret prealloc values as whole FIL

### DIFF
--- a/fixtures/setup.json
+++ b/fixtures/setup.json
@@ -3,12 +3,12 @@
   "keysToGen": 5,
   "importKeys": [{"privateKey":"/8UoXvzGIU2H/TgTAmswx96m2dVCXkRqnIIlDhJrGCo=","sigType":2}],
   "preallocatedFunds": [
-    "10000000000",
-    "10000000000",
-    "10000000000",
-    "10000000000",
-    "10000000000",
-    "10000000000"
+    "1000000",
+    "1000000",
+    "1000000",
+    "1000000",
+    "1000000",
+    "1000000"
   ],
   "miners": [{
     "owner": 5,

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -238,6 +238,9 @@ func (c *Expected) validateMining(ctx context.Context,
 		}
 
 		// Verify all partial tickets are winners
+		// TODO this is not using nominal power, which must take into account undeclared faults
+		// TODO the nominal power must be tested against the minimum (power.minerNominalPowerMeetsConsensusMinimum)
+		// See https://github.com/filecoin-project/go-filecoin/issues/3958
 		sectorNum, err := powerTable.NumSectors(ctx, blk.Miner)
 		if err != nil {
 			return errors.Wrap(err, "failed to read sectorNum from power table")


### PR DESCRIPTION
### Motivation
The prealloc values in setup.json are tiny when evaluated as attofil, very hard to use with non-zero gas prices.

### Proposed changes
Give the reward actor a representative balance, and pre-alloc accounts 1mm FIL each.