### PR TITLE
remove text encoders from commands

### DIFF
--- a/cmd/go-filecoin/address.go
+++ b/cmd/go-filecoin/address.go
@@ -1,10 +1,8 @@
 package commands
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 
 	"github.com/filecoin-project/go-address"
 	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
@@ -68,12 +66,6 @@ var addrsNewCmd = &cmds.Command{
 		cmdkit.StringOption("type", "The type of address to create: bls or secp256k1 (default)").WithDefault("secp256k1"),
 	},
 	Type: &addressResult{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, a *addressResult) error {
-			_, err := fmt.Fprintln(w, a.Address.String())
-			return err
-		}),
-	},
 }
 
 var addrsLsCmd = &cmds.Command{
@@ -88,17 +80,6 @@ var addrsLsCmd = &cmds.Command{
 		return re.Emit(&alr)
 	},
 	Type: &AddressLsResult{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, addrs *AddressLsResult) error {
-			for _, addr := range addrs.Addresses {
-				_, err := fmt.Fprintln(w, addr.String())
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		}),
-	},
 }
 
 var defaultAddressCmd = &cmds.Command{
@@ -111,12 +92,6 @@ var defaultAddressCmd = &cmds.Command{
 		return re.Emit(&addressResult{addr})
 	},
 	Type: &addressResult{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, a *addressResult) error {
-			_, err := fmt.Fprintln(w, a.Address.String())
-			return err
-		}),
-	},
 }
 
 var balanceCmd = &cmds.Command{
@@ -136,11 +111,6 @@ var balanceCmd = &cmds.Command{
 		return re.Emit(balance)
 	},
 	Type: &types.AttoFIL{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, b types.AttoFIL) error {
-			return PrintString(w, b)
-		}),
-	},
 }
 
 // WalletSerializeResult is the type wallet export and import return and expect.
@@ -186,17 +156,6 @@ var walletImportCmd = &cmds.Command{
 		return re.Emit(&alr)
 	},
 	Type: &AddressLsResult{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, addrs *AddressLsResult) error {
-			for _, addr := range addrs.Addresses {
-				_, err := fmt.Fprintln(w, addr.String())
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		}),
-	},
 }
 
 var walletExportCmd = &cmds.Command{
@@ -224,20 +183,4 @@ var walletExportCmd = &cmds.Command{
 		return re.Emit(klr)
 	},
 	Type: &WalletSerializeResult{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, klr *WalletSerializeResult) error {
-			for _, k := range klr.KeyInfo {
-				a, err := k.Address()
-				if err != nil {
-					return err
-				}
-				privateKeyInBase64 := base64.StdEncoding.EncodeToString(k.PrivateKey)
-				_, err = fmt.Fprintf(w, "Address:\t%s\nPrivateKey:\t%s\nCurve:\t\t%d\n\n", a, privateKeyInBase64, k.SigType)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		}),
-	},
 }

--- a/cmd/go-filecoin/address_integration_test.go
+++ b/cmd/go-filecoin/address_integration_test.go
@@ -167,7 +167,7 @@ func TestWalletExportImportRoundTrip(t *testing.T) {
 	cmdClient.RunMarshaledJSON(ctx, &lsResult, "address", "ls")
 	require.Len(t, lsResult.Addresses, 1)
 
-	exportJSON := cmdClient.RunSuccess(ctx, "wallet", "export", lsResult.Addresses[0].String()	).ReadStdout()
+	exportJSON := cmdClient.RunSuccess(ctx, "wallet", "export", lsResult.Addresses[0].String()).ReadStdout()
 	var exportResult commands.WalletSerializeResult
 	err := json.Unmarshal([]byte(exportJSON), &exportResult)
 	require.NoError(t, err)

--- a/cmd/go-filecoin/address_integration_test.go
+++ b/cmd/go-filecoin/address_integration_test.go
@@ -167,7 +167,7 @@ func TestWalletExportImportRoundTrip(t *testing.T) {
 	cmdClient.RunMarshaledJSON(ctx, &lsResult, "address", "ls")
 	require.Len(t, lsResult.Addresses, 1)
 
-	exportJSON := cmdClient.RunSuccess(ctx, "wallet", "export", lsResult.Addresses[0].String()).ReadStdout()
+	exportJSON := cmdClient.RunSuccess(ctx, "wallet", "export", lsResult.Addresses[0].String()	).ReadStdout()
 	var exportResult commands.WalletSerializeResult
 	err := json.Unmarshal([]byte(exportJSON), &exportResult)
 	require.NoError(t, err)

--- a/cmd/go-filecoin/bootstrap.go
+++ b/cmd/go-filecoin/bootstrap.go
@@ -1,9 +1,6 @@
 package commands
 
 import (
-	"fmt"
-	"io"
-
 	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
 	cmds "github.com/ipfs/go-ipfs-cmds"
 )
@@ -32,10 +29,4 @@ var bootstrapLsCmd = &cmds.Command{
 		return re.Emit(&BootstrapLsResult{peers.([]string)})
 	},
 	Type: &BootstrapLsResult{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, br *BootstrapLsResult) error {
-			_, err := fmt.Fprintln(w, br)
-			return err
-		}),
-	},
 }

--- a/cmd/go-filecoin/bootstrap_integration_test.go
+++ b/cmd/go-filecoin/bootstrap_integration_test.go
@@ -20,5 +20,5 @@ func TestBootstrapList(t *testing.T) {
 
 	bs := cmdClient.RunSuccess(ctx, "bootstrap", "ls")
 
-	assert.Equal(t, "{\"Peers\":[]}\n", bs.ReadStdout())
+	assert.Equal(t, "{\n\t\"Peers\": []\n}\n", bs.ReadStdout())
 }

--- a/cmd/go-filecoin/bootstrap_integration_test.go
+++ b/cmd/go-filecoin/bootstrap_integration_test.go
@@ -20,5 +20,5 @@ func TestBootstrapList(t *testing.T) {
 
 	bs := cmdClient.RunSuccess(ctx, "bootstrap", "ls")
 
-	assert.Equal(t, "&{[]}\n", bs.ReadStdout())
+	assert.Equal(t, "{\"Peers\":[]}\n", bs.ReadStdout())
 }

