### PR TITLE
Make the block structure compatible with Lotus

### DIFF
--- a/internal/pkg/block/block.go
+++ b/internal/pkg/block/block.go
@@ -31,7 +31,7 @@ type Block struct {
 	Ticket Ticket `json:"ticket"`
 
 	// ElectionProof is the vrf proof giving this block's miner authoring rights
-	ElectionProof crypto.VRFPi
+	ElectionProof crypto.ElectionProof
 
 	// DrandEntries contain the verifiable oracle randomness used to elect
 	// this block's author leader

--- a/internal/pkg/block/block.go
+++ b/internal/pkg/block/block.go
@@ -33,9 +33,6 @@ type Block struct {
 	// ElectionProof is the vrf proof giving this block's miner authoring rights
 	ElectionProof crypto.VRFPi
 
-	// EPoStInfo wraps all data for verifying this block's Election PoSt
-	EPoStInfo EPoStInfo `json:"ePoStInfo"`
-
 	// DrandEntries contain the verifiable oracle randomness used to elect
 	// this block's author leader
 	DrandEntries []*drand.Entry
@@ -80,10 +77,10 @@ type Block struct {
 }
 
 // IndexMessagesField is the message field position in the encoded block
-const IndexMessagesField = 10
+const IndexMessagesField = 9
 
 // IndexParentsField is the parents field position in the encoded block
-const IndexParentsField = 5
+const IndexParentsField = 4
 
 // Cid returns the content id of this block.
 func (b *Block) Cid() cid.Cid {
@@ -168,7 +165,6 @@ func (b *Block) SignatureData() []byte {
 		Messages:        b.Messages,
 		StateRoot:       b.StateRoot,
 		MessageReceipts: b.MessageReceipts,
-		EPoStInfo:       b.EPoStInfo,
 		DrandEntries:    b.DrandEntries,
 		Timestamp:       b.Timestamp,
 		BLSAggregateSig: b.BLSAggregateSig,

--- a/internal/pkg/block/block_test.go
+++ b/internal/pkg/block/block_test.go
@@ -64,15 +64,12 @@ func TestTriangleEncoding(t *testing.T) {
 		b := &blk.Block{
 			Miner:         newAddress(),
 			Ticket:        blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
-			ElectionProof: []byte{0x0a, 0x0b},
+			ElectionProof: crypto.ElectionProof{VRFProof: []byte{0x0a, 0x0b}},
 			Height:        2,
 			DrandEntries: []*drand.Entry{
 				{
-					Round: drand.Round(1),
-					Signature: crypto.Signature{
-						Type: crypto.SigTypeBLS,
-						Data: []byte{0x3},
-					},
+					Round:     drand.Round(1),
+					Signature: []byte{0x3},
 				},
 			},
 			Messages:        e.NewCid(types.CidFromString(t, "somecid")),
@@ -230,14 +227,11 @@ func TestSignatureData(t *testing.T) {
 	b := &blk.Block{
 		Miner:         newAddress(),
 		Ticket:        blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
-		ElectionProof: []byte{0x0a, 0x0b},
+		ElectionProof: crypto.ElectionProof{VRFProof: []byte{0x0a, 0x0b}},
 		DrandEntries: []*drand.Entry{
 			{
-				Round: drand.Round(5),
-				Signature: crypto.Signature{
-					Type: crypto.SigTypeBLS,
-					Data: []byte{0x0c},
-				},
+				Round:     drand.Round(5),
+				Signature: []byte{0x0c},
 			},
 		},
 		Height:          2,
@@ -257,14 +251,11 @@ func TestSignatureData(t *testing.T) {
 	diff := &blk.Block{
 		Miner:         newAddress(),
 		Ticket:        blk.Ticket{VRFProof: []byte{0x03, 0x01, 0x02}},
-		ElectionProof: []byte{0x0c, 0x0d},
+		ElectionProof: crypto.ElectionProof{VRFProof: []byte{0x0c, 0x0d}},
 		DrandEntries: []*drand.Entry{
 			{
-				Round: drand.Round(44),
-				Signature: crypto.Signature{
-					Type: crypto.SigTypeBLS,
-					Data: []byte{0xc0},
-				},
+				Round:     drand.Round(44),
+				Signature: []byte{0xc0},
 			},
 		},
 		Height:          3,

--- a/internal/pkg/block/epost_info.go
+++ b/internal/pkg/block/epost_info.go
@@ -4,14 +4,6 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 )
 
-// EPoStInfo wraps all data needed to verify an election post proof
-type EPoStInfo struct {
-	_          struct{} `cbor:",toarray"`
-	PoStProofs []EPoStProof
-	VRFProof   abi.PoStRandomness
-	Winners    []EPoStCandidate
-}
-
 // EPoStCandidate wraps the input data needed to verify an election PoSt
 type EPoStCandidate struct {
 	_                    struct{} `cbor:",toarray"`
@@ -32,15 +24,6 @@ func NewEPoStCandidate(sID uint64, pt []byte, sci int64) EPoStCandidate {
 		SectorID:             abi.SectorNumber(sID),
 		PartialTicket:        pt,
 		SectorChallengeIndex: sci,
-	}
-}
-
-// NewEPoStInfo constructs an epost info from data
-func NewEPoStInfo(proofs []EPoStProof, rand abi.PoStRandomness, winners ...EPoStCandidate) EPoStInfo {
-	return EPoStInfo{
-		PoStProofs: proofs,
-		VRFProof:   rand,
-		Winners:    winners,
 	}
 }
 

--- a/internal/pkg/consensus/block_validation_test.go
+++ b/internal/pkg/consensus/block_validation_test.go
@@ -102,8 +102,6 @@ func TestBlockValidSyntax(t *testing.T) {
 	validSt := e.NewCid(types.NewCidForTestGetter()())
 	validAd := vmaddr.NewForTestGetter()()
 	validTi := block.Ticket{VRFProof: []byte{1}}
-	validCandidate := block.NewEPoStCandidate(1, []byte{1}, 1)
-	validPoStInfo := block.NewEPoStInfo(consensus.MakeFakePoStsForTest(), []byte{1}, validCandidate)
 	// create a valid block
 	blk := &block.Block{
 		Timestamp: validTs,
@@ -112,7 +110,6 @@ func TestBlockValidSyntax(t *testing.T) {
 		Ticket:    validTi,
 		Height:    1,
 
-		EPoStInfo: validPoStInfo,
 		BlockSig: &crypto.Signature{
 			Type: crypto.SigTypeBLS,
 			Data: []byte{0x3},

--- a/internal/pkg/consensus/election.go
+++ b/internal/pkg/consensus/election.go
@@ -217,6 +217,6 @@ func electionVRFRandomness(entry *drand.Entry, miner address.Address, epoch abi.
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to encode entropy")
 	}
-	seed := blake2b.Sum256(entry.Signature.Data)
+	seed := blake2b.Sum256(entry.Signature)
 	return crypto.BlendEntropy(acrypto.DomainSeparationTag_ElectionPoStChallengeSeed, seed[:], epoch, entropy)
 }

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -285,7 +285,7 @@ func (c *Expected) validateMining(ctx context.Context,
 		if err != nil {
 			return errors.Wrapf(err, "failed to get election entry")
 		}
-		err = c.VerifyElectionProof(ctx, electionEntry, blk.Height, blk.Miner, workerSignerAddr, blk.ElectionProof)
+		err = c.VerifyElectionProof(ctx, electionEntry, blk.Height, blk.Miner, workerSignerAddr, blk.ElectionProof.VRFProof)
 		if err != nil {
 			return errors.Wrapf(err, "failed to verify election proof")
 		}
@@ -304,7 +304,7 @@ func (c *Expected) validateMining(ctx context.Context,
 		if err != nil {
 			return errors.Wrap(err, "failed to read sectorSize from power table")
 		}
-		electionVRFDigest := blk.ElectionProof.Digest()
+		electionVRFDigest := blk.ElectionProof.VRFProof.Digest()
 		wins := c.IsWinner(electionVRFDigest[:], sectorNum, networkPower.Uint64(), uint64(sectorSize))
 		if !wins {
 			return errors.Errorf("Block did not win election")

--- a/internal/pkg/crypto/vrf.go
+++ b/internal/pkg/crypto/vrf.go
@@ -5,6 +5,12 @@ import "github.com/minio/blake2b-simd"
 // VRFPi is the proof output from running a VRF.
 type VRFPi []byte
 
+type ElectionProof struct {
+	_ struct{} `cbor:",toarray"`
+	// A proof output by running a VRF on the VRFProof of the parent ticket
+	VRFProof VRFPi
+}
+
 // Digest returns the digest (hash) of a proof, for use generating challenges etc.
 func (p VRFPi) Digest() [32]byte {
 	proofDigest := blake2b.Sum256(p)

--- a/internal/pkg/drand/drand.go
+++ b/internal/pkg/drand/drand.go
@@ -3,8 +3,6 @@ package drand
 import (
 	"context"
 	"time"
-
-	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 )
 
 // IFace is the standard inferface for interacting with the drand network
@@ -25,7 +23,7 @@ type Round uint64
 type Entry struct {
 	_         struct{} `cbor:",toarray"`
 	Round     Round
-	Signature crypto.Signature
+	Signature []byte
 
 	parentRound Round
 }

--- a/internal/pkg/drand/drand_grpc.go
+++ b/internal/pkg/drand/drand_grpc.go
@@ -10,7 +10,6 @@ import (
 	"github.com/drand/drand/key"
 	"github.com/drand/drand/net"
 	"github.com/drand/kyber"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	logging "github.com/ipfs/go-log"
 )
 
@@ -83,11 +82,8 @@ func (d *GRPC) ReadEntry(ctx context.Context, drandRound Round) (*Entry, error) 
 		}
 
 		entry := &Entry{
-			Round: drandRound,
-			Signature: crypto.Signature{
-				Type: crypto.SigTypeBLS,
-				Data: pub.GetSignature(),
-			},
+			Round:       drandRound,
+			Signature:   pub.GetSignature(),
 			parentRound: Round(pub.PreviousRound),
 		}
 		d.updateLocalState(entry)
@@ -108,8 +104,8 @@ func (d *GRPC) updateLocalState(entry *Entry) {
 
 // VerifyEntry verifies that the child's signature is a valid signature of the previous entry.
 func (d *GRPC) VerifyEntry(parent, child *Entry) (bool, error) {
-	msg := beacon.Message(parent.Signature.Data, uint64(parent.Round), uint64(child.Round))
-	err := key.Scheme.VerifyRecovered(d.key.Coefficients[0], msg, child.Signature.Data)
+	msg := beacon.Message(parent.Signature, uint64(parent.Round), uint64(child.Round))
+	err := key.Scheme.VerifyRecovered(d.key.Coefficients[0], msg, child.Signature)
 	if err != nil {
 		return false, err
 	}

--- a/internal/pkg/drand/testing.go
+++ b/internal/pkg/drand/testing.go
@@ -5,8 +5,6 @@ import (
 	"encoding/binary"
 	"time"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
-
 	ffi "github.com/filecoin-project/filecoin-ffi"
 )
 
@@ -33,11 +31,8 @@ func (d *Fake) ReadEntry(ctx context.Context, drandRound Round) (*Entry, error) 
 		parentRound = drandRound - 1
 	}
 	return &Entry{
-		Round: drandRound,
-		Signature: crypto.Signature{
-			Type: crypto.SigTypeBLS,
-			Data: fakeSigData,
-		},
+		Round:       drandRound,
+		Signature:   fakeSigData,
 		parentRound: parentRound,
 	}, nil
 }

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -99,7 +99,7 @@ func (w *DefaultWorker) Generate(
 		Miner:           w.minerAddr,
 		Height:          blockHeight,
 		DrandEntries:    drandEntries,
-		ElectionProof:   electionProof,
+		ElectionProof:   crypto.ElectionProof{VRFProof: electionProof},
 		Messages:        e.NewCid(txMetaCid),
 		MessageReceipts: e.NewCid(baseReceiptRoot),
 		Parents:         baseTipSet.Key(),

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -28,7 +28,6 @@ func (w *DefaultWorker) Generate(
 	ticket block.Ticket,
 	electionProof crypto.VRFPi,
 	nullBlockCount abi.ChainEpoch,
-	ePoStInfo block.EPoStInfo,
 	drandEntries []*drand.Entry,
 ) Output {
 
@@ -105,7 +104,6 @@ func (w *DefaultWorker) Generate(
 		MessageReceipts: e.NewCid(baseReceiptRoot),
 		Parents:         baseTipSet.Key(),
 		ParentWeight:    weight,
-		EPoStInfo:       ePoStInfo,
 		StateRoot:       e.NewCid(baseStateRoot),
 		Ticket:          ticket,
 		Timestamp:       uint64(epochStartTime.Unix()),

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -310,10 +310,8 @@ func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCoun
 		return
 	}
 	_ = sortedSectorInfos // TODO use for winning post
-	//postInfo := block.NewEPoStInfo(block.FromABIPoStProofs([]abi.PoStProof{})), abi.PoStRandomness(postVrfProof), block.FromFFICandidates(winners...)...)
-	postInfo := block.EPoStInfo{}
 
-	next := w.Generate(ctx, base, nextTicket, electionVRFProof, abi.ChainEpoch(nullBlkCount), postInfo, drandEntries)
+	next := w.Generate(ctx, base, nextTicket, electionVRFProof, abi.ChainEpoch(nullBlkCount), drandEntries)
 	if next.Err == nil {
 		log.Debugf("Worker.Mine generates new winning block! %s", next.Header.Cid().String())
 	}

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -24,15 +24,11 @@ import (
 // RequireSignedTestBlockFromTipSet creates a block with a valid signature by
 // the passed in miner work and a Miner field set to the minerAddr.
 func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, stateRootCid cid.Cid, receiptRootCid cid.Cid, height abi.ChainEpoch, minerAddr address.Address, minerWorker address.Address, signer types.Signer) *block.Block {
-	electionProof := consensus.MakeFakePoStsForTest()
 	ticket := consensus.MakeFakeTicketForTest()
 	emptyBLSSig := crypto.Signature{
 		Type: crypto.SigTypeBLS,
 		Data: (*bls.Aggregate([]bls.Signature{}))[:],
 	}
-	winner := block.NewEPoStCandidate(0, []byte{0xe}, 0)
-	vrfProof := []byte{0xff}
-	postInfo := block.NewEPoStInfo(electionProof, vrfProof, winner)
 
 	b := &block.Block{
 		Miner:           minerAddr,
@@ -43,7 +39,6 @@ func RequireSignedTestBlockFromTipSet(t *testing.T, baseTipSet block.TipSet, sta
 		StateRoot:       e.NewCid(stateRootCid),
 		MessageReceipts: e.NewCid(receiptRootCid),
 		BLSAggregateSig: &emptyBLSSig,
-		EPoStInfo:       postInfo,
 	}
 	sig, err := signer.SignBytes(context.TODO(), b.SignatureData(), minerWorker)
 	require.NoError(t, err)

--- a/tools/gengen/util/generator.go
+++ b/tools/gengen/util/generator.go
@@ -281,13 +281,8 @@ func (g *GenesisGenerator) genBlock(ctx context.Context) (cid.Cid, error) {
 	}
 
 	geneblk := &block.Block{
-		Miner:  builtin.SystemActorAddr,
-		Ticket: genesis.Ticket,
-		EPoStInfo: block.EPoStInfo{
-			PoStProofs: []block.EPoStProof{},
-			VRFProof:   abi.PoStRandomness(make([]byte, 32)),
-			Winners:    []block.EPoStCandidate{},
-		},
+		Miner:           builtin.SystemActorAddr,
+		Ticket:          genesis.Ticket,
 		Parents:         block.NewTipSetKey(),
 		ParentWeight:    specsbig.Zero(),
 		Height:          0,


### PR DESCRIPTION
The first commit simply removes the (now unused) ElectionPoSt field.

The second commit does the following:

- Puts the `ElectionProof` bytes in a struct (this is what Lotus does, and is preferred for future changes)
- Simplifies the signature field in Drand entries to just be a byte array (since I believe Drand is using a different version of BLS than "everything else", and so it isn't meaningfully associated with type BLS anyway).

With this, Lotus and go-filecoin agree on the serialisation of the new block headers.