### PR TITLE
Power Table handles consensus faults

### DIFF
--- a/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
@@ -67,7 +67,7 @@ func NewSyncerSubmodule(ctx context.Context, config syncerConfig, blockstore *Bl
 	}
 
 	// set up consensus
-	stateViewer := consensus.AsPowerStateViewer(state.NewViewer(blockstore.CborStore))
+	stateViewer := consensus.AsConsensusStateViewer(state.NewViewer(blockstore.CborStore))
 	elections := consensus.NewElectionMachine(chn.State)
 	tickets := consensus.NewTicketMachine(chn.State)
 	nodeConsensus := consensus.NewExpected(blockstore.CborStore, blockstore.Blockstore, chn.Processor, &stateViewer,

--- a/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
@@ -67,7 +67,7 @@ func NewSyncerSubmodule(ctx context.Context, config syncerConfig, blockstore *Bl
 	}
 
 	// set up consensus
-	stateViewer := consensus.AsConsensusStateViewer(state.NewViewer(blockstore.CborStore))
+	stateViewer := consensus.AsDefaultStateViewer(state.NewViewer(blockstore.CborStore))
 	elections := consensus.NewElectionMachine(chn.State)
 	tickets := consensus.NewTicketMachine(chn.State)
 	nodeConsensus := consensus.NewExpected(blockstore.CborStore, blockstore.Blockstore, chn.Processor, &stateViewer,

--- a/internal/app/go-filecoin/porcelain/api.go
+++ b/internal/app/go-filecoin/porcelain/api.go
@@ -150,6 +150,10 @@ func (a *API) MinerStateView(baseKey block.TipSetKey) (MinerStateView, error) {
 	return a.StateView(baseKey)
 }
 
+func (a *API) FaultsStateView(baseKey block.TipSetKey) (consensus.FaultStateView, error) {
+	return a.StateView(baseKey)
+}
+
 func (a *API) ProtocolStateView(baseKey block.TipSetKey) (ProtocolStateView, error) {
 	return a.StateView(baseKey)
 }

--- a/internal/pkg/chainsync/internal/syncer/syncer_integration_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_integration_test.go
@@ -6,11 +6,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	fbig "github.com/filecoin-project/specs-actors/actors/abi/big"
-	"github.com/ipfs/go-cid"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
-	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -20,14 +16,10 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chainsync/internal/syncer"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/chainsync/status"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
-	appstate "github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	th "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
 )
 
 // Syncer is capable of recovering from a fork reorg after the store is loaded.
@@ -118,193 +110,6 @@ func TestLoadFork(t *testing.T) {
 
 	// The left chain is ok without any fetching though.
 	assert.NoError(t, offlineSyncer.HandleNewTipSet(ctx, block.NewChainInfo("", "", left.Key(), heightFromTip(t, left)), false))
-}
-
-// Power table weight comparisons impact syncer's selection.
-// One fork has more blocks but less total power.
-// Verify that the heavier fork is the one with more power.
-// All blocks in this test follow protocol version 1 upgrade weighting rules.
-func TestSyncerWeighsPower(t *testing.T) {
-	t.Skip("turn back on once the vm integration is complete")
-	repo := repo.NewInMemoryRepo()
-	bs := bstore.NewBlockstore(repo.Datastore())
-	cst := cborutil.NewIpldStore(bs)
-	ctx := context.Background()
-	isb := newIntegrationStateBuilder(t, cst)
-	builder := chain.NewBuilderWithDeps(t, address.Undef, isb, &chain.ZeroTimestamper{})
-
-	// Construct genesis with readable state tree root
-	gen := builder.BuildOneOn(block.UndefTipSet, func(bb *chain.BlockBuilder) {})
-
-	// Builder constructs two different blocks with different state trees
-	// for building two forks.
-	split := builder.BuildOn(gen, 2, func(bb *chain.BlockBuilder, i int) {
-		if i == 1 {
-			keys := types.MustGenerateKeyInfo(1, 42)
-			mm := vm.NewMessageMaker(t, keys)
-			addr := mm.Addresses()[0]
-			bb.AddMessages(
-				[]*types.SignedMessage{mm.NewSignedMessage(addr, 1)},
-				[]*types.UnsignedMessage{},
-			)
-		}
-	})
-	fork1 := block.RequireNewTipSet(t, split.At(0))
-	fork2 := block.RequireNewTipSet(t, split.At(1))
-
-	// Builder adds 3 blocks to fork 1 and total storage power 2^0
-	// 3 + 3*delta = 3 + 3[V*1 + bits(2^0)] = 3 + 3[2 + 1] = 3 + 9 = 12
-	head1 := builder.AppendManyOn(3, fork1)
-
-	// Builder adds 1 block to fork 2 and total storage power 2^9
-	// 3 + 1*delta = 3 + 1[V*1 + bits(2^9)] = 3 + 2 + 10 = 15
-	head2 := builder.AppendOn(fork2, 1)
-
-	viewer := consensus.FakePowerStateViewer{
-		Views: map[cid.Cid]*appstate.FakeStateView{},
-	}
-	viewer.Views[isb.cGen] = appstate.NewFakeStateView(abi.NewStoragePower(1))
-	viewer.Views[isb.c512] = appstate.NewFakeStateView(abi.NewStoragePower(512))
-
-	// Verify that the syncer selects fork 2 (15 > 12)
-	dumpBlocksToCborStore(t, builder, cst, head1, head2)
-	store := chain.NewStore(repo.ChainDatastore(), cst, chain.NewStatusReporter(), gen.At(0).Cid())
-	require.NoError(t, store.PutTipSetMetadata(ctx, &chain.TipSetMetadata{TipSetStateRoot: gen.At(0).StateRoot.Cid, TipSet: gen, TipSetReceipts: gen.At(0).MessageReceipts.Cid}))
-	require.NoError(t, store.SetHead(ctx, gen))
-	eval := &integrationStateEvaluator{c512: isb.c512}
-	syncer, err := syncer.NewSyncer(eval, eval, consensus.NewChainSelector(cst, &viewer, gen.At(0).Cid()), store, builder, builder, status.NewReporter(), clock.NewFake(time.Unix(1234567890, 0)), &noopFaultDetector{})
-	require.NoError(t, err)
-	require.NoError(t, syncer.InitStaged())
-
-	// sync fork 1
-	assert.NoError(t, syncer.HandleNewTipSet(ctx, block.NewChainInfo("", "", head1.Key(), heightFromTip(t, head1)), false))
-	assert.Equal(t, head1.Key(), store.GetHead())
-	// sync fork 2
-	assert.NoError(t, syncer.HandleNewTipSet(ctx, block.NewChainInfo("", "", head2.Key(), heightFromTip(t, head1)), false))
-	assert.Equal(t, head2.Key(), store.GetHead())
-}
-
-// integrationStateBuilder is a chain/testing.go `StateBuilder` used for
-// construction of a chain where the state root cids signify the total power
-// in the power table without actually needing to construct a valid state
-// state machine tree.
-//
-// All blocks with at least one message are assigned a special cid: c512.
-// In TestSyncerWeighsPower this state root is interpreted as having
-// 512 bytes of power.
-//
-// integrationStateBuilder also weighs the chain according to the protocol
-// version 1 upgrade.
-type integrationStateBuilder struct {
-	t    *testing.T
-	c512 cid.Cid
-	cGen cid.Cid
-	cst  cbor.IpldStore
-}
-
-func newIntegrationStateBuilder(t *testing.T, cst cbor.IpldStore) *integrationStateBuilder {
-	return &integrationStateBuilder{
-		t:    t,
-		c512: cid.Undef,
-		cst:  cst,
-		cGen: cid.Undef,
-	}
-}
-
-func (isb *integrationStateBuilder) ComputeState(prev cid.Cid, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage) (cid.Cid, []vm.MessageReceipt, error) {
-	// setup genesis with a state we can fetch from cborstor
-	if prev.Equals(types.CidFromString(isb.t, "null")) {
-		treeGen := state.NewFromString(isb.t, "1Power", isb.cst)
-		genRoot, err := treeGen.Commit(context.Background())
-		require.NoError(isb.t, err)
-		return genRoot, []vm.MessageReceipt{}, nil
-	}
-	// Setup fork with state we associate with more power.
-	// This fork is distiguished by a block with a single secp message.
-	if len(secpMessages[0]) > 0 {
-		treeFork := state.NewFromString(isb.t, "512Power", isb.cst)
-		forkRoot, err := treeFork.Commit(context.Background())
-		require.NoError(isb.t, err)
-		isb.c512 = forkRoot
-		return forkRoot, []vm.MessageReceipt{}, nil
-	}
-	return prev, []vm.MessageReceipt{}, nil
-}
-
-func (isb *integrationStateBuilder) Weigh(tip block.TipSet, pstate cid.Cid) (fbig.Int, error) {
-	if tip.Equals(block.UndefTipSet) {
-		return fbig.Zero(), nil
-	}
-	if isb.cGen.Equals(cid.Undef) && tip.Len() == 1 {
-		isb.cGen = tip.At(0).Cid()
-	}
-
-	if tip.At(0).Cid().Equals(isb.cGen) {
-		return fbig.Zero(), nil
-	}
-	viewer := consensus.FakePowerStateViewer{
-		Views: map[cid.Cid]*appstate.FakeStateView{},
-	}
-	viewer.Views[isb.cGen] = appstate.NewFakeStateView(abi.NewStoragePower(1))
-	viewer.Views[isb.c512] = appstate.NewFakeStateView(abi.NewStoragePower(512))
-
-	sel := consensus.NewChainSelector(isb.cst, &viewer, isb.cGen)
-	w, err := sel.Weight(context.Background(), tip, pstate)
-	return w, err
-}
-
-// integrationStateEvaluator returns the parent state root.  If there are multiple
-// parent blocks and any contain state root c512 then it will return c512.
-type integrationStateEvaluator struct {
-	c512 cid.Cid
-}
-
-func (n *integrationStateEvaluator) RunStateTransition(ctx context.Context, ts block.TipSet, blsMessages [][]*types.UnsignedMessage, secpMessages [][]*types.SignedMessage, parentWeight fbig.Int, stateID cid.Cid, receiptRoot cid.Cid) (cid.Cid, []vm.MessageReceipt, error) {
-	for i := 0; i < ts.Len(); i++ {
-		if ts.At(i).StateRoot.Cid.Equals(n.c512) {
-			return n.c512, []vm.MessageReceipt{}, nil
-		}
-	}
-	return ts.At(0).StateRoot.Cid, []vm.MessageReceipt{}, nil
-}
-
-func (n *integrationStateEvaluator) ValidateSemantic(_ context.Context, _ *block.Block, _ block.TipSet) error {
-	return nil
-}
-
-// dumpBlocksToCborStore is a helper method that
-// TODO #3078 we can avoid this byte shuffling by creating a simple testing type
-// that implements the needed interface and grabs blocks from the builder as
-// needed.  Once #3078 is in place we will have the flexibility to use a
-// testing type as the cbor store.
-func dumpBlocksToCborStore(t *testing.T, builder *chain.Builder, cst cbor.IpldStore, heads ...block.TipSet) {
-	cids := make(map[cid.Cid]struct{})
-	// traverse builder frontier adding cids to the map. Traverse
-	// duplicates over doing anything clever.
-	var err error
-	for _, head := range heads {
-		it := chain.IterAncestors(context.Background(), builder, head)
-		for ; !it.Complete(); err = it.Next() {
-			require.NoError(t, err)
-			for i := 0; i < it.Value().Len(); i++ {
-				blk := head.At(i)
-				c := blk.Cid()
-				cids[c] = struct{}{}
-			}
-		}
-	}
-
-	// get all blocks corresponding to the cids and put to the cst
-	var searchKey []cid.Cid
-	for c := range cids {
-		searchKey = append(searchKey, c)
-	}
-	blocks, err := builder.GetBlocks(context.Background(), searchKey)
-	require.NoError(t, err)
-	for _, blk := range blocks {
-		_, err = cst.Put(context.Background(), blk)
-		require.NoError(t, err)
-	}
 }
 
 type noopFaultDetector struct{}

--- a/internal/pkg/consensus/chain_selector.go
+++ b/internal/pkg/consensus/chain_selector.go
@@ -55,7 +55,7 @@ func (c *ChainSelector) Weight(ctx context.Context, ts block.TipSet, pStateID ci
 	if !pStateID.Defined() {
 		return fbig.Zero(), errors.New("undefined state passed to chain selector new weight")
 	}
-	powerTableView := NewPowerTableView(c.state.StateView(pStateID))
+	powerTableView := NewPowerTableView(c.state.PowerStateView(pStateID), c.state.FaultStateView(pStateID))
 	totalBytes, err := powerTableView.Total(ctx)
 	if err != nil {
 		return fbig.Zero(), err

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -86,7 +86,8 @@ type ElectionValidator interface {
 
 // StateViewer provides views into the chain state.
 type StateViewer interface {
-	StateView(root cid.Cid) PowerStateView
+	PowerStateView(root cid.Cid) PowerStateView
+	FaultStateView(root cid.Cid) FaultStateView
 }
 
 type chainReader interface {
@@ -199,9 +200,10 @@ func (c *Expected) validateMining(ctx context.Context,
 	parentWeight fbig.Int,
 	parentReceiptRoot cid.Cid) error {
 
-	keyStateView := c.state.StateView(parentStateRoot)
+	keyStateView := c.state.PowerStateView(parentStateRoot)
 	sigValidator := appstate.NewSignatureValidator(keyStateView)
-	keyPowerTable := NewPowerTableView(keyStateView)
+	faultsStateView := c.state.FaultStateView(parentStateRoot)
+	keyPowerTable := NewPowerTableView(keyStateView, faultsStateView)
 
 	tsHeight, err := ts.Height()
 	if err != nil {
@@ -216,8 +218,8 @@ func (c *Expected) validateMining(ctx context.Context,
 	if err != nil {
 		return errors.Wrap(err, "failed to get state root for sectorSet ancestor")
 	}
-	sectorSetStateView := c.state.StateView(sectorSetStateRoot)
-	sectorSetPowerTable := NewPowerTableView(sectorSetStateView)
+	sectorSetStateView := c.state.PowerStateView(sectorSetStateRoot)
+	sectorSetPowerTable := NewPowerTableView(sectorSetStateView, faultsStateView)
 
 	electionPowerAncestor, err := chain.FindTipsetAtEpoch(ctx, ts, tsHeight-ElectionPowerTableLookback, c.chainState)
 	if err != nil {
@@ -227,8 +229,8 @@ func (c *Expected) validateMining(ctx context.Context,
 	if err != nil {
 		return errors.Wrap(err, "failed to get state root for election power ancestor")
 	}
-	electionPowerStateView := c.state.StateView(electionPowerStateRoot)
-	electionPowerTable := NewPowerTableView(electionPowerStateView)
+	electionPowerStateView := c.state.PowerStateView(electionPowerStateRoot)
+	electionPowerTable := NewPowerTableView(electionPowerStateView, faultsStateView)
 
 	for i := 0; i < ts.Len(); i++ {
 		blk := ts.At(i)
@@ -433,17 +435,22 @@ func (c *Expected) loadStateTree(ctx context.Context, id cid.Cid) (*state.State,
 	return state.LoadState(ctx, c.cstore, id)
 }
 
-// PowerStateViewer a state viewer to the power state view interface.
-type PowerStateViewer struct {
+// ConsensusStateViewer a state viewer to the power state view interface.
+type ConsensusStateViewer struct {
 	*appstate.Viewer
 }
 
-// AsPowerStateViewer adapts a state viewer to a power state viewer.
-func AsPowerStateViewer(v *appstate.Viewer) PowerStateViewer {
-	return PowerStateViewer{v}
+// AsConsensusStateViewer adapts a state viewer to a power state viewer.
+func AsConsensusStateViewer(v *appstate.Viewer) ConsensusStateViewer {
+	return ConsensusStateViewer{v}
 }
 
-// StateView returns a power state view for a state root.
-func (p *PowerStateViewer) StateView(root cid.Cid) PowerStateView {
-	return p.Viewer.StateView(root)
+// PowerStateView returns a power state view for a state root.
+func (v *ConsensusStateViewer) PowerStateView(root cid.Cid) PowerStateView {
+	return v.Viewer.StateView(root)
+}
+
+// FaultStateView returns a fault state view for a state root.
+func (v *ConsensusStateViewer) FaultStateView(root cid.Cid) FaultStateView {
+	return v.Viewer.StateView(root)
 }

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -435,22 +435,22 @@ func (c *Expected) loadStateTree(ctx context.Context, id cid.Cid) (*state.State,
 	return state.LoadState(ctx, c.cstore, id)
 }
 
-// ConsensusStateViewer a state viewer to the power state view interface.
-type ConsensusStateViewer struct {
+// DefaultStateViewer a state viewer to the power state view interface.
+type DefaultStateViewer struct {
 	*appstate.Viewer
 }
 
-// AsConsensusStateViewer adapts a state viewer to a power state viewer.
-func AsConsensusStateViewer(v *appstate.Viewer) ConsensusStateViewer {
-	return ConsensusStateViewer{v}
+// AsDefaultStateViewer adapts a state viewer to a power state viewer.
+func AsDefaultStateViewer(v *appstate.Viewer) DefaultStateViewer {
+	return DefaultStateViewer{v}
 }
 
 // PowerStateView returns a power state view for a state root.
-func (v *ConsensusStateViewer) PowerStateView(root cid.Cid) PowerStateView {
+func (v *DefaultStateViewer) PowerStateView(root cid.Cid) PowerStateView {
 	return v.Viewer.StateView(root)
 }
 
 // FaultStateView returns a fault state view for a state root.
-func (v *ConsensusStateViewer) FaultStateView(root cid.Cid) FaultStateView {
+func (v *DefaultStateViewer) FaultStateView(root cid.Cid) FaultStateView {
 	return v.Viewer.StateView(root)
 }

--- a/internal/pkg/consensus/expected_test.go
+++ b/internal/pkg/consensus/expected_test.go
@@ -68,7 +68,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		pTipSet := block.RequireNewTipSet(t, genesisBlock)
 		nextRoot, miners, m2w := setTree(ctx, t, kis, cistore, bstore, genesisBlock.StateRoot.Cid)
 
-		views := consensus.AsConsensusStateViewer(appstate.NewViewer(cistore))
+		views := consensus.AsDefaultStateViewer(appstate.NewViewer(cistore))
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), &views, th.BlockTimeTest,
 			&consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{}, &consensus.TestElectionPoster{}, &TestChainReader{}, cl, drand)
 
@@ -89,7 +89,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		pTipSet := block.RequireNewTipSet(t, genesisBlock)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
-		views := consensus.AsConsensusStateViewer(appstate.NewViewer(cistore))
+		views := consensus.AsDefaultStateViewer(appstate.NewViewer(cistore))
 		exp := consensus.NewExpected(cistore, bstore, consensus.NewDefaultProcessor(&vm.FakeSyscalls{}, &consensus.FakeChainRandomness{}), &views, th.BlockTimeTest,
 			&consensus.FailingElectionValidator{}, &consensus.FakeTicketMachine{}, &consensus.TestElectionPoster{}, &TestChainReader{}, cl, drand)
 
@@ -111,7 +111,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
-		views := consensus.AsConsensusStateViewer(appstate.NewViewer(cistore))
+		views := consensus.AsDefaultStateViewer(appstate.NewViewer(cistore))
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), &views, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{}, &consensus.TestElectionPoster{}, &TestChainReader{}, cl, drand)
 
 		pTipSet := block.RequireNewTipSet(t, genesisBlock)
@@ -140,7 +140,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
-		views := consensus.AsConsensusStateViewer(appstate.NewViewer(cistore))
+		views := consensus.AsDefaultStateViewer(appstate.NewViewer(cistore))
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), &views, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{}, &consensus.TestElectionPoster{}, &TestChainReader{}, cl, drand)
 
 		pTipSet := block.RequireNewTipSet(t, genesisBlock)
@@ -176,7 +176,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
-		views := consensus.AsConsensusStateViewer(appstate.NewViewer(cistore))
+		views := consensus.AsDefaultStateViewer(appstate.NewViewer(cistore))
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), &views, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FailingTicketValidator{}, &consensus.TestElectionPoster{}, &TestChainReader{}, cl, drand)
 
 		pTipSet := block.RequireNewTipSet(t, genesisBlock)
@@ -196,7 +196,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
-		views := consensus.AsConsensusStateViewer(appstate.NewViewer(cistore))
+		views := consensus.AsDefaultStateViewer(appstate.NewViewer(cistore))
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), &views, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{}, &consensus.TestElectionPoster{}, &TestChainReader{}, cl, drand)
 
 		pTipSet := block.RequireNewTipSet(t, genesisBlock)
@@ -218,7 +218,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
-		views := consensus.AsConsensusStateViewer(appstate.NewViewer(cistore))
+		views := consensus.AsDefaultStateViewer(appstate.NewViewer(cistore))
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), &views, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{}, &consensus.TestElectionPoster{}, &TestChainReader{}, cl, drand)
 
 		pTipSet := block.RequireNewTipSet(t, genesisBlock)

--- a/internal/pkg/consensus/expected_test.go
+++ b/internal/pkg/consensus/expected_test.go
@@ -68,7 +68,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		pTipSet := block.RequireNewTipSet(t, genesisBlock)
 		nextRoot, miners, m2w := setTree(ctx, t, kis, cistore, bstore, genesisBlock.StateRoot.Cid)
 
-		views := consensus.AsPowerStateViewer(appstate.NewViewer(cistore))
+		views := consensus.AsConsensusStateViewer(appstate.NewViewer(cistore))
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), &views, th.BlockTimeTest,
 			&consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{}, &consensus.TestElectionPoster{}, &TestChainReader{}, cl, drand)
 
@@ -89,7 +89,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		pTipSet := block.RequireNewTipSet(t, genesisBlock)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
-		views := consensus.AsPowerStateViewer(appstate.NewViewer(cistore))
+		views := consensus.AsConsensusStateViewer(appstate.NewViewer(cistore))
 		exp := consensus.NewExpected(cistore, bstore, consensus.NewDefaultProcessor(&vm.FakeSyscalls{}, &consensus.FakeChainRandomness{}), &views, th.BlockTimeTest,
 			&consensus.FailingElectionValidator{}, &consensus.FakeTicketMachine{}, &consensus.TestElectionPoster{}, &TestChainReader{}, cl, drand)
 
@@ -111,7 +111,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
-		views := consensus.AsPowerStateViewer(appstate.NewViewer(cistore))
+		views := consensus.AsConsensusStateViewer(appstate.NewViewer(cistore))
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), &views, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{}, &consensus.TestElectionPoster{}, &TestChainReader{}, cl, drand)
 
 		pTipSet := block.RequireNewTipSet(t, genesisBlock)
@@ -140,7 +140,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
-		views := consensus.AsPowerStateViewer(appstate.NewViewer(cistore))
+		views := consensus.AsConsensusStateViewer(appstate.NewViewer(cistore))
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), &views, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{}, &consensus.TestElectionPoster{}, &TestChainReader{}, cl, drand)
 
 		pTipSet := block.RequireNewTipSet(t, genesisBlock)
