### PR TITLE
Deterministic BLS key generation

### DIFF
--- a/internal/pkg/consensus/election_test.go
+++ b/internal/pkg/consensus/election_test.go
@@ -25,11 +25,7 @@ func TestGenValidTicketChain(t *testing.T) {
 	head := block.NewTipSetKey() // Tipset key is unused by fake randomness
 
 	// Interleave 3 signers
-	kis := []crypto.KeyInfo{
-		crypto.NewBLSKeyRandom(),
-		crypto.NewBLSKeyRandom(),
-		crypto.NewBLSKeyRandom(),
-	}
+	kis := types.MustGenerateBLSKeyInfo(3, 0)
 
 	miner, err := address.NewIDAddress(uint64(1))
 	require.NoError(t, err)

--- a/internal/pkg/consensus/power_table_view_test.go
+++ b/internal/pkg/consensus/power_table_view_test.go
@@ -29,7 +29,7 @@ func TestTotal(t *testing.T) {
 	ctx := context.Background()
 	numCommittedSectors := uint64(19)
 	numMiners := 3
-	kis := types.MustGenerateBLSKeyInfo(numMiners)
+	kis := types.MustGenerateBLSKeyInfo(numMiners, 0)
 
 	cst, _, root := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors, kis)
 
@@ -46,7 +46,7 @@ func TestMiner(t *testing.T) {
 	t.Skip("power setting has become more complex and gengen setup and testing expectations need to reflect that")
 
 	ctx := context.Background()
-	kis := types.MustGenerateBLSKeyInfo(1)
+	kis := types.MustGenerateBLSKeyInfo(1, 0)
 
 	numCommittedSectors := uint64(10)
 	cst, addrs, root := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors, kis)
@@ -67,7 +67,7 @@ func TestNoPowerAfterSlash(t *testing.T) {
 	ctx := context.Background()
 	numCommittedSectors := uint64(19)
 	numMiners := 3
-	kis := types.MustGenerateBLSKeyInfo(numMiners)
+	kis := types.MustGenerateBLSKeyInfo(numMiners, 0)
 	cstPower, addrsPower, rootPower := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors, kis)
 	cstFaults, _, rootFaults := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors, kis[0:2]) // drop the third key
 	table := consensus.NewPowerTableView(state.NewView(cstPower, rootPower), state.NewView(cstFaults, rootFaults))
@@ -83,7 +83,7 @@ func TestTotalPowerUnaffectedBySlash(t *testing.T) {
 	ctx := context.Background()
 	numCommittedSectors := uint64(19)
 	numMiners := 3
-	kis := types.MustGenerateBLSKeyInfo(numMiners)
+	kis := types.MustGenerateBLSKeyInfo(numMiners, 0)
 	cstPower, _, rootPower := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors, kis)
 	cstFaults, _, rootFaults := requireMinerWithNumCommittedSectors(ctx, t, numCommittedSectors, kis[0:2]) // drop the third key
 	table := consensus.NewPowerTableView(state.NewView(cstPower, rootPower), state.NewView(cstFaults, rootFaults))

--- a/internal/pkg/crypto/crypto.go
+++ b/internal/pkg/crypto/crypto.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"fmt"
 	"io"
 
 	secp256k1 "github.com/ipsn/go-secp256k1"
@@ -97,12 +98,20 @@ func NewSecpKeyFromSeed(seed io.Reader) (KeyInfo, error) {
 	}, nil
 }
 
