### PR TITLE
client propose-deal

### DIFF
--- a/cmd/go-filecoin/client.go
+++ b/cmd/go-filecoin/client.go
@@ -98,14 +98,9 @@ var ClientProposeStorageDealCmd = &cmds.Command{
 		Tagline:          "Propose a storage deal with a storage miner",
 		ShortDescription: `Sends a storage deal proposal to a miner`,
 		LongDescription: `
-Send a storage deal proposal to a miner. IDs provided to this command should
-represent valid asks. Existing asks can be listed with the following command:
+Send a storage deal proposal to a miner.
 
-$ go-filecoin client list-asks
-
-See the miner command help text for more information on asks.
-
-Duration should be specified with the number of blocks for which to store the
+Start and end should be specified with the number of blocks for which to store the
 data. New blocks are generated about every 30 seconds, so the time given should
 be represented as a count of 30 second intervals. For example, 1 minute would
 be 2, 1 hour would be 120, and 1 day would be 2880.
@@ -116,7 +111,7 @@ be 2, 1 hour would be 120, and 1 day would be 2880.
 		cmdkit.StringArg("data", true, false, "CID of the data to be stored"),
 		cmdkit.StringArg("start", true, false, "Chain epoch at which deal should start"),
 		cmdkit.StringArg("end", true, false, "Chain epoch at which deal should end"),
-		cmdkit.StringArg("price", true, false, "Price of deal in FIL (e.g. 0.01)"),
+		cmdkit.StringArg("price", true, false, "Storage price per epoch of all data in FIL (e.g. 0.01)"),
 		cmdkit.StringArg("collateral", true, false, "Collateral of deal in FIL (e.g. 0.01)"),
 	},
 	Options: []cmdkit.Option{

--- a/cmd/go-filecoin/client.go
+++ b/cmd/go-filecoin/client.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
-	"github.com/filecoin-project/go-fil-markets/storagemarket/network"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/constants"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -200,7 +199,7 @@ be 2, 1 hour would be 120, and 1 day would be 2880.
 
 		return re.Emit(resp)
 	},
-	Type: network.Response{},
+	Type: storagemarket.ProposeStorageDealResult{},
 }
 
 var ClientQueryStorageDealCmd = &cmds.Command{
@@ -228,7 +227,7 @@ format is specified with the --enc flag.
 
 		return re.Emit(deal)
 	},
-	Type: network.SignedResponse{},
+	Type: storagemarket.ClientDeal{},
 }
 
 // VerifyStorageDealResult wraps the success in an interface type

--- a/cmd/go-filecoin/client.go
+++ b/cmd/go-filecoin/client.go
@@ -27,7 +27,7 @@ var clientCmd = &cmds.Command{
 		"cat":                  clientCatCmd,
 		"import":               clientImportDataCmd,
 		"propose-storage-deal": ClientProposeStorageDealCmd,
-		"query-storage-deal":   clientQueryStorageDealCmd,
+		"query-storage-deal":   ClientQueryStorageDealCmd,
 		"verify-storage-deal":  clientVerifyStorageDealCmd,
 		"list-asks":            clientListAsksCmd,
 	},
@@ -208,7 +208,7 @@ be 2, 1 hour would be 120, and 1 day would be 2880.
 	Type: network.Response{},
 }
 
-var clientQueryStorageDealCmd = &cmds.Command{
+var ClientQueryStorageDealCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Query a storage deal's status",
 		ShortDescription: `
@@ -221,19 +221,17 @@ format is specified with the --enc flag.
 		cmdkit.StringArg("id", true, false, "CID of deal to query"),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
-		panic("not implemented pending full storage market integration")
+		dealCID, err := cid.Decode(req.Arguments[0])
+		if err != nil {
+			return errors.Wrap(err, "could not decode deal cid")
+		}
 
-		//propcid, err := cid.Decode(req.Arguments[0])
-		//if err != nil {
-		//	return err
-		//}
-		//
-		//resp, err := GetStorageAPI(env).QueryStorageDeal(req.Context, propcid)
-		//if err != nil {
-		//	return err
-		//}
-		//
-		//return re.Emit(resp)
+		deal, err := GetStorageAPI(env).GetStorageDeal(req.Context, dealCID)
+		if err != nil {
+			return err
+		}
+
+		return re.Emit(deal)
 	},
 	Type: network.SignedResponse{},
 }

--- a/cmd/go-filecoin/client_integration_test.go
+++ b/cmd/go-filecoin/client_integration_test.go
@@ -40,7 +40,10 @@ func TestProposeDeal(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add enough funds (1 FIL) for client and miner to to cover deal
-	err = miner.StorageProtocol.Provider().AddStorageCollateral(ctx, types.NewAttoFILFromFIL(1))
+	provider, err := miner.StorageProtocol.Provider()
+	require.NoError(t, err)
+
+	err = provider.AddStorageCollateral(ctx, types.NewAttoFILFromFIL(1))
 	require.NoError(t, err)
 	err = client.StorageProtocol.Client().AddPaymentEscrow(ctx, clientAddr, types.NewAttoFILFromFIL(1))
 	require.NoError(t, err)

--- a/cmd/go-filecoin/client_integration_test.go
+++ b/cmd/go-filecoin/client_integration_test.go
@@ -1,0 +1,87 @@
+package commands_test
+
+import (
+	"context"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	commands "github.com/filecoin-project/go-filecoin/cmd/go-filecoin"
+	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
+	cmds "github.com/ipfs/go-ipfs-cmds"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
+	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
+)
+
+func TestProposeDeal(t *testing.T) {
+	tf.IntegrationTest(t)
+
+	// setup 2 nodes: bootstrap, client
+	// bootstrap: miner stats
+	// client: create file, import file, get cid
+	// client; propose storage deal
+
+	ctx := context.Background()
+	nodes, cancel := test.MustCreateNodesWithBootstrap(ctx, t, 1)
+	defer cancel()
+
+	miner := nodes[0]
+
+	maddr, err := miner.BlockMining.BlockMiningAPI.MinerAddress()
+	require.NoError(t, err)
+
+	mstats, err := miner.PorcelainAPI.MinerGetStatus(ctx, maddr, miner.PorcelainAPI.ChainHeadKey())
+	require.NoError(t, err)
+
+	client := nodes[1]
+
+	// create a temp file to import
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "test_propose_deal-")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	// Example writing to the file
+	if _, err = tmpFile.Write([]byte("he was way behind and he was in a bind and willing to make a deal.")); err != nil {
+		log.Fatal("Failed to write to temporary file", err)
+	}
+
+	node, err := client.PorcelainAPI.DAGImportData(ctx, tmpFile)
+	require.NoError(t, err)
+
+	req, err := cmds.NewRequest(ctx, []string{"client", "propose-storage-deal"}, cmdkit.OptMap{}, []string{
+		mstats.ActorAddress.String(),
+		node.Cid().String(),
+		"1000",
+		"2000",
+		".0001",
+		"1",
+	}, nil, commands.RootCmd)
+	require.NoError(t, err)
+
+	emitter := &TestEmitter{}
+	err = commands.ClientProposeStorageDealCmd.Run(req, emitter, commands.CreateServerEnv(ctx, client))
+	require.NoError(t, err)
+	require.NoError(t, emitter.err)
+}
+
+type TestEmitter struct {
+	value interface{}
+	err   error
+}
+
+func (t *TestEmitter) SetLength(_ uint64) {}
+func (t *TestEmitter) Close() error       { return nil }
+
+func (t *TestEmitter) CloseWithError(err error) error {
+	t.err = err
+	return nil
+}
+
+func (t *TestEmitter) Emit(value interface{}) error {
+	t.value = value
+	return nil
+}

