### PR TITLE
Remove some unnecessary coupling to miner info chain state structures.

### DIFF
--- a/cmd/go-filecoin/client_integration_test.go
+++ b/cmd/go-filecoin/client_integration_test.go
@@ -26,11 +26,7 @@ func TestProposeDeal(t *testing.T) {
 
 	miner := nodes[0]
 
-	// get miner stats
 	maddr, err := miner.BlockMining.BlockMiningAPI.MinerAddress()
-	require.NoError(t, err)
-
-	mstats, err := miner.PorcelainAPI.MinerGetStatus(ctx, maddr, miner.PorcelainAPI.ChainHeadKey())
 	require.NoError(t, err)
 
 	client := nodes[1]
@@ -58,7 +54,7 @@ func TestProposeDeal(t *testing.T) {
 	var result storagemarket.ProposeStorageDealResult
 	clientAPI.RunMarshaledJSON(ctx, &result, "client", "propose-storage-deal",
 		"--peerid", miner.Host().ID().String(),
-		mstats.ActorAddress.String(),
+		maddr.String(),
 		node.Cid().String(),
 		"1000",
 		"2000",

--- a/cmd/go-filecoin/miner.go
+++ b/cmd/go-filecoin/miner.go
@@ -126,7 +126,7 @@ additional sectors.`,
 		}
 
 		return re.Emit(&MinerCreateResult{
-			Address: *addr,
+			Address: addr,
 			GasUsed: gas.NewGas(0),
 			Preview: false,
 		})

--- a/cmd/go-filecoin/miner_integration_test.go
+++ b/cmd/go-filecoin/miner_integration_test.go
@@ -36,17 +36,17 @@ func TestMinerCreateIntegration(t *testing.T) {
 	minerAddr, err := porcelainAPI.MinerCreate(ctx, defaultAddr, types.NewAttoFILFromFIL(1), 10000, 2048, peer, types.NewAttoFILFromFIL(1))
 	require.NoError(t, err)
 
-	tsk := newMiner.Chain().ChainReader.GetHead()
-	status, err := porcelainAPI.MinerGetStatus(ctx, *minerAddr, tsk)
-	require.NoError(t, err)
-
 	// inspect results on chain
+	tsk := newMiner.Chain().ChainReader.GetHead()
 	view, err := newMiner.Chain().ActorState.StateView(tsk)
 	require.NoError(t, err)
+	owner, _, err := view.MinerControlAddresses(ctx, minerAddr)
+	require.NoError(t, err)
+
 	resolvedDefaultAddress, err := view.InitResolveAddress(ctx, defaultAddr)
 	require.NoError(t, err)
 
-	assert.Equal(t, resolvedDefaultAddress, status.OwnerAddress)
+	assert.Equal(t, resolvedDefaultAddress, owner)
 }
 
 func TestSetPrice(t *testing.T) {

--- a/internal/app/go-filecoin/connectors/fsm_node/connector.go
+++ b/internal/app/go-filecoin/connectors/fsm_node/connector.go
@@ -85,7 +85,7 @@ func (f FiniteStateMachineNodeConnector) StateWaitMsg(ctx context.Context, mcid 
 	return lookup, err
 }
 
-func (f FiniteStateMachineNodeConnector) StateComputeDataCommitment(ctx context.Context, maddr address.Address, sectorType abi.RegisteredProof, deals []abi.DealID, tok fsm.TipSetToken) (cid.Cid, error) {
+func (f FiniteStateMachineNodeConnector) StateComputeDataCommitment(ctx context.Context, _ address.Address, sectorType abi.RegisteredProof, deals []abi.DealID, tok fsm.TipSetToken) (cid.Cid, error) {
 	view, err := f.stateViewForToken(tok)
 	if err != nil {
 		return cid.Undef, err
@@ -157,22 +157,12 @@ func (f FiniteStateMachineNodeConnector) StateMinerDeadlines(ctx context.Context
 		return nil, err
 	}
 
-	ts, err := f.chainState.GetTipSet(tsk)
-	if err != nil {
-		return nil, err
-	}
-
-	chainHeight, err := ts.Height()
-	if err != nil {
-		return nil, err
-	}
-
 	view, err := f.stateViewer.StateView(tsk)
 	if err != nil {
 		return nil, err
 	}
 
-	return view.MinerDeadlines(ctx, maddr, chainHeight)
+	return view.MinerDeadlines(ctx, maddr)
 }
 
 func (f FiniteStateMachineNodeConnector) SendMsg(ctx context.Context, from, to address.Address, method abi.MethodNum, value, gasPrice big.Int, gasLimit int64, params []byte) (cid.Cid, error) {
@@ -197,7 +187,7 @@ func (f FiniteStateMachineNodeConnector) SendMsg(ctx context.Context, from, to a
 	return mcid, nil
 }
 
-func (f FiniteStateMachineNodeConnector) ChainHead(ctx context.Context) (fsm.TipSetToken, abi.ChainEpoch, error) {
+func (f FiniteStateMachineNodeConnector) ChainHead(_ context.Context) (fsm.TipSetToken, abi.ChainEpoch, error) {
 	ts, err := f.chain.GetTipSet(f.chain.GetHead())
 	if err != nil {
 		return fsm.TipSetToken{}, 0, err

--- a/internal/app/go-filecoin/porcelain/api.go
+++ b/internal/app/go-filecoin/porcelain/api.go
@@ -71,7 +71,7 @@ func (a *API) MinerCreate(
 	sectorSize abi.SectorSize,
 	pid peer.ID,
 	collateral types.AttoFIL,
-) (_ *address.Address, err error) {
+) (_ address.Address, err error) {
 	return MinerCreate(ctx, a, accountAddr, gasPrice, gasLimit, sectorSize, pid, collateral)
 }
 

--- a/internal/app/go-filecoin/porcelain/miner_test.go
+++ b/internal/app/go-filecoin/porcelain/miner_test.go
@@ -115,7 +115,7 @@ func TestMinerCreate(t *testing.T) {
 			collateral,
 		)
 		require.NoError(t, err)
-		assert.Equal(t, expectedAddress, *addr)
+		assert.Equal(t, expectedAddress, addr)
 	})
 
 	t.Run("failure to send", func(t *testing.T) {

--- a/internal/pkg/state/testing.go
+++ b/internal/pkg/state/testing.go
@@ -149,7 +149,7 @@ func (v *FakeStateView) MinerPledgeCollateral(_ context.Context, maddr address.A
 	return m.PledgeRequirement, m.PledgeBalance, nil
 }
 
-func (v *FakeStateView) MinerDeadlines(ctx context.Context, maddr address.Address, currentEpoch abi.ChainEpoch) (*miner.Deadlines, error) {
+func (v *FakeStateView) MinerDeadlines(ctx context.Context, maddr address.Address) (*miner.Deadlines, error) {
 	return nil, nil
 }
 

--- a/internal/pkg/state/view.go
+++ b/internal/pkg/state/view.go
@@ -146,7 +146,11 @@ func (v *View) MinerSectorCount(ctx context.Context, maddr addr.Address) (int, e
 }
 
 // DeadlineInfo returns information about the next proving period
-func (v *View) MinerDeadlines(ctx context.Context, maddr addr.Address, currentEpoch abi.ChainEpoch) (*miner.Deadlines, error) {
+// This concrete chain state type is exposed because it's referenced directly by the storage-fsm module.
+// This is in conflict with the general goal of the state view of hiding the chain state representations from
+// consumers in order to support versioning that representation through protocol upgrades.
+// See https://github.com/filecoin-project/storage-fsm/issues/13
+func (v *View) MinerDeadlines(ctx context.Context, maddr addr.Address) (*miner.Deadlines, error) {
 	minerState, err := v.loadMinerActor(ctx, maddr)
 	if err != nil {
 		return nil, err
@@ -156,6 +160,8 @@ func (v *View) MinerDeadlines(ctx context.Context, maddr addr.Address, currentEp
 }
 
 // DeadlineInfo returns information about the next proving period
+// Do not use this, it exposes chain state specifics unnecessarily.
+// https://github.com/filecoin-project/go-filecoin/issues/4025
 func (v *View) MinerInfo(ctx context.Context, maddr addr.Address) (miner.MinerInfo, error) {
 	minerState, err := v.loadMinerActor(ctx, maddr)
 	if err != nil {


### PR DESCRIPTION
### Motivation
As far as possible, code should not depend directly on the on-chain state structures. Such deps will be massively painful if the structure changes in a protocol migration. The state view exists specifically to abstract such details.

This doesn't solve the whole problem, see #4025 for the rest.

### Proposed changes
Replace some uses of the MinerStatus (which embeds a miner.Info state object) with existing state view methods.

FYI @ZenGround0 so you're also aware and can maintain this boundary.