--- a/cmd/go-filecoin/chain.go
+++ b/cmd/go-filecoin/chain.go
@@ -3,10 +3,7 @@ package commands
 
 import (
 	"fmt"
-	"io"
 	"os"
-	"strconv"
-	"strings"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/ipfs/go-cid"
@@ -43,17 +40,6 @@ var storeHeadCmd = &cmds.Command{
 		return re.Emit(head.Key())
 	},
 	Type: []cid.Cid{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res []cid.Cid) error {
-			for _, r := range res {
-				_, err := fmt.Fprintln(w, r.String())
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		}),
-	},
 }
 
 var storeLsCmd = &cmds.Command{
@@ -83,37 +69,6 @@ var storeLsCmd = &cmds.Command{
 		return nil
 	},
 	Type: []block.Block{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *[]block.Block) error {
-			showAll, _ := req.Options["long"].(bool)
-			blocks := *res
-
-			for _, block := range blocks {
-				var output strings.Builder
-
-				if showAll {
-					output.WriteString(block.Cid().String())
-					output.WriteString("\t")
-					output.WriteString(block.Miner.String())
-					output.WriteString("\t")
-					output.WriteString(block.StateRoot.String())
-					output.WriteString("\t")
-					output.WriteString(strconv.FormatInt(int64(block.Height), 10))
-					output.WriteString("\t")
-					output.WriteString(block.Messages.String())
-				} else {
-					output.WriteString(block.Cid().String())
-				}
-
-				_, err := fmt.Fprintln(w, output.String())
-				if err != nil {
-					return err
-				}
-			}
-
-			return nil
-		}),
-	},
 }
 
 var storeStatusCmd = &cmds.Command{

--- a/cmd/go-filecoin/chain_integration_test.go
+++ b/cmd/go-filecoin/chain_integration_test.go
@@ -31,11 +31,6 @@ func TestChainHead(t *testing.T) {
 	var cidsFromJSON []cid.Cid
 	err := json.Unmarshal([]byte(jsonResult), &cidsFromJSON)
 	assert.NoError(t, err)
-
-	textResult := cmdClient.RunSuccess(ctx, "chain", "ls", "--enc", "text").ReadStdoutTrimNewlines()
-	textCid, err := cid.Decode(textResult)
-	require.NoError(t, err)
-	assert.Equal(t, textCid, cidsFromJSON[0])
 }
 
 func TestChainLs(t *testing.T) {

--- a/cmd/go-filecoin/client.go
+++ b/cmd/go-filecoin/client.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/filecoin-project/go-fil-markets/storagemarket/network"
 
@@ -86,11 +85,6 @@ See the go-filecoin client cat command for more details.
 		return re.Emit(out.Cid())
 	},
 	Type: cid.Cid{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, c cid.Cid) error {
-			return PrintString(w, c)
-		}),
-	},
 }
 
 var clientProposeStorageDealCmd = &cmds.Command{
@@ -153,14 +147,6 @@ be 2, 1 hour would be 120, and 1 day would be 2880.
 		//return re.Emit(resp)
 	},
 	Type: network.Response{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, resp *network.Response) error {
-			fmt.Fprintf(w, "State:   %d\n", resp.State)               // nolint: errcheck
-			fmt.Fprintf(w, "Message: %s\n", resp.Message)             // nolint: errcheck
-			fmt.Fprintf(w, "Message CID:  %s\n", resp.PublishMessage) // nolint: errcheck
-			return nil
-		}),
-	},
 }
 
 var clientQueryStorageDealCmd = &cmds.Command{
@@ -191,13 +177,6 @@ format is specified with the --enc flag.
 		//return re.Emit(resp)
 	},
 	Type: network.SignedResponse{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, resp *network.SignedResponse) error {
-			fmt.Fprintf(w, "Status: %d\n", resp.Response.State)    // nolint: errcheck
-			fmt.Fprintf(w, "Message: %s\n", resp.Response.Message) // nolint: errcheck
-			return nil
-		}),
-	},
 }
 
 // VerifyStorageDealResult wraps the success in an interface type
@@ -263,10 +242,4 @@ respectively.
 		return nil
 	},
 	Type: porcelain.Ask{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, ask *porcelain.Ask) error {
-			fmt.Fprintf(w, "%s %.3d %s %d\n", ask.Miner, ask.ID, ask.Price, ask.Expiry) // nolint: errcheck
-			return nil
-		}),
-	},
 }

--- a/cmd/go-filecoin/config.go
+++ b/cmd/go-filecoin/config.go
@@ -1,12 +1,10 @@
 package commands
 
 import (
-	"encoding/json"
-	"io"
 	"strings"
 
-	"github.com/ipfs/go-ipfs-cmdkit"
-	"github.com/ipfs/go-ipfs-cmds"
+	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
+	cmds "github.com/ipfs/go-ipfs-cmds"
 )
 
 var configCmd = &cmds.Command{
@@ -100,12 +98,5 @@ $ go-filecoin config bootstrap
 		}
 
 		return re.Emit(res)
-	},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeEncoder(func(req *cmds.Request, w io.Writer, res interface{}) error {
-			encoder := json.NewEncoder(w)
-			encoder.SetIndent("", "\t")
-			return encoder.Encode(res)
-		}),
 	},
 }

--- a/cmd/go-filecoin/config_integration_test.go
+++ b/cmd/go-filecoin/config_integration_test.go
@@ -74,7 +74,7 @@ func TestConfigDaemon(t *testing.T) {
 		jsonOut := op1.ReadStdout()
 		bootstrapConfig := config.NewDefaultConfig().Bootstrap
 		bootstrapConfig.Addresses = []string{"fake1", "fake2"}
-		someJSON, err := json.MarshalIndent(bootstrapConfig, "", "\t")
+		someJSON, err := json.Marshal(bootstrapConfig)
 		require.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf("%s\n", string(someJSON)), jsonOut)
 

--- a/cmd/go-filecoin/daemon.go
+++ b/cmd/go-filecoin/daemon.go
@@ -42,9 +42,6 @@ var daemonCmd = &cmds.Command{
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		return daemonRun(req, re)
 	},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.Encoders[cmds.Text],
-	},
 }
 
 func daemonRun(req *cmds.Request, re cmds.ResponseEmitter) error {

--- a/cmd/go-filecoin/daemon_daemon_test.go
+++ b/cmd/go-filecoin/daemon_daemon_test.go
@@ -23,8 +23,8 @@ func TestDaemonStartupMessage(t *testing.T) {
 	daemon.ShutdownSuccess()
 
 	out := daemon.ReadStdout()
-	assert.Regexp(t, "^My peer ID is [a-zA-Z0-9]*", out)
-	assert.Regexp(t, "\\nSwarm listening on.*", out)
+	assert.Regexp(t, "^\"My peer ID is [a-zA-Z0-9]*", out)
+	assert.Regexp(t, "\\n\"Swarm listening on.*", out)
 }
 
 func TestDaemonApiFile(t *testing.T) {

--- a/cmd/go-filecoin/deals.go
+++ b/cmd/go-filecoin/deals.go
@@ -1,9 +1,6 @@
 package commands
 
 import (
-	"encoding/json"
-	"io"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
@@ -54,13 +51,6 @@ deals, active deals, finished deals and cancelled deals.
 		panic("implement me in terms of the storage market module")
 	},
 	Type: DealsListResult{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *DealsListResult) error {
-			encoder := json.NewEncoder(w)
-			encoder.SetIndent("", "\t")
-			return encoder.Encode(res)
-		}),
-	},
 }
 
 // DealsShowResult contains Deal output with Payment Vouchers.
@@ -84,11 +74,4 @@ var dealsShowCmd = &cmds.Command{
 		panic("implement me in terms of the storage market module")
 	},
 	Type: DealsShowResult{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, dealResult *DealsShowResult) error {
-			encoder := json.NewEncoder(w)
-			encoder.SetIndent("", "\t")
-			return encoder.Encode(dealResult)
-		}),
-	},
 }

