### PR TITLE
set-price and list-asks commands

### DIFF
--- a/cmd/go-filecoin/daemon.go
+++ b/cmd/go-filecoin/daemon.go
@@ -165,7 +165,7 @@ func RunAPIAndWait(ctx context.Context, nd *node.Node, config *config.APIConfig,
 	}
 
 	if nd.StorageProtocol != nil {
-		servenv.storageAPI = storage.NewAPI(nd.StorageProtocol.StorageClient, nd.PieceManager())
+		servenv.storageAPI = storage.NewAPI(nd.StorageProtocol.StorageClient, nd.StorageProtocol.StorageProvider, nd.PieceManager())
 	}
 
 	cfg := cmdhttp.NewServerConfig()

--- a/cmd/go-filecoin/daemon.go
+++ b/cmd/go-filecoin/daemon.go
@@ -10,6 +10,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/protocol/storage"
+
 	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	cmdhttp "github.com/ipfs/go-ipfs-cmds/http"
@@ -23,7 +25,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/config"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/journal"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/protocol/storage"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
 )
 
@@ -155,18 +156,7 @@ func getRepo(req *cmds.Request) (repo.Repo, error) {
 // saved to the node's repo.
 // A message sent to or closure of the `terminate` channel signals the server to stop.
 func RunAPIAndWait(ctx context.Context, nd *node.Node, config *config.APIConfig, ready chan interface{}, terminate chan os.Signal) error {
-	servenv := &Env{
-		blockMiningAPI: nd.BlockMining.BlockMiningAPI,
-		drandAPI:       nd.DrandAPI,
-		ctx:            ctx,
-		inspectorAPI:   NewInspectorAPI(nd.Repo),
-		porcelainAPI:   nd.PorcelainAPI,
-		retrievalAPI:   nd.RetrievalProtocol,
-	}
-
-	if nd.StorageProtocol != nil {
-		servenv.storageAPI = storage.NewAPI(nd.StorageProtocol.StorageClient, nd.StorageProtocol.StorageProvider, nd.PieceManager())
-	}
+	servenv := CreateServerEnv(ctx, nd)
 
 	cfg := cmdhttp.NewServerConfig()
 	cfg.APIPath = APIPrefix
@@ -223,4 +213,21 @@ func RunAPIAndWait(ctx context.Context, nd *node.Node, config *config.APIConfig,
 	}
 
 	return nil
+}
+
+func CreateServerEnv(ctx context.Context, nd *node.Node) *Env {
+	var storageAPI *storage.API
+	if nd.StorageProtocol != nil {
+		storageAPI = storage.NewAPI(nd.StorageProtocol.StorageClient, nd.StorageProtocol.StorageProvider, nd.PieceManager())
+	}
+
+	return &Env{
+		blockMiningAPI: nd.BlockMining.BlockMiningAPI,
+		drandAPI:       nd.DrandAPI,
+		ctx:            ctx,
+		inspectorAPI:   NewInspectorAPI(nd.Repo),
+		porcelainAPI:   nd.PorcelainAPI,
+		retrievalAPI:   nd.RetrievalProtocol,
+		storageAPI:     storageAPI,
+	}
 }

--- a/cmd/go-filecoin/miner_integration_test.go
+++ b/cmd/go-filecoin/miner_integration_test.go
@@ -1,0 +1,60 @@
+package commands_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
+	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+)
+
+func TestMinerCreateIntegration(t *testing.T) {
+	tf.IntegrationTest(t)
+
+	ctx := context.Background()
+	nodes, cancel := test.MustCreateNodesWithBootstrap(ctx, t, 1)
+	defer cancel()
+
+	newMiner := nodes[1]
+
+	defaultAddr := newMiner.Repo.Config().Wallet.DefaultAddress
+	peer := newMiner.Network().Network.GetPeerID()
+
+	minerAddr, err := newMiner.PorcelainAPI.MinerCreate(ctx, defaultAddr, types.NewAttoFILFromFIL(1), 10000, 2048, peer, types.NewAttoFILFromFIL(1))
+	require.NoError(t, err)
+
+	tsk := newMiner.Chain().ChainReader.GetHead()
+	status, err := newMiner.PorcelainAPI.MinerGetStatus(ctx, *minerAddr, tsk)
+	require.NoError(t, err)
+
+	view, err := newMiner.Chain().ActorState.StateView(tsk)
+	require.NoError(t, err)
+	resolvedDefaultAddress, err := view.InitResolveAddress(ctx, defaultAddr)
+	require.NoError(t, err)
+
+	assert.Equal(t, resolvedDefaultAddress, status.OwnerAddress)
+}
+
+func TestSetPrice(t *testing.T) {
+	tf.IntegrationTest(t)
+
+	ctx := context.Background()
+	nodes, cancel := test.MustCreateNodesWithBootstrap(ctx, t, 0)
+	defer cancel()
+
+	err := nodes[0].StorageProtocol.StorageProvider.AddAsk(abi.NewTokenAmount(1000), abi.ChainEpoch(400))
+	require.NoError(t, err)
+
+	minerAddr, err := nodes[0].BlockMining.BlockMiningAPI.MinerAddress()
+	require.NoError(t, err)
+
+	asks := nodes[0].StorageProtocol.StorageProvider.ListAsks(minerAddr)
+	require.Len(t, asks, 1)
+	assert.Equal(t, abi.NewTokenAmount(1000), asks[0].Ask.Price)
+	assert.Equal(t, abi.ChainEpoch(400), asks[0].Ask.Expiry)
+}

