### PR TITLE
Update gengen with quality-adjusted power and verified deals actor

### DIFF
--- a/fixtures/setup.json
+++ b/fixtures/setup.json
@@ -21,6 +21,7 @@
       "dealCfg": {
         "commP": {"/":"bafk4chzavlx2s3zsomp6beohyevpbql477qyr7qnvgkvfwbbcqzfijo62arq"},
         "pieceSize": 2048,
+        "verified": false,
         "endEpoch": 9001
       }
     },{
@@ -31,6 +32,7 @@
       "dealCfg": {
         "commP": {"/":"bafk4chzaqfni3wpij32pzgv2vuf63utnufburrjzrcoud75oz3pxkfisligq"},
         "pieceSize": 2048,
+        "verified": false,
         "endEpoch": 9001
       }
     }]

--- a/internal/app/go-filecoin/node/block_propagate_test.go
+++ b/internal/app/go-filecoin/node/block_propagate_test.go
@@ -109,9 +109,7 @@ func TestChainSyncWithMessages(t *testing.T) {
 	// genesis has two accounts
 	genCfg := &gengen.GenesisCfg{}
 	require.NoError(t, gengen.MinerConfigs(MakeTestGenCfg(t, 1).Miners)(genCfg))
-	require.NoError(t, gengen.GenKeys(3)(genCfg))
-	require.NoError(t, gengen.GenKeyPrealloc(1, "100000")(genCfg))
-	require.NoError(t, gengen.GenKeyPrealloc(2, "100")(genCfg))
+	require.NoError(t, gengen.GenKeys(3, "1000000")(genCfg))
 	require.NoError(t, gengen.NetworkName(version.TEST)(genCfg))
 	cs := MakeChainSeed(t, genCfg)
 	genUnixSeconds := int64(1234567890)

--- a/internal/app/go-filecoin/node/message_propagate_test.go
+++ b/internal/app/go-filecoin/node/message_propagate_test.go
@@ -34,8 +34,7 @@ func TestMessagePropagation(t *testing.T) {
 
 	// Generate a key and install an account actor at genesis which will be able to send messages.
 	genCfg := &gengen.GenesisCfg{}
-	require.NoError(t, gengen.GenKeys(1)(genCfg))
-	require.NoError(t, gengen.GenKeyPrealloc(0, "100000")(genCfg))
+	require.NoError(t, gengen.GenKeys(1, "1000000")(genCfg))
 	require.NoError(t, gengen.NetworkName(version.TEST)(genCfg))
 
 	cs := MakeChainSeed(t, genCfg)

--- a/internal/pkg/consensus/power_table_view_test.go
+++ b/internal/pkg/consensus/power_table_view_test.go
@@ -106,24 +106,17 @@ func requireMinerWithNumCommittedSectors(ctx context.Context, t *testing.T, numC
 		commCfgs, err := gengen.MakeCommitCfgs(int(numCommittedSectors))
 		require.NoError(t, err)
 		minerConfigs[i] = &gengen.CreateStorageMinerConfig{
+			Owner:            i,
 			CommittedSectors: commCfgs,
 			SectorSize:       constants.DevSectorSize,
 		}
 	}
 
-	// Tedious conversion to pointer type
-	genKis := make([]*crypto.KeyInfo, numMiners)
-	for i, ki := range ownerKeys {
-		genKis[i] = &ki
-	}
-
 	// set up genesis block containing some miners with non-zero power
-	genCfg := &gengen.GenesisCfg{
-		ProofsMode: types.TestProofsMode,
-		Miners:     minerConfigs,
-		Network:    "ptvtest",
-		ImportKeys: genKis,
-	}
+	genCfg := &gengen.GenesisCfg{}
+	require.NoError(t, gengen.MinerConfigs(minerConfigs)(genCfg))
+	require.NoError(t, gengen.NetworkName("ptvtest")(genCfg))
+	require.NoError(t, gengen.ImportKeys(ownerKeys, "1000000")(genCfg))
 
 	info, err := gengen.GenGen(ctx, genCfg, bs)
 	require.NoError(t, err)

--- a/tools/gengen/util/gengen_test.go
+++ b/tools/gengen/util/gengen_test.go
@@ -28,7 +28,7 @@ func testConfig(t *testing.T) *GenesisCfg {
 	return &GenesisCfg{
 		ProofsMode:        types.TestProofsMode,
 		KeysToGen:         4,
-		PreallocatedFunds: []string{"10", "50"},
+		PreallocatedFunds: []string{"1000000", "500000"},
 		Miners: []*CreateStorageMinerConfig{
 			{
 				Owner:            0,

--- a/tools/gengen/util/testing.go
+++ b/tools/gengen/util/testing.go
@@ -3,6 +3,7 @@ package gengen
 import (
 	"fmt"
 
+	"github.com/filecoin-project/specs-actors/actors/abi"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	cbornode "github.com/ipfs/go-ipld-cbor"
 
@@ -31,13 +32,14 @@ func MakeCommitCfgs(n int) ([]*CommitConfig, error) {
 		dealCfg := &DealConfig{
 			CommP:     commP,
 			PieceSize: uint64(1),
+			Verified:  false,
 			EndEpoch:  int64(1024),
 		}
 
 		cfgs[i] = &CommitConfig{
 			CommR:     commR,
 			CommD:     commD,
-			SectorNum: uint64(i),
+			SectorNum: abi.SectorNumber(i),
 			DealCfg:   dealCfg,
 			ProofType: constants.DevRegisteredSealProof,
 		}


### PR DESCRIPTION
### Motivation
My goal here was to set up quality-adjusted power (which depends on verified deals) properly gengen. I discovered so much wrong with how genesis state was being constructed that it resulted in rather a large change. I don't think this is yet capable of producing a mainnet-ready genesis state.

Related to #4011

### Proposed changes
- Install verified deal registry built-in actor
- Include verified deal flag in deal configs
- Compute QA and raw byte power
- Accumulate network total power so pledge amounts can be calculated properly
- Transfer the right pledge value from miner owner to actor (pending updated pledge calculations in actors)
- Fix up invalid genesis configs that didn't pre-allocate any/sufficient value to the miner owner to cover initial pledge
