### PR TITLE
Add logs for heaviest tipset handling

### DIFF
--- a/internal/app/go-filecoin/internal/submodule/chain_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/chain_submodule.go
@@ -20,9 +20,6 @@ type ChainSubmodule struct {
 	ChainReader  *chain.Store
 	MessageStore *chain.MessageStore
 	State        *cst.ChainStateReadWriter
-	// HeavyTipSetCh is a subscription to the heaviest tipset topic on the chain.
-	// https://github.com/filecoin-project/go-filecoin/issues/2309
-	HeaviestTipSetCh chan interface{}
 
 	Sampler    *chain.Sampler
 	ActorState *appstate.TipSetStateViewer
@@ -66,9 +63,8 @@ func NewChainSubmodule(config chainConfig, repo chainRepo, blockstore *Blockstor
 	processor := consensus.NewDefaultProcessor(syscalls, chainState)
 
 	return ChainSubmodule{
-		ChainReader:  chainStore,
-		MessageStore: messageStore,
-		// HeaviestTipSetCh nil
+		ChainReader:    chainStore,
+		MessageStore:   messageStore,
 		ActorState:     actorState,
 		State:          chainState,
 		Processor:      processor,

--- a/internal/pkg/chain/store.go
+++ b/internal/pkg/chain/store.go
@@ -87,6 +87,8 @@ type Store struct {
 	// Successive published tipsets may be supersets of previously published tipsets.
 	// TODO: rename to notifications.  Also, reconsider ordering assumption depending
 	// on decisions made around the FC node notification system.
+	// TODO: replace this with a synchronous event bus
+	// https://github.com/filecoin-project/go-filecoin/issues/2309
 	headEvents *pubsub.PubSub
 
 	// Tracks tipsets by height/parentset for use by expected consensus.
@@ -101,7 +103,7 @@ func NewStore(ds repo.Datastore, cst cbor.IpldStore, sr Reporter, genesisCid cid
 	return &Store{
 		stateAndBlockSource: newSource(cst),
 		ds:                  ds,
-		headEvents:          pubsub.New(128),
+		headEvents:          pubsub.New(12),
 		tipIndex:            NewTipIndex(),
 		genesis:             genesisCid,
 		reporter:            sr,

--- a/internal/pkg/chainsampler/height_threshold_scheduler.go
+++ b/internal/pkg/chainsampler/height_threshold_scheduler.go
@@ -4,11 +4,13 @@ import (
 	"context"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/prometheus/common/log"
+	logging "github.com/ipfs/go-log"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
 )
+
+var log = logging.Logger("chainsampler") // nolint: deadcode
 
 // HeightThresholdScheduler listens for changes to chain height and notifies when the threshold is hit or invalidated
 type HeightThresholdScheduler struct {
@@ -32,6 +34,7 @@ func NewHeightThresholdScheduler(chainStore *chain.Store) *HeightThresholdSchedu
 // StartHeightListener starts the scheduler that manages height listeners.
 func (m *HeightThresholdScheduler) StartHeightListener(ctx context.Context, htc <-chan interface{}) {
 	go func() {
+		defer log.Infof("height listener exiting")
 		var previousHead block.TipSet
 		for {
 			select {
@@ -53,8 +56,10 @@ func (m *HeightThresholdScheduler) StartHeightListener(ctx context.Context, htc 
 				}
 				m.heightListeners = listeners
 			case <-m.schedulerDone:
+				log.Debugf("height listener scheduler done")
 				return
 			case <-ctx.Done():
+				log.Debugf("height listener context done")
 				return
 			}
 		}


### PR DESCRIPTION
### Motivation
Debugging chain sync halt (#3959). Hypothesis is that the new heads pubsub channel is not being drained.

### Proposed changes
Add log messages around the subscribers to the new head. Clean up unsub handling.

These messages revealed that the problem is the storage mining module's height listener shutting down and then blocking in `HandleNewHead`.