--- a/cmd/go-filecoin/dht.go
+++ b/cmd/go-filecoin/dht.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -79,20 +78,6 @@ var queryDhtCmd = &cmds.Command{
 
 		return nil
 	},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *routing.QueryEvent) error {
-			pfm := pfuncMap{
-				routing.PeerResponse: func(obj *routing.QueryEvent, out io.Writer, verbose bool) {
-					for _, p := range obj.Responses {
-						fmt.Fprintf(out, "%s\n", p.ID.Pretty()) // nolint: errcheck
-					}
-				},
-			}
-			verbose, _ := req.Options[dhtVerboseOptionName].(bool)
-			printEvent(out, w, verbose, pfm)
-			return nil
-		}),
-	},
 	Type: routing.QueryEvent{},
 }
 
@@ -148,95 +133,7 @@ var findProvidersDhtCmd = &cmds.Command{
 
 		return nil
 	},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *routing.QueryEvent) error {
-			pfm := pfuncMap{
-				routing.FinalPeer: func(obj *routing.QueryEvent, out io.Writer, verbose bool) {
-					if verbose {
-						fmt.Fprintf(out, "* closest peer %s\n", obj.ID) // nolint: errcheck
-					}
-				},
-				routing.Provider: func(obj *routing.QueryEvent, out io.Writer, verbose bool) {
-					prov := obj.Responses[0]
-					if verbose {
-						fmt.Fprintf(out, "provider: ") // nolint: errcheck
-					}
-					fmt.Fprintf(out, "%s\n", prov.ID.Pretty()) // nolint: errcheck
-					if verbose {
-						for _, a := range prov.Addrs {
-							fmt.Fprintf(out, "\t%s\n", a) // nolint: errcheck
-						}
-					}
-				},
-			}
-
-			verbose, _ := req.Options[dhtVerboseOptionName].(bool)
-			printEvent(out, w, verbose, pfm)
-
-			return nil
-		}),
-	},
 	Type: routing.QueryEvent{},
-}
-
-type printFunc func(obj *routing.QueryEvent, out io.Writer, verbose bool)
-type pfuncMap map[routing.QueryEventType]printFunc
-
-// printEvent writes a libp2p event to a user friendly output on the out writer.
-// Note that this function is only needed to enable the output logging of
-// events that only show up during a "verbose" run. If we choose to eliminate
-// the verbose option this can be removed. However if we keep the verbose option
-// in findprovs and on any other dht subcommands we decide to copy over from
-// ipfs this function will stay needed.
-func printEvent(obj *routing.QueryEvent, out io.Writer, verbose bool, override pfuncMap) {
-	if verbose {
-		fmt.Fprintf(out, "%s: ", time.Now().Format("15:04:05.000")) // nolint: errcheck
-	}
-
-	if override != nil {
-		if pf, ok := override[obj.Type]; ok {
-			pf(obj, out, verbose)
-			return
-		}
-	}
-
-	switch obj.Type {
-	case routing.SendingQuery:
-		if verbose {
-			fmt.Fprintf(out, "* querying %s\n", obj.ID) // nolint: errcheck
-		}
-	case routing.Value:
-		if verbose {
-			fmt.Fprintf(out, "got value: '%s'\n", obj.Extra) // nolint: errcheck
-		} else {
-			fmt.Fprint(out, obj.Extra) // nolint: errcheck
-		}
-	case routing.PeerResponse:
-		if verbose {
-			fmt.Fprintf(out, "* %s says use ", obj.ID) // nolint: errcheck
-			for _, p := range obj.Responses {
-				fmt.Fprintf(out, "%s ", p.ID) // nolint: errcheck
-			}
-			fmt.Fprintln(out) // nolint: errcheck
-		}
-	case routing.QueryError:
-		if verbose {
-			fmt.Fprintf(out, "error: %s\n", obj.Extra) // nolint: errcheck
-		}
-	case routing.DialingPeer:
-		if verbose {
-			fmt.Fprintf(out, "dialing peer: %s\n", obj.ID) // nolint: errcheck
-		}
-	case routing.AddingPeer:
-		if verbose {
-			fmt.Fprintf(out, "adding peer to query: %s\n", obj.ID) // nolint: errcheck
-		}
-	case routing.FinalPeer:
-	default:
-		if verbose {
-			fmt.Fprintf(out, "unrecognized event type: %d\n", obj.Type) // nolint: errcheck
-		}
-	}
 }
 
 var findPeerDhtCmd = &cmds.Command{
@@ -264,11 +161,5 @@ var findPeerDhtCmd = &cmds.Command{
 			}
 		}
 		return nil
-	},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, addr string) error {
-			_, err := fmt.Fprintln(w, addr)
-			return err
-		}),
 	},
 }

--- a/cmd/go-filecoin/dht_integration_test.go
+++ b/cmd/go-filecoin/dht_integration_test.go
@@ -31,7 +31,7 @@ func TestDhtFindPeer(t *testing.T) {
 	findpeerOutput := cmdClient.RunSuccess(ctx, "dht", "findpeer", n2Id.String()).ReadStdoutTrimNewlines()
 	n2Addr := n2.PorcelainAPI.NetworkGetPeerAddresses()[0]
 
-	assert.Contains(t, n2Addr.String(), findpeerOutput)
+	assert.Contains(t, findpeerOutput, n2Addr.String())
 }
 
 // TODO: findprovs will have to be untested until

--- a/cmd/go-filecoin/id.go
+++ b/cmd/go-filecoin/id.go
@@ -4,8 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
-	"strings"
 
 	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
 	cmds "github.com/ipfs/go-ipfs-cmds"
@@ -50,41 +48,6 @@ var idCmd = &cmds.Command{
 		return re.Emit(&details)
 	},
 	Type: IDDetails{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, val *IDDetails) error {
-			format, found := req.Options["format"].(string)
-			if found {
-				output := idFormatSubstitute(format, val)
-				_, err := fmt.Fprint(w, output)
-				return err
-			}
-
-			marshaled, err := json.MarshalIndent(val, "", "\t")
-			if err != nil {
-				return err
-			}
-			marshaled = append(marshaled, byte('\n'))
-
-			_, err = w.Write(marshaled)
-			return err
-		}),
-	},
-}
-
-func idFormatSubstitute(format string, val *IDDetails) string {
-	addrStrings := make([]string, len(val.Addresses))
-	for i, addr := range val.Addresses {
-		addrStrings[i] = addr.String()
-	}
-	output := format
-	output = strings.Replace(output, "<id>", val.ID.Pretty(), -1)
-	output = strings.Replace(output, "<aver>", val.AgentVersion, -1)
-	output = strings.Replace(output, "<pver>", val.ProtocolVersion, -1)
-	output = strings.Replace(output, "<pubkey>", base64.StdEncoding.EncodeToString(val.PublicKey), -1)
-	output = strings.Replace(output, "<addrs>", strings.Join(addrStrings, "\n"), -1)
-	output = strings.Replace(output, "\\n", "\n", -1)
-	output = strings.Replace(output, "\\t", "\t", -1)
-	return output
 }
 
 // MarshalJSON implements json.Marshaler

