### PR TITLE
Make election proof a pointer to match lotus

### DIFF
--- a/internal/pkg/block/block.go
+++ b/internal/pkg/block/block.go
@@ -31,7 +31,7 @@ type Block struct {
 	Ticket Ticket `json:"ticket"`
 
 	// ElectionProof is the vrf proof giving this block's miner authoring rights
-	ElectionProof crypto.ElectionProof
+	ElectionProof *crypto.ElectionProof
 
 	// PoStProofs are the winning post proofs
 	PoStProofs []PoStProof `json:"PoStProofs"`

--- a/internal/pkg/block/block_test.go
+++ b/internal/pkg/block/block_test.go
@@ -66,7 +66,7 @@ func TestTriangleEncoding(t *testing.T) {
 		b := &blk.Block{
 			Miner:         newAddress(),
 			Ticket:        blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
-			ElectionProof: crypto.ElectionProof{VRFProof: []byte{0x0a, 0x0b}},
+			ElectionProof: &crypto.ElectionProof{VRFProof: []byte{0x0a, 0x0b}},
 			Height:        2,
 			DrandEntries: []*drand.Entry{
 				{
@@ -231,7 +231,7 @@ func TestSignatureData(t *testing.T) {
 	b := &blk.Block{
 		Miner:         newAddress(),
 		Ticket:        blk.Ticket{VRFProof: []byte{0x01, 0x02, 0x03}},
-		ElectionProof: crypto.ElectionProof{VRFProof: []byte{0x0a, 0x0b}},
+		ElectionProof: &crypto.ElectionProof{VRFProof: []byte{0x0a, 0x0b}},
 		DrandEntries: []*drand.Entry{
 			{
 				Round:     drand.Round(5),
@@ -258,7 +258,7 @@ func TestSignatureData(t *testing.T) {
 	diff := &blk.Block{
 		Miner:         newAddress(),
 		Ticket:        blk.Ticket{VRFProof: []byte{0x03, 0x01, 0x02}},
-		ElectionProof: crypto.ElectionProof{VRFProof: []byte{0x0c, 0x0d}},
+		ElectionProof: &crypto.ElectionProof{VRFProof: []byte{0x0c, 0x0d}},
 		DrandEntries: []*drand.Entry{
 			{
 				Round:     drand.Round(44),

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -100,7 +100,7 @@ func (w *DefaultWorker) Generate(
 		Miner:           w.minerAddr,
 		Height:          blockHeight,
 		DrandEntries:    drandEntries,
-		ElectionProof:   crypto.ElectionProof{VRFProof: electionProof},
+		ElectionProof:   &crypto.ElectionProof{VRFProof: electionProof},
 		Messages:        e.NewCid(txMetaCid),
 		MessageReceipts: e.NewCid(baseReceiptRoot),
 		Parents:         baseTipSet.Key(),


### PR DESCRIPTION
### Motivation
lotus special cases election proof serialization as null in the genesis block and this matches their serialization.

If we don't do this we get different data when deserializing and serializing lotus genesis blocks with their current protocol implementation
### Proposed changes

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

