### PR TITLE
fix: update invoke actor state after transfer

### DIFF
--- a/internal/pkg/vm/internal/vmcontext/invocation_context.go
+++ b/internal/pkg/vm/internal/vmcontext/invocation_context.go
@@ -189,7 +189,9 @@ func (ctx *invocationContext) invoke() (ret returnWrapper, errcode exitcode.Exit
 	ctx.toActor, ctx.msg.to = ctx.resolveTarget(ctx.msg.to)
 
 	// 3. transfer funds carried by the msg
-	ctx.rt.transfer(ctx.msg.from, ctx.msg.to, ctx.msg.value)
+	if !ctx.msg.value.Nil() && !ctx.msg.value.IsZero() {
+		ctx.toActor, ctx.fromActor = ctx.rt.transfer(ctx.msg.from, ctx.msg.to, ctx.msg.value)
+	}
 
 	// 4. if we are just sending funds, there is nothing else to do.
 	if ctx.msg.method == builtin.MethodSend {

--- a/internal/pkg/vm/internal/vmcontext/validation_test.go
+++ b/internal/pkg/vm/internal/vmcontext/validation_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/chain-validation/suites"
-	"github.com/filecoin-project/chain-validation/suites/tipset"
 )
 
 // TestSkipper contains a list of test cases skipped by the implementation.
@@ -33,8 +32,7 @@ var TestSuiteSkipper TestSkipper
 func init() {
 	// initialize the test skipper with tests being skipped
 	TestSuiteSkipper = TestSkipper{testSkips: []suites.TestCase{
-		tipset.TestBlockMessageDeduplication,
-		tipset.TestMinerRewardsAndPenalties,
+		// None!
 	}}
 }
 


### PR DESCRIPTION
The actor state references held by `invocationContext` were outdated after calls to transfer. This prevented reward funds from being distributed to miners by the reward actor.