--- a/cmd/go-filecoin/id_daemon_test.go
+++ b/cmd/go-filecoin/id_daemon_test.go
@@ -29,27 +29,6 @@ func TestId(t *testing.T) {
 	assert.Contains(t, idContent, "ID")
 }
 
-func TestIdFormat(t *testing.T) {
-	tf.IntegrationTest(t)
-
-	ctx := context.Background()
-
-	builder := test.NewNodeBuilder(t)
-	_, cmdClient, done := builder.BuildAndStartAPI(ctx)
-	defer done()
-
-	idContent := cmdClient.RunSuccess(
-		ctx,
-		"id",
-		"--format=\"<id>\\t<aver>\\t<pver>\\t<pubkey>\\n<addrs>\"",
-	).ReadStdout()
-
-	assert.Contains(t, idContent, "\t")
-	assert.Contains(t, idContent, "\n")
-	assert.Containsf(t, idContent, "/ip4/127.0.0.1/tcp/", "default addr")
-	assert.NotContains(t, idContent, "ID")
-}
-
 func TestPersistId(t *testing.T) {
 	tf.IntegrationTest(t)
 

--- a/cmd/go-filecoin/init.go
+++ b/cmd/go-filecoin/init.go
@@ -118,9 +118,6 @@ var initCmd = &cmds.Command{
 		}
 		return nil
 	},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeEncoder(initTextEncoder),
-	},
 }
 
 func setConfigFromOptions(cfg *config.Config, options cmdkit.OptMap) error {

--- a/cmd/go-filecoin/init.go
+++ b/cmd/go-filecoin/init.go
@@ -179,11 +179,6 @@ func setConfigFromOptions(cfg *config.Config, options cmdkit.OptMap) error {
 	return nil
 }
 
-func initTextEncoder(_ *cmds.Request, w io.Writer, val interface{}) error {
-	_, err := fmt.Fprintf(w, val.(string))
-	return err
-}
-
 func loadGenesis(ctx context.Context, rep repo.Repo, sourceName string) (genesis.InitFunc, error) {
 	if sourceName == "" {
 		return gengen.MakeGenesisFunc(gengen.ProofsMode(types.LiveProofsMode)), nil

--- a/cmd/go-filecoin/inspector.go
+++ b/cmd/go-filecoin/inspector.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"encoding/json"
-	"io"
 	"os"
 	"runtime"
 
@@ -56,52 +54,6 @@ Prints out information about filecoin process and its environment.
 		return cmds.EmitOnce(res, allInfo)
 	},
 	Type: AllInspectorInfo{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, info *AllInspectorInfo) error {
-			sw := NewSilentWriter(w)
-
-			// Print Version
-			sw.Printf("Version:\t%s\n", info.FilecoinVersion)
-
-			// Print Runtime Info
-			sw.Printf("\nRuntime\n")
-			sw.Printf("OS:           \t%s\n", info.Runtime.OS)
-			sw.Printf("Arch:         \t%s\n", info.Runtime.Arch)
-			sw.Printf("Version:      \t%s\n", info.Runtime.Version)
-			sw.Printf("Compiler:     \t%s\n", info.Runtime.Compiler)
-			sw.Printf("NumProc:      \t%d\n", info.Runtime.NumProc)
-			sw.Printf("GoMaxProcs:   \t%d\n", info.Runtime.GoMaxProcs)
-			sw.Printf("NumGoRoutines:\t%d\n", info.Runtime.NumGoRoutines)
-			sw.Printf("NumCGoCalls:  \t%d\n", info.Runtime.NumCGoCalls)
-
-			// Print Disk Info
-			sw.Printf("\nDisk\n")
-			sw.Printf("Free:  \t%d\n", info.Disk.Free)
-			sw.Printf("Total: \t%d\n", info.Disk.Total)
-			sw.Printf("FSType:\t%s\n", info.Disk.FSType)
-
-			// Print Memory Info
-			sw.Printf("\nMemory\n")
-			sw.Printf("Swap:   \t%d\n", info.Memory.Swap)
-			sw.Printf("Virtual:\t%d\n", info.Memory.Virtual)
-
-			// Print Environment Info
-			sw.Printf("\nEnvironment\n")
-			sw.Printf("FilAPI: \t%s\n", info.Environment.FilAPI)
-			sw.Printf("FilPath:\t%s\n", info.Environment.FilPath)
-			sw.Printf("GoPath: \t%s\n", info.Environment.GoPath)
-
-			// Print Config Info
-			sw.Printf("\nConfig\n")
-			marshaled, err := json.MarshalIndent(info.Config, "", "\t")
-			if err != nil {
-				return err
-			}
-			sw.Printf("%s\n", marshaled)
-
-			return sw.Error()
-		}),
-	},
 }
 
 var runtimeInspectCmd = &cmds.Command{
@@ -116,20 +68,6 @@ Prints out information about the golang runtime.
 		return cmds.EmitOnce(res, out)
 	},
 	Type: RuntimeInfo{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, info *RuntimeInfo) error {
-			sw := NewSilentWriter(w)
-			sw.Printf("OS:           \t%s\n", info.OS)
-			sw.Printf("Arch:         \t%s\n", info.Arch)
-			sw.Printf("Version:      \t%s\n", info.Version)
-			sw.Printf("Compiler:     \t%s\n", info.Compiler)
-			sw.Printf("NumProc:      \t%d\n", info.NumProc)
-			sw.Printf("GoMaxProcs:   \t%d\n", info.GoMaxProcs)
-			sw.Printf("NumGoRoutines:\t%d\n", info.NumGoRoutines)
-			sw.Printf("NumCGoCalls:  \t%d\n", info.NumCGoCalls)
-			return sw.Error()
-		}),
-	},
 }
 
 var diskInspectCmd = &cmds.Command{
@@ -147,15 +85,6 @@ Prints out information about the filesystem.
 		return cmds.EmitOnce(res, out)
 	},
 	Type: DiskInfo{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, info *DiskInfo) error {
-			sw := NewSilentWriter(w)
-			sw.Printf("Free:  \t%d\n", info.Free)
-			sw.Printf("Total: \t%d\n", info.Total)
-			sw.Printf("FSType:\t%s\n", info.FSType)
-			return sw.Error()
-		}),
-	},
 }
 
 var memoryInspectCmd = &cmds.Command{
@@ -173,14 +102,6 @@ Prints out information about memory usage.
 		return cmds.EmitOnce(res, out)
 	},
 	Type: MemoryInfo{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, info *MemoryInfo) error {
-			sw := NewSilentWriter(w)
-			sw.Printf("Swap:   \t%d\n", info.Swap)
-			sw.Printf("Virtual:\t%d\n", info.Virtual)
-			return sw.Error()
-		}),
-	},
 }
 
 var configInspectCmd = &cmds.Command{
@@ -195,17 +116,6 @@ Prints out information about your filecoin nodes config.
 		return cmds.EmitOnce(res, out)
 	},
 	Type: config.Config{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, info *config.Config) error {
-			marshaled, err := json.MarshalIndent(info, "", "\t")
-			if err != nil {
-				return err
-			}
-			marshaled = append(marshaled, byte('\n'))
-			_, err = w.Write(marshaled)
-			return err
-		}),
-	},
 }
 
 var envInspectCmd = &cmds.Command{
@@ -220,15 +130,6 @@ Prints out information about your filecoin nodes environment.
 		return cmds.EmitOnce(res, out)
 	},
 	Type: EnvironmentInfo{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, info *EnvironmentInfo) error {
-			sw := NewSilentWriter(w)
-			sw.Printf("FilAPI: \t%s\n", info.FilAPI)
-			sw.Printf("FilPath:\t%s\n", info.FilPath)
-			sw.Printf("GoPath: \t%s\n", info.GoPath)
-			return sw.Error()
-		}),
-	},
 }
 
 // NewInspectorAPI returns a `Inspector` used to inspect the go-filecoin node.