@@ -176,7 +176,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
-		views := consensus.AsPowerStateViewer(appstate.NewViewer(cistore))
+		views := consensus.AsConsensusStateViewer(appstate.NewViewer(cistore))
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), &views, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FailingTicketValidator{}, &consensus.TestElectionPoster{}, &TestChainReader{}, cl, drand)
 
 		pTipSet := block.RequireNewTipSet(t, genesisBlock)
@@ -196,7 +196,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
-		views := consensus.AsPowerStateViewer(appstate.NewViewer(cistore))
+		views := consensus.AsConsensusStateViewer(appstate.NewViewer(cistore))
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), &views, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{}, &consensus.TestElectionPoster{}, &TestChainReader{}, cl, drand)
 
 		pTipSet := block.RequireNewTipSet(t, genesisBlock)
@@ -218,7 +218,7 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 		require.NoError(t, err)
 
 		miners, minerToWorker := minerToWorkerFromAddrs(ctx, t, state.NewState(cistore), vm.NewStorage(bstore), kis)
-		views := consensus.AsPowerStateViewer(appstate.NewViewer(cistore))
+		views := consensus.AsConsensusStateViewer(appstate.NewViewer(cistore))
 		exp := consensus.NewExpected(cistore, bstore, th.NewFakeProcessor(), &views, th.BlockTimeTest, &consensus.FakeElectionMachine{}, &consensus.FakeTicketMachine{}, &consensus.TestElectionPoster{}, &TestChainReader{}, cl, drand)
 
 		pTipSet := block.RequireNewTipSet(t, genesisBlock)

