### PR TITLE
restore miner create

### DIFF
--- a/internal/app/go-filecoin/node/test/setup.go
+++ b/internal/app/go-filecoin/node/test/setup.go
@@ -1,0 +1,113 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-filecoin/build/project"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
+	gengen "github.com/filecoin-project/go-filecoin/tools/gengen/util"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/stretchr/testify/require"
+)
+
+func MustCreateNodesWithBootstrap(ctx context.Context, t *testing.T, additionalNodes uint) ([]*node.Node, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(ctx)
+	nodes := make([]*node.Node, 1+additionalNodes)
+
+	// set up paths and fake clock.
+	presealPath := project.Root("fixtures/genesis-sectors")
+	genCfgPath := project.Root("fixtures/setup.json")
+	genTime := int64(1000000000)
+	blockTime := 1 * time.Second
+	fakeClock := clock.NewFake(time.Unix(genTime, 0))
+
+	// Load genesis config fixture.
+	genCfg := loadGenesisConfig(t, genCfgPath)
+	genCfg.Miners = append(genCfg.Miners, &gengen.CreateStorageMinerConfig{
+		Owner:      1,
+		SectorSize: 2048,
+	})
+	seed := node.MakeChainSeed(t, genCfg)
+	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, fakeClock)
+
+	// create bootstrap miner
+	bootstrapMiner := NewNodeBuilder(t).
+		WithGenesisInit(seed.GenesisInitFunc).
+		WithBuilderOpt(node.FakeProofVerifierBuilderOpts()...).
+		WithBuilderOpt(node.ChainClockConfigOption(chainClock)).
+		Build(ctx)
+
+	_, _, err := initNodeGenesisMiner(t, bootstrapMiner, seed, genCfg.Miners[0].Owner, presealPath, genCfg.Miners[0].SectorSize)
+	require.NoError(t, err)
+	bootstrapMiner.Start(ctx)
+
+	nodes[0] = bootstrapMiner
+
+	// create addtiional nodes
+	for i := uint(0); i < additionalNodes; i++ {
+		nodes[i+1] = NewNodeBuilder(t).
+			WithGenesisInit(seed.GenesisInitFunc).
+			WithBuilderOpt(node.FakeProofVerifierBuilderOpts()...).
+			WithBuilderOpt(node.ChainClockConfigOption(chainClock)).
+			Build(ctx)
+		addr := seed.GiveKey(t, nodes[i+1], int(i+1))
+		nodes[i+1].PorcelainAPI.ConfigSet("wallet.defaultAddress", addr.String())
+		nodes[i+1].Start(ctx)
+	}
+
+	// connect all nodes
+	for i := 0; i < len(nodes); i++ {
+		for j := 0; j < i; j++ {
+			node.ConnectNodes(t, nodes[i], nodes[j])
+		}
+	}
+
+	// start simulated mining and wait for shutdown
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				for _, nd := range nodes {
+					nd.Stop(ctx)
+				}
+				return
+			default:
+				fakeClock.Advance(blockTime)
+				_, err := bootstrapMiner.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+				require.NoError(t, err)
+			}
+		}
+	}()
+
+	return nodes, cancel
+}
+
+func initNodeGenesisMiner(t *testing.T, nd *node.Node, seed *node.ChainSeed, minerIdx int, presealPath string, sectorSize abi.SectorSize) (address.Address, address.Address, error) {
+	seed.GiveKey(t, nd, minerIdx)
+	miner, owner := seed.GiveMiner(t, nd, 0)
+
+	err := node.ImportPresealedSectors(nd.Repo, presealPath, sectorSize, true)
+	require.NoError(t, err)
+	return miner, owner, err
+}
+
+func loadGenesisConfig(t *testing.T, path string) *gengen.GenesisCfg {
+	configFile, err := os.Open(path)
+	if err != nil {
+		t.Errorf("failed to open config file %s: %s", path, err)
+	}
+	defer func() { _ = configFile.Close() }()
+
+	var cfg gengen.GenesisCfg
+	if err := json.NewDecoder(configFile).Decode(&cfg); err != nil {
+		t.Errorf("failed to parse config: %s", err)
+	}
+	return &cfg
+}

--- a/internal/pkg/message/outbox.go
+++ b/internal/pkg/message/outbox.go
@@ -164,7 +164,13 @@ func sendSignedMsg(ctx context.Context, ob *Outbox, signed *types.SignedMessage,
 		return cid.Undef, nil, errors.Wrap(err, "failed to add message to outbound queue")
 	}
 
-	c, err := signed.Cid()
+	var c cid.Cid
+	if signed.Message.From.Protocol() == address.BLS {
+		// drop signature before generating Cid to match cid of message retrieved from block.
+		c, err = signed.Message.Cid()
+	} else {
+		c, err = signed.Cid()
+	}
 	if err != nil {
 		return cid.Undef, nil, err
 	}


### PR DESCRIPTION
### Motivation

The miner create is the first real step towards creating functioning non-bootstrap miner. Unfortunately, it hasn't been working since the move to specs actors.

### Proposed changes

This PR resolves it's issues and adds an integration test. In the process, it introduces some new test infrastructure, `MustCreateNodesWithBootstrap`, that makes it simple to create a new in-process integration test that allows a node to send messages and receive mined blocks containing their receipts.

The bug fixes are:
1. The test needs to send sufficient gas.
2. CreateMiner is an operation on the power actor, but we were sending the message to the market actor.
3. The CreateMiner return type is now a struct containing the miner id address and the robust address instead of a single address.

I wanted to test that the miner's state actually appeared on chain, but the miner address stored in config is the robust address, not the miner id (for good reason). Actor addresses did not work in the state viewer. I added address resolution logic to fix this.