--- a/cmd/go-filecoin/leb128.go
+++ b/cmd/go-filecoin/leb128.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"fmt"
-	"io"
 	"strconv"
 
 	"github.com/filecoin-project/go-leb128"
@@ -35,12 +33,6 @@ var decodeLeb128Cmd = &cmds.Command{
 		return cmds.EmitOnce(res, val)
 	},
 	Type: uint64(0),
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, info uint64) error {
-			_, err := fmt.Fprintln(w, info)
-			return err
-		}),
-	},
 }
 
 var encodeLeb128Cmd = &cmds.Command{
@@ -60,16 +52,4 @@ var encodeLeb128Cmd = &cmds.Command{
 		return cmds.EmitOnce(res, out)
 	},
 	Type: []byte{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, info []byte) error {
-			result := string(info)
-			if len(result)%3 == 1 {
-				result += "=="
-			} else if len(result)%3 == 2 {
-				result += "="
-			}
-			_, err := fmt.Fprintln(w, result)
-			return err
-		}),
-	},
 }

--- a/cmd/go-filecoin/leb128_test.go
+++ b/cmd/go-filecoin/leb128_test.go
@@ -39,7 +39,7 @@ func TestLeb128Encode(t *testing.T) {
 		Text string
 		Want string
 	}{
-		{"65", "A=="},
+		{"65", "QQ=="},
 	}
 
 	ctx := context.Background()

--- a/cmd/go-filecoin/log.go
+++ b/cmd/go-filecoin/log.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/ipfs/go-ipfs-cmdkit"
-	"github.com/ipfs/go-ipfs-cmds"
+	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
+	cmds "github.com/ipfs/go-ipfs-cmds"
 	logging "github.com/ipfs/go-log"
 	writer "github.com/ipfs/go-log/writer"
 )
@@ -99,12 +99,6 @@ the event log.
 		return cmds.EmitOnce(res, s)
 	},
 	Type: string(""),
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out string) error {
-			_, err := fmt.Fprint(w, out)
-			return err
-		}),
-	},
 }
 
 var logLsCmd = &cmds.Command{
@@ -119,12 +113,4 @@ subsystems of a running daemon.
 		return cmds.EmitOnce(res, logging.GetSubsystems())
 	},
 	Type: []string{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, list []string) error {
-			for _, s := range list {
-				fmt.Fprintln(w, s) // nolint: errcheck
-			}
-			return nil
-		}),
-	},
 }

--- a/cmd/go-filecoin/main.go
+++ b/cmd/go-filecoin/main.go
@@ -2,7 +2,9 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -99,6 +101,17 @@ const (
 	IsRelay = "is-relay"
 )
 
+func init() {
+	// add pretty json as an encoding type
+	cmds.Encoders["pretty-json"] = func(req *cmds.Request) func(io.Writer) cmds.Encoder {
+		return func(w io.Writer) cmds.Encoder {
+			enc := json.NewEncoder(w)
+			enc.SetIndent("", "\t")
+			return enc
+		}
+	}
+}
+
 // command object for the local cli
 var rootCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
@@ -153,7 +166,7 @@ TOOL COMMANDS
 	Options: []cmdkit.Option{
 		cmdkit.StringOption(OptionAPI, "set the api port to use"),
 		cmdkit.StringOption(OptionRepoDir, "set the repo directory, defaults to ~/.filecoin/repo"),
-		cmds.OptionEncodingType,
+		cmdkit.StringOption(cmds.EncLong, cmds.EncShort, "The encoding type the output should be encoded with (pretty-json or json)").WithDefault("pretty-json"),
 		cmdkit.BoolOption("help", "Show the full command help text."),
 		cmdkit.BoolOption("h", "Show a short version of the command help text."),
 	},

--- a/cmd/go-filecoin/miner.go
+++ b/cmd/go-filecoin/miner.go
@@ -2,9 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"io"
 	"math/big"
-	"strconv"
 
 	address "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
@@ -133,16 +131,6 @@ additional sectors.`,
 		})
 	},
 	Type: &MinerCreateResult{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *MinerCreateResult) error {
-			if res.Preview {
-				output := strconv.FormatUint(uint64(res.GasUsed), 10)
-				_, err := w.Write([]byte(output))
-				return err
-			}
-			return PrintString(w, res.Address)
-		}),
-	},
 }
 
 // MinerSetPriceResult is the return type for miner set-price command
@@ -211,12 +199,6 @@ This command waits for the ask to be mined.`,
 		return re.Emit(&MinerSetPriceResult{minerAddr, res.Price})
 	},
 	Type: &MinerSetPriceResult{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *MinerSetPriceResult) error {
-			_, err := fmt.Fprintf(w, "%s", res)
-			return err
-		}),
-	},
 }
 
 // MinerUpdatePeerIDResult is the return type for miner update-peerid command
@@ -304,16 +286,6 @@ var minerUpdatePeerIDCmd = &cmds.Command{
 		})
 	},
 	Type: &MinerUpdatePeerIDResult{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *MinerUpdatePeerIDResult) error {
-			if res.Preview {
-				output := strconv.FormatUint(uint64(res.GasUsed), 10)
-				_, err := w.Write([]byte(output))
-				return err
-			}
-			return PrintString(w, res.Cid)
-		}),
-	},
 }
 
 var minerStatusCommand = &cmds.Command{
@@ -370,10 +342,4 @@ var minerSetWorkerAddressCmd = &cmds.Command{
 		return re.Emit(msgCid)
 	},
 	Type: cid.Cid{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, c cid.Cid) error {
-			fmt.Fprintln(w, c) // nolint: errcheck
-			return nil
-		}),
-	},
 }

