### PR TITLE
Remove channels and goroutine from HeightThresholdScheduler and storage mining module.

### DIFF
--- a/internal/app/go-filecoin/connectors/storage_miner/connector.go
+++ b/internal/app/go-filecoin/connectors/storage_miner/connector.go
@@ -70,19 +70,8 @@ func NewStorageMinerNodeConnector(minerAddress address.Address, chainStore *chai
 	}
 }
 
-// StartHeightListener starts the scheduler that manages height listeners.
-func (m *StorageMinerNodeConnector) StartHeightListener(ctx context.Context, htc <-chan interface{}) {
-	m.chainHeightScheduler.StartHeightListener(ctx, htc)
-}
-
-// StopHeightListener stops the scheduler that manages height listeners.
-func (m *StorageMinerNodeConnector) StopHeightListener() {
-	m.chainHeightScheduler.Stop()
-}
-
-func (m *StorageMinerNodeConnector) handleNewTipSet(ctx context.Context, previousHead block.TipSet) (block.TipSet, error) {
-
-	return m.chainHeightScheduler.HandleNewTipSet(ctx, previousHead)
+func (m *StorageMinerNodeConnector) HandleNewTipSet(ctx context.Context, newHead block.TipSet) error {
+	return m.chainHeightScheduler.HandleNewTipSet(ctx, newHead)
 }
 
 // SendSelfDeals creates self-deals and sends them to the network.

--- a/internal/app/go-filecoin/internal/submodule/chain_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/chain_submodule.go
@@ -20,9 +20,6 @@ type ChainSubmodule struct {
 	ChainReader  *chain.Store
 	MessageStore *chain.MessageStore
 	State        *cst.ChainStateReadWriter
-	// HeavyTipSetCh is a subscription to the heaviest tipset topic on the chain.
-	// https://github.com/filecoin-project/go-filecoin/issues/2309
-	HeaviestTipSetCh chan interface{}
 
 	Sampler    *chain.Sampler
 	ActorState *appstate.TipSetStateViewer
@@ -66,9 +63,8 @@ func NewChainSubmodule(config chainConfig, repo chainRepo, blockstore *Blockstor
 	processor := consensus.NewDefaultProcessor(syscalls, chainState)
 
 	return ChainSubmodule{
-		ChainReader:  chainStore,
-		MessageStore: messageStore,
-		// HeaviestTipSetCh nil
+		ChainReader:    chainStore,
+		MessageStore:   messageStore,
 		ActorState:     actorState,
 		State:          chainState,
 		Processor:      processor,

--- a/internal/pkg/chain/store.go
+++ b/internal/pkg/chain/store.go
@@ -87,6 +87,8 @@ type Store struct {
 	// Successive published tipsets may be supersets of previously published tipsets.
 	// TODO: rename to notifications.  Also, reconsider ordering assumption depending
 	// on decisions made around the FC node notification system.
+	// TODO: replace this with a synchronous event bus
+	// https://github.com/filecoin-project/go-filecoin/issues/2309
 	headEvents *pubsub.PubSub
 
 	// Tracks tipsets by height/parentset for use by expected consensus.
@@ -101,7 +103,7 @@ func NewStore(ds repo.Datastore, cst cbor.IpldStore, sr Reporter, genesisCid cid
 	return &Store{
 		stateAndBlockSource: newSource(cst),
 		ds:                  ds,
-		headEvents:          pubsub.New(128),
+		headEvents:          pubsub.New(12),
 		tipIndex:            NewTipIndex(),
 		genesis:             genesisCid,
 		reporter:            sr,

--- a/internal/pkg/chainsampler/height_threshold_listener_test.go
+++ b/internal/pkg/chainsampler/height_threshold_listener_test.go
@@ -33,7 +33,7 @@ func TestNewHeightThresholdListener(t *testing.T) {
 		require.NoError(t, err)
 
 		go func() {
-			_, err := listener.Handle(ctx, newChain)
+			_, err := listener.Handle(newChain)
 			require.NoError(t, err)
 			cancel()
 		}()
@@ -47,7 +47,7 @@ func TestNewHeightThresholdListener(t *testing.T) {
 
 		nextTS := builder.Build(startHead, 1, nil)
 		go func() {
-			_, err := listener.Handle(context.TODO(), []block.TipSet{nextTS})
+			_, err := listener.Handle([]block.TipSet{nextTS})
 			require.NoError(t, err)
 		}()
 
@@ -64,7 +64,7 @@ func TestNewHeightThresholdListener(t *testing.T) {
 		require.NoError(t, err)
 
 		go func() {
-			_, err := listener.Handle(context.TODO(), newChain)
+			_, err := listener.Handle(newChain)
 			require.NoError(t, err)
 		}()
 
@@ -73,7 +73,7 @@ func TestNewHeightThresholdListener(t *testing.T) {
 
 		shorterFork := builder.BuildManyOn(1, startHead, nil)
 		go func() {
-			_, err := listener.Handle(context.TODO(), []block.TipSet{shorterFork})
+			_, err := listener.Handle([]block.TipSet{shorterFork})
 			require.NoError(t, err)
 		}()
 
@@ -89,7 +89,7 @@ func TestNewHeightThresholdListener(t *testing.T) {
 		require.NoError(t, err)
 
 		go func() {
-			_, err := listener.Handle(context.TODO(), newChain)
+			_, err := listener.Handle(newChain)
 			require.NoError(t, err)
 		}()
 
@@ -101,7 +101,7 @@ func TestNewHeightThresholdListener(t *testing.T) {
 		require.NoError(t, err)
 
 		go func() {
-			_, err := listener.Handle(context.TODO(), forkSlice)
+			_, err := listener.Handle(forkSlice)
 			require.NoError(t, err)
 		}()
 
@@ -125,7 +125,7 @@ func TestNewHeightThresholdListener(t *testing.T) {
 		require.NoError(t, err)
 
 		go func() {
-			_, err := listener.Handle(context.TODO(), newChain)
+			_, err := listener.Handle(newChain)
 			require.NoError(t, err)
 		}()
 
@@ -138,7 +138,7 @@ func TestNewHeightThresholdListener(t *testing.T) {
 		require.NoError(t, err)
 
 		go func() {
-			_, err := listener.Handle(ctx, newChain)
+			_, err := listener.Handle(newChain)
 			require.NoError(t, err)
 			cancel()
 		}()
@@ -156,7 +156,7 @@ func TestNewHeightThresholdListener(t *testing.T) {
 		require.NoError(t, err)
 
 		go func() {
-			_, err := listener.Handle(context.TODO(), newChain)
+			_, err := listener.Handle(newChain)
 			require.NoError(t, err)
 		}()
 
@@ -167,7 +167,7 @@ func TestNewHeightThresholdListener(t *testing.T) {
 		go func() {
 			for i := abi.ChainEpoch(0); i < miner.ChainFinalityish; i++ {
 				nextTS = builder.BuildOn(nextTS, 1, nil)
-				valid, err := listener.Handle(context.TODO(), []block.TipSet{nextTS})
+				valid, err := listener.Handle([]block.TipSet{nextTS})
 				require.NoError(t, err)
 
 				h, err := nextTS.Height()

--- a/internal/pkg/chainsampler/height_threshold_scheduler.go
+++ b/internal/pkg/chainsampler/height_threshold_scheduler.go
@@ -4,11 +4,13 @@ import (
 	"context"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/prometheus/common/log"
+	logging "github.com/ipfs/go-log"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
 )
+
+var log = logging.Logger("chainsampler") // nolint: deadcode
 
 // HeightThresholdScheduler listens for changes to chain height and notifies when the threshold is hit or invalidated
 type HeightThresholdScheduler struct {
@@ -32,6 +34,7 @@ func NewHeightThresholdScheduler(chainStore *chain.Store) *HeightThresholdSchedu
 // StartHeightListener starts the scheduler that manages height listeners.
 func (m *HeightThresholdScheduler) StartHeightListener(ctx context.Context, htc <-chan interface{}) {
 	go func() {
+		defer log.Infof("height listener exiting")
 		var previousHead block.TipSet
 		for {
 			select {
@@ -53,8 +56,10 @@ func (m *HeightThresholdScheduler) StartHeightListener(ctx context.Context, htc 
 				}
 				m.heightListeners = listeners
 			case <-m.schedulerDone:
+				log.Debugf("height listener scheduler done")
 				return
 			case <-ctx.Done():
+				log.Debugf("height listener context done")
 				return
 			}
 		}

--- a/internal/pkg/chainsampler/height_threshold_scheduler.go
+++ b/internal/pkg/chainsampler/height_threshold_scheduler.go
@@ -2,9 +2,11 @@ package chainsampler
 
 import (
 	"context"
+	"sync"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	logging "github.com/ipfs/go-log"
+	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chain"
@@ -14,101 +16,67 @@ var log = logging.Logger("chainsampler") // nolint: deadcode
 
 // HeightThresholdScheduler listens for changes to chain height and notifies when the threshold is hit or invalidated
 type HeightThresholdScheduler struct {
-	newListener     chan *HeightThresholdListener
-	cancelListener  chan *HeightThresholdListener
+	mtx             sync.Mutex
 	heightListeners []*HeightThresholdListener
-	schedulerDone   chan struct{}
 	chainStore      *chain.Store
+	prevHead        block.TipSet
 }
 
 // NewHeightThresholdScheduler creates a new scheduler
 func NewHeightThresholdScheduler(chainStore *chain.Store) *HeightThresholdScheduler {
 	return &HeightThresholdScheduler{
-		newListener:    make(chan *HeightThresholdListener),
-		cancelListener: make(chan *HeightThresholdListener),
-		schedulerDone:  make(chan struct{}),
-		chainStore:     chainStore,
+		chainStore: chainStore,
 	}
 }
 
-// StartHeightListener starts the scheduler that manages height listeners.
-func (m *HeightThresholdScheduler) StartHeightListener(ctx context.Context, htc <-chan interface{}) {
-	go func() {
-		defer log.Infof("height listener exiting")
-		var previousHead block.TipSet
-		for {
-			select {
-			case <-htc:
-				head, err := m.HandleNewTipSet(ctx, previousHead)
-				if err != nil {
-					log.Warn("failed to handle new tipset")
-				} else {
-					previousHead = head
-				}
-			case heightListener := <-m.newListener:
-				m.heightListeners = append(m.heightListeners, heightListener)
-			case canceled := <-m.cancelListener:
-				listeners := []*HeightThresholdListener{}
-				for _, l := range listeners {
-					if l != canceled {
-						listeners = append(listeners, l)
-					}
-				}
-				m.heightListeners = listeners
-			case <-m.schedulerDone:
-				log.Debugf("height listener scheduler done")
-				return
-			case <-ctx.Done():
-				log.Debugf("height listener context done")
-				return
-			}
-		}
-	}()
-}
-
-// Stop stops the scheduler.
-func (m *HeightThresholdScheduler) Stop() {
-	m.schedulerDone <- struct{}{}
-}
-
 // AddListener adds a new listener for the target height
-func (m *HeightThresholdScheduler) AddListener(target abi.ChainEpoch) *HeightThresholdListener {
+func (hts *HeightThresholdScheduler) AddListener(target abi.ChainEpoch) *HeightThresholdListener {
 	hc := make(chan block.TipSetKey)
 	ec := make(chan error)
 	ic := make(chan struct{})
 	dc := make(chan struct{})
-	listener := NewHeightThresholdListener(target, hc, ec, ic, dc)
-	m.newListener <- listener
-	return listener
+	newListener := NewHeightThresholdListener(target, hc, ec, ic, dc)
+
+	hts.mtx.Lock()
+	defer hts.mtx.Unlock()
+	hts.heightListeners = append(hts.heightListeners, newListener)
+	return newListener
 }
 
 // CancelListener stops a listener from listening and sends a message over its done channel
-func (m *HeightThresholdScheduler) CancelListener(listener *HeightThresholdListener) {
-	m.cancelListener <- listener
-	listener.DoneCh <- struct{}{}
+func (hts *HeightThresholdScheduler) CancelListener(cancelledListener *HeightThresholdListener) {
+	hts.mtx.Lock()
+	defer hts.mtx.Unlock()
+	var remainingListeners []*HeightThresholdListener
+	for _, l := range hts.heightListeners {
+		if l != cancelledListener {
+			remainingListeners = append(remainingListeners, l)
+		}
+	}
+	hts.heightListeners = remainingListeners
+	cancelledListener.DoneCh <- struct{}{}
 }
 
 // HandleNewTipSet must be called when the chain head changes.
-func (m *HeightThresholdScheduler) HandleNewTipSet(ctx context.Context, previousHead block.TipSet) (block.TipSet, error) {
-	newHeadKey := m.chainStore.GetHead()
-	newHead, err := m.chainStore.GetTipSet(newHeadKey)
-	if err != nil {
-		return block.TipSet{}, err
-	}
-
+func (hts *HeightThresholdScheduler) HandleNewTipSet(ctx context.Context, newHead block.TipSet) error {
+	var err error
 	var newTips []block.TipSet
-	if previousHead.Defined() {
-		_, newTips, err = chain.CollectTipsToCommonAncestor(ctx, m.chainStore, previousHead, newHead)
+
+	hts.mtx.Lock()
+	defer hts.mtx.Unlock()
+	if hts.prevHead.Defined() {
+		_, newTips, err = chain.CollectTipsToCommonAncestor(ctx, hts.chainStore, hts.prevHead, newHead)
 		if err != nil {
-			return block.TipSet{}, err
+			return errors.Wrapf(err, "failed to collect tips between %s and %s", hts.prevHead, newHead)
 		}
 	} else {
 		newTips = []block.TipSet{newHead}
 	}
+	hts.prevHead = newHead
 
-	newListeners := []*HeightThresholdListener{}
-	for _, listener := range m.heightListeners {
-		valid, err := listener.Handle(ctx, newTips)
+	var newListeners []*HeightThresholdListener
+	for _, listener := range hts.heightListeners {
+		valid, err := listener.Handle(newTips)
 		if err != nil {
 			log.Error("Error checking storage miner chainStore listener", err)
 		}
@@ -117,7 +85,6 @@ func (m *HeightThresholdScheduler) HandleNewTipSet(ctx context.Context, previous
 			newListeners = append(newListeners, listener)
 		}
 	}
-	m.heightListeners = newListeners
-
-	return newHead, nil
+	hts.heightListeners = newListeners
+	return nil
 }


### PR DESCRIPTION
### Motivation
Fewer channels = fewer problems. All the asynchrony here was unnecessary. This fixes a few bugs.
- the context being passed to Start() was not long-running, so the scheduler's goroutine exited immediately
- after the goroutine exited, the module HandleNewHead blocked on the unbuffered heaviestTipSet channel
- the argument to HandleNewTipSet was named and treated as the previous head, rather than new head; the chain store was inspected for head which might race with other writes to it
- CancelListener iterated over an empty slice and always forgot all listeners

I have no idea how things worked at all here.

This will probably fix issue #3959, but I'll wait to close it until we observe better behaviour in devnets.

### Proposed changes
Remove all the channel control flow from HeightThresholdScheduler along with the unbuffered channel in the module, and just call HandleNewTipSet directly. Track the previous head inside the schedule for correct CollectTipsToCommonAncestor call (like the message pool handler does).