--- a/cmd/go-filecoin/client_integration_test.go
+++ b/cmd/go-filecoin/client_integration_test.go
@@ -62,6 +62,7 @@ func TestProposeDeal(t *testing.T) {
 		".0000000000001",
 		"1",
 	)
+	require.NoError(t, err)
 	res := out.(*storagemarket.ProposeStorageDealResult)
 
 	// wait for deal to process
@@ -71,9 +72,15 @@ func TestProposeDeal(t *testing.T) {
 
 		deal := out.(storagemarket.ClientDeal)
 		switch deal.State {
-		case storagemarket.StorageDealUnknown, storagemarket.StorageDealValidating:
+		case storagemarket.StorageDealUnknown,
+			storagemarket.StorageDealValidating:
 			time.Sleep(1 * time.Second) // in progress, wait and continue
-		case storagemarket.StorageDealProposalAccepted:
+		case storagemarket.StorageDealProposalAccepted,
+			storagemarket.StorageDealStaged,
+			storagemarket.StorageDealSealing,
+			storagemarket.StorageDealActive:
+
+			// Deal accepted. Test passed.
 			return
 		default:
 			t.Errorf("unexpected state: %d %s", deal.State, deal.Message)

--- a/cmd/go-filecoin/daemon.go
+++ b/cmd/go-filecoin/daemon.go
@@ -10,8 +10,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/protocol/storage"
-
 	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	cmdhttp "github.com/ipfs/go-ipfs-cmds/http"
@@ -223,6 +221,6 @@ func CreateServerEnv(ctx context.Context, nd *node.Node) *Env {
 		inspectorAPI:   NewInspectorAPI(nd.Repo),
 		porcelainAPI:   nd.PorcelainAPI,
 		retrievalAPI:   nd.RetrievalProtocol,
-		storageAPI:     storage.NewAPI(nd.StorageProtocol),
+		storageAPI:     nd.StorageAPI,
 	}
 }

--- a/cmd/go-filecoin/daemon.go
+++ b/cmd/go-filecoin/daemon.go
@@ -216,11 +216,6 @@ func RunAPIAndWait(ctx context.Context, nd *node.Node, config *config.APIConfig,
 }
 
 func CreateServerEnv(ctx context.Context, nd *node.Node) *Env {
-	var storageAPI *storage.API
-	if nd.StorageProtocol != nil {
-		storageAPI = storage.NewAPI(nd.StorageProtocol.StorageClient, nd.StorageProtocol.StorageProvider, nd.PieceManager())
-	}
-
 	return &Env{
 		blockMiningAPI: nd.BlockMining.BlockMiningAPI,
 		drandAPI:       nd.DrandAPI,
@@ -228,6 +223,6 @@ func CreateServerEnv(ctx context.Context, nd *node.Node) *Env {
 		inspectorAPI:   NewInspectorAPI(nd.Repo),
 		porcelainAPI:   nd.PorcelainAPI,
 		retrievalAPI:   nd.RetrievalProtocol,
-		storageAPI:     storageAPI,
+		storageAPI:     storage.NewAPI(nd.StorageProtocol),
 	}
 }

--- a/cmd/go-filecoin/main.go
+++ b/cmd/go-filecoin/main.go
@@ -113,7 +113,7 @@ func init() {
 }
 
 // command object for the local cli
-var rootCmd = &cmds.Command{
+var RootCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "A decentralized storage network",
 		Subcommands: `
@@ -221,18 +221,18 @@ var rootSubcmdsDaemon = map[string]*cmds.Command{
 
 func init() {
 	for k, v := range rootSubcmdsLocal {
-		rootCmd.Subcommands[k] = v
+		RootCmd.Subcommands[k] = v
 	}
 
 	for k, v := range rootSubcmdsDaemon {
-		rootCmd.Subcommands[k] = v
+		RootCmd.Subcommands[k] = v
 		rootCmdDaemon.Subcommands[k] = v
 	}
 }
 
 // Run processes the arguments and stdin
 func Run(ctx context.Context, args []string, stdin, stdout, stderr *os.File) (int, error) {
-	err := cli.Run(ctx, rootCmd, args, stdin, stdout, stderr, buildEnv, makeExecutor)
+	err := cli.Run(ctx, RootCmd, args, stdin, stdout, stderr, buildEnv, makeExecutor)
 	if err == nil {
 		return 0, nil
 	}
@@ -297,7 +297,7 @@ func makeExecutor(req *cmds.Request, env interface{}) (cmds.Executor, error) {
 
 	return &executor{
 		api:  api,
-		exec: cmds.NewExecutor(rootCmd),
+		exec: cmds.NewExecutor(RootCmd),
 	}, nil
 }
 

--- a/cmd/go-filecoin/main_test.go
+++ b/cmd/go-filecoin/main_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
-	"github.com/ipfs/go-ipfs-cmds"
+	cmds "github.com/ipfs/go-ipfs-cmds"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,11 +16,11 @@ func TestRequiresDaemon(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, requiresDaemon(reqWithDaemon))
 
-	reqWithoutDaemon, err := cmds.NewRequest(context.Background(), []string{"daemon"}, nil, []string{}, nil, rootCmd)
+	reqWithoutDaemon, err := cmds.NewRequest(context.Background(), []string{"daemon"}, nil, []string{}, nil, RootCmd)
 	assert.NoError(t, err)
 	assert.False(t, requiresDaemon(reqWithoutDaemon))
 
-	reqSubcmdDaemon, err := cmds.NewRequest(context.Background(), []string{"leb128", "decode"}, nil, []string{"A=="}, nil, rootCmd)
+	reqSubcmdDaemon, err := cmds.NewRequest(context.Background(), []string{"leb128", "decode"}, nil, []string{"A=="}, nil, RootCmd)
 	assert.NoError(t, err)
 	assert.False(t, requiresDaemon(reqSubcmdDaemon))
 }

--- a/cmd/go-filecoin/miner_integration_test.go
+++ b/cmd/go-filecoin/miner_integration_test.go
@@ -60,7 +60,8 @@ func TestSetPrice(t *testing.T) {
 	minerAddr, err := commands.GetBlockAPI(env).MinerAddress()
 	require.NoError(t, err)
 
-	asks := commands.GetStorageAPI(env).ListAsks(minerAddr)
+	asks, err := commands.GetStorageAPI(env).ListAsks(minerAddr)
+	require.NoError(t, err)
 	require.Len(t, asks, 1)
 	assert.Equal(t, abi.NewTokenAmount(1000), asks[0].Ask.Price)
 	assert.Equal(t, abi.ChainEpoch(400), asks[0].Ask.Expiry)

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/libp2p/go-libp2p-circuit v0.1.4
 	github.com/libp2p/go-libp2p-core v0.3.0
 	github.com/libp2p/go-libp2p-kad-dht v0.1.1
+	github.com/libp2p/go-libp2p-peer v0.2.0
 	github.com/libp2p/go-libp2p-peerstore v0.1.4
 	github.com/libp2p/go-libp2p-pubsub v0.2.5
 	github.com/libp2p/go-libp2p-swarm v0.2.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.4.12 // indirect
-	github.com/benbjohnson/clock v1.0.0 // indirect
 	github.com/cskr/pubsub v1.0.2
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v0.7.3-0.20190315170154-87d593639c77
@@ -65,14 +64,12 @@ require (
 	github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52
 	github.com/jbenet/goprocess v0.1.3
 	github.com/jstemmer/go-junit-report v0.9.1
-	github.com/kilic/bls12-381 v0.0.0-20191103193557-038659eaa189 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/libp2p/go-libp2p v0.5.2
 	github.com/libp2p/go-libp2p-autonat-svc v0.1.0
 	github.com/libp2p/go-libp2p-circuit v0.1.4
 	github.com/libp2p/go-libp2p-core v0.3.0
 	github.com/libp2p/go-libp2p-kad-dht v0.1.1
-	github.com/libp2p/go-libp2p-peer v0.2.0
 	github.com/libp2p/go-libp2p-peerstore v0.1.4
 	github.com/libp2p/go-libp2p-pubsub v0.2.5
 	github.com/libp2p/go-libp2p-swarm v0.2.2
@@ -102,7 +99,6 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.5.0 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/urfave/cli v1.22.2 // indirect
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200206220010-03c9665e2a66
 	github.com/whyrusleeping/go-logging v0.0.1
 	github.com/whyrusleeping/go-sysinfo v0.0.0-20190219211824-4a357d4b90b1

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/filecoin-project/filecoin-ffi v0.0.0-20200304181354-4446ff8a1bb9
 	github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be
 	github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e
+	github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v0.0.0-20191219005021-4accf56bd2ce
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,6 @@ github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQY
 github.com/apache/thrift v0.12.0 h1:pODnxUFNcjP9UTLZGTdeh+j16A8lJbRvD3rOtrk/7bs=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/benbjohnson/clock v1.0.0 h1:78Jk/r6m4wCi6sndMpty7A//t4dw/RW5fV4ZgDVfX1w=
-github.com/benbjohnson/clock v1.0.0/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
@@ -128,17 +126,11 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.3.3 h1:Xk8S3Xj5sLGlG5g67hJmYMmUgXv5N4PhkjJHHqrwnTk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/drand/bls12-381 v0.0.0-20200110233355-faca855b3a67 h1:+zwFBPeS6Tx0ShngG44wyJ8wBh8ENK9upPxN2fE58Uc=
-github.com/drand/bls12-381 v0.0.0-20200110233355-faca855b3a67/go.mod h1:HRtP9ULniFcAfoXvSrD5Kebk1e3/g4cvtBfjlT80PuQ=
 github.com/drand/bls12-381 v0.2.0 h1:nsHrbHaz5Ys0OwAdWERn49hRSkoWUr7lwXrT+ZRLybY=
 github.com/drand/bls12-381 v0.2.0/go.mod h1:dtcLgPtYT38L3NO6mPDYH0nbpc5tjPassDqiniuAt4Y=
-github.com/drand/drand v0.5.5-0.20200404170830-998c611fb395 h1:o8JJheqgJhhz1UGtbOUhRIOYI4kffWU9+wuJu0rZVj4=
-github.com/drand/drand v0.5.5-0.20200404170830-998c611fb395/go.mod h1:n9JV/s1TIL/kx/4002pct7qjilbdzScQKVu05IfHf8c=
 github.com/drand/drand v0.7.2 h1:y18ZS0UgIvZVhKiib0rOYn0Gn3ZlZ8zicW20UmE3404=
 github.com/drand/drand v0.7.2/go.mod h1:fsPW9+Vl3h4/6Gjjt2ZNJc+fjo1lJeqbBcG0t8MCoxo=
 github.com/drand/kyber v1.0.1-0.20200110225416-8de27ed8c0e2/go.mod h1:UpXoA0Upd1N9l4TvRPHr1qAUBBERj6JQ/mnKI3BPEmw=
-github.com/drand/kyber v1.0.1-0.20200128205555-52819dbafde7 h1:ItV7+85W8JU5bQd/DxjT9y5Khsetlrp9CErHvDtYlE4=
-github.com/drand/kyber v1.0.1-0.20200128205555-52819dbafde7/go.mod h1:Rzu9PGFt3q8d7WWdrHmR8dktHucO0dSTWlMYrgqjSpA=
 github.com/drand/kyber v1.0.1-0.20200331114745-30e90cc60f99 h1:BxLbcT0yq9ii6ShXn7U+0oXB2ABfEfw6GutaVPxoj2Y=
 github.com/drand/kyber v1.0.1-0.20200331114745-30e90cc60f99/go.mod h1:Rzu9PGFt3q8d7WWdrHmR8dktHucO0dSTWlMYrgqjSpA=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
@@ -346,8 +338,6 @@ github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.m
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
-github.com/grpc-ecosystem/grpc-gateway v1.12.1 h1:zCy2xE9ablevUOrUZc3Dl72Dt+ya2FNAvC2yLYMHzi4=
-github.com/grpc-ecosystem/grpc-gateway v1.12.1/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
 github.com/grpc-ecosystem/grpc-gateway v1.14.3 h1:OCJlWkOUoTnl0neNGlf4fUm3TmbEtguw7vR+nGtnDjY=
 github.com/grpc-ecosystem/grpc-gateway v1.14.3/go.mod h1:6CwZWGDSPRJidgKAtJVvND6soZe6fT7iteq8wDPdhb0=
 github.com/gxed/go-shellwords v1.0.3 h1:2TP32H4TAklZUdz84oj95BJhVnIrRasyx2j1cqH5K38=
@@ -580,7 +570,6 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3 h1:Iy7Ifq2ysilWU4QlCx/97OoI4xT1IV7i8byT/EyIT/M=
 github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3/go.mod h1:BYpt4ufZiIGv2nXn4gMxnfKV306n3mWXgNu/d2TqdTU=
 github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=
-github.com/kilic/bls12-381 v0.0.0-20191103193557-038659eaa189/go.mod h1:INznczsRc7ASFbWFUI9GnIvpi9s2FhenKE+24rdTmBQ=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
@@ -1127,8 +1116,6 @@ github.com/ultraware/whitespace v0.0.4 h1:If7Va4cM03mpgrNH9k49/VOicWpGoG70XPBFFO
 github.com/ultraware/whitespace v0.0.4/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89uZnzAmWSineA=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
-github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
-github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.0.0 h1:+HU9SCbu8GnEUFtIBfuUNXN39ofWViIEJIp6SURMpCg=
 github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
@@ -1247,8 +1234,6 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
-golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200406173513-056763e48d71 h1:DOmugCavvUtnUD114C1Wh+UgTgQZ4pMLzXxi1pSt+/Y=
 golang.org/x/crypto v0.0.0-20200406173513-056763e48d71/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1348,8 +1333,6 @@ golang.org/x/sys v0.0.0-20191025090151-53bf42e6b339/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 h1:gSbV7h1NRL2G1xTg/owz62CST1oJBmxy4QpMMregXVQ=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200219091948-cb0a6d8edb6c h1:jceGD5YNJGgGMkJz79agzOln1K9TaZUjv5ird16qniQ=
-golang.org/x/sys v0.0.0-20200219091948-cb0a6d8edb6c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200409092240-59c9f1ba88fa h1:mQTN3ECqfsViCNBgq+A40vdwhkGykrrQlYe3mPj6BoU=
 golang.org/x/sys v0.0.0-20200409092240-59c9f1ba88fa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
@@ -1424,8 +1407,6 @@ google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873 h1:nfPFGzJkUDX6uBm
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
-google.golang.org/genproto v0.0.0-20200117163144-32f20d992d24 h1:wDju+RU97qa0FZT0QnZDg9Uc2dH0Ql513kFvHocz+WM=
-google.golang.org/genproto v0.0.0-20200117163144-32f20d992d24/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20200406120821-33397c535dc2 h1:KlOjjpQjL4dqscfbhtQvAnRMm5PaRTchHHczffkUiq0=
 google.golang.org/genproto v0.0.0-20200406120821-33397c535dc2/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
@@ -1437,8 +1418,6 @@ google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.24.0 h1:vb/1TCsVn3DcJlQ0Gs1yB1pKI6Do2/QNwxdKqmc/b0s=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
-google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
-google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
@@ -1467,8 +1446,6 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
-gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=

--- a/internal/app/go-filecoin/connectors/storage_market/client.go
+++ b/internal/app/go-filecoin/connectors/storage_market/client.go
@@ -259,7 +259,7 @@ func (s *StorageClientNodeConnector) OnDealSectorCommitted(ctx context.Context, 
 			return false
 		}
 
-		if msg.Message.Method != abi.MethodNum(builtin.MethodsMiner.ProveCommitSector) {
+		if msg.Message.Method != builtin.MethodsMiner.ProveCommitSector {
 			return false
 		}
 

--- a/internal/app/go-filecoin/connectors/storage_market/client.go
+++ b/internal/app/go-filecoin/connectors/storage_market/client.go
@@ -3,6 +3,8 @@ package storagemarketconnector
 import (
 	"context"
 
+	cborutil "github.com/filecoin-project/go-cbor-util"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
@@ -148,7 +150,12 @@ func (s *StorageClientNodeConnector) ValidatePublishedDeal(ctx context.Context, 
 
 	unsigned := chnMsg.Message.Message
 
-	minerWorker, err := s.GetMinerWorkerAddress(ctx, deal.Proposal.Provider, nil)
+	tok, err := encoding.Encode(s.chainStore.Head())
+	if err != nil {
+		return 0, err
+	}
+
+	minerWorker, err := s.GetMinerWorkerAddress(ctx, deal.Proposal.Provider, tok)
 	if err != nil {
 		return 0, err
 	}
@@ -191,7 +198,7 @@ func (s *StorageClientNodeConnector) ValidatePublishedDeal(ctx context.Context, 
 
 // SignProposal uses the local wallet to sign the given proposal
 func (s *StorageClientNodeConnector) SignProposal(ctx context.Context, signer address.Address, proposal market.DealProposal) (*market.ClientDealProposal, error) {
-	buf, err := encoding.Encode(proposal)
+	buf, err := cborutil.Dump(&proposal)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/go-filecoin/connectors/storage_market/common.go
+++ b/internal/app/go-filecoin/connectors/storage_market/common.go
@@ -95,7 +95,7 @@ func (c *connectorCommon) addFunds(ctx context.Context, fromAddr address.Address
 		builtin.StorageMarketActorAddr,
 		types.NewAttoFIL(amount.Int),
 		types.NewGasPrice(1),
-		gas.NewGas(300),
+		gas.NewGas(5000),
 		true,
 		builtin.MethodsMarket.AddBalance,
 		&addr,
@@ -127,12 +127,21 @@ func (c *connectorCommon) GetBalance(ctx context.Context, addr address.Address, 
 		return storagemarket.Balance{}, err
 	}
 
-	available, err := c.getBalance(ctx, smState.EscrowTable, addr)
+	view, err := c.chainStore.StateView(tsk)
+	if err != nil {
+		return storagemarket.Balance{}, err
+	}
+	resAddr, err := view.InitResolveAddress(ctx, addr)
 	if err != nil {
 		return storagemarket.Balance{}, err
 	}
 
-	locked, err := c.getBalance(ctx, smState.LockedTable, addr)
+	available, err := c.getBalance(ctx, smState.EscrowTable, resAddr)
+	if err != nil {
+		return storagemarket.Balance{}, err
+	}
+
+	locked, err := c.getBalance(ctx, smState.LockedTable, resAddr)
 	if err != nil {
 		return storagemarket.Balance{}, err
 	}

--- a/internal/app/go-filecoin/connectors/storage_market/provider.go
+++ b/internal/app/go-filecoin/connectors/storage_market/provider.go
@@ -60,7 +60,12 @@ func NewStorageProviderNodeConnector(ma address.Address,
 
 // AddFunds sends a message to add storage market collateral for the given address
 func (s *StorageProviderNodeConnector) AddFunds(ctx context.Context, addr address.Address, amount abi.TokenAmount) error {
-	workerAddr, err := s.GetMinerWorkerAddress(ctx, s.minerAddr, nil)
+	tok, err := encoding.Encode(s.chainStore.Head())
+	if err != nil {
+		return err
+	}
+
+	workerAddr, err := s.GetMinerWorkerAddress(ctx, s.minerAddr, tok)
 	if err != nil {
 		return err
 	}
@@ -87,7 +92,12 @@ func (s *StorageProviderNodeConnector) EnsureFunds(ctx context.Context, addr, wa
 func (s *StorageProviderNodeConnector) PublishDeals(ctx context.Context, deal storagemarket.MinerDeal) (abi.DealID, cid.Cid, error) {
 	params := market.PublishStorageDealsParams{Deals: []market.ClientDealProposal{deal.ClientDealProposal}}
 
-	workerAddr, err := s.GetMinerWorkerAddress(ctx, s.minerAddr, nil)
+	tok, err := encoding.Encode(s.chainStore.Head())
+	if err != nil {
+		return 0, cid.Undef, err
+	}
+
+	workerAddr, err := s.GetMinerWorkerAddress(ctx, s.minerAddr, tok)
 	if err != nil {
 		return 0, cid.Undef, err
 	}
@@ -98,7 +108,7 @@ func (s *StorageProviderNodeConnector) PublishDeals(ctx context.Context, deal st
 		builtin.StorageMarketActorAddr,
 		types.ZeroAttoFIL,
 		types.NewGasPrice(1),
-		gas.NewGas(300),
+		gas.NewGas(10000),
 		true,
 		builtin.MethodsMarket.PublishStorageDeals,
 		&params,

--- a/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
@@ -57,7 +57,10 @@ func NewStorageProtocolSubmodule(
 	cnode := storagemarketconnector.NewStorageClientNodeConnector(cborutil.NewIpldStore(bs), c.State, mw, s, m.Outbox, clientAddr, stateViewer)
 
 	dt := graphsyncimpl.NewGraphSyncDataTransfer(h, gsync)
-	dt.RegisterVoucherType(reflect.TypeOf(&smvalid.StorageDataTransferVoucher{}), smvalid.NewClientRequestValidator(statestore.New(ds)))
+	err := dt.RegisterVoucherType(reflect.TypeOf(&smvalid.StorageDataTransferVoucher{}), smvalid.NewClientRequestValidator(statestore.New(ds)))
+	if err != nil {
+		return nil, err
+	}
 
 	client, err := impl.NewClient(smnetwork.NewFromLibp2pHost(h), bs, dt, discovery.NewLocal(ds), ds, cnode)
 	if err != nil {
@@ -106,7 +109,10 @@ func (sm *StorageProtocolSubmodule) AddStorageProvider(
 	}
 
 	dt := graphsyncimpl.NewGraphSyncDataTransfer(h, gsync)
-	dt.RegisterVoucherType(reflect.TypeOf(&smvalid.StorageDataTransferVoucher{}), smvalid.NewProviderRequestValidator(statestore.New(ds)))
+	err = dt.RegisterVoucherType(reflect.TypeOf(&smvalid.StorageDataTransferVoucher{}), smvalid.NewProviderRequestValidator(statestore.New(ds)))
+	if err != nil {
+		return err
+	}
 
 	sm.StorageProvider, err = impl.NewProvider(smnetwork.NewFromLibp2pHost(h), ds, bs, fs, piecestore.NewPieceStore(ds), dt, pnode, minerAddr, sealProofType)
 	return err

--- a/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
@@ -118,14 +118,20 @@ func (sm *StorageProtocolSubmodule) AddStorageProvider(
 	return err
 }
 
-func (sm *StorageProtocolSubmodule) Provider() iface.StorageProvider {
-	return sm.StorageProvider
+func (sm *StorageProtocolSubmodule) Provider() (iface.StorageProvider, error) {
+	if sm.StorageProvider == nil {
+		return nil, errors.New("Mining has not been started so storage provider is not available")
+	}
+	return sm.StorageProvider, nil
 }
 
 func (sm *StorageProtocolSubmodule) Client() iface.StorageClient {
 	return sm.StorageClient
 }
 
-func (sm *StorageProtocolSubmodule) PieceManager() piecemanager.PieceManager {
-	return sm.pieceManager
+func (sm *StorageProtocolSubmodule) PieceManager() (piecemanager.PieceManager, error) {
+	if sm.StorageProvider == nil {
+		return nil, errors.New("Mining has not been started so piece manager is not available")
+	}
+	return sm.pieceManager, nil
 }

--- a/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
@@ -44,6 +44,7 @@ func NewStorageProtocolSubmodule(
 	mw *msg.Waiter,
 	s types.Signer,
 	h host.Host,
+	ds datastore.Batching,
 	bs blockstore.Blockstore,
 	gsync graphsync.GraphExchange,
 	stateViewer *appstate.Viewer,
@@ -52,7 +53,7 @@ func NewStorageProtocolSubmodule(
 
 	dt := graphsyncimpl.NewGraphSyncDataTransfer(h, gsync)
 
-	client, err := impl.NewClient(smnetwork.NewFromLibp2pHost(h), bs, dt, nil, nil, cnode)
+	client, err := impl.NewClient(smnetwork.NewFromLibp2pHost(h), bs, dt, nil, ds, cnode)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating storage client")
 	}

--- a/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
@@ -8,6 +8,7 @@ import (
 	graphsyncimpl "github.com/filecoin-project/go-data-transfer/impl/graphsync"
 	"github.com/filecoin-project/go-fil-markets/filestore"
 	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/discovery"
 	iface "github.com/filecoin-project/go-fil-markets/storagemarket"
 	impl "github.com/filecoin-project/go-fil-markets/storagemarket/impl"
 	smnetwork "github.com/filecoin-project/go-fil-markets/storagemarket/network"
@@ -53,7 +54,7 @@ func NewStorageProtocolSubmodule(
 
 	dt := graphsyncimpl.NewGraphSyncDataTransfer(h, gsync)
 
-	client, err := impl.NewClient(smnetwork.NewFromLibp2pHost(h), bs, dt, nil, ds, cnode)
+	client, err := impl.NewClient(smnetwork.NewFromLibp2pHost(h), bs, dt, discovery.NewLocal(ds), ds, cnode)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating storage client")
 	}

--- a/internal/app/go-filecoin/node/builder.go
+++ b/internal/app/go-filecoin/node/builder.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/protocol/storage"
+
 	"github.com/filecoin-project/go-filecoin/internal/pkg/state"
 
 	"github.com/filecoin-project/go-sectorbuilder"
@@ -289,6 +291,7 @@ func (b *Builder) build(ctx context.Context) (*Node, error) {
 		return nil, err
 	}
 
+	nd.StorageAPI = storage.NewAPI(nd.StorageProtocol)
 	nd.DrandAPI = drandapi.New(b.drand, nd.PorcelainAPI)
 
 	return nd, nil

--- a/internal/app/go-filecoin/node/builder.go
+++ b/internal/app/go-filecoin/node/builder.go
@@ -280,6 +280,7 @@ func (b *Builder) build(ctx context.Context) (*Node, error) {
 		waiter,
 		nd.Wallet.Signer,
 		nd.Host(),
+		nd.Repo.Datastore(),
 		nd.Blockstore.Blockstore,
 		nd.network.GraphExchange,
 		state.NewViewer(nd.Blockstore.CborStore),

--- a/internal/app/go-filecoin/node/builder.go
+++ b/internal/app/go-filecoin/node/builder.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/state"
+
 	"github.com/filecoin-project/go-sectorbuilder"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-merkledag"
@@ -248,6 +250,8 @@ func (b *Builder) build(ctx context.Context) (*Node, error) {
 		return nil, errors.Wrap(err, "failed to build node.BlockMining")
 	}
 
+	waiter := msg.NewWaiter(nd.chain.ChainReader, nd.chain.MessageStore, nd.Blockstore.Blockstore, nd.Blockstore.CborStore)
+
 	nd.PorcelainAPI = porcelain.New(plumbing.New(&plumbing.APIDeps{
 		Chain:        nd.chain.State,
 		Sync:         cst.NewChainSyncProvider(nd.syncer.ChainSyncManager),
@@ -256,12 +260,33 @@ func (b *Builder) build(ctx context.Context) (*Node, error) {
 		Expected:     nd.syncer.Consensus,
 		MsgPool:      nd.Messaging.MsgPool,
 		MsgPreviewer: msg.NewPreviewer(nd.chain.ChainReader, nd.Blockstore.CborStore, nd.Blockstore.Blockstore, nd.chain.Processor),
-		MsgWaiter:    msg.NewWaiter(nd.chain.ChainReader, nd.chain.MessageStore, nd.Blockstore.Blockstore, nd.Blockstore.CborStore),
+		MsgWaiter:    waiter,
 		Network:      nd.network.Network,
 		Outbox:       nd.Messaging.Outbox,
 		PieceManager: nd.PieceManager,
 		Wallet:       nd.Wallet.Wallet,
 	}))
+
+	addr, err := nd.PorcelainAPI.WalletDefaultAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	nd.StorageProtocol, err = submodule.NewStorageProtocolSubmodule(
+		ctx,
+		addr,
+		&nd.chain,
+		&nd.Messaging,
+		waiter,
+		nd.Wallet.Signer,
+		nd.Host(),
+		nd.Blockstore.Blockstore,
+		nd.network.GraphExchange,
+		state.NewViewer(nd.Blockstore.CborStore),
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	nd.DrandAPI = drandapi.New(b.drand, nd.PorcelainAPI)
 

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -405,6 +405,19 @@ func (node *Node) SetupMining(ctx context.Context) error {
 		}
 	}
 
+	if err := node.StorageMining.Start(ctx); err != nil {
+		fmt.Printf("error starting storage miner: %s\n", err)
+	}
+
+	if err := node.StorageProtocol.StorageProvider.Start(ctx); err != nil {
+		fmt.Printf("error starting storage provider: %s\n", err)
+	}
+
+	// TODO: Retrieval Market Integration
+	//if err := node.RetrievalProtocol.RetrievalProvider.Start(); err != nil {
+	//	fmt.Printf("error starting retrieval provider: %s\n", err)
+	//}
+
 	return nil
 }
 
@@ -595,19 +608,6 @@ func (node *Node) StartMining(ctx context.Context) error {
 	node.BlockMining.AddNewlyMinedBlock = node.addNewlyMinedBlock
 	node.BlockMining.MiningDoneWg.Add(1)
 	go node.handleNewMiningOutput(miningCtx, outCh)
-
-	if err := node.StorageMining.Start(ctx); err != nil {
-		fmt.Printf("error starting storage miner: %s\n", err)
-	}
-
-	if err := node.StorageProtocol.StorageProvider.Start(ctx); err != nil {
-		fmt.Printf("error starting storage provider: %s\n", err)
-	}
-
-	// TODO: Retrieval Market Integration
-	//if err := node.RetrievalProtocol.RetrievalProvider.Start(); err != nil {
-	//	fmt.Printf("error starting retrieval provider: %s\n", err)
-	//}
 
 	node.setIsMining(true)
 

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"runtime"
 
+	"github.com/filecoin-project/go-filecoin/internal/pkg/protocol/storage"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-sectorbuilder"
 	"github.com/filecoin-project/go-sectorbuilder/fs"
@@ -66,6 +68,7 @@ type Node struct {
 
 	PorcelainAPI *porcelain.API
 	DrandAPI     *drand.API
+	StorageAPI   *storage.API
 
 	//
 	// Core services
@@ -412,11 +415,6 @@ func (node *Node) SetupMining(ctx context.Context) error {
 	if err := node.StorageProtocol.StorageProvider.Start(ctx); err != nil {
 		fmt.Printf("error starting storage provider: %s\n", err)
 	}
-
-	// TODO: Retrieval Market Integration
-	//if err := node.RetrievalProtocol.RetrievalProvider.Start(); err != nil {
-	//	fmt.Printf("error starting retrieval provider: %s\n", err)
-	//}
 
 	return nil
 }

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -484,10 +484,9 @@ func (node *Node) setupStorageMining(ctx context.Context) error {
 		return err
 	}
 
-	node.StorageProtocol, err = submodule.NewStorageProtocolSubmodule(
+	return node.StorageProtocol.AddStorageProvider(
 		ctx,
 		minerAddr,
-		address.Undef, // TODO: This is for setting up mining, we need to pass the client address in if this is going to be a storage client also
 		&node.chain,
 		&node.Messaging,
 		waiter,
@@ -501,11 +500,6 @@ func (node *Node) setupStorageMining(ctx context.Context) error {
 		sectorBuilder.SealProofType(),
 		stateViewer,
 	)
-	if err != nil {
-		return errors.Wrap(err, "error initializing storage protocol")
-	}
-
-	return nil
 }
 
 func (node *Node) setupRetrievalMining(ctx context.Context) error {

--- a/internal/app/go-filecoin/node/test/setup.go
+++ b/internal/app/go-filecoin/node/test/setup.go
@@ -87,9 +87,6 @@ func MustCreateNodesWithBootstrap(ctx context.Context, t *testing.T, additionalN
 		for {
 			select {
 			case <-ctx.Done():
-				for _, nd := range nodes {
-					nd.Stop(ctx)
-				}
 				return
 			default:
 				fakeClock.Advance(blockTime)

--- a/internal/app/go-filecoin/node/test/setup.go
+++ b/internal/app/go-filecoin/node/test/setup.go
@@ -7,10 +7,6 @@ import (
 	"testing"
 	"time"
 
-	commands "github.com/filecoin-project/go-filecoin/cmd/go-filecoin"
-	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
-	cmds "github.com/ipfs/go-ipfs-cmds"
-
 	"github.com/filecoin-project/go-filecoin/build/project"
 
 	"github.com/filecoin-project/go-address"
@@ -99,22 +95,6 @@ func MustCreateNodesWithBootstrap(ctx context.Context, t *testing.T, additionalN
 	return nodes, cancel
 }
 
-func RunCommandInProcess(ctx context.Context, nd *node.Node, cmd *cmds.Command, optMap cmdkit.OptMap, args ...string) (interface{}, error) {
-	req, err := cmds.NewRequest(ctx, []string{}, optMap, args, nil, cmd)
-	if err != nil {
-		return nil, err
-	}
-	emitter := &testEmitter{}
-	err = cmd.Run(req, emitter, commands.CreateServerEnv(ctx, nd))
-	if err != nil {
-		return nil, err
-	}
-	if emitter.err != nil {
-		return nil, err
-	}
-	return emitter.value, nil
-}
-
 func initNodeGenesisMiner(t *testing.T, nd *node.Node, seed *node.ChainSeed, minerIdx int, presealPath string, sectorSize abi.SectorSize) (address.Address, address.Address, error) {
 	seed.GiveKey(t, nd, minerIdx)
 	miner, owner := seed.GiveMiner(t, nd, 0)
@@ -136,22 +116,4 @@ func loadGenesisConfig(t *testing.T, path string) *gengen.GenesisCfg {
 		t.Errorf("failed to parse config: %s", err)
 	}
 	return &cfg
-}
-
-type testEmitter struct {
-	value interface{}
-	err   error
-}
-
-func (t *testEmitter) SetLength(_ uint64) {}
-func (t *testEmitter) Close() error       { return nil }
-
-func (t *testEmitter) CloseWithError(err error) error {
-	t.err = err
-	return nil
-}
-
-func (t *testEmitter) Emit(value interface{}) error {
-	t.value = value
-	return nil
 }

--- a/internal/app/go-filecoin/node/test/setup.go
+++ b/internal/app/go-filecoin/node/test/setup.go
@@ -57,7 +57,7 @@ func MustCreateNodesWithBootstrap(ctx context.Context, t *testing.T, additionalN
 
 	nodes[0] = bootstrapMiner
 
-	// create addtiional nodes
+	// create additional nodes
 	for i := uint(0); i < additionalNodes; i++ {
 		node := NewNodeBuilder(t).
 			WithGenesisInit(seed.GenesisInitFunc).

--- a/internal/pkg/protocol/storage/api.go
+++ b/internal/pkg/protocol/storage/api.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/ipfs/go-cid"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/piecemanager"
@@ -69,4 +71,9 @@ func (api *API) ProposeStorageDeal(
 	rt abi.RegisteredProof,
 ) (*storagemarket.ProposeStorageDealResult, error) {
 	return api.storage.Client().ProposeStorageDeal(ctx, addr, info, data, startEpoch, endEpoch, price, collateral, rt)
+}
+
+// GetStorageDeal retrieves information about an in-progress deal
+func (api *API) GetStorageDeal(ctx context.Context, c cid.Cid) (storagemarket.ClientDeal, error) {
+	return api.storage.Client().GetInProgressDeal(ctx, c)
 }

--- a/internal/pkg/protocol/storage/api.go
+++ b/internal/pkg/protocol/storage/api.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"errors"
 
 	"github.com/ipfs/go-cid"
 
@@ -14,8 +13,8 @@ import (
 
 type storage interface {
 	Client() storagemarket.StorageClient
-	Provider() storagemarket.StorageProvider
-	PieceManager() piecemanager.PieceManager
+	Provider() (storagemarket.StorageProvider, error)
+	PieceManager() (piecemanager.PieceManager, error)
 }
 
 // API is the storage API for the test environment
@@ -30,9 +29,9 @@ func NewAPI(storage storage) *API {
 
 // PledgeSector creates a new, empty sector and seals it.
 func (api *API) PledgeSector(ctx context.Context) error {
-	pm := api.storage.PieceManager()
-	if pm == nil {
-		return errors.New("Piece manager not initialized")
+	pm, err := api.storage.PieceManager()
+	if err != nil {
+		return err
 	}
 
 	return pm.PledgeSector(ctx)
@@ -40,9 +39,9 @@ func (api *API) PledgeSector(ctx context.Context) error {
 
 // AddAsk stores a new price for storage
 func (api *API) AddAsk(price abi.TokenAmount, duration abi.ChainEpoch) error {
-	provider := api.storage.Provider()
-	if provider == nil {
-		return errors.New("Storage provider not initialized")
+	provider, err := api.storage.Provider()
+	if err != nil {
+		return err
 	}
 
 	return provider.AddAsk(price, duration)
@@ -50,9 +49,9 @@ func (api *API) AddAsk(price abi.TokenAmount, duration abi.ChainEpoch) error {
 
 // ListAsks lists all asks for the miner
 func (api *API) ListAsks(maddr address.Address) ([]*storagemarket.SignedStorageAsk, error) {
-	provider := api.storage.Provider()
-	if provider == nil {
-		return nil, errors.New("Storage provider not initialized")
+	provider, err := api.storage.Provider()
+	if err != nil {
+		return nil, err
 	}
 
 	return provider.ListAsks(maddr), nil

--- a/internal/pkg/protocol/storage/api.go
+++ b/internal/pkg/protocol/storage/api.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
@@ -9,30 +10,63 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 )
 
+type storage interface {
+	Client() storagemarket.StorageClient
+	Provider() storagemarket.StorageProvider
+	PieceManager() piecemanager.PieceManager
+}
+
 // API is the storage API for the test environment
 type API struct {
-	storageClient   storagemarket.StorageClient
-	storageProvider storagemarket.StorageProvider
-
-	piecemanager piecemanager.PieceManager
+	storage storage
 }
 
 // NewAPI creates a new API
-func NewAPI(s storagemarket.StorageClient, sp storagemarket.StorageProvider, pm piecemanager.PieceManager) *API {
-	return &API{s, sp, pm}
+func NewAPI(storage storage) *API {
+	return &API{storage}
 }
 
 // PledgeSector creates a new, empty sector and seals it.
 func (api *API) PledgeSector(ctx context.Context) error {
-	return api.piecemanager.PledgeSector(ctx)
+	pm := api.storage.PieceManager()
+	if pm == nil {
+		return errors.New("Piece manager not initialized")
+	}
+
+	return pm.PledgeSector(ctx)
 }
 
 // AddAsk stores a new price for storage
 func (api *API) AddAsk(price abi.TokenAmount, duration abi.ChainEpoch) error {
-	return api.storageProvider.AddAsk(price, duration)
+	provider := api.storage.Provider()
+	if provider == nil {
+		return errors.New("Storage provider not initialized")
+	}
+
+	return provider.AddAsk(price, duration)
 }
 
 // ListAsks lists all asks for the miner
-func (api *API) ListAsks(maddr address.Address) []*storagemarket.SignedStorageAsk {
-	return api.storageProvider.ListAsks(maddr)
+func (api *API) ListAsks(maddr address.Address) ([]*storagemarket.SignedStorageAsk, error) {
+	provider := api.storage.Provider()
+	if provider == nil {
+		return nil, errors.New("Storage provider not initialized")
+	}
+
+	return provider.ListAsks(maddr), nil
+}
+
+// ProposeStorageDeal proposes a storage deal
+func (api *API) ProposeStorageDeal(
+	ctx context.Context,
+	addr address.Address,
+	info *storagemarket.StorageProviderInfo,
+	data *storagemarket.DataRef,
+	startEpoch abi.ChainEpoch,
+	endEpoch abi.ChainEpoch,
+	price abi.TokenAmount,
+	collateral abi.TokenAmount,
+	rt abi.RegisteredProof,
+) (*storagemarket.ProposeStorageDealResult, error) {
+	return api.storage.Client().ProposeStorageDeal(ctx, addr, info, data, startEpoch, endEpoch, price, collateral, rt)
 }

--- a/internal/pkg/state/view.go
+++ b/internal/pkg/state/view.go
@@ -198,6 +198,24 @@ func (v *View) MarketEscrowBalance(ctx context.Context, addr addr.Address) (foun
 	return
 }
 
+// MarketGetDeal finds a deal by (resolved) provider and deal id
+func (v *View) MarketGetDealIDs(ctx context.Context, addr addr.Address) ([]abi.DealID, error) {
+	marketState, err := v.loadMarketActor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	byParty := market.AsSetMultimap(StoreFromCbor(ctx, v.ipldStore), marketState.DealIDsByParty)
+	var providerDealIds []abi.DealID
+	if err = byParty.ForEach(addr, func(i abi.DealID) error {
+		providerDealIds = append(providerDealIds, i)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return providerDealIds, err
+}
+
 // NetworkTotalPower Returns the storage power actor's value for network total power.
 func (v *View) NetworkTotalPower(ctx context.Context) (abi.StoragePower, error) {
 	powerState, err := v.loadPowerActor(ctx)

--- a/internal/pkg/state/view.go
+++ b/internal/pkg/state/view.go
@@ -199,21 +199,23 @@ func (v *View) MarketEscrowBalance(ctx context.Context, addr addr.Address) (foun
 }
 
 // MarketGetDeal finds a deal by (resolved) provider and deal id
-func (v *View) MarketGetDealIDs(ctx context.Context, addr addr.Address) ([]abi.DealID, error) {
+func (v *View) MarketHasDealID(ctx context.Context, addr addr.Address, dealID abi.DealID) (bool, error) {
 	marketState, err := v.loadMarketActor(ctx)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 
+	found := false
 	byParty := market.AsSetMultimap(StoreFromCbor(ctx, v.ipldStore), marketState.DealIDsByParty)
-	var providerDealIds []abi.DealID
 	if err = byParty.ForEach(addr, func(i abi.DealID) error {
-		providerDealIds = append(providerDealIds, i)
+		if i == dealID {
+			found = true
+		}
 		return nil
 	}); err != nil {
-		return nil, err
+		return false, err
 	}
-	return providerDealIds, err
+	return found, err
 }
 
 // NetworkTotalPower Returns the storage power actor's value for network total power.


### PR DESCRIPTION
### Motivation

Although the storage market has been integrated into go-filecoin, it has not been fully tested because the CLI commands have never been connected and the necessary chain interactions have only recently been completed. This PR restores the `client propose-deal` and `client query` commands and fixes multiple minor issues with the integration so that storage miners and storage clients can now make deals.

### Proposed changes

1. Restore the `client propose-deal` and `client query` commands.
2. Introduce a new integration test to test this functionality. This is an in-process test that tests a deal proposal from first contact, through multiple actor interactions up to the point where the client sees the miner has accepted the deal. This test actually works through staging and sealing until the deal is active, but the sealing part of it isn't appropriate for an integration test.
3. I reworked the storage submodule so that it can be mostly initialized when the node is built. Only its storage provider component is constructed when mining is started. This allows the node to act as a storage client without needing to start mining.
4. Fix signature encodings in the client to match the expectations in go-fil-market.
5. Implement the unimplemented `OnDealSectorCommitted`
6. Adjust gas limits and resolve addresses where needed.