--- a/cmd/go-filecoin/mining.go
+++ b/cmd/go-filecoin/mining.go
@@ -1,10 +1,6 @@
 package commands
 
 import (
-	"fmt"
-	"io"
-	"strconv"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-cid"
 	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
@@ -38,12 +34,6 @@ var miningAddrCmd = &cmds.Command{
 		return re.Emit(minerAddress.String())
 	},
 	Type: address.Address{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, a address.Address) error {
-			fmt.Fprintln(w, a.String()) // nolint: errcheck
-			return nil
-		}),
-	},
 }
 
 var miningOnceCmd = &cmds.Command{
@@ -58,12 +48,6 @@ var miningOnceCmd = &cmds.Command{
 		return re.Emit(blk.Cid())
 	},
 	Type: cid.Cid{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, c cid.Cid) error {
-			fmt.Fprintln(w, c) // nolint: errcheck
-			return nil
-		}),
-	},
 }
 
 var miningSetupCmd = &cmds.Command{
@@ -76,8 +60,7 @@ var miningSetupCmd = &cmds.Command{
 		}
 		return re.Emit("mining ready")
 	},
-	Type:     "",
-	Encoders: stringEncoderMap,
+	Type: "",
 }
 
 var miningStartCmd = &cmds.Command{
@@ -90,8 +73,7 @@ var miningStartCmd = &cmds.Command{
 		}
 		return re.Emit("Started mining")
 	},
-	Type:     "",
-	Encoders: stringEncoderMap,
+	Type: "",
 }
 
 // MiningStatusResult is the type returned when get mining status.
@@ -119,16 +101,6 @@ var miningStatusCmd = &cmds.Command{
 		})
 	},
 	Type: &MiningStatusResult{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, res *MiningStatusResult) error {
-			_, err := fmt.Fprintf(w, `Mining Status
-Active:     %s
-Address:    %s
-`, strconv.FormatBool(res.Active), res.Miner)
-
-			return err
-		}),
-	},
 }
 
 var miningStopCmd = &cmds.Command{
@@ -139,14 +111,6 @@ var miningStopCmd = &cmds.Command{
 		GetBlockAPI(env).MiningStop(req.Context)
 		return re.Emit("Stopped mining")
 	},
-	Encoders: stringEncoderMap,
-}
-
-var stringEncoderMap = cmds.EncoderMap{
-	cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, t string) error {
-		fmt.Fprintln(w, t) // nolint: errcheck
-		return nil
-	}),
 }
 
 var miningPledgeSectorCmd = &cmds.Command{
@@ -160,6 +124,5 @@ var miningPledgeSectorCmd = &cmds.Command{
 		}
 		return re.Emit("Sector pledged")
 	},
-	Type:     "",
-	Encoders: stringEncoderMap,
+	Type: "",
 }

--- a/cmd/go-filecoin/mpool.go
+++ b/cmd/go-filecoin/mpool.go
@@ -1,14 +1,11 @@
 package commands
 
 import (
-	"encoding/base64"
 	"fmt"
-	"io"
-	"strconv"
 
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-ipfs-cmdkit"
-	"github.com/ipfs/go-ipfs-cmds"
+	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
+	cmds "github.com/ipfs/go-ipfs-cmds"
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
@@ -43,18 +40,6 @@ var mpoolLsCmd = &cmds.Command{
 		return re.Emit(pending)
 	},
 	Type: []*types.SignedMessage{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, msgs *[]*types.SignedMessage) error {
-			for _, msg := range *msgs {
-				c, err := msg.Cid()
-				if err != nil {
-					return err
-				}
-				_ = PrintString(w, c)
-			}
-			return nil
-		}),
-	},
 }
 
 var mpoolShowCmd = &cmds.Command{
@@ -77,33 +62,6 @@ var mpoolShowCmd = &cmds.Command{
 		return re.Emit(msg)
 	},
 	Type: &types.SignedMessage{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, smsg *types.SignedMessage) error {
-			msg := smsg.Message
-			_, err := fmt.Fprintf(w, `Message Details
-To:        %s
-From:      %s
-CallSeqNum:     %s
-Value:     %s
-Method:    %d
-Params:    %s
-Gas price: %s
-Gas limit: %s
-Signature: %s
-`,
-				msg.To,
-				msg.From,
-				strconv.FormatUint(msg.CallSeqNum, 10),
-				msg.Value,
-				msg.Method,
-				base64.StdEncoding.EncodeToString(msg.Params),
-				msg.GasPrice.String(),
-				strconv.FormatUint(uint64(msg.GasLimit), 10),
-				base64.StdEncoding.EncodeToString(smsg.Signature.Data),
-			)
-			return err
-		}),
-	},
 }
 
 var mpoolRemoveCmd = &cmds.Command{

--- a/cmd/go-filecoin/outbox.go
+++ b/cmd/go-filecoin/outbox.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"io"
-
 	"github.com/filecoin-project/go-address"
 	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
 	cmds "github.com/ipfs/go-ipfs-cmds"
@@ -49,17 +47,6 @@ var outboxLsCmd = &cmds.Command{
 		return nil
 	},
 	Type: OutboxLsResult{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, queue *OutboxLsResult) error {
-			sw := NewSilentWriter(w)
-			sw.Println("From:", queue.Address.String())
-			for _, qm := range queue.Messages {
-				msg := qm.Msg
-				sw.Printf("%s, height: %d\n", msg.String(), qm.Stamp)
-			}
-			return sw.Error()
-		}),
-	},
 }
 
 var outboxClearCmd = &cmds.Command{
@@ -80,7 +67,6 @@ var outboxClearCmd = &cmds.Command{
 		}
 		return nil
 	},
-	Encoders: cmds.EncoderMap{},
 }
 
 // Reads an address from an argument, or lists addresses of all outbox queues if no arg is given.

--- a/cmd/go-filecoin/ping.go
+++ b/cmd/go-filecoin/ping.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"io"
 	"time"
 
 	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
@@ -70,13 +69,6 @@ trip latency information.
 		}
 
 		return nil
-	},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, result *PingResult) error {
-			milliseconds := result.RTT.Seconds() * 1000
-			fmt.Fprintf(w, "Pong received: seq=%d time=%.2f ms\n", result.Count, milliseconds) // nolint: errcheck
-			return nil
-		}),
 	},
 	Type: PingResult{},
 }

--- a/cmd/go-filecoin/protocol.go
+++ b/cmd/go-filecoin/protocol.go
@@ -1,11 +1,8 @@
 package commands
 
 import (
-	"fmt"
-	"io"
-
-	"github.com/ipfs/go-ipfs-cmdkit"
-	"github.com/ipfs/go-ipfs-cmds"
+	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
+	cmds "github.com/ipfs/go-ipfs-cmds"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/porcelain"
 )
@@ -22,38 +19,4 @@ var protocolCmd = &cmds.Command{
 		return re.Emit(params)
 	},
 	Type: porcelain.ProtocolParams{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, pp *porcelain.ProtocolParams) error {
-			_, err := fmt.Fprintf(w, "Network: %s\n", pp.Network)
-			if err != nil {
-				return err
-			}
-
-			_, err = fmt.Fprintf(w, "Auto-Seal Interval: %d seconds\nSector Sizes:\n", pp.AutoSealInterval)
-			if err != nil {
-				return err
-			}
-
-			for _, sectorInfo := range pp.SupportedSectors {
-				_, err = fmt.Fprintf(w, "\t%s (%s writeable)\n", readableBytesAmount(float64(sectorInfo.Size)), readableBytesAmount(float64(sectorInfo.MaxPieceSize)))
-				if err != nil {
-					return err
-				}
-			}
-
-			return nil
-		}),
-	},
-}
-
-func readableBytesAmount(amt float64) string {
-	unit := 0
-	units := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
-
-	for amt >= 1024 && unit < len(units)-1 {
-		amt /= 1024
-		unit++
-	}
-
-	return fmt.Sprintf("%.2f %s", amt, units[unit])
 }

