### PR TITLE
Plumb QA power through the power table

### DIFF
--- a/cmd/go-filecoin/mining_integration_test.go
+++ b/cmd/go-filecoin/mining_integration_test.go
@@ -101,7 +101,7 @@ func TestMiningAddPieceAndSealNow(t *testing.T) {
 		power, err := minerNode.MinerStatus(ctx, miningAddress)
 		require.NoError(t, err)
 
-		if power.Power.GreaterThan(fbig.Zero()) {
+		if power.QualityAdjustedPower.GreaterThan(fbig.Zero()) {
 			// miner has gained power, so seal was successful
 			return
 		}

--- a/functional-tests/mining_sync_test.go
+++ b/functional-tests/mining_sync_test.go
@@ -55,8 +55,8 @@ func TestBootstrapMineOnce(t *testing.T) {
 
 	// expected miner power is 2 2kib sectors
 	expectedMinerPower := constants.DevSectorSize * 2
-	actualMinerPower := status.Power.Uint64()
-	assert.Equal(t, uint64(expectedMinerPower), status.Power.Uint64(), "expected miner power: %d actual miner power: %d", expectedMinerPower, actualMinerPower)
+	actualMinerPower := status.QualityAdjustedPower.Uint64()
+	assert.Equal(t, uint64(expectedMinerPower), status.QualityAdjustedPower.Uint64(), "expected miner power: %d actual miner power: %d", expectedMinerPower, actualMinerPower)
 
 	// Assert that the chain head is genesis block
 	var blocks []block.Block

--- a/internal/pkg/consensus/chain_selector.go
+++ b/internal/pkg/consensus/chain_selector.go
@@ -23,8 +23,7 @@ var (
 	wPrecision = fbig.NewInt(256)
 )
 
-// ChainSelector weighs and compares chains according to the deprecated v0
-// Storage Power Consensus Protocol
+// ChainSelector weighs and compares chains.
 type ChainSelector struct {
 	cstore     cbor.IpldStore
 	state      StateViewer
@@ -56,11 +55,11 @@ func (c *ChainSelector) Weight(ctx context.Context, ts block.TipSet, pStateID ci
 		return fbig.Zero(), errors.New("undefined state passed to chain selector new weight")
 	}
 	powerTableView := NewPowerTableView(c.state.PowerStateView(pStateID), c.state.FaultStateView(pStateID))
-	totalBytes, err := powerTableView.Total(ctx)
+	networkPower, err := powerTableView.NetworkTotalPower(ctx)
 	if err != nil {
 		return fbig.Zero(), err
 	}
-	powerMeasure := log2b(totalBytes)
+	powerMeasure := log2b(networkPower)
 
 	wPowerFactor := fbig.Mul(wPrecision, powerMeasure)
 	wBlocksFactorNum := fbig.Mul(wRatioNum, fbig.Mul(powerMeasure, fbig.NewInt(int64(ts.Len()))))

--- a/internal/pkg/consensus/election.go
+++ b/internal/pkg/consensus/election.go
@@ -90,7 +90,7 @@ func (em ElectionMachine) VerifyElectionProof(_ context.Context, entry *drand.En
 }
 
 // IsWinner returns true if the input challengeTicket wins the election
-func (em ElectionMachine) IsWinner(challengeTicket []byte, minerPower, networkPower big.Int) bool {
+func (em ElectionMachine) IsWinner(challengeTicket []byte, minerPower, networkPower abi.StoragePower) bool {
 	// (ChallengeTicket / MaxChallengeTicket) < ExpectedLeadersPerEpoch * (MinerPower / NetworkPower)
 	// ->
 	// ChallengeTicket * NetworkPower < ExpectedLeadersPerEpoch * MinerPower * MaxChallengeTicket

--- a/internal/pkg/consensus/expected.go
+++ b/internal/pkg/consensus/expected.go
@@ -66,7 +66,7 @@ type TicketValidator interface {
 
 // ElectionValidator validates that an election fairly produced a winner.
 type ElectionValidator interface {
-	IsWinner(challengeTicket []byte, minerPower, networkPower big.Int) bool
+	IsWinner(challengeTicket []byte, minerPower, networkPower abi.StoragePower) bool
 	VerifyElectionProof(ctx context.Context, entry *drand.Entry, epoch abi.ChainEpoch, miner address.Address, workerSigner address.Address, vrfProof crypto.VRFPi) error
 	VerifyWinningPoSt(ctx context.Context, ep EPoStVerifier, allSectorInfos []abi.SectorInfo, seedEntry *drand.Entry, epoch abi.ChainEpoch, proofs []block.PoStProof, mIDAddr address.Address) (bool, error)
 }
@@ -279,13 +279,13 @@ func (c *Expected) validateMining(ctx context.Context,
 		// TODO this is not using nominal power, which must take into account undeclared faults
 		// TODO the nominal power must be tested against the minimum (power.minerNominalPowerMeetsConsensusMinimum)
 		// See https://github.com/filecoin-project/go-filecoin/issues/3958
-		minerPower, err := electionPowerTable.MinerClaim(ctx, blk.Miner)
+		minerPower, err := electionPowerTable.MinerClaimedPower(ctx, blk.Miner)
 		if err != nil {
 			return errors.Wrap(err, "failed to read miner claim from power table")
 		}
-		networkPower, err := electionPowerTable.Total(ctx)
+		networkPower, err := electionPowerTable.NetworkTotalPower(ctx)
 		if err != nil {
-			return errors.Wrap(err, "failed to read networkPower from power table")
+			return errors.Wrap(err, "failed to read power table")
 		}
 		electionVRFDigest := blk.ElectionProof.VRFProof.Digest()
 		wins := c.IsWinner(electionVRFDigest[:], minerPower, networkPower)

--- a/internal/pkg/consensus/power_table_view.go
+++ b/internal/pkg/consensus/power_table_view.go
@@ -9,34 +9,32 @@ import (
 	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/state"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
-// PowerStateView is the consensus package's interface to chain state.
+// PowerStateView is a view of chain state for election computations, typically at some lookback from the
+// immediate parent state.
 type PowerStateView interface {
 	state.AccountStateView
 	MinerSectorSize(ctx context.Context, maddr addr.Address) (abi.SectorSize, error)
 	MinerControlAddresses(ctx context.Context, maddr addr.Address) (owner, worker addr.Address, err error)
 	MinerSectorsForEach(ctx context.Context, maddr addr.Address, f func(id abi.SectorNumber, sealedCID cid.Cid, rpp abi.RegisteredProof, dealIDs []abi.DealID) error) error
-	NetworkTotalRawBytePower(ctx context.Context) (abi.StoragePower, error)
-	MinerClaimedRawBytePower(ctx context.Context, miner addr.Address) (abi.StoragePower, error)
+	PowerNetworkTotal(ctx context.Context) (*state.NetworkPower, error)
+	MinerClaimedPower(ctx context.Context, miner addr.Address) (raw, qa abi.StoragePower, err error)
 }
 
-// FaultStateView is the interface needed by the recent fault state to adjust
-// miner power claims based on consensus slashing events.
+// FaultStateView is a view of chain state for adjustment of miner power claims based on changes since the
+// power state's lookback (primarily, the miner ceasing to be registered).
 type FaultStateView interface {
 	MinerExists(ctx context.Context, maddr addr.Address) (bool, error)
 }
 
-// PowerTableView defines the set of functions used by the ChainManager to view
-// the power table encoded in the tipset's state tree
-// PowerTableView is the power table view used for running expected consensus in
+// An interface to the network power table for elections.
+// Elections use the quality-adjusted power, rather than raw byte power.
 type PowerTableView struct {
 	state      PowerStateView
 	faultState FaultStateView
 }
 
-// NewPowerTableView constructs a new view with a snapshot pinned to a particular tip set.
 func NewPowerTableView(state PowerStateView, faultState FaultStateView) PowerTableView {
 	return PowerTableView{
 		state:      state,
@@ -44,30 +42,33 @@ func NewPowerTableView(state PowerStateView, faultState FaultStateView) PowerTab
 	}
 }
 
-// Total returns the total storage as a BytesAmount.
-func (v PowerTableView) Total(ctx context.Context) (abi.StoragePower, error) {
-	return v.state.NetworkTotalRawBytePower(ctx)
+// Returns the network's total quality-adjusted power.
+func (v PowerTableView) NetworkTotalPower(ctx context.Context) (abi.StoragePower, error) {
+	total, err := v.state.PowerNetworkTotal(ctx)
+	if err != nil {
+		return big.Zero(), err
+	}
+	return total.QualityAdjustedPower, nil
 }
 
-// MinerClaim returns the storage that this miner claims to have committed to the network.
-func (v PowerTableView) MinerClaim(ctx context.Context, mAddr addr.Address) (abi.StoragePower, error) {
-	claim, err := v.state.MinerClaimedRawBytePower(ctx, mAddr)
+// Returns a miner's claimed quality-adjusted power.
+func (v PowerTableView) MinerClaimedPower(ctx context.Context, mAddr addr.Address) (abi.StoragePower, error) {
+	_, qa, err := v.state.MinerClaimedPower(ctx, mAddr)
 	if err != nil {
-		return abi.NewStoragePower(0), err
+		return big.Zero(), err
 	}
 	// Only return claim if fault state still tracks miner
 	exists, err := v.faultState.MinerExists(ctx, mAddr)
 	if err != nil {
-		return abi.NewStoragePower(0), err
+		return big.Zero(), err
 	}
 	if !exists { // miner was slashed
-		return abi.NewStoragePower(0), nil
+		return big.Zero(), nil
 	}
-
-	return claim, nil
+	return qa, nil
 }
 
-// WorkerAddr returns the address of the miner worker given the miner address.
+// WorkerAddr returns the worker address for a miner actor.
 func (v PowerTableView) WorkerAddr(ctx context.Context, mAddr addr.Address) (addr.Address, error) {
 	_, worker, err := v.state.MinerControlAddresses(ctx, mAddr)
 	return worker, err
@@ -78,19 +79,7 @@ func (v PowerTableView) SignerAddress(ctx context.Context, a addr.Address) (addr
 	return v.state.AccountSignerAddress(ctx, a)
 }
 
-// HasClaimedPower returns true if the provided address belongs to a miner with claimed power in the storage market
-func (v PowerTableView) HasClaimedPower(ctx context.Context, mAddr addr.Address) (bool, error) {
-	numBytes, err := v.MinerClaim(ctx, mAddr)
-	if err == types.ErrNotFound {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return numBytes.GreaterThan(big.Zero()), nil
-}
-
-// SortedSectorInfos returns the sector information for the given miner
+// SortedSectorInfos returns the sector information for a given miner
 func (v PowerTableView) SortedSectorInfos(ctx context.Context, mAddr addr.Address) ([]abi.SectorInfo, error) {
 	var infos []abi.SectorInfo
 	err := v.state.MinerSectorsForEach(ctx, mAddr, func(id abi.SectorNumber, sealedCID cid.Cid, rpp abi.RegisteredProof, _ []abi.DealID) error {

--- a/internal/pkg/consensus/testing.go
+++ b/internal/pkg/consensus/testing.go
@@ -7,7 +7,6 @@ import (
 
 	address "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	acrypto "github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
@@ -72,7 +71,7 @@ func (fem *FakeElectionMachine) GenerateWinningPoSt(ctx context.Context, allSect
 	}}, nil
 }
 
-func (fem *FakeElectionMachine) IsWinner(challengeTicket []byte, minerPower, networkPower big.Int) bool {
+func (fem *FakeElectionMachine) IsWinner(challengeTicket []byte, minerPower, networkPower abi.StoragePower) bool {
 	return true
 }
 
@@ -112,7 +111,7 @@ type FailingElectionValidator struct{}
 
 var _ ElectionValidator = new(FailingElectionValidator)
 
-func (fev *FailingElectionValidator) IsWinner(challengeTicket []byte, minerPower, networkPower big.Int) bool {
+func (fev *FailingElectionValidator) IsWinner(challengeTicket []byte, minerPower, networkPower abi.StoragePower) bool {
 	return false
 }
 

--- a/internal/pkg/consensus/weight_test.go
+++ b/internal/pkg/consensus/weight_test.go
@@ -107,7 +107,7 @@ func TestWeight(t *testing.T) {
 func makeStateViewer(stateRoot cid.Cid, networkPower abi.StoragePower) consensus.FakeConsensusStateViewer {
 	return consensus.FakeConsensusStateViewer{
 		Views: map[cid.Cid]*appstate.FakeStateView{
-			stateRoot: appstate.NewFakeStateView(networkPower),
+			stateRoot: appstate.NewFakeStateView(networkPower, networkPower, 0, 0),
 		},
 	}
 }

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -87,7 +87,7 @@ type workerPorcelainAPI interface {
 
 type electionUtil interface {
 	GenerateElectionProof(ctx context.Context, entry *drand.Entry, epoch abi.ChainEpoch, miner address.Address, worker address.Address, signer types.Signer) (crypto.VRFPi, error)
-	IsWinner(challengeTicket []byte, minerPower, networkPower big.Int) bool
+	IsWinner(challengeTicket []byte, minerPower, networkPower abi.StoragePower) bool
 	GenerateWinningPoSt(ctx context.Context, allSectorInfos []abi.SectorInfo, entry *drand.Entry, epoch abi.ChainEpoch, ep postgenerator.PoStGenerator, maddr address.Address) ([]block.PoStProof, error)
 }
 
@@ -264,13 +264,13 @@ func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCoun
 		outCh <- NewOutputErr(err)
 		return
 	}
-	networkPower, err := electionPowerTable.Total(ctx)
+	networkPower, err := electionPowerTable.NetworkTotalPower(ctx)
 	if err != nil {
-		log.Errorf("failed to get total power: %s", err)
+		log.Errorf("failed to get network power: %s", err)
 		outCh <- NewOutputErr(err)
 		return
 	}
-	minerPower, err := electionPowerTable.MinerClaim(ctx, w.minerAddr)
+	minerPower, err := electionPowerTable.MinerClaimedPower(ctx, w.minerAddr)
 	if err != nil {
 		log.Errorf("failed to get power claim for miner: %s", err)
 		outCh <- NewOutputErr(err)

--- a/internal/pkg/testhelpers/mining.go
+++ b/internal/pkg/testhelpers/mining.go
@@ -31,8 +31,13 @@ func NewDefaultFakeWorkerPorcelainAPI(signer address.Address, rnd consensus.Chai
 	return &FakeWorkerPorcelainAPI{
 		blockTime: BlockTimeTest,
 		stateView: &state.FakeStateView{
-			NetworkPower: abi.NewStoragePower(1),
-			Miners:       map[address.Address]*state.FakeMinerState{},
+			Power: &state.NetworkPower{
+				RawBytePower:         big.NewInt(1),
+				QualityAdjustedPower: big.NewInt(1),
+				MinerCount:           0,
+				MinPowerMinerCount:   0,
+			},
+			Miners: map[address.Address]*state.FakeMinerState{},
 		},
 		rnd: rnd,
 	}
@@ -43,8 +48,13 @@ func NewFakeWorkerPorcelainAPI(rnd consensus.ChainRandomness, totalPower uint64,
 	f := &FakeWorkerPorcelainAPI{
 		blockTime: BlockTimeTest,
 		stateView: &state.FakeStateView{
-			NetworkPower: abi.NewStoragePower(int64(totalPower)),
-			Miners:       map[address.Address]*state.FakeMinerState{},
+			Power: &state.NetworkPower{
+				RawBytePower:         big.NewIntUnsigned(totalPower),
+				QualityAdjustedPower: big.NewIntUnsigned(totalPower),
+				MinerCount:           0,
+				MinPowerMinerCount:   0,
+			},
+			Miners: map[address.Address]*state.FakeMinerState{},
 		},
 		rnd: rnd,
 	}
@@ -52,7 +62,8 @@ func NewFakeWorkerPorcelainAPI(rnd consensus.ChainRandomness, totalPower uint64,
 		f.stateView.Miners[k] = &state.FakeMinerState{
 			Owner:             v,
 			Worker:            v,
-			ClaimedPower:      big.Zero(),
+			ClaimedRawPower:   big.Zero(),
+			ClaimedQAPower:    big.Zero(),
 			PledgeRequirement: big.Zero(),
 			PledgeBalance:     big.Zero(),
 		}

--- a/tools/fast/action_miner_test.go
+++ b/tools/fast/action_miner_test.go
@@ -39,6 +39,6 @@ func assertPowerOutput(ctx context.Context, t *testing.T, d *fast.Filecoin, expM
 	minerAddr := requireGetMinerAddress(ctx, t, d)
 	status, err := d.MinerStatus(ctx, minerAddr)
 	require.NoError(t, err)
-	assert.Equal(t, expMinerPwr, status.Power.Uint64(), "for miner power")
-	assert.Equal(t, expTotalPwr, status.NetworkPower.Uint64(), "for total power")
+	assert.Equal(t, expMinerPwr, status.QualityAdjustedPower.Uint64(), "for miner power")
+	assert.Equal(t, expTotalPwr, status.NetworkQualityAdjustedPower.Uint64(), "for total power")
 }

--- a/tools/gengen/main.go
+++ b/tools/gengen/main.go
@@ -129,7 +129,7 @@ func main() {
 	}
 
 	for _, m := range info.Miners {
-		fmt.Fprintf(os.Stderr, "created miner %s, owned by %d, power = %s\n", m.Address, m.Owner, m.Power) // nolint: errcheck
+		fmt.Fprintf(os.Stderr, "created miner %s, owned by %d, power = %s (raw %s)\n", m.Address, m.Owner, m.QAPower, m.RawPower) // nolint: errcheck
 	}
 }
 

--- a/tools/gengen/util/gengen.go
+++ b/tools/gengen/util/gengen.go
@@ -120,8 +120,9 @@ type RenderedMinerInfo struct {
 	// Address is the address generated on-chain for the miner
 	Address address.Address
 
-	// Power is the amount of storage power this miner was created with
-	Power abi.StoragePower
+	// The amount of storage power this miner was created with
+	RawPower abi.StoragePower
+	QAPower  abi.StoragePower
 }
 
 // GenOption is a configuration option.


### PR DESCRIPTION
### Motivation
There are now two notions of power, raw and quality adjusted.

### Proposed changes
This plumbs the distinction through most of the code and uses QA power for the election power table.

This is most, but not all, of #4011.
