### PR TITLE
Halt execution if address resolution fails for a reason other than not-found

### DIFF
--- a/internal/pkg/vm/internal/vmcontext/invocation_context.go
+++ b/internal/pkg/vm/internal/vmcontext/invocation_context.go
@@ -275,10 +275,8 @@ func (ctx *invocationContext) resolveTarget(target address.Address) (*actor.Acto
 
 	// lookup the ActorID based on the address
 	targetIDAddr, err := state.ResolveAddress(ctx.rt.ContextStore(), target)
-	// Dragons: move this logic to resolve address
-	notFound := (targetIDAddr == target && target.Protocol() != address.ID)
 	created := false
-	if err != nil || notFound {
+	if err == init_.ErrAddressNotFound {
 		// actor does not exist, create an account actor
 		// - precond: address must be a pub-key
 		// - sent init actor a msg to create the new account
@@ -324,6 +322,8 @@ func (ctx *invocationContext) resolveTarget(target address.Address) (*actor.Acto
 		}
 
 		created = true
+	} else if err != nil {
+		panic(err)
 	}
 
 	// load actor

--- a/internal/pkg/vm/internal/vmcontext/vmcontext.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext.go
@@ -9,7 +9,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/account"
-	notinit "github.com/filecoin-project/specs-actors/actors/builtin/init"
+	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
 	specsruntime "github.com/filecoin-project/specs-actors/actors/runtime"
@@ -164,16 +164,17 @@ func (vm *VM) normalizeAddress(addr address.Address) (address.Address, bool) {
 	}
 
 	// get a view into the actor state
-	var state notinit.State
+	var state init_.State
 	if _, err := vm.store.Get(vm.context, initActorEntry.Head.Cid, &state); err != nil {
 		panic(err)
 	}
 
 	idAddr, err := state.ResolveAddress(vm.ContextStore(), addr)
-	if err != nil {
+	if err == init_.ErrAddressNotFound {
 		return address.Undef, false
+	} else if err != nil {
+		panic(err)
 	}
-
 	return idAddr, true
 }
 


### PR DESCRIPTION
### Motivation
Except for not-found, failure is probably not reproducible across impls.

### Proposed changes
Inspect error for ErrAddrNotFound before returning false. Otherwise panic.