--- a/cmd/go-filecoin/protocol_cmd_test.go
+++ b/cmd/go-filecoin/protocol_cmd_test.go
@@ -30,6 +30,6 @@ func TestProtocol(t *testing.T) {
 	defer stop()
 
 	out := cmd.RunSuccess(ctx, "protocol").ReadStdout()
-	assert.Contains(t, out, "Network: gfctest")
-	assert.Contains(t, out, "Auto-Seal Interval: 120 seconds")
+	assert.Contains(t, out, "\"Network\":\"gfctest\"")
+	assert.Contains(t, out, "\"AutoSealInterval\":120")
 }

--- a/cmd/go-filecoin/protocol_cmd_test.go
+++ b/cmd/go-filecoin/protocol_cmd_test.go
@@ -30,6 +30,6 @@ func TestProtocol(t *testing.T) {
 	defer stop()
 
 	out := cmd.RunSuccess(ctx, "protocol").ReadStdout()
-	assert.Contains(t, out, "\"Network\":\"gfctest\"")
-	assert.Contains(t, out, "\"AutoSealInterval\":120")
+	assert.Contains(t, out, "\"Network\": \"gfctest\"")
+	assert.Contains(t, out, "\"AutoSealInterval\": 120")
 }

--- a/cmd/go-filecoin/show.go
+++ b/cmd/go-filecoin/show.go
@@ -1,10 +1,6 @@
 package commands
 
 import (
-	"fmt"
-	"io"
-	"strconv"
-
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
@@ -53,40 +49,6 @@ all other block properties will be included as well.`,
 		return re.Emit(block)
 	},
 	Type: block.FullBlock{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, block *block.FullBlock) error {
-			wStr := block.Header.ParentWeight.String()
-			_, err := fmt.Fprintf(w, `Block Details
-Miner:  %s
-Weight: %s
-Height: %s
-Messages:  %s
-Timestamp:  %s
-`,
-				block.Header.Miner,
-				wStr,
-				strconv.FormatInt(int64(block.Header.Height), 10),
-				block.Header.Messages.String(),
-				strconv.FormatUint(block.Header.Timestamp, 10),
-			)
-			if err != nil {
-				return err
-			}
-
-			showMessages, _ := req.Options["messages"].(bool)
-			if showMessages == true {
-				_, err = fmt.Fprintf(w, `BLS Messages:\n  %s`+"\n", block.BLSMessages)
-				if err != nil {
-					return err
-				}
-				_, err = fmt.Fprintf(w, `SECP Messages:\n  %s`+"\n", block.SECPMessages)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		}),
-	},
 }
 
 var showHeaderCmd = &cmds.Command{
@@ -113,23 +75,6 @@ all other block properties will be included as well.`,
 		return re.Emit(block)
 	},
 	Type: block.Block{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, block *block.Block) error {
-			wStr := block.ParentWeight.String()
-			_, err := fmt.Fprintf(w, `Block Details
-Miner:  %s
-Weight: %s
-Height: %s
-Timestamp:  %s
-`,
-				block.Miner,
-				wStr,
-				strconv.FormatInt(int64(block.Height), 10),
-				strconv.FormatUint(block.Timestamp, 10),
-			)
-			return err
-		}),
-	},
 }
 
 type allMessages struct {
@@ -161,20 +106,6 @@ the filecoin block header.`,
 		return re.Emit(&allMessages{BLS: bls, SECP: secp})
 	},
 	Type: &allMessages{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, messages *allMessages) error {
-			outStr := "BLS messages \n"
-			for _, msg := range messages.BLS {
-				outStr += msg.String() + "\n"
-			}
-			outStr += "\nSECP messages \n"
-			for _, msg := range messages.SECP {
-				outStr += msg.String() + "\n"
-			}
-			_, err := fmt.Fprint(w, outStr)
-			return err
-		}),
-	},
 }
 
 var showReceiptsCmd = &cmds.Command{
@@ -201,14 +132,4 @@ field of the filecoin block header.`,
 		return re.Emit(receipts)
 	},
 	Type: []vm.MessageReceipt{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, receipts []vm.MessageReceipt) error {
-			outStr := "Receipt Details\n"
-			for _, r := range receipts {
-				outStr += r.String() + "\n"
-			}
-			_, err := fmt.Fprint(w, outStr)
-			return err
-		}),
-	},
 }

--- a/cmd/go-filecoin/stats_integration_test.go
+++ b/cmd/go-filecoin/stats_integration_test.go
@@ -20,5 +20,5 @@ func TestStatsBandwidth(t *testing.T) {
 
 	stats := cmdClient.RunSuccess(ctx, "stats", "bandwidth").ReadStdoutTrimNewlines()
 
-	assert.Equal(t, "{\"TotalIn\":0,\"TotalOut\":0,\"RateIn\":0,\"RateOut\":0}", stats)
+	assert.Equal(t, "{\n\t\"TotalIn\": 0,\n\t\"TotalOut\": 0,\n\t\"RateIn\": 0,\n\t\"RateOut\": 0\n}", stats)
 }

--- a/cmd/go-filecoin/swarm.go
+++ b/cmd/go-filecoin/swarm.go
@@ -1,14 +1,9 @@
 package commands
 
 import (
-	"fmt"
-	"io"
-	"strings"
-
-	"github.com/ipfs/go-ipfs-cmdkit"
-	"github.com/ipfs/go-ipfs-cmds"
+	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
+	cmds "github.com/ipfs/go-ipfs-cmds"
 	"github.com/libp2p/go-libp2p-core/peer"
-	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/net"
 )
@@ -53,33 +48,6 @@ var swarmPeersCmd = &cmds.Command{
 
 		return re.Emit(&out)
 	},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, ci *net.SwarmConnInfos) error {
-			pipfs := ma.ProtocolWithCode(ma.P_IPFS).Name
-			for _, info := range ci.Peers {
-				ids := fmt.Sprintf("/%s/%s", pipfs, info.Peer)
-				if strings.HasSuffix(info.Addr, ids) {
-					fmt.Fprintf(w, "%s", info.Addr) // nolint: errcheck
-				} else {
-					fmt.Fprintf(w, "%s%s", info.Addr, ids) // nolint: errcheck
-				}
-				if info.Latency != "" {
-					fmt.Fprintf(w, " %s", info.Latency) // nolint: errcheck
-				}
-				fmt.Fprintln(w) // nolint: errcheck
-
-				for _, s := range info.Streams {
-					if s.Protocol == "" {
-						s.Protocol = "<no protocol name>"
-					}
-
-					fmt.Fprintf(w, "  %s\n", s.Protocol) // nolint: errcheck
-				}
-			}
-
-			return nil
-		}),
-	},
 	Type: net.SwarmConnInfos{},
 }
 