--- a/internal/pkg/consensus/power_table_view_test.go
+++ b/internal/pkg/consensus/power_table_view_test.go
@@ -62,6 +62,7 @@ func TestMiner(t *testing.T) {
 }
 
 func TestNoPowerAfterSlash(t *testing.T) {
+	tf.UnitTest(t)
 	// setup lookback state with 3 miners
 	ctx := context.Background()
 	numCommittedSectors := uint64(19)
@@ -78,7 +79,7 @@ func TestNoPowerAfterSlash(t *testing.T) {
 }
 
 func TestTotalPowerUnaffectedBySlash(t *testing.T) {
-
+	tf.UnitTest(t)
 	ctx := context.Background()
 	numCommittedSectors := uint64(19)
 	numMiners := 3

--- a/internal/pkg/consensus/power_table_view_test.go
+++ b/internal/pkg/consensus/power_table_view_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/cborutil"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/consensus"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/constants"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
@@ -24,62 +25,113 @@ import (
 
 func TestTotal(t *testing.T) {
 	tf.UnitTest(t)
-	t.Skip("requires new init actor address resolution")
 
 	ctx := context.Background()
-
 	numCommittedSectors := uint64(19)
-	cst, _, root := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors)
+	numMiners := 3
+	kis := types.MustGenerateBLSKeyInfo(numMiners)
 
-	table := consensus.NewPowerTableView(state.NewView(cst, root))
+	cst, _, root := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors, kis)
+
+	table := consensus.NewPowerTableView(state.NewView(cst, root), state.NewView(cst, root))
 	actual, err := table.Total(ctx)
 	require.NoError(t, err)
 
-	expected := abi.NewStoragePower(int64(uint64(constants.DevSectorSize) * numCommittedSectors))
+	expected := abi.NewStoragePower(int64(uint64(constants.DevSectorSize) * numCommittedSectors * uint64(numMiners)))
 	assert.True(t, expected.Equals(actual))
 }
 
 func TestMiner(t *testing.T) {
 	tf.UnitTest(t)
-	t.Skip("requires new init actor address resolution")
+	t.Skip("power setting has become more complex and gengen setup and testing expectations need to reflect that")
 
 	ctx := context.Background()
+	kis := types.MustGenerateBLSKeyInfo(1)
 
-	numCommittedSectors := uint64(12)
-	cst, addr, root := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors)
+	numCommittedSectors := uint64(10)
+	cst, addrs, root := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors, kis)
+	addr := addrs[0]
 
