### PR TITLE
Use power table miner power rather than computing from sector size and count

### DIFF
--- a/internal/pkg/consensus/power_table_view.go
+++ b/internal/pkg/consensus/power_table_view.go
@@ -2,7 +2,6 @@ package consensus
 
 import (
 	"context"
-	"fmt"
 
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -103,26 +102,4 @@ func (v PowerTableView) SortedSectorInfos(ctx context.Context, mAddr addr.Addres
 		return nil
 	})
 	return infos, err
-}
-
-// SectorSize returns the sector size for this miner
-func (v PowerTableView) SectorSize(ctx context.Context, mAddr addr.Address) (abi.SectorSize, error) {
-	return v.state.MinerSectorSize(ctx, mAddr)
-}
-
-// NumSectors returns the number of sectors this miner has committed, computed as the quotient of the miner's claimed
-// power and sector size.
-func (v PowerTableView) NumSectors(ctx context.Context, mAddr addr.Address) (uint64, error) {
-	minerBytes, err := v.MinerClaim(ctx, mAddr)
-	if err != nil {
-		return 0, err
-	}
-	sectorSize, err := v.SectorSize(ctx, mAddr)
-	if err != nil {
-		return 0, err
-	}
-	if minerBytes.Uint64()%uint64(sectorSize) != 0 {
-		return 0, fmt.Errorf("total power byte count %d is not a multiple of sector size %d ", minerBytes.Uint64(), sectorSize)
-	}
-	return minerBytes.Uint64() / uint64(sectorSize), nil
 }

--- a/internal/pkg/consensus/testing.go
+++ b/internal/pkg/consensus/testing.go
@@ -7,6 +7,7 @@ import (
 
 	address "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	acrypto "github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
@@ -71,7 +72,7 @@ func (fem *FakeElectionMachine) GenerateWinningPoSt(ctx context.Context, allSect
 	}}, nil
 }
 
-func (fem *FakeElectionMachine) IsWinner(_ []byte, _, _, _ uint64) bool {
+func (fem *FakeElectionMachine) IsWinner(challengeTicket []byte, minerPower, networkPower big.Int) bool {
 	return true
 }
 
@@ -111,7 +112,7 @@ type FailingElectionValidator struct{}
 
 var _ ElectionValidator = new(FailingElectionValidator)
 
-func (fev *FailingElectionValidator) IsWinner(_ []byte, _, _, _ uint64) bool {
+func (fev *FailingElectionValidator) IsWinner(challengeTicket []byte, minerPower, networkPower big.Int) bool {
 	return false
 }
 


### PR DESCRIPTION
### Motivation
Miner power is no longer a simple function of sector size and count. See #4011.

### Proposed changes
Reads the power from the power table directly. This would be an improvement even if the underlying computation wasn't becoming more complicated.

This is a peer of #4027 and will have a small conflict in the naming of power table functions.
