### PR TITLE
Upgrade to specs-actors v0.3.0

### DIFF
--- a/cmd/go-filecoin/client.go
+++ b/cmd/go-filecoin/client.go
@@ -157,7 +157,7 @@ be 2, 1 hour would be 120, and 1 day would be 2880.
 			Address:    maddr,
 			Owner:      status.OwnerAddress,
 			Worker:     status.WorkerAddress,
-			SectorSize: uint64(status.SectorSize),
+			SectorSize: uint64(status.SectorConfiguration.SectorSize),
 			PeerID:     peerID,
 		}
 

--- a/cmd/go-filecoin/miner.go
+++ b/cmd/go-filecoin/miner.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	address "github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/sector-storage/ffiwrapper"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
@@ -68,6 +69,11 @@ additional sectors.`,
 			return err
 		}
 
+		sealProofType, err := ffiwrapper.SealProofTypeFromSectorSize(sectorSize)
+		if err != nil {
+			return err
+		}
+
 		fromAddr, err := fromAddrOrDefault(req, env)
 		if err != nil {
 			return err
@@ -117,7 +123,7 @@ additional sectors.`,
 			fromAddr,
 			gasPrice,
 			gasLimit,
-			sectorSize,
+			sealProofType,
 			pid,
 			collateral,
 		)

--- a/cmd/go-filecoin/miner_daemon_test.go
+++ b/cmd/go-filecoin/miner_daemon_test.go
@@ -367,12 +367,12 @@ func minerDaemonTestConfig(t *testing.T) *gengen.GenesisCfg {
 			{
 				Owner:            0,
 				CommittedSectors: commCfgs,
-				SectorSize:       constants.DevSectorSize,
+				SealProofType:    constants.DevSealProofType,
 			},
 			{
 				Owner:            1,
 				CommittedSectors: commCfgs,
-				SectorSize:       constants.DevSectorSize,
+				SealProofType:    constants.DevSealProofType,
 			},
 		},
 		Network: "gfctest",