-	table := consensus.NewPowerTableView(state.NewView(cst, root))
+	table := consensus.NewPowerTableView(state.NewView(cst, root), state.NewView(cst, root))
 	actual, err := table.MinerClaim(ctx, addr)
 	require.NoError(t, err)
 
 	expected := abi.NewStoragePower(int64(uint64(constants.DevSectorSize) * numCommittedSectors))
+	assert.True(t, expected.Equals(actual))
 	assert.Equal(t, expected, actual)
 }
 
-func requireMinerWithNumCommittedSectors(ctx context.Context, t *testing.T, numCommittedSectors uint64) (*cborutil.IpldStore, address.Address, cid.Cid) {
+func TestNoPowerAfterSlash(t *testing.T) {
+	// setup lookback state with 3 miners
+	ctx := context.Background()
+	numCommittedSectors := uint64(19)
+	numMiners := 3
+	kis := types.MustGenerateBLSKeyInfo(numMiners)
+	cstPower, addrsPower, rootPower := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors, kis)
+	cstFaults, _, rootFaults := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors, kis[0:2]) // drop the third key
+	table := consensus.NewPowerTableView(state.NewView(cstPower, rootPower), state.NewView(cstFaults, rootFaults))
+
+	// verify that faulted miner claim is 0 power
+	claim, err := table.MinerClaim(ctx, addrsPower[2])
+	require.NoError(t, err)
+	assert.Equal(t, abi.NewStoragePower(0), claim)
+}
+
+func TestTotalPowerUnaffectedBySlash(t *testing.T) {
+
+	ctx := context.Background()
+	numCommittedSectors := uint64(19)
+	numMiners := 3
+	kis := types.MustGenerateBLSKeyInfo(numMiners)
+	cstPower, _, rootPower := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors, kis)
+	cstFaults, _, rootFaults := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors, kis[0:2]) // drop the third key
+	table := consensus.NewPowerTableView(state.NewView(cstPower, rootPower), state.NewView(cstFaults, rootFaults))
+
+	// verify that faulted miner claim is 0 power
+	total, err := table.Total(ctx)
+	require.NoError(t, err)
+	expected := abi.NewStoragePower(int64(uint64(constants.DevSectorSize) * numCommittedSectors * uint64(numMiners)))
+
+	assert.Equal(t, expected, total)
+}
+
+func requireMinerWithNumCommittedSectors(ctx context.Context, t *testing.T, numCommittedSectors uint64, ownerKeys []crypto.KeyInfo) (*cborutil.IpldStore, []address.Address, cid.Cid) {
 	r := repo.NewInMemoryRepo()
 	bs := bstore.NewBlockstore(r.Datastore())
 	cst := cborutil.NewIpldStore(bs)
-	commCfgs, err := gengen.MakeCommitCfgs(int(numCommittedSectors))
-	require.NoError(t, err)
+	numMiners := len(ownerKeys)
+	minerConfigs := make([]*gengen.CreateStorageMinerConfig, numMiners)
+	for i := 0; i < numMiners; i++ {
+		commCfgs, err := gengen.MakeCommitCfgs(int(numCommittedSectors))
+		require.NoError(t, err)
+		minerConfigs[i] = &gengen.CreateStorageMinerConfig{
+			CommittedSectors: commCfgs,
+			SectorSize:       constants.DevSectorSize,
+		}
+	}
+
+	// Tedious conversion to pointer type
+	genKis := make([]*crypto.KeyInfo, numMiners)
+	for i, ki := range ownerKeys {
+		genKis[i] = &ki
+	}
 
 	// set up genesis block containing some miners with non-zero power
 	genCfg := &gengen.GenesisCfg{
 		ProofsMode: types.TestProofsMode,
-		Miners: []*gengen.CreateStorageMinerConfig{
-			{
-				CommittedSectors: commCfgs,
-				SectorSize:       constants.DevSectorSize,
-			},
-		},
-		Network: "ptvtest",
+		Miners:     minerConfigs,
+		Network:    "ptvtest",
+		ImportKeys: genKis,
 	}
-	require.NoError(t, gengen.GenKeys(1)(genCfg))
 
 	info, err := gengen.GenGen(ctx, genCfg, bs)
 	require.NoError(t, err)
 
 	var genesis block.Block
 	require.NoError(t, cst.Get(ctx, info.GenesisCid, &genesis))
-	return cst, info.Miners[0].Address, genesis.StateRoot.Cid
+	retAddrs := make([]address.Address, numMiners)
+	for i := 0; i < numMiners; i++ {
+		retAddrs[i] = info.Miners[i].Address
+	}
+	return cst, retAddrs, genesis.StateRoot.Cid
 }

