### PR TITLE
Feat/drand remove firstround cfg

### DIFF
--- a/internal/app/go-filecoin/node/block_propagate_test.go
+++ b/internal/app/go-filecoin/node/block_propagate_test.go
@@ -113,20 +113,17 @@ func TestChainSyncWithMessages(t *testing.T) {
 	require.NoError(t, gengen.NetworkName(version.TEST)(genCfg))
 	cs := MakeChainSeed(t, genCfg)
 	genUnixSeconds := int64(1234567890)
-	fakeClock := clock.NewFake(time.Unix(genUnixSeconds, 0))
+	genTime := time.Unix(genUnixSeconds, 0)
+	fakeClock := clock.NewFake(genTime)
 	blockTime := 30 * time.Second
 	c := clock.NewChainClockFromClock(uint64(genUnixSeconds), blockTime, fakeClock)
-	drandGenUnixSeconds := genUnixSeconds - int64(blockTime.Seconds())
 
 	// first node is the message sender.
 	builder1 := test.NewNodeBuilder(t).
 		WithBuilderOpt(ChainClockConfigOption(c)).
 		WithGenesisInit(cs.GenesisInitFunc).
 		WithBuilderOpt(VerifierConfigOption(&proofs.FakeVerifier{})).
-		WithBuilderOpt(DrandConfigOption(&drand.Fake{
-			GenesisTime:   time.Unix(drandGenUnixSeconds, 0),
-			FirstFilecoin: 0,
-		}))
+		WithBuilderOpt(DrandConfigOption(drand.NewFake(genTime)))
 	nodeSend := builder1.Build(ctx)
 	senderAddress := cs.GiveKey(t, nodeSend, 1)
 
@@ -135,10 +132,7 @@ func TestChainSyncWithMessages(t *testing.T) {
 		WithBuilderOpt(ChainClockConfigOption(c)).
 		WithGenesisInit(cs.GenesisInitFunc).
 		WithBuilderOpt(VerifierConfigOption(&proofs.FakeVerifier{})).
-		WithBuilderOpt(DrandConfigOption(&drand.Fake{
-			GenesisTime:   time.Unix(drandGenUnixSeconds, 0),
-			FirstFilecoin: 0,
-		}))
+		WithBuilderOpt(DrandConfigOption(drand.NewFake(genTime)))
 	nodeReceive := builder2.Build(ctx)
 	receiverAddress := cs.GiveKey(t, nodeReceive, 2)
 
@@ -148,10 +142,7 @@ func TestChainSyncWithMessages(t *testing.T) {
 		WithGenesisInit(cs.GenesisInitFunc).
 		WithBuilderOpt(VerifierConfigOption(&proofs.FakeVerifier{})).
 		WithBuilderOpt(PoStGeneratorOption(&consensus.TestElectionPoster{})).
-		WithBuilderOpt(DrandConfigOption(&drand.Fake{
-			GenesisTime:   time.Unix(drandGenUnixSeconds, 0),
-			FirstFilecoin: 0,
-		}))
+		WithBuilderOpt(DrandConfigOption(drand.NewFake(genTime)))
 	nodeMine := builder3.Build(ctx)
 	cs.GiveKey(t, nodeMine, 0)
 	cs.GiveMiner(t, nodeMine, 0)
@@ -215,20 +206,17 @@ func makeNodesBlockPropTests(t *testing.T, numNodes int) (address.Address, []*No
 	seed := MakeChainSeed(t, MakeTestGenCfg(t, 3))
 	ctx := context.Background()
 	genUnixSeconds := int64(1234567890)
-	fc := clock.NewFake(time.Unix(genUnixSeconds, 0))
+	genTime := time.Unix(genUnixSeconds, 0)
+	fc := clock.NewFake(genTime)
 	blockTime := 30 * time.Second
 	c := clock.NewChainClockFromClock(1234567890, blockTime, fc)
-	drandGenUnixSeconds := genUnixSeconds - int64(blockTime.Seconds())
 
 	builder := test.NewNodeBuilder(t).
 		WithGenesisInit(seed.GenesisInitFunc).
 		WithBuilderOpt(ChainClockConfigOption(c)).
 		WithBuilderOpt(VerifierConfigOption(&proofs.FakeVerifier{})).
 		WithBuilderOpt(PoStGeneratorOption(&consensus.TestElectionPoster{})).
-		WithBuilderOpt(DrandConfigOption(&drand.Fake{
-			GenesisTime:   time.Unix(drandGenUnixSeconds, 0),
-			FirstFilecoin: 0,
-		})).
+		WithBuilderOpt(DrandConfigOption(drand.NewFake(genTime))).
 		WithInitOpt(PeerKeyOpt(PeerKeys[0]))
 	minerNode := builder.Build(ctx)
 	seed.GiveKey(t, minerNode, 0)
@@ -245,10 +233,7 @@ func makeNodesBlockPropTests(t *testing.T, numNodes int) (address.Address, []*No
 		WithBuilderOpt(ChainClockConfigOption(c)).
 		WithBuilderOpt(VerifierConfigOption(&proofs.FakeVerifier{})).
 		WithBuilderOpt(PoStGeneratorOption(&consensus.TestElectionPoster{})).
-		WithBuilderOpt(DrandConfigOption(&drand.Fake{
-			GenesisTime:   time.Unix(drandGenUnixSeconds, 0),
-			FirstFilecoin: 0,
-		}))
+		WithBuilderOpt(DrandConfigOption(drand.NewFake(genTime)))
 
 	for i := 0; i < nodeLimit; i++ {
 		nodes = append(nodes, builder2.Build(ctx))

--- a/internal/app/go-filecoin/node/builder.go
+++ b/internal/app/go-filecoin/node/builder.go
@@ -212,7 +212,7 @@ func (b *Builder) build(ctx context.Context) (*Node, error) {
 	}
 	nd.ChainClock = b.chainClock
 
-	nd.syncer, err = submodule.NewSyncerSubmodule(ctx, (*builder)(b), &nd.Blockstore, &nd.network, &nd.Discovery, &nd.chain, nd.ProofVerification.ProofVerifier, b.drand)
+	nd.syncer, err = submodule.NewSyncerSubmodule(ctx, (*builder)(b), &nd.Blockstore, &nd.network, &nd.Discovery, &nd.chain, nd.ProofVerification.ProofVerifier, b.drand, b.repo.Config())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build node.Syncer")
 	}

--- a/internal/app/go-filecoin/node/builder.go
+++ b/internal/app/go-filecoin/node/builder.go
@@ -154,20 +154,6 @@ func (b *Builder) build(ctx context.Context) (*Node, error) {
 
 	var err error
 
-	if b.drand == nil {
-		drandConfig := b.repo.Config().Drand
-		addrs := make([]drand.Address, len(drandConfig.Addresses))
-		for i, a := range drandConfig.Addresses {
-			addrs[i] = drand.NewAddress(a, drandConfig.Secure)
-		}
-		d, err := drand.NewGRPC(addrs, drandConfig.DistKey, time.Unix(drandConfig.StartTimeUnix, 0),
-			drand.Round(drandConfig.FirstFilecoinRound), time.Duration(drandConfig.RoundSeconds)*time.Second)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to build Drand client")
-		}
-		b.drand = d
-	}
-
 	if b.journal == nil {
 		b.journal = journal.NewNoopJournal()
 	}

--- a/internal/app/go-filecoin/node/test/setup.go
+++ b/internal/app/go-filecoin/node/test/setup.go
@@ -48,18 +48,13 @@ func MustCreateNodesWithBootstrap(ctx context.Context, t *testing.T, additionalN
 	seed := node.MakeChainSeed(t, genCfg)
 	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, fakeClock)
 
-	drandGenUnixSeconds := genTime - int64(blockTime.Seconds())
-
 	// create bootstrap miner
 	bootstrapMiner := NewNodeBuilder(t).
 		WithGenesisInit(seed.GenesisInitFunc).
 		WithBuilderOpt(node.FakeProofVerifierBuilderOpts()...).
 		WithBuilderOpt(node.PoStGeneratorOption(&consensus.TestElectionPoster{})).
 		WithBuilderOpt(node.ChainClockConfigOption(chainClock)).
-		WithBuilderOpt(node.DrandConfigOption(&drand.Fake{
-			GenesisTime:   time.Unix(drandGenUnixSeconds, 0),
-			FirstFilecoin: 0,
-		})).
+		WithBuilderOpt(node.DrandConfigOption(drand.NewFake(time.Unix(genTime, 0)))).
 		WithConfig(func(c *config.Config) {
 			c.SectorBase.PreSealedSectorsDirPath = presealPath
 			c.Mining.MinerAddress = minerAddress
@@ -81,10 +76,7 @@ func MustCreateNodesWithBootstrap(ctx context.Context, t *testing.T, additionalN
 			WithBuilderOpt(node.PoStGeneratorOption(&consensus.TestElectionPoster{})).
 			WithBuilderOpt(node.FakeProofVerifierBuilderOpts()...).
 			WithBuilderOpt(node.ChainClockConfigOption(chainClock)).
-			WithBuilderOpt(node.DrandConfigOption(&drand.Fake{
-				GenesisTime:   time.Unix(drandGenUnixSeconds, 0),
-				FirstFilecoin: 0,
-			})).
+			WithBuilderOpt(node.DrandConfigOption(drand.NewFake(time.Unix(genTime, 0)))).
 			Build(ctx)
 		addr := seed.GiveKey(t, node, int(i+1))
 		err := node.PorcelainAPI.ConfigSet("wallet.defaultAddress", addr.String())

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -135,10 +135,9 @@ type DrandConfig struct {
 	// Secure is whether or not the drand address are secure (e.g. TLS)
 	Secure bool `json:"secure"`
 	// DistKey is the distributed public key of the server group expressed as hex encoded coefficients
-	DistKey            [][]byte `json:"distKey"`
-	StartTimeUnix      int64    `json:"startTimeUnix"`
-	RoundSeconds       int      `json:"roundSeconds"`
-	FirstFilecoinRound uint64   `json:"firstFilecoinRound"`
+	DistKey       [][]byte `json:"distKey"`
+	StartTimeUnix int64    `json:"startTimeUnix"`
+	RoundSeconds  int      `json:"roundSeconds"`
 }
 
 func newDefaultDrandConfig() *DrandConfig {
@@ -150,11 +149,10 @@ func newDefaultDrandConfig() *DrandConfig {
 			"localhost:8083",
 			"localhost:8084",
 		},
-		Secure:             false,
-		DistKey:            [][]byte{},
-		StartTimeUnix:      0,
-		RoundSeconds:       30,
-		FirstFilecoinRound: 0,
+		Secure:        false,
+		DistKey:       [][]byte{},
+		StartTimeUnix: 0,
+		RoundSeconds:  30,
 	}
 }
 

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -77,8 +77,7 @@ func TestWriteFile(t *testing.T) {
 		"secure": false,
 		"distKey": [],
 		"startTimeUnix": 0,
-		"roundSeconds": 30,
-		"firstFilecoinRound": 0
+		"roundSeconds": 30
 	},
 	"heartbeat": {
 		"beatTarget": "",

--- a/internal/pkg/drand/drand_grpc.go
+++ b/internal/pkg/drand/drand_grpc.go
@@ -49,11 +49,15 @@ var _ IFace = &GRPC{}
 // NewGRPC creates a client that will draw randomness from the given addresses.
 // distKeyCoeff are hex encoded strings representing a distributed public key
 // Behavior is undefined if provided address do not point to Drand servers in the same group.
-func NewGRPC(addresses []Address, distKeyCoeff [][]byte, gt time.Time, ffr Round, rd time.Duration) (*GRPC, error) {
+func NewGRPC(addresses []Address, distKeyCoeff [][]byte, drandGenTime time.Time, filecoinGenTime time.Time, rd time.Duration) (*GRPC, error) {
 	distKey, err := groupKeycoefficientsToDistPublic(distKeyCoeff)
 	if err != nil {
 		return nil, err
 	}
+
+	// First filecoin round is the first drand round before filecoinGenesisTime
+
+	// check that there is a drand round between drandGenTime and filecoinGenTime and error otherwise
 
 	return &GRPC{
 		addresses:     addresses,

--- a/internal/pkg/drand/testing.go
+++ b/internal/pkg/drand/testing.go
@@ -19,6 +19,16 @@ type Fake struct {
 
 var _ IFace = &Fake{}
 
+// NewFake sets up a fake drand that starts exactly one testDRANDRoundDuration before
+// the provided filecoin genesis time.
+func NewFake(filecoinGenTime time.Time) *Fake {
+	drandGenTime := filecoinGenTime.Add(-1 * testDRANDRoundDuration)
+	return &Fake{
+		GenesisTime:   drandGenTime,
+		FirstFilecoin: Round(0),
+	}
+}
+
 // ReadEntry immediately returns a drand entry with a signature equal to the
 // round number
 func (d *Fake) ReadEntry(ctx context.Context, drandRound Round) (*Entry, error) {

--- a/internal/pkg/repo/fsrepo_test.go
+++ b/internal/pkg/repo/fsrepo_test.go
@@ -55,8 +55,7 @@ const (
 		"secure": false,
 		"distKey": [],
 		"startTimeUnix": 0,
-		"roundSeconds": 30,
-		"firstFilecoinRound": 0
+		"roundSeconds": 30
 	},
 	"heartbeat": {
 		"beatTarget": "",


### PR DESCRIPTION
### Motivation
We don't need another degree of freedom in setup.  It makes operation harder and more error prone and it is technically unnecessary.

### Proposed changes
Instead of configuring the first drand round as a node operator as part of agreed upon genesis state, derive it directly from the genesis block by looking at the timestamp.

Partially Closes #4023, but we should keep that open to track matching lotus validation rule on the first block.

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