@@ -115,10 +83,4 @@ go-filecoin swarm connect /ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUE
 		return nil
 	},
 	Type: peer.ID(""),
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, result peer.ID) error {
-			fmt.Fprintf(w, "connect %s success\n", result.Pretty()) // nolint: errcheck
-			return nil
-		}),
-	},
 }

--- a/cmd/go-filecoin/version.go
+++ b/cmd/go-filecoin/version.go
@@ -1,9 +1,6 @@
 package commands
 
 import (
-	"fmt"
-	"io"
-
 	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
 	cmds "github.com/ipfs/go-ipfs-cmds"
 
@@ -25,10 +22,4 @@ var versionCmd = &cmds.Command{
 		})
 	},
 	Type: versionInfo{},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, vo *versionInfo) error {
-			_, err := fmt.Fprintf(w, "commit: %s\n", vo.Commit)
-			return err
-		}),
-	},
 }

--- a/cmd/go-filecoin/version_daemon_test.go
+++ b/cmd/go-filecoin/version_daemon_test.go
@@ -25,7 +25,7 @@ func TestVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	version := string(verOut)
-	assert.Exactly(t, fmt.Sprintf("{\"Commit\":\"%s\"}\n", commit), version)
+	assert.Exactly(t, fmt.Sprintf("{\n\t\"Commit\": \"%s\"\n}\n", commit), version)
 }
 
 func TestVersionOverHttp(t *testing.T) {

--- a/cmd/go-filecoin/version_daemon_test.go
+++ b/cmd/go-filecoin/version_daemon_test.go
@@ -10,8 +10,8 @@ import (
 
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
+	manet "github.com/multiformats/go-multiaddr-net"
 
-	"github.com/multiformats/go-multiaddr-net"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +25,7 @@ func TestVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	version := string(verOut)
-	assert.Exactly(t, version, fmt.Sprintf("commit: %s", commit))
+	assert.Exactly(t, fmt.Sprintf("{\"Commit\":\"%s\"}\n", commit), version)
 }
 
 func TestVersionOverHttp(t *testing.T) {
@@ -63,5 +63,5 @@ func getCodeCommit(t *testing.T) string {
 	if gitOut, err = exec.Command("git", gitArgs...).Output(); err != nil {
 		assert.NoError(t, err)
 	}
-	return string(gitOut)
+	return strings.TrimSpace(string(gitOut))
 }

--- a/go.mod
+++ b/go.mod
@@ -111,8 +111,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	google.golang.org/api v0.13.0 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
-	google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6 // indirect
-	google.golang.org/grpc v1.24.0 // indirect
 	gopkg.in/urfave/cli.v2 v2.0.0-20180128182452-d3ae77c26ac8
 	gopkg.in/yaml.v2 v2.2.5 // indirect
 	gotest.tools v2.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,7 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.0 h1:yTUvW7Vhb89inJ+8irsUqiWjh8iT6sQPZiQzI6ReGkA=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/coreos/bbolt v1.3.2 h1:wZwiHHUieZCquLkDL0B8UhzreNWsPHooDAG3q34zk0s=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible h1:jFneRYjIvLMLhDLCzuTuU4rSJUjRplcJQ7pD7MnhC04=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -179,6 +180,7 @@ github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclK
 github.com/go-critic/go-critic v0.3.5-0.20190904082202-d79a9f0c64db h1:GYXWx7Vr3+zv833u+8IoXbNnQY0AdXsxAgI0kX7xcwA=
 github.com/go-critic/go-critic v0.3.5-0.20190904082202-d79a9f0c64db/go.mod h1:+sE8vrLDS2M0pZkBk0wy6+nLdKexVDrl/jBqQOTDThA=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-lintpack/lintpack v0.5.2 h1:DI5mA3+eKdWeJ40nU4d6Wc26qmdG8RCi/btYq0TuRN0=
 github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTDqfpXvXAN0sXM=
@@ -1024,6 +1026,7 @@ github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 h1:WN9BUFbd
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smola/gocompat v0.2.0 h1:6b1oIMlUXIpz//VKEDzPVBK8KG7beVwmHIUEBIs/Pns=
 github.com/smola/gocompat v0.2.0/go.mod h1:1B0MlxbmoZNo3h8guHp8HztB3BSYR5itql9qtVc0ypY=
+github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sourcegraph/go-diff v0.5.1 h1:gO6i5zugwzo1RVTvgvfwCOSVegNuvnNi6bAD1QCmkHs=
 github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34cd2MNlA9u1mE=
@@ -1308,7 +1311,6 @@ golang.org/x/tools v0.0.0-20190322203728-c1a832b0ad89/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190521203540-521d6ed310dd/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
-golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190719005602-e377ae9d6386/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/tools v0.0.0-20190910044552-dd2b5c81c578/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -1348,16 +1350,14 @@ google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19 h1:Lj2SnHtxkRGJDqn
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
+google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873 h1:nfPFGzJkUDX6uBmpN/pSw7MbOAWegH5QDQuoXFHedLg=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
-google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6 h1:UXl+Zk3jqqcbEVV7ace5lrt4YdA4tXiz3f/KbmD29Vo=
-google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0 h1:cfg4PD8YEdSFnm7qLV4++93WcmhH2nIUhMjhdCvl3j8=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
+google.golang.org/grpc v1.21.0 h1:G+97AoqBnmZIT91cLG/EkCoK9NSelj64P8bOHHNmGn0=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
-google.golang.org/grpc v1.24.0 h1:vb/1TCsVn3DcJlQ0Gs1yB1pKI6Do2/QNwxdKqmc/b0s=
-google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -1391,7 +1391,6 @@ honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed h1:WX1yoOaKQfddO/mLzdV4wptyWgoH/6hwLs7QHTixo0I=

--- a/internal/app/go-filecoin/node/test/api.go
+++ b/internal/app/go-filecoin/node/test/api.go
@@ -124,6 +124,12 @@ func (c *Client) RunJSON(ctx context.Context, command ...string) map[string]inte
 	return parsed
 }
 
+// RunMarshaledJSON runs a command, asserts success, and marshals the JSON response.
+func (c *Client) RunMarshaledJSON(ctx context.Context, result interface{}, command ...string) {
+	out := c.RunSuccess(ctx, command...)
+	require.NoError(c.tb, json.Unmarshal([]byte(out.ReadStdout()), &result))
+}
+
 // RunSuccessFirstLine executes the given command, asserts success and returns
 // the first line of stdout.
 func (c *Client) RunSuccessFirstLine(ctx context.Context, args ...string) string {


### PR DESCRIPTION
### Motivation

We want a JSON-only command API, so we need to remove all the existing text encoders.

### Proposed changes

1. Remove text encoders.
2. Fix tests that depend on them.

Closes #287, closes #599