--- a/internal/pkg/consensus/testing.go
+++ b/internal/pkg/consensus/testing.go
@@ -29,13 +29,18 @@ func RequireNewTipSet(require *require.Assertions, blks ...*block.Block) block.T
 	return ts
 }
 
-// FakePowerStateViewer is a fake power state viewer.
-type FakePowerStateViewer struct {
+// FakeConsensusStateViewer is a fake power state viewer.
+type FakeConsensusStateViewer struct {
 	Views map[cid.Cid]*state.FakeStateView
 }
 
-// StateView returns the state view for a root.
-func (f *FakePowerStateViewer) StateView(root cid.Cid) PowerStateView {
+// PowerStateView returns the state view for a root.
+func (f *FakeConsensusStateViewer) PowerStateView(root cid.Cid) PowerStateView {
+	return f.Views[root]
+}
+
+// FaultStateView returns the state view for a root.
+func (f *FakeConsensusStateViewer) FaultStateView(root cid.Cid) FaultStateView {
 	return f.Views[root]
 }
 

--- a/internal/pkg/consensus/weight_test.go
+++ b/internal/pkg/consensus/weight_test.go
@@ -104,8 +104,8 @@ func TestWeight(t *testing.T) {
 	})
 }
 
-func makeStateViewer(stateRoot cid.Cid, networkPower abi.StoragePower) consensus.FakePowerStateViewer {
-	return consensus.FakePowerStateViewer{
+func makeStateViewer(stateRoot cid.Cid, networkPower abi.StoragePower) consensus.FakeConsensusStateViewer {
+	return consensus.FakeConsensusStateViewer{
 		Views: map[cid.Cid]*appstate.FakeStateView{
 			stateRoot: appstate.NewFakeStateView(networkPower),
 		},

--- a/internal/pkg/poster/poster.go
+++ b/internal/pkg/poster/poster.go
@@ -193,7 +193,7 @@ func (p *Poster) sendPoSt(ctx context.Context, stateView *appstate.View, candida
 }
 
 func (p *Poster) getProvingSet(ctx context.Context, stateView *appstate.View) ([]abi.SectorInfo, error) {
-	return consensus.NewPowerTableView(stateView).SortedSectorInfos(ctx, p.minerAddr)
+	return consensus.NewPowerTableView(stateView, stateView).SortedSectorInfos(ctx, p.minerAddr)
 }
 
 func (p *Poster) getChallengeSeed(ctx context.Context, head block.TipSetKey, height abi.ChainEpoch, minerAddr address.Address) ([32]byte, error) {

--- a/internal/pkg/state/testing.go
+++ b/internal/pkg/state/testing.go
@@ -83,6 +83,10 @@ func (v *FakeStateView) MinerControlAddresses(_ context.Context, maddr address.A
 	return m.Owner, m.Worker, nil
 }
 
+func (v *FakeStateView) MinerExists(_ context.Context, _ address.Address) (bool, error) {
+	return true, nil
+}
+
 func (v *FakeStateView) MinerPeerID(ctx context.Context, maddr address.Address) (peer.ID, error) {
 	m, ok := v.Miners[maddr]
 	if !ok {

--- a/internal/pkg/state/view.go
+++ b/internal/pkg/state/view.go
@@ -166,6 +166,18 @@ func (v *View) MinerProvingSetForEach(ctx context.Context, maddr addr.Address,
 	})
 }
 
+// MinerExists Returns true iff the miner exists.
+func (v *View) MinerExists(ctx context.Context, maddr addr.Address) (bool, error) {
+	_, err := v.loadMinerActor(ctx, maddr)
+	if err == nil {
+		return true, nil
+	}
+	if err == types.ErrNotFound {
+		return false, nil
+	}
+	return false, err
+}
+
 // MinerFaults Returns all sector ids that are faults
 func (v *View) MinerFaults(ctx context.Context, maddr addr.Address) ([]uint64, error) {
 	minerState, err := v.loadMinerActor(ctx, maddr)

--- a/internal/pkg/testhelpers/mining.go
+++ b/internal/pkg/testhelpers/mining.go
@@ -70,6 +70,10 @@ func (t *FakeWorkerPorcelainAPI) PowerStateView(_ block.TipSetKey) (consensus.Po
 	return t.stateView, nil
 }
 
+func (t *FakeWorkerPorcelainAPI) FaultsStateView(_ block.TipSetKey) (consensus.FaultStateView, error) {
+	return t.stateView, nil
+}
+
 func (t *FakeWorkerPorcelainAPI) SampleChainRandomness(ctx context.Context, head block.TipSetKey, tag acrypto.DomainSeparationTag,
 	epoch abi.ChainEpoch, entropy []byte) (abi.Randomness, error) {
 	return t.rnd.SampleChainRandomness(ctx, head, tag, epoch, entropy)

--- a/internal/pkg/types/testing.go
+++ b/internal/pkg/types/testing.go
@@ -85,6 +85,16 @@ func MustGenerateMixedKeyInfo(m int, n int) []crypto.KeyInfo {
 	return info
 }
 
+// MustGenerateBLSKeyInfo produces n distinct BLS keyinfos.
+func MustGenerateBLSKeyInfo(n int) []crypto.KeyInfo {
+	info := []crypto.KeyInfo{}
+	for i := 0; i < n; i++ {
+		ki := crypto.NewBLSKeyRandom()
+		info = append(info, ki)
+	}
+	return info
+}
+
 // MustGenerateKeyInfo generates `n` distinct keyinfos using seed `seed`.
 // The result is deterministic (for stable tests), don't use this for real keys!
 func MustGenerateKeyInfo(n int, seed byte) []crypto.KeyInfo {


### PR DESCRIPTION
### Motivation
Power calculations need to handle the case where consensus faults have slashed a miner in between the current head and power table lookback.

### Proposed changes
Power table now takes in two different state view and checks that a miner exists in the new `faultsState` before returning the power claim in the power state.  

Closes #3976 

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