--- a/internal/app/go-filecoin/porcelain/api.go
+++ b/internal/app/go-filecoin/porcelain/api.go
@@ -3,7 +3,6 @@ package porcelain
 import (
 	"context"
 	"io"
-	"math/big"
 	"time"
 
 	"github.com/filecoin-project/go-address"
@@ -89,11 +88,6 @@ func (a *API) MinerPreviewCreate(
 // MinerGetStatus queries for status of a miner.
 func (a *API) MinerGetStatus(ctx context.Context, minerAddr address.Address, baseKey block.TipSetKey) (MinerStatus, error) {
 	return MinerGetStatus(ctx, a, minerAddr, baseKey)
-}
-
-// MinerSetPrice configures the price of storage. See implementation for details.
-func (a *API) MinerSetPrice(ctx context.Context, from address.Address, miner address.Address, gasPrice types.AttoFIL, gasLimit gas.Unit, price types.AttoFIL, expiry *big.Int) (MinerSetPriceResponse, error) {
-	panic("implement me in terms of the storage market module")
 }
 
 // ProtocolParameters fetches the current protocol configuration parameters.

--- a/internal/app/go-filecoin/porcelain/api.go
+++ b/internal/app/go-filecoin/porcelain/api.go
@@ -106,11 +106,6 @@ func (a *API) WalletDefaultAddress() (address.Address, error) {
 	return WalletDefaultAddress(a)
 }
 
-// ClientListAsks returns a channel with asks from the latest chain state
-func (a *API) ClientListAsks(ctx context.Context) <-chan Ask {
-	panic("implement me in terms of the storage market module")
-}
-
 // SealPieceIntoNewSector writes the provided piece into a new sector
 func (a *API) SealPieceIntoNewSector(ctx context.Context, dealID abi.DealID, dealStart, dealEnd abi.ChainEpoch, pieceSize uint64, pieceReader io.Reader) error {
 	return SealPieceIntoNewSector(ctx, a, dealID, dealStart, dealEnd, pieceSize, pieceReader)

--- a/internal/app/go-filecoin/porcelain/miner_test.go
+++ b/internal/app/go-filecoin/porcelain/miner_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/plumbing/cfg"
 	. "github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
@@ -136,33 +135,6 @@ func TestMinerCreate(t *testing.T) {
 		)
 		assert.Error(t, err, "Test Error")
 	})
-}
-
-func TestMinerCreateIntegration(t *testing.T) {
-	tf.IntegrationTest(t)
-
-	ctx := context.Background()
-	nodes, cancel := test.MustCreateNodesWithBootstrap(ctx, t, 1)
-	defer cancel()
-
-	newMiner := nodes[1]
-
-	defaultAddr := newMiner.Repo.Config().Wallet.DefaultAddress
-	peer := newMiner.Network().Network.GetPeerID()
-
-	minerAddr, err := newMiner.PorcelainAPI.MinerCreate(ctx, defaultAddr, types.NewAttoFILFromFIL(1), 10000, 2048, peer, types.NewAttoFILFromFIL(1))
-	require.NoError(t, err)
-
-	tsk := newMiner.Chain().ChainReader.GetHead()
-	status, err := newMiner.PorcelainAPI.MinerGetStatus(ctx, *minerAddr, tsk)
-	require.NoError(t, err)
-
-	view, err := newMiner.Chain().ActorState.StateView(tsk)
-	require.NoError(t, err)
-	resolvedDefaultAddress, err := view.InitResolveAddress(ctx, defaultAddr)
-	require.NoError(t, err)
-
-	assert.Equal(t, resolvedDefaultAddress, status.OwnerAddress)
 }
 
 type mStatusPlumbing struct {

--- a/internal/pkg/protocol/storage/api.go
+++ b/internal/pkg/protocol/storage/api.go
@@ -3,22 +3,36 @@ package storage
 import (
 	"context"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/piecemanager"
+	"github.com/filecoin-project/specs-actors/actors/abi"
 )
 
 // API is the storage API for the test environment
 type API struct {
-	storage      storagemarket.StorageClient
+	storageClient   storagemarket.StorageClient
+	storageProvider storagemarket.StorageProvider
+
 	piecemanager piecemanager.PieceManager
 }
 
 // NewAPI creates a new API
-func NewAPI(s storagemarket.StorageClient, pm piecemanager.PieceManager) *API {
-	return &API{s, pm}
+func NewAPI(s storagemarket.StorageClient, sp storagemarket.StorageProvider, pm piecemanager.PieceManager) *API {
+	return &API{s, sp, pm}
 }
 
 // PledgeSector creates a new, empty sector and seals it.
 func (api *API) PledgeSector(ctx context.Context) error {
 	return api.piecemanager.PledgeSector(ctx)
+}
+
+// AddAsk stores a new price for storage
+func (api *API) AddAsk(price abi.TokenAmount, duration abi.ChainEpoch) error {
+	return api.storageProvider.AddAsk(price, duration)
+}
+
+// ListAsks lists all asks for the miner
+func (api *API) ListAsks(maddr address.Address) []*storagemarket.SignedStorageAsk {
+	return api.storageProvider.ListAsks(maddr)
 }


### PR DESCRIPTION
### Motivation

We're trying to build the UI back up to a working storage and retrieval flow.  This PR restores the set-price and list-asks command using the corresponding go-fil-storagemarket operations.

### Proposed changes

1. Add storage provider API to storageAPI for commands.
2. Implement `set-price` and `list-asks' commands, modifying parameters to fit the expectations of the storage provider methods (asks no longer go on chain and don't need, say, a gas price).
3. Move miner integration test from porcelain to commands.
4. Add a miner set-price integration test.