-func NewBLSKeyRandom() KeyInfo {
-	k := bls.PrivateKeyGenerate()
+func NewBLSKeyFromSeed(seed io.Reader) (KeyInfo, error) {
+	var seedBytes bls.PrivateKeyGenSeed
+	read, err := seed.Read(seedBytes[:])
+	if err != nil {
+		return KeyInfo{}, err
+	}
+	if read != len(seedBytes) {
+		return KeyInfo{}, fmt.Errorf("read only %d bytes of %d required from seed", read, len(seedBytes))
+	}
+	k := bls.PrivateKeyGenerateWithSeed(seedBytes)
 	return KeyInfo{
 		PrivateKey: k[:],
 		SigType:    SigTypeBLS,
-	}
+	}, nil
 }
 
 // EcRecover recovers the public key from a message, signature pair.

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -315,15 +315,14 @@ func TestApplyBLSMessages(t *testing.T) {
 	defer cancel()
 
 	ki := types.MustGenerateMixedKeyInfo(5, 5)
-	mockSignerVal := types.NewMockSigner(ki)
-	mockSigner := &mockSignerVal
+	mockSigner := types.NewMockSigner(ki)
 
 	newCid := types.NewCidForTestGetter()
 	stateRoot := newCid()
 	baseBlock := &block.Block{Height: 0, StateRoot: e.NewCid(stateRoot), Ticket: block.Ticket{VRFProof: []byte{0}}}
 	tipSet := block.RequireNewTipSet(t, baseBlock)
 
-	st, pool, addrs, bs := sharedSetup(t, mockSignerVal)
+	st, pool, addrs, bs := sharedSetup(t, mockSigner)
 	getStateTree := func(c context.Context, tsKey block.TipSetKey) (state.Tree, error) {
 		return st, nil
 	}
@@ -345,17 +344,17 @@ func TestApplyBLSMessages(t *testing.T) {
 		} else {
 			addr = secpAddress
 		}
-		smsg := requireSignedMessage(t, mockSigner, addr, addrs[3], uint64(i/2), types.NewAttoFILFromFIL(1))
+		smsg := requireSignedMessage(t, &mockSigner, addr, addrs[3], uint64(i/2), types.NewAttoFILFromFIL(1))
 		_, err := pool.Add(ctx, smsg, abi.ChainEpoch(0))
 		require.NoError(t, err)
 	}
 
 	worker := mining.NewDefaultWorker(mining.WorkerParameters{
-		API: th.NewDefaultFakeWorkerPorcelainAPI(mockSigner.Addresses[5], rnd),
+		API: th.NewDefaultFakeWorkerPorcelainAPI((&mockSigner).Addresses[5], rnd),
 
 		MinerAddr:      addrs[3],
 		MinerOwnerAddr: addrs[4],
-		WorkerSigner:   mockSigner,
+		WorkerSigner:   &mockSigner,
 
 		TipSetMetadata: fakeTSMetadata{},
 		GetStateTree:   getStateTree,

--- a/internal/pkg/types/testing.go
+++ b/internal/pkg/types/testing.go
@@ -68,7 +68,10 @@ func MustGenerateMixedKeyInfo(m int, n int) []crypto.KeyInfo {
 	info := []crypto.KeyInfo{}
 	for m > 0 && n > 0 {
 		if m > 0 {
-			ki := crypto.NewBLSKeyRandom()
+			ki, err := crypto.NewBLSKeyFromSeed(rand.Reader)
+			if err != nil {
+				panic(err)
+			}
 			info = append(info, ki)
 			m--
 		}
@@ -86,13 +89,18 @@ func MustGenerateMixedKeyInfo(m int, n int) []crypto.KeyInfo {
 }
 
 // MustGenerateBLSKeyInfo produces n distinct BLS keyinfos.
-func MustGenerateBLSKeyInfo(n int) []crypto.KeyInfo {
-	info := []crypto.KeyInfo{}
+func MustGenerateBLSKeyInfo(n int, seed byte) []crypto.KeyInfo {
+	token := bytes.Repeat([]byte{seed}, 512)
+	var keyinfos []crypto.KeyInfo
 	for i := 0; i < n; i++ {
-		ki := crypto.NewBLSKeyRandom()
-		info = append(info, ki)
+		token[0] = byte(i)
+		ki, err := crypto.NewBLSKeyFromSeed(bytes.NewReader(token))
+		if err != nil {
+			panic(err)
+		}
+		keyinfos = append(keyinfos, ki)
 	}
-	return info
+	return keyinfos
 }
 
 // MustGenerateKeyInfo generates `n` distinct keyinfos using seed `seed`.

--- a/internal/pkg/wallet/dsbackend.go
+++ b/internal/pkg/wallet/dsbackend.go
@@ -109,12 +109,15 @@ func (backend *DSBackend) newSecpAddress() (address.Address, error) {
 	if err := backend.putKeyInfo(&ki); err != nil {
 		return address.Undef, err
 	}
-
 	return ki.Address()
 }
 
 func (backend *DSBackend) newBLSAddress() (address.Address, error) {
-	ki := crypto.NewBLSKeyRandom()
+	ki, err := crypto.NewBLSKeyFromSeed(rand.Reader)
+	if err != nil {
+		return address.Undef, err
+	}
+
 	if err := backend.putKeyInfo(&ki); err != nil {
 		return address.Undef, err
 	}

--- a/tools/gengen/util/generator.go
+++ b/tools/gengen/util/generator.go
@@ -299,10 +299,12 @@ func (g *GenesisGenerator) genBlock(ctx context.Context) (cid.Cid, error) {
 func genKeys(cfgkeys int, pnrg io.Reader) ([]*crypto.KeyInfo, error) {
 	keys := make([]*crypto.KeyInfo, cfgkeys)
 	for i := 0; i < cfgkeys; i++ {
-		ki := crypto.NewBLSKeyRandom() // TODO: use seed, https://github.com/filecoin-project/go-filecoin/issues/3781
+		ki, err := crypto.NewBLSKeyFromSeed(pnrg)
+		if err != nil {
+			return nil, err
+		}
 		keys[i] = &ki
 	}
-
 	return keys, nil
 }
 

--- a/tools/gengen/util/gengen_test.go
+++ b/tools/gengen/util/gengen_test.go
@@ -71,13 +71,12 @@ func TestGenGenLoading(t *testing.T) {
 	assert.Contains(t, stdout, builtin.InitActorCodeID.String())
 }
 
-func TestGenGenDeterministicBetweenBuilds(t *testing.T) {
-	tf.UnitTest(t)
-	t.Skip("Non-deterministic BLS key generation https://github.com/filecoin-project/go-filecoin/issues/3781")
+func TestGenGenDeterministic(t *testing.T) {
+	tf.IntegrationTest(t)
 
 	ctx := context.Background()
 	var info *RenderedGenInfo
-	for i := 0; i < 50; i++ {
+	for i := 0; i < 5; i++ {
 		bstore := blockstore.NewBlockstore(ds.NewMapDatastore())
 		inf, err := GenGen(ctx, testConfig(t), bstore)
 		assert.NoError(t, err)


### PR DESCRIPTION
### Motivation
Determinism by default, for stability of testing. Randomness optional, most specifically for the wallet backend.

Closes #3781