--- a/fixtures/setup.json
+++ b/fixtures/setup.json
@@ -12,7 +12,7 @@
   ],
   "miners": [{
     "owner": 5,
-    "sectorSize": 2048,
+    "sealProofType": 3,
     "committedSectors": [{
       "commR": {"/":"bafk4ehzaqugph7z7yajugw6wz6nn7x3akr3e32wecwexllfgqndnjt3nsaya"},
       "commD": {"/":"bafk4chzavlx2s3zsomp6beohyevpbql477qyr7qnvgkvfwbbcqzfijo62arq"},

--- a/functional-tests/plege_sector_test.go
+++ b/functional-tests/plege_sector_test.go
@@ -36,8 +36,8 @@ func TestMiningPledgeSector(t *testing.T) {
 	// Load genesis config fixture.
 	genCfg := loadGenesisConfig(t, genCfgPath)
 	genCfg.Miners = append(genCfg.Miners, &gengen.CreateStorageMinerConfig{
-		Owner:      1,
-		SectorSize: constants.DevSectorSize,
+		Owner:         1,
+		SealProofType: constants.DevSealProofType,
 	})
 	seed := node.MakeChainSeed(t, genCfg)
 	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, fakeClock)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/drand/drand v0.7.2
 	github.com/drand/kyber v1.0.1-0.20200331114745-30e90cc60f99
 	github.com/elastic/go-windows v1.0.1 // indirect
-	github.com/filecoin-project/chain-validation v0.0.6-0.20200429030643-df5c922faea1
+	github.com/filecoin-project/chain-validation v0.0.6-0.20200429181200-c83b25321997
 	github.com/filecoin-project/filecoin-ffi v0.0.0-20200427223233-a0014b17f124
 	github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be
 	github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e
@@ -23,13 +23,13 @@ require (
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v0.0.0-20200408061858-82c58b423ca6
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
-	github.com/filecoin-project/go-fil-markets v0.0.0-20200427202705-c923d094d901
+	github.com/filecoin-project/go-fil-markets v0.1.1
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663
 	github.com/filecoin-project/go-statemachine v0.0.0-20200314004106-2e7830fc1948 // indirect
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
-	github.com/filecoin-project/sector-storage v0.0.0-20200425102315-c19a25449861
+	github.com/filecoin-project/sector-storage v0.0.0-20200429180615-83b1b9403480
 	github.com/filecoin-project/specs-actors v0.3.0
 	github.com/filecoin-project/specs-storage v0.0.0-20200427220711-ae5a7f26c65f // indirect
 	github.com/filecoin-project/storage-fsm v0.0.0-20200427182014-01487d5ad3c8

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
 	github.com/filecoin-project/sector-storage v0.0.0-20200425102315-c19a25449861
-	github.com/filecoin-project/specs-actors v0.2.0
+	github.com/filecoin-project/specs-actors v0.3.0
 	github.com/filecoin-project/specs-storage v0.0.0-20200427220711-ae5a7f26c65f // indirect
 	github.com/filecoin-project/storage-fsm v0.0.0-20200427182014-01487d5ad3c8
 	github.com/fxamacker/cbor v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/fatih/color v1.8.0/go.mod h1:3l45GVGkyrnYNl9HoIjnp2NnNWvh6hLAqD8yTfGj
 github.com/fd/go-nat v1.0.0 h1:DPyQ97sxA9ThrWYRPcWUz/z9TnpTIGRYODIQc/dy64M=
 github.com/fd/go-nat v1.0.0/go.mod h1:BTBu/CKvMmOMUPkKVef1pngt2WFH/lg7E6yQnulfp6E=
 github.com/filecoin-project/chain-validation v0.0.3/go.mod h1:NCEGFjcWRjb8akWFSOXvU6n2efkWIqAeOKU6o5WBGQw=
-github.com/filecoin-project/chain-validation v0.0.6-0.20200429030643-df5c922faea1 h1:J34+wu8i3gDMQgAe1v1V3roq3UYXHWOG5iErnD6t24k=
-github.com/filecoin-project/chain-validation v0.0.6-0.20200429030643-df5c922faea1/go.mod h1:3NdTOM8ICczyXfrPfzIAUCgKrbqvNbuwSEh71cqBFso=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200429181200-c83b25321997 h1:r92U7SyeHhvqjQKMkIGdYesKNAAcqGCLtGKPdhVS/OI=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200429181200-c83b25321997/go.mod h1:Lk9OjM6bsvk1KlTwkQN+RGOusGPqmaxcllvaz119xtc=
 github.com/filecoin-project/go-address v0.0.0-20191219011437-af739c490b4f/go.mod h1:rCbpXPva2NKF9/J4X6sr7hbKBgQCxyFtRj7KOZqoIms=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5 h1:/MmWluswvDIbuPvBct4q6HeQgVm62O2DzWYTB38kt4A=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
@@ -198,8 +198,8 @@ github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200114015428-74d100f305f8 h1:g3oodvSz+Ou+ObwcVBB2wyt8SHdWpwzMiNJ19U1zZNA=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200114015428-74d100f305f8/go.mod h1:c8NTjvFVy1Ud02mmGDjOiMeawY2t6ALfrrdvAB01FQc=
-github.com/filecoin-project/go-fil-markets v0.0.0-20200427202705-c923d094d901 h1:IH30Tqjt0eo2cIi1yiAaYFhRIm3VxPSJg6pAsuZ/G0o=
-github.com/filecoin-project/go-fil-markets v0.0.0-20200427202705-c923d094d901/go.mod h1:l0fV9dM7hdcwDkSd45UEwvGeUm/GhSDV/atFnZJ9Zt8=
+github.com/filecoin-project/go-fil-markets v0.1.1 h1:k54xzJjGP+XanAUDv5DrPbV1OfTlh2s/rhOOZMKWCGo=
+github.com/filecoin-project/go-fil-markets v0.1.1/go.mod h1:YHQ61i3zpyW09sQ2KutG8UjtezEd0VHpO1iqI6vfPEI=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543 h1:aMJGfgqe1QDhAVwxRg5fjCRF533xHidiKsugk7Vvzug=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543/go.mod h1:mjrHv1cDGJWDlGmC0eDc1E5VJr8DmL9XMUcaFwiuKg8=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:92PET+sx1Hb4W/8CgFwGuxaKbttwY+UNspYZTvXY0vs=
@@ -222,8 +222,8 @@ github.com/filecoin-project/lotus v0.2.10 h1:ijrj/nYdKu5GiMo9r1+Zcp2A4jKHSOMZ2WN
 github.com/filecoin-project/lotus v0.2.10/go.mod h1:om5PQA9ZT0lf16qI7Fz/ZGLn4LDCMqPC8ntZA9uncRE=
 github.com/filecoin-project/sector-storage v0.0.0-20200411000242-61616264b16d h1:vD83B+dP/YCTVvsnk76auROLjurEOl/VLseRKbmoFYI=
 github.com/filecoin-project/sector-storage v0.0.0-20200411000242-61616264b16d/go.mod h1:/yueJueMh0Yc+0G1adS0lhnedcSnjY86EjKsA20+DVY=
-github.com/filecoin-project/sector-storage v0.0.0-20200425102315-c19a25449861 h1:TKcVIq20EZeJwvxnCDSHE+QWLd19aGY1Y0XP7DMjt5E=
-github.com/filecoin-project/sector-storage v0.0.0-20200425102315-c19a25449861/go.mod h1:q/V90xaSKTlu7KovS0uj+cAvlPPFrGn141ZO3iQNEdw=
+github.com/filecoin-project/sector-storage v0.0.0-20200429180615-83b1b9403480 h1:ibHG4Qk+5rD+YxiT0EfbE5SWja1VtqUail9hO7J+voY=
+github.com/filecoin-project/sector-storage v0.0.0-20200429180615-83b1b9403480/go.mod h1:gPU0JuYDxbOKq8hpaRzoaf5QFwcxRRwM7l9tMMr6KhY=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.0.0-20200409043918-e569f4a2f504 h1:mwuAaqxKThl70+7FkGdFKVLdwaQZQ8XmscKdhSBBtnc=
 github.com/filecoin-project/specs-actors v0.0.0-20200409043918-e569f4a2f504/go.mod h1:mdJraXq5vMy0+/FqVQIrnNlpQ/Em6zeu06G/ltQ0/lA=

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/filecoin-project/specs-actors v0.0.0-20200409043918-e569f4a2f504 h1:m
 github.com/filecoin-project/specs-actors v0.0.0-20200409043918-e569f4a2f504/go.mod h1:mdJraXq5vMy0+/FqVQIrnNlpQ/Em6zeu06G/ltQ0/lA=
 github.com/filecoin-project/specs-actors v0.2.0 h1:bKxloHLegeYJttIJbQjl4/tdsKOUtYtpiZsEfB4eOnI=
 github.com/filecoin-project/specs-actors v0.2.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=
+github.com/filecoin-project/specs-actors v0.3.0 h1:QxgAuTrZr5TPqjyprZk0nTYW5o0JWpzbb5v+4UHHvN0=
+github.com/filecoin-project/specs-actors v0.3.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=
 github.com/filecoin-project/specs-storage v0.0.0-20200410185809-9fbaaa08f275 h1:6OTcpsTQBQM0f/A67oEi4E4YtYd6fzkMqbU8cPIWMMs=
 github.com/filecoin-project/specs-storage v0.0.0-20200410185809-9fbaaa08f275/go.mod h1:xJ1/xl9+8zZeSSSFmDC3Wr6uusCTxyYPI0VeNVSFmPE=
 github.com/filecoin-project/specs-storage v0.0.0-20200417134612-61b2d91a6102/go.mod h1:xJ1/xl9+8zZeSSSFmDC3Wr6uusCTxyYPI0VeNVSFmPE=

--- a/internal/app/go-filecoin/connectors/fsm_node/connector.go
+++ b/internal/app/go-filecoin/connectors/fsm_node/connector.go
@@ -118,7 +118,11 @@ func (f *FiniteStateMachineNodeConnector) StateMinerSectorSize(ctx context.Conte
 		return 0, err
 	}
 
-	return view.MinerSectorSize(ctx, maddr)
+	conf, err := view.MinerSectorConfiguration(ctx, maddr)
+	if err != nil {
+		return 0, err
+	}
+	return conf.SectorSize, err
 }
 
 func (f *FiniteStateMachineNodeConnector) StateMinerWorkerAddress(ctx context.Context, maddr address.Address, tok fsm.TipSetToken) (address.Address, error) {

--- a/internal/app/go-filecoin/internal/submodule/storage_mining_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/storage_mining_submodule.go
@@ -53,7 +53,6 @@ func NewStorageMiningSubmodule(
 	mw *msg.Waiter,
 	stateViewer *appstate.Viewer,
 	sealProofType abi.RegisteredProof,
-	postProofType abi.RegisteredProof,
 	r repo.Repo,
 	postGeneratorOverride postgenerator.PoStGenerator,
 ) (*StorageMiningSubmodule, error) {

--- a/internal/app/go-filecoin/node/init.go
+++ b/internal/app/go-filecoin/node/init.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/sector-storage/ffiwrapper"
 	"github.com/filecoin-project/sector-storage/stores"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	fsm "github.com/filecoin-project/storage-fsm"
@@ -284,12 +283,7 @@ func ensureSectorDirAndMetadata(containsPreSealedSectors bool, dirPath string) e
 func createGenesisFSMState(ctx context.Context, rep repo.Repo, genesisBlock *block.Block, maddr address.Address) ([]fsm.SectorInfo, error) {
 	view := state.NewViewer(cborutil.NewIpldStore(bstore.NewBlockstore(rep.Datastore()))).StateView(genesisBlock.StateRoot.Cid)
 
-	size, err := view.MinerSectorSize(ctx, maddr)
-	if err != nil {
-		return nil, err
-	}
-
-	spt, err := ffiwrapper.SealProofTypeFromSectorSize(size)
+	conf, err := view.MinerSectorConfiguration(ctx, maddr)
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +316,7 @@ func createGenesisFSMState(ctx context.Context, rep repo.Repo, genesisBlock *blo
 			}
 		}
 
-		unsealedCID, err := view.MarketComputeDataCommitment(ctx, spt, dealIDs)
+		unsealedCID, err := view.MarketComputeDataCommitment(ctx, conf.SealProofType, dealIDs)
 		if err != nil {
 			return err
 		}

--- a/internal/app/go-filecoin/node/test/setup.go
+++ b/internal/app/go-filecoin/node/test/setup.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/build/project"
@@ -42,8 +41,8 @@ func MustCreateNodesWithBootstrap(ctx context.Context, t *testing.T, additionalN
 	// Load genesis config fixture.
 	genCfg := loadGenesisConfig(t, genCfgPath)
 	genCfg.Miners = append(genCfg.Miners, &gengen.CreateStorageMinerConfig{
-		Owner:      5,
-		SectorSize: constants.DevSectorSize,
+		Owner:         5,
+		SealProofType: constants.DevSealProofType,
 	})
 	seed := node.MakeChainSeed(t, genCfg)
 	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, fakeClock)
@@ -61,7 +60,7 @@ func MustCreateNodesWithBootstrap(ctx context.Context, t *testing.T, additionalN
 		}).
 		Build(ctx)
 
-	_, _, err = initNodeGenesisMiner(ctx, t, bootstrapMiner, seed, genCfg.Miners[0].Owner, presealPath, genCfg.Miners[0].SectorSize)
+	_, _, err = initNodeGenesisMiner(ctx, t, bootstrapMiner, seed, genCfg.Miners[0].Owner)
 	require.NoError(t, err)
 	err = bootstrapMiner.Start(ctx)
 	require.NoError(t, err)
@@ -110,7 +109,7 @@ func MustCreateNodesWithBootstrap(ctx context.Context, t *testing.T, additionalN
 	return nodes, cancel
 }
 
-func initNodeGenesisMiner(ctx context.Context, t *testing.T, nd *node.Node, seed *node.ChainSeed, minerIdx int, presealPath string, sectorSize abi.SectorSize) (address.Address, address.Address, error) {
+func initNodeGenesisMiner(ctx context.Context, t *testing.T, nd *node.Node, seed *node.ChainSeed, minerIdx int) (address.Address, address.Address, error) {
 	seed.GiveKey(t, nd, minerIdx)
 	miner, owner := seed.GiveMiner(t, nd, 0)
 

--- a/internal/app/go-filecoin/node/testing.go
+++ b/internal/app/go-filecoin/node/testing.go
@@ -209,7 +209,7 @@ func MakeTestGenCfg(t *testing.T, numSectors int) *gengen.GenesisCfg {
 				Owner:            0,
 				PeerID:           mustPeerID(PeerKeys[0]).Pretty(),
 				CommittedSectors: commCfgs,
-				SectorSize:       constants.DevSectorSize,
+				SealProofType:    constants.DevSealProofType,
 			},
 		},
 		Network: "gfctest",

--- a/internal/app/go-filecoin/porcelain/api.go
+++ b/internal/app/go-filecoin/porcelain/api.go
@@ -68,11 +68,11 @@ func (a *API) MinerCreate(
 	accountAddr address.Address,
 	gasPrice types.AttoFIL,
 	gasLimit gas.Unit,
-	sectorSize abi.SectorSize,
+	sealProofType abi.RegisteredProof,
 	pid peer.ID,
 	collateral types.AttoFIL,
 ) (_ address.Address, err error) {
-	return MinerCreate(ctx, a, accountAddr, gasPrice, gasLimit, sectorSize, pid, collateral)
+	return MinerCreate(ctx, a, accountAddr, gasPrice, gasLimit, sealProofType, pid, collateral)
 }
 
 // MinerPreviewCreate previews the Gas cost of creating a miner

--- a/internal/app/go-filecoin/porcelain/miner_test.go
+++ b/internal/app/go-filecoin/porcelain/miner_test.go
@@ -110,7 +110,7 @@ func TestMinerCreate(t *testing.T) {
 			address.Address{},
 			types.NewGasPrice(0),
 			gas.NewGas(100),
-			constants.DevSectorSize,
+			constants.DevSealProofType,
 			"",
 			collateral,
 		)
@@ -129,7 +129,7 @@ func TestMinerCreate(t *testing.T) {
 			address.Address{},
 			types.NewGasPrice(0),
 			gas.NewGas(100),
-			constants.DevSectorSize,
+			constants.DevSealProofType,
 			"",
 			collateral,
 		)

--- a/internal/pkg/consensus/power_table_view.go
+++ b/internal/pkg/consensus/power_table_view.go
@@ -15,7 +15,7 @@ import (
 // immediate parent state.
 type PowerStateView interface {
 	state.AccountStateView
-	MinerSectorSize(ctx context.Context, maddr addr.Address) (abi.SectorSize, error)
+	MinerSectorConfiguration(ctx context.Context, maddr addr.Address) (*state.MinerSectorConfiguration, error)
 	MinerControlAddresses(ctx context.Context, maddr addr.Address) (owner, worker addr.Address, err error)
 	MinerSectorsForEach(ctx context.Context, maddr addr.Address, f func(id abi.SectorNumber, sealedCID cid.Cid, rpp abi.RegisteredProof, dealIDs []abi.DealID) error) error
 	PowerNetworkTotal(ctx context.Context) (*state.NetworkPower, error)

--- a/internal/pkg/consensus/power_table_view_test.go
+++ b/internal/pkg/consensus/power_table_view_test.go
@@ -110,7 +110,7 @@ func requireMinerWithNumCommittedSectors(ctx context.Context, t *testing.T, numC
 		minerConfigs[i] = &gengen.CreateStorageMinerConfig{
 			Owner:            i,
 			CommittedSectors: commCfgs,
-			SectorSize:       constants.DevSectorSize,
+			SealProofType:    constants.DevSealProofType,
 		}
 	}
 

--- a/internal/pkg/constants/sector_size.go
+++ b/internal/pkg/constants/sector_size.go
@@ -2,8 +2,18 @@ package constants
 
 import "github.com/filecoin-project/specs-actors/actors/abi"
 
+const DevSealProofType = abi.RegisteredProof_StackedDRG2KiBSeal
+
 // DevSectorSize is a tiny sector useful only for testing.
-var DevSectorSize = abi.SectorSize(2048)
+var DevSectorSize abi.SectorSize
+
+func init() {
+	var err error
+	DevSectorSize, err = DevSealProofType.SectorSize()
+	if err != nil {
+		panic(err)
+	}
+}
 
 // FiveHundredTwelveMiBSectorSize contain 512MiB after sealing.
 var FiveHundredTwelveMiBSectorSize = abi.SectorSize(512 << 20)

--- a/internal/pkg/state/testing.go
+++ b/internal/pkg/state/testing.go
@@ -36,19 +36,19 @@ func NewFakeStateView(rawBytePower, qaPower abi.StoragePower, minerCount, minPow
 
 // FakeMinerState is fake state for a single miner.
 type FakeMinerState struct {
-	SectorSize         abi.SectorSize
-	Owner              address.Address
-	Worker             address.Address
-	PeerID             peer.ID
-	ProvingPeriodStart abi.ChainEpoch
-	ProvingPeriodEnd   abi.ChainEpoch
-	PoStFailures       int
-	Sectors            []miner.SectorOnChainInfo
-	ProvingSet         []FakeSectorInfo
-	ClaimedRawPower    abi.StoragePower
-	ClaimedQAPower     abi.StoragePower
-	PledgeRequirement  abi.TokenAmount
-	PledgeBalance      abi.TokenAmount
+	SectorConfiguration *MinerSectorConfiguration
+	Owner               address.Address
+	Worker              address.Address
+	PeerID              peer.ID
+	ProvingPeriodStart  abi.ChainEpoch
+	ProvingPeriodEnd    abi.ChainEpoch
+	PoStFailures        int
+	Sectors             []miner.SectorOnChainInfo
+	ProvingSet          []FakeSectorInfo
+	ClaimedRawPower     abi.StoragePower
+	ClaimedQAPower      abi.StoragePower
+	PledgeRequirement   abi.TokenAmount
+	PledgeBalance       abi.TokenAmount
 }
 
 // FakeSectorInfo fakes a subset of sector onchain info
@@ -61,13 +61,13 @@ func (v *FakeStateView) InitNetworkName(_ context.Context) (string, error) {
 	return v.NetworkName, nil
 }
 
-// MinerSectorSize reports a miner's sector size.
-func (v *FakeStateView) MinerSectorSize(_ context.Context, maddr address.Address) (abi.SectorSize, error) {
+// MinerSectorConfiguration reports a miner's sector size.
+func (v *FakeStateView) MinerSectorConfiguration(ctx context.Context, maddr address.Address) (*MinerSectorConfiguration, error) {
 	m, ok := v.Miners[maddr]
 	if !ok {
-		return 0, errors.Errorf("no miner %s", maddr)
+		return nil, errors.Errorf("no miner %s", maddr)
 	}
-	return m.SectorSize, nil
+	return m.SectorConfiguration, nil
 }
 
 // MinerSectorCount reports the number of sectors a miner has pledged

--- a/internal/pkg/state/view.go
+++ b/internal/pkg/state/view.go
@@ -174,7 +174,8 @@ func (v *View) MinerPartitionIndicesForDeadline(ctx context.Context, maddr addr.
 	}
 
 	// compute first partition index
-	start, sectorCount, err := miner.PartitionsForDeadline(deadlines, deadlineIndex)
+	partitionSize := minerState.Info.WindowPoStPartitionSectors
+	start, sectorCount, err := miner.PartitionsForDeadline(deadlines, partitionSize, deadlineIndex)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +186,7 @@ func (v *View) MinerPartitionIndicesForDeadline(ctx context.Context, maddr addr.
 	}
 
 	// compute number of partitions
-	partitionCount, _, err := miner.DeadlineCount(deadlines, deadlineIndex)
+	partitionCount, _, err := miner.DeadlineCount(deadlines, partitionSize, deadlineIndex)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +212,8 @@ func (v *View) MinerSectorInfoForDeadline(ctx context.Context, maddr addr.Addres
 	}
 
 	// This is copied from miner.Actor SubmitWindowedPoSt. It should be logic in miner.State.
-	partitionsSectors, err := miner.ComputePartitionsSectors(deadlines, deadlineIndex, partitions)
+	partitionSize := minerState.Info.WindowPoStPartitionSectors
+	partitionsSectors, err := miner.ComputePartitionsSectors(deadlines, partitionSize, deadlineIndex, partitions)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/state/view.go
+++ b/internal/pkg/state/view.go
@@ -117,13 +117,23 @@ func (v *View) MinerPeerID(ctx context.Context, maddr addr.Address) (peer.ID, er
 	return minerState.Info.PeerId, nil
 }
 
-// MinerSectorSize returns the sector size for a miner actor
-func (v *View) MinerSectorSize(ctx context.Context, maddr addr.Address) (abi.SectorSize, error) {
+type MinerSectorConfiguration struct {
+	SealProofType              abi.RegisteredProof
+	SectorSize                 abi.SectorSize
+	WindowPoStPartitionSectors uint64
+}
+
+// MinerSectorConfiguration returns the sector size for a miner actor
+func (v *View) MinerSectorConfiguration(ctx context.Context, maddr addr.Address) (*MinerSectorConfiguration, error) {
 	minerState, err := v.loadMinerActor(ctx, maddr)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	return minerState.Info.SectorSize, nil
+	return &MinerSectorConfiguration{
+		SealProofType:              minerState.Info.SealProofType,
+		SectorSize:                 minerState.Info.SectorSize,
+		WindowPoStPartitionSectors: minerState.Info.WindowPoStPartitionSectors,
+	}, nil
 }
 
 // MinerSectorCount counts all the on-chain sectors

--- a/internal/pkg/testhelpers/iptbtester/genesis.go
+++ b/internal/pkg/testhelpers/iptbtester/genesis.go
@@ -54,7 +54,7 @@ func RequireGenerateGenesis(t *testing.T, funds int64, dir string, genesisTime t
 			{
 				Owner:            0,
 				CommittedSectors: commCfgs,
-				SectorSize:       constants.DevSectorSize,
+				SealProofType:    constants.DevSealProofType,
 			},
 		},
 		Network: "gfctest",

--- a/internal/pkg/vm/internal/vmcontext/vmcontext.go
+++ b/internal/pkg/vm/internal/vmcontext/vmcontext.go
@@ -343,7 +343,8 @@ func (vm *VM) applyImplicitMessage(imsg internalMessage, rnd crypto.RandomnessSo
 	// 4. invoke message
 	ret, code := ctx.invoke()
 	if code.IsError() {
-		return nil, fmt.Errorf("Invalid exit code during implicit message execution (code: %d)", code)
+		return nil, fmt.Errorf("invalid exit code %d during implicit message execution: from %s, to %s, method %d, value %s, params %v",
+			code, imsg.from, imsg.to, imsg.method, imsg.value, imsg.params)
 	}
 	return ret.inner, nil
 }

--- a/tools/fast/environment/environment_memory_genesis.go
+++ b/tools/fast/environment/environment_memory_genesis.go
@@ -238,7 +238,7 @@ func (e *MemoryGenesis) buildGenesis(funds *big.Int) error {
 		Miners: []*gengen.CreateStorageMinerConfig{
 			{
 				Owner:            0,
-				SectorSize:       constants.DevSectorSize,
+				SealProofType:    constants.DevSealProofType,
 				CommittedSectors: commCfgs,
 			},
 		},

--- a/tools/gengen/util/generator.go
+++ b/tools/gengen/util/generator.go
@@ -363,7 +363,11 @@ func (g *GenesisGenerator) setupMiners(ctx context.Context) ([]*RenderedMinerInf
 				return nil, err
 			}
 
-			rawPower, qaPower := computeSectorPower(m.SectorSize, sectorExpiration, dealWeight, verifiedWeight)
+			sectorSize, err := m.SealProofType.SectorSize()
+			if err != nil {
+				return nil, err
+			}
+			rawPower, qaPower := computeSectorPower(sectorSize, sectorExpiration, dealWeight, verifiedWeight)
 
 			sectorsToCommit = append(sectorsToCommit, &sectorCommitInfo{
 				miner:          actorAddr,
@@ -463,10 +467,10 @@ func (g *GenesisGenerator) createMiner(ctx context.Context, m *CreateStorageMine
 	}
 
 	out, err := g.vm.ApplyGenesisMessage(ownerAddr, builtin.StoragePowerActorAddr, builtin.MethodsPower.CreateMiner, big.Zero(), &power.CreateMinerParams{
-		Owner:      ownerAddr,
-		Worker:     ownerAddr,
-		Peer:       pid,
-		SectorSize: m.SectorSize,
+		Owner:         ownerAddr,
+		Worker:        ownerAddr,
+		Peer:          pid,
+		SealProofType: m.SealProofType,
 	}, &g.chainRand)
 	if err != nil {
 		return address.Undef, address.Undef, err

--- a/tools/gengen/util/gengen.go
+++ b/tools/gengen/util/gengen.go
@@ -38,8 +38,9 @@ type CreateStorageMinerConfig struct {
 	// CommittedSectors is the list of sector commitments in this miner's proving set
 	CommittedSectors []*CommitConfig
 
-	// SectorSize is the size of the sectors that this miner commits, in bytes.
-	SectorSize abi.SectorSize
+	// SealProofType is the proof configuration used by this miner
+	// (which implies sector size and window post partition size)
+	SealProofType abi.RegisteredProof
 
 	// ProvingPeriodStart is next chain epoch at which a miner will need to submit a windowed post
 	// If unset, it will be set to the proving period.

--- a/tools/gengen/util/gengen_test.go
+++ b/tools/gengen/util/gengen_test.go
@@ -31,12 +31,12 @@ func testConfig(t *testing.T) *GenesisCfg {
 			{
 				Owner:            0,
 				CommittedSectors: fiftyCommCfgs,
-				SectorSize:       constants.DevSectorSize,
+				SealProofType:    constants.DevSealProofType,
 			},
 			{
 				Owner:            1,
 				CommittedSectors: tenCommCfgs,
-				SectorSize:       constants.DevSectorSize,
+				SealProofType:    constants.DevSealProofType,
 			},
 		},
 		Network: "gfctest",


### PR DESCRIPTION
This is fairly painless. Tests won't pass until https://github.com/filecoin-project/chain-validation/pull/179 lands and this PR also consumes the appropriate chain validation tests.

It would be beneficial to also consume compatible upstream repos at the same time, though in this case I think the changes are small enough that it's also safe not to.
- [ ] https://github.com/filecoin-project/filecoin-ffi/pull/81
- [ ] https://github.com/filecoin-project/specs-storage/pull/8
- [x] https://github.com/filecoin-project/go-fil-markets/pull/207
- [ ] https://github.com/filecoin-project/storage-fsm/pull/15
- [x] https://github.com/filecoin-project/sector-storage/pull/21