### PR TITLE
Feat/retrieval market #3988

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.5.1
+	github.com/prometheus/common v0.9.1
 	github.com/prometheus/procfs v0.0.11 // indirect
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/internal/app/go-filecoin/connectors/retrieval_market/client.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/client.go
@@ -80,7 +80,8 @@ func (r *RetrievalClientConnector) GetOrCreatePaymentChannel(ctx context.Context
 	// If there was one already, what CID should this return?
 	// What happens if that message is subsequently re-orged out of the chain and never replayed?
 	// https://github.com/filecoin-project/go-filecoin/issues/4034
-	return chinfo.UniqueAddr, cid.Undef, nil
+	mcid, err := r.paychMgr.AddFundsToChannel(chinfo.UniqueAddr, clientFundsAvailable)
+	return chinfo.UniqueAddr, mcid, err
 }
 
 // AllocateLane creates a new lane for this paymentChannel with 0 FIL in the lane
@@ -137,14 +138,12 @@ func (r *RetrievalClientConnector) CreatePaymentVoucher(ctx context.Context, pay
 	return &v, nil
 }
 
-func (r *RetrievalClientConnector) WaitForPaymentChannelCreation(messageCID cid.Cid) (address.Address, error) {
-	// TODO https://github.com/filecoin-project/go-filecoin/issues/4034
-	panic("implement me")
+func (r *RetrievalClientConnector) WaitForPaymentChannelAddFunds(messageCID cid.Cid) error {
+	return r.paychMgr.WaitForAddFundsMessage(context.Background(), messageCID)
 }
 
-func (r *RetrievalClientConnector) WaitForPaymentChannelAddFunds(messageCID cid.Cid) error {
-	// TODO https://github.com/filecoin-project/go-filecoin/issues/4034
-	panic("implement me")
+func (r *RetrievalClientConnector) WaitForPaymentChannelCreation(messageCID cid.Cid) (address.Address, error) {
+	return r.paychMgr.WaitForCreatePaychMessage(context.Background(), messageCID)
 }
 
 func (r *RetrievalClientConnector) getBlockHeight(tok shared.TipSetToken) (abi.ChainEpoch, error) {

--- a/internal/app/go-filecoin/connectors/retrieval_market/client_test.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/client_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/message"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor/builtin"
@@ -37,6 +38,7 @@ import (
 )
 
 func TestRetrievalClientConnector_GetOrCreatePaymentChannel(t *testing.T) {
+	testflags.IntegrationTest(t)
 	ctx := context.Background()
 
 	paych := specst.NewActorAddr(t, "paych")
@@ -113,6 +115,7 @@ func TestRetrievalClientConnector_GetOrCreatePaymentChannel(t *testing.T) {
 }
 
 func TestRetrievalClientConnector_AllocateLane(t *testing.T) {
+	testflags.IntegrationTest(t)
 	ctx := context.Background()
 	bs, cs, client, miner, _ := testSetup(ctx, t, abi.NewTokenAmount(100))
 
@@ -147,6 +150,7 @@ func TestRetrievalClientConnector_AllocateLane(t *testing.T) {
 }
 
 func TestRetrievalClientConnector_CreatePaymentVoucher(t *testing.T) {
+	testflags.IntegrationTest(t)
 	ctx := context.Background()
 	balance := abi.NewTokenAmount(1000)
 	bs, cs, client, miner, genTs := testSetup(ctx, t, balance)

--- a/internal/app/go-filecoin/connectors/retrieval_market/common.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/common.go
@@ -37,6 +37,9 @@ type PaychMgrAPI interface {
 	GetPaymentChannelInfo(paychAddr address.Address) (*paymentchannel.ChannelInfo, error)
 	GetPaymentChannelByAccounts(payer, payee address.Address) (*paymentchannel.ChannelInfo, error)
 	CreatePaymentChannel(payer, payee address.Address, amt abi.TokenAmount) (address.Address, cid.Cid, error)
+	AddFundsToChannel(paychAddr address.Address, amt abi.TokenAmount) (cid.Cid, error)
 	AddVoucherToChannel(paychAddr address.Address, voucher *paychActor.SignedVoucher) error
 	AddVoucher(paychAddr address.Address, voucher *paychActor.SignedVoucher, proof []byte, expected big.Int, tok shared.TipSetToken) (abi.TokenAmount, error)
+	WaitForCreatePaychMessage(ctx context.Context, mcid cid.Cid) (address.Address, error)
+	WaitForAddFundsMessage(ctx context.Context, mcid cid.Cid) error
 }

--- a/internal/app/go-filecoin/connectors/retrieval_market/fake_api.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/fake_api.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ipfs/go-cid"
 	xerrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/paymentchannel"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
@@ -94,9 +93,6 @@ func (rmFake *RetrievalMarketClientFakeAPI) UnsealSector(_ context.Context, sect
 }
 
 // ---------------  Testing methods
-func (rmFake *RetrievalMarketClientFakeAPI) Verify() {
-	assert.Equal(rmFake.t, len(rmFake.ActualSectorIDs), len(rmFake.ExpectedSectorIDs))
-}
 
 // StubMessageResponse sets up a message, message receipt and return value for a create payment
 // channel message

--- a/internal/app/go-filecoin/connectors/retrieval_market/provider_test.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/provider_test.go
@@ -37,11 +37,10 @@ func TestNewRetrievalProviderNodeConnector(t *testing.T) {
 	pm := piecemanager.NewFiniteStateMachineBackEnd(nil, nil)
 	bs := blockstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 
-	pchMgr := makePaychMgr(context.Background(), t,
+	pchMgr, _ := makePaychMgr(context.Background(), t,
 		specst.NewIDAddr(t, 99),
 		specst.NewIDAddr(t, 100),
-		specst.NewActorAddr(t, "foobar"),
-		abi.NewTokenAmount(10))
+		specst.NewActorAddr(t, "foobar"))
 	rpc := NewRetrievalProviderConnector(rmnet, &pm, bs, pchMgr, nil)
 	assert.NotZero(t, rpc)
 }
@@ -87,7 +86,6 @@ func TestRetrievalProviderConnector_UnsealSector(t *testing.T) {
 
 				// check that it read something & the offset worked
 				assert.Equal(t, "xtures", string(readBytes[0:6]))
-				rmp.Verify()
 			}
 		})
 	}
@@ -97,11 +95,10 @@ func unsealTestSetup(ctx context.Context, t *testing.T) (*RetrievalMarketClientF
 	rmnet := gfmtut.NewTestRetrievalMarketNetwork(gfmtut.TestNetworkParams{})
 	bs := blockstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 	rmp := NewRetrievalMarketClientFakeAPI(t)
-	pchMgr := makePaychMgr(ctx, t,
+	pchMgr, _ := makePaychMgr(ctx, t,
 		specst.NewIDAddr(t, 99),
 		specst.NewIDAddr(t, 100),
-		specst.NewActorAddr(t, "foobar"),
-		abi.NewTokenAmount(10))
+		specst.NewActorAddr(t, "foobar"))
 	rpc := NewRetrievalProviderConnector(rmnet, rmp, bs, pchMgr, nil)
 	return rmp, rpc
 }
@@ -146,7 +143,6 @@ func TestRetrievalProviderConnector_SavePaymentVoucher(t *testing.T) {
 		chinfo, err := pchMgr.GetPaymentChannelInfo(pchan)
 		require.NoError(t, err)
 		assert.True(t, chinfo.HasVoucher(voucher))
-		rmp.Verify()
 	})
 
 	t.Run("errors if manager fails to save voucher, does not store new channel info", func(t *testing.T) {

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -128,9 +128,6 @@ func (node *Node) Start(ctx context.Context) error {
 		return errors.Wrap(err, "failed to set up protocols:")
 	}
 
-	// DRAGONS: uncomment when we have retrieval market integration
-	//node.RetrievalProtocol.RetrievalProvider = retrieval.NewMiner()
-
 	var syncCtx context.Context
 	syncCtx, node.syncer.CancelChainSync = context.WithCancel(context.Background())
 

--- a/internal/app/go-filecoin/paymentchannel/integration_test.go
+++ b/internal/app/go-filecoin/paymentchannel/integration_test.go
@@ -87,7 +87,6 @@ func TestPaymentChannel(t *testing.T) {
 		Client:         client,
 		ClientID:       spect.NewIDAddr(t, 999),
 		Miner:          miner,
-		PcActorHarness: new(paychtest.PcActorHarness),
 	}
 	paychActorUtil.ConstructPaychActor(t, initialChannelAmt)
 

--- a/internal/app/go-filecoin/paymentchannel/integration_test.go
+++ b/internal/app/go-filecoin/paymentchannel/integration_test.go
@@ -70,8 +70,9 @@ func TestPaymentChannel(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, address.Undef, addr)
 
-	// give a chance for the goroutine to finish creating channel info
+	// let the goroutine finish creating channel info
 	time.Sleep(100 * time.Millisecond)
+
 	addr, err = connector.WaitForPaymentChannelCreation(mcid)
 	require.NoError(t, err)
 	assert.Equal(t, paych, addr)
@@ -133,13 +134,6 @@ func testSetup2(ctx context.Context, t *testing.T) (*chain.Builder, bstore.Block
 	ds := repo.NewInMemoryRepo().ChainDatastore()
 	bs := bstore.NewBlockstore(ds)
 	return builder, bs, genTs
-}
-
-func TestPaychActorIFace(t *testing.T) {
-	tf.UnitTest(t)
-	ctx := context.Background()
-	fai := paychtest.NewFakePaychActorUtil(ctx, t, abi.NewTokenAmount(1200))
-	require.NotNil(t, fai)
 }
 
 func requireNewEmptyChainStore(ctx context.Context, t *testing.T) (cid.Cid, *chain.Builder, block.TipSet, *chain.Store, state.Tree) {

--- a/internal/app/go-filecoin/paymentchannel/integration_test.go
+++ b/internal/app/go-filecoin/paymentchannel/integration_test.go
@@ -3,12 +3,13 @@ package paymentchannel_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
-	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	spect "github.com/filecoin-project/specs-actors/support/testing"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	dss "github.com/ipfs/go-datastore/sync"
@@ -31,21 +32,21 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
 )
 
-// TestCreatePaymentChannel tests that the RetrievalClient can call through to the InitActor and
-// successfully cause a new payment channel to be created.
-func TestCreatePaymentChannel(t *testing.T) {
+// TestAddFundsToChannel verifies that a call to GetOrCreatePaymentChannel sends
+// funds to the actor if it  already exists
+func TestPaymentChannel(t *testing.T) {
 	tf.UnitTest(t)
 	ctx := context.Background()
-	balance := abi.NewTokenAmount(1000000)
 	chainBuilder, bs, genTs := testSetup2(ctx, t)
 	ds := dss.MutexWrap(datastore.NewMapDatastore())
-	fms := paychtest.NewFakeInitActorUtil(ctx, t, balance)
-	rt := fms.Runtime
+
+	balance := abi.NewTokenAmount(1000000)
+	initActorUtil := paychtest.NewFakeInitActorUtil(ctx, t, balance)
 	root, err := chainBuilder.GetTipSetStateRoot(genTs.Key())
 	require.NoError(t, err)
 
-	channelAmt := abi.NewTokenAmount(101)
-	_, client, miner, paychID, paych := fms.StubCtorSendResponse(channelAmt)
+	initialChannelAmt := abi.NewTokenAmount(1200)
+	_, client, miner, paychID, paych := initActorUtil.StubCtorSendResponse(initialChannelAmt)
 	fakeProvider := message.NewFakeProvider(t)
 	fakeProvider.Builder = chainBuilder
 	clientActor := actor.NewActor(builtin.AccountActorCodeID, balance, root)
@@ -54,25 +55,64 @@ func TestCreatePaymentChannel(t *testing.T) {
 
 	viewer := paychtest.NewFakeStateViewer(t)
 
-	pchMgr := pch.NewManager(context.Background(), ds, fms, fms, viewer)
+	pchMgr := pch.NewManager(context.Background(), ds, initActorUtil, initActorUtil, viewer)
 
 	viewer.GetFakeStateView().AddActorWithState(paych, client, miner, address.Undef)
 
 	rmc := retrievalmarketconnector.NewRetrievalMarketClientFakeAPI(t)
 
-	rcnc := retrievalmarketconnector.NewRetrievalClientConnector(bs, fakeProvider, rmc, pchMgr)
-	assert.NotNil(t, rcnc)
+	connector := retrievalmarketconnector.NewRetrievalClientConnector(bs, fakeProvider, rmc, pchMgr)
+	assert.NotNil(t, connector)
 	tok, err := encoding.Encode(genTs.Key())
 	require.NoError(t, err)
 
-	res, _, err := rcnc.GetOrCreatePaymentChannel(ctx, client, miner, channelAmt, tok)
+	addr, mcid, err := connector.GetOrCreatePaymentChannel(ctx, client, miner, initialChannelAmt, tok)
 	require.NoError(t, err)
-	assert.Equal(t, paych, res)
-	var st init_.State
-	rt.GetState(&st)
-	actualIDAddr, err := st.ResolveAddress(adt.AsStore(rt), paych)
+	assert.Equal(t, address.Undef, addr)
+
+	// give a chance for the goroutine to finish creating channel info
+	time.Sleep(100 * time.Millisecond)
+	addr, err = connector.WaitForPaymentChannelCreation(mcid)
 	require.NoError(t, err)
-	require.Equal(t, paychID, actualIDAddr)
+	assert.Equal(t, paych, addr)
+
+	chinfo, err := pchMgr.GetPaymentChannelInfo(paych)
+	require.NoError(t, err)
+	require.Equal(t, paych, chinfo.UniqueAddr)
+
+	paychActorUtil := paychtest.FakePaychActorUtil{
+		PaychAddr:      paych,
+		PaychIDAddr:    paychID,
+		Client:         client,
+		ClientID:       spect.NewIDAddr(t, 999),
+		Miner:          miner,
+		PcActorHarness: new(paychtest.PcActorHarness),
+	}
+	paychActorUtil.ConstructPaychActor(t, initialChannelAmt)
+
+	fakeProvider.SetHead(genTs.Key())
+	fakeProvider.SetActor(client, clientActor)
+
+	viewer.GetFakeStateView().AddActorWithState(paychActorUtil.PaychAddr, paychActorUtil.Client, paychActorUtil.Miner, address.Undef)
+	assert.NotNil(t, connector)
+
+	addVal := abi.NewTokenAmount(333)
+	expCid := paychActorUtil.StubSendFundsResponse(paychActorUtil.Client, addVal, exitcode.Ok, 1)
+
+	// set up sends and waits to go to the payment channel actor util / harness
+	initActorUtil.DelegateSender(paychActorUtil.Send)
+	initActorUtil.DelegateWaiter(paychActorUtil.Wait)
+
+	addr, mcid, err = connector.GetOrCreatePaymentChannel(ctx, client, miner, addVal, tok)
+	require.NoError(t, err)
+	assert.Equal(t, paychActorUtil.PaychAddr, addr)
+	assert.True(t, mcid.Equals(expCid))
+
+	paychActorUtil.Runtime.Verify()
+
+	err = connector.WaitForPaymentChannelAddFunds(mcid)
+	require.NoError(t, err)
+	assert.Equal(t, abi.NewTokenAmount(333), paychActorUtil.Runtime.ValueReceived())
 }
 
 func testSetup2(ctx context.Context, t *testing.T) (*chain.Builder, bstore.Blockstore, block.TipSet) {

--- a/internal/app/go-filecoin/paymentchannel/integration_test.go
+++ b/internal/app/go-filecoin/paymentchannel/integration_test.go
@@ -77,16 +77,17 @@ func TestPaymentChannel(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, paych, addr)
 
+	// make sure the channel info is there
 	chinfo, err := pchMgr.GetPaymentChannelInfo(paych)
 	require.NoError(t, err)
 	require.Equal(t, paych, chinfo.UniqueAddr)
 
 	paychActorUtil := paychtest.FakePaychActorUtil{
-		PaychAddr:      paych,
-		PaychIDAddr:    paychID,
-		Client:         client,
-		ClientID:       spect.NewIDAddr(t, 999),
-		Miner:          miner,
+		PaychAddr:   paych,
+		PaychIDAddr: paychID,
+		Client:      client,
+		ClientID:    spect.NewIDAddr(t, 999),
+		Miner:       miner,
 	}
 	paychActorUtil.ConstructPaychActor(t, initialChannelAmt)
 

--- a/internal/app/go-filecoin/paymentchannel/integration_test.go
+++ b/internal/app/go-filecoin/paymentchannel/integration_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math/big"
 	"testing"
-	"time"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -70,9 +69,6 @@ func TestPaymentChannel(t *testing.T) {
 	addr, mcid, err := connector.GetOrCreatePaymentChannel(ctx, client, miner, initialChannelAmt, tok)
 	require.NoError(t, err)
 	assert.Equal(t, address.Undef, addr)
-
-	// let the goroutine finish creating channel info
-	time.Sleep(100 * time.Millisecond)
 
 	addr, err = connector.WaitForPaymentChannelCreation(mcid)
 	require.NoError(t, err)

--- a/internal/app/go-filecoin/paymentchannel/manager.go
+++ b/internal/app/go-filecoin/paymentchannel/manager.go
@@ -175,7 +175,7 @@ func (pm *Manager) AddVoucher(paychAddr address.Address, voucher *paychActor.Sig
 		return zeroAmt, err
 	}
 	if !has {
-		return pm.createPaymentChannelWithVoucher(paychAddr, voucher, proof, tok)
+		return pm.providerCreatePaymentChannelWithVoucher(paychAddr, voucher, proof, tok)
 	}
 
 	chinfo, err := pm.GetPaymentChannelInfo(paychAddr)
@@ -218,7 +218,7 @@ func PaychActorCtorExecParamsFor(client, miner address.Address) (initActor.ExecP
 	return p, nil
 }
 
-// GetMinerWorkerAddress mocks getting a miner worker address from the miner address
+// GetMinerWorkerAddress gets a miner worker address from the miner address
 func (pm *Manager) GetMinerWorkerAddress(ctx context.Context, miner address.Address, tok shared.TipSetToken) (address.Address, error) {
 	view, err := pm.stateViewer.GetStateView(ctx, tok)
 	if err != nil {
@@ -290,7 +290,7 @@ func (pm *Manager) WaitForAddFundsMessage(ctx context.Context, mcid cid.Cid) err
 func (pm *Manager) handlePaychCreateResult(ctx context.Context, mcid cid.Cid, client, miner address.Address) {
 
 	handleResult := func(_ *block.Block, _ *types.SignedMessage, mr *vm.MessageReceipt) error {
-		if mr.ExitCode != 0 {
+		if mr.ExitCode != exitcode.Ok {
 			log.Errorf("create message failed with exit code %d", mr.ExitCode)
 		}
 
@@ -317,7 +317,7 @@ func (pm *Manager) handlePaychCreateResult(ctx context.Context, mcid cid.Cid, cl
 }
 
 // Called ONLY in context of a retrieval provider.
-func (pm *Manager) createPaymentChannelWithVoucher(paychAddr address.Address, voucher *paychActor.SignedVoucher, proof []byte, tok shared.TipSetToken) (abi.TokenAmount, error) {
+func (pm *Manager) providerCreatePaymentChannelWithVoucher(paychAddr address.Address, voucher *paychActor.SignedVoucher, proof []byte, tok shared.TipSetToken) (abi.TokenAmount, error) {
 	view, err := pm.stateViewer.GetStateView(pm.ctx, tok)
 	if err != nil {
 		return zeroAmt, err

--- a/internal/app/go-filecoin/paymentchannel/manager_test.go
+++ b/internal/app/go-filecoin/paymentchannel/manager_test.go
@@ -178,7 +178,7 @@ func TestManager_AddVoucherToChannel(t *testing.T) {
 
 	t.Run("errors if channel doesn't exist", func(t *testing.T) {
 		_, manager := setupViewerManager(ctx, t, root)
-		assert.EqualError(t, manager.AddVoucherToChannel(spect.NewActorAddr(t, "not-there"), &v), "No state for /t2bfuuk4wniuwo2tfso3bfar55hf4d6zq4fbcagui: datastore: key not found")
+		assert.EqualError(t, manager.AddVoucherToChannel(spect.NewActorAddr(t, "not-there"), &v), "channel does not exist t2bfuuk4wniuwo2tfso3bfar55hf4d6zq4fbcagui")
 	})
 
 	t.Run("returns error if lane does not exist", func(t *testing.T) {

--- a/internal/app/go-filecoin/paymentchannel/manager_test.go
+++ b/internal/app/go-filecoin/paymentchannel/manager_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/shared_testutil"
@@ -342,13 +341,13 @@ func requireSetupPaymentChannel(t *testing.T, testAPI *paychtest.FakePaymentChan
 	_, mcid, err := m.CreatePaymentChannel(clientAddr, minerAddr, balance)
 	require.NoError(t, err)
 
-	// give goroutine a chance to update channel store
-	time.Sleep(100 * time.Millisecond)
-	assert.True(t, testAPI.ExpectedMsgCid.Equals(testAPI.ActualWaitCid))
-	assert.True(t, testAPI.ExpectedMsgCid.Equals(mcid))
-
 	chinfo, err := m.GetPaymentChannelInfo(paychUniqueAddr)
 	require.NoError(t, err)
 	require.Equal(t, paychUniqueAddr, chinfo.UniqueAddr)
+
+	// give goroutine a chance to update channel store
+	assert.True(t, testAPI.ExpectedMsgCid.Equals(testAPI.ActualWaitCid))
+	assert.True(t, testAPI.ExpectedMsgCid.Equals(mcid))
+
 	return clientAddr, minerAddr, paychUniqueAddr, blockHeight
 }

--- a/internal/app/go-filecoin/paymentchannel/testing/fake_init_actor_util.go
+++ b/internal/app/go-filecoin/paymentchannel/testing/fake_init_actor_util.go
@@ -86,10 +86,7 @@ func (fai *FakeInitActorUtil) defaultSend(ctx context.Context,
 	params interface{}) (out cid.Cid, pubErrCh chan error, err error) {
 	execParams, ok := params.(*init_.ExecParams)
 	require.True(fai.t, ok)
-	if method == builtin.MethodsInit.Exec {
-		fai.ExecAndVerify(from, value, execParams)
-	}
-
+	fai.ExecAndVerify(from, value, execParams)
 	return fai.result.MsgCid, nil, nil
 }
 
@@ -104,12 +101,12 @@ func (fai *FakeInitActorUtil) defaultWait(_ context.Context, msgCid cid.Cid, cb 
 	return cb(res.Block, res.Msg, res.Rcpt)
 }
 
-// DelegateSender allows test to substitute a sender function
+// DelegateSender allows test to delegate a sender function
 func (fai *FakeInitActorUtil) DelegateSender(delegate sender) {
 	fai.msgSender = delegate
 }
 
-// DelegateWaiter allows test to substitute a waiter function
+// DelegateWaiter allows test to deletate a waiter function
 func (fai *FakeInitActorUtil) DelegateWaiter(delegate waiter) {
 	fai.msgWaiter = delegate
 }

--- a/internal/app/go-filecoin/paymentchannel/testing/fake_mgr_api.go
+++ b/internal/app/go-filecoin/paymentchannel/testing/fake_mgr_api.go
@@ -102,6 +102,7 @@ func (f *FakePaymentChannelAPI) Send(_ context.Context,
 // testing methods
 
 // GenCreatePaychActorMessage sets up a message response, with desired exit code and block height
+// for creating a payment channel actor
 func GenCreatePaychActorMessage(
 	t *testing.T,
 	clientAccountAddr, minerAccountAddr, paychUniqueAddr address.Address,
@@ -134,6 +135,28 @@ func GenCreatePaychActorMessage(
 		MsgCid:        newcid,
 		Rcpt:          &vm.MessageReceipt{ExitCode: code, ReturnValue: requireEncode(t, &retVal)},
 		DecodedParams: &params,
+	}
+}
+
+// GenSendFundsMessage sets up a message response, with desired exit code and block height
+// for a message that just sends funds between two addresses
+func GenSendFundsMessage(
+	from, to address.Address,
+	amt abi.TokenAmount,
+	code exitcode.ExitCode,
+	height uint64) (cid.Cid, MsgResult) {
+	newcid := shared_testutil.GenerateCids(1)[0]
+
+	msg := types.NewUnsignedMessage(from, to, 2,
+		types.NewAttoFIL(amt.Int), builtin.MethodSend, []byte{})
+	msg.GasPrice = types.NewAttoFILFromFIL(100)
+	msg.GasLimit = gas.NewGas(5000)
+	emptySig := crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{'0'}}
+	return newcid, MsgResult{
+		Block:  &block.Block{Height: abi.ChainEpoch(height)},
+		Msg:    &types.SignedMessage{Message: *msg, Signature: emptySig},
+		MsgCid: newcid,
+		Rcpt:   &vm.MessageReceipt{ExitCode: code},
 	}
 }
 

--- a/internal/app/go-filecoin/paymentchannel/testing/fake_paych_actor_util.go
+++ b/internal/app/go-filecoin/paymentchannel/testing/fake_paych_actor_util.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-fil-markets/shared_testutil"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/filecoin-project/specs-actors/support/mock"
 	spect "github.com/filecoin-project/specs-actors/support/testing"
 	"github.com/ipfs/go-cid"
@@ -16,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/crypto"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
@@ -24,43 +27,51 @@ import (
 // FakePaychActorUtil fulfils the MsgSender and MsgWaiter interfaces for a Manager
 // via the specs_actors mock runtime. It executes paych.Actor exports directly.
 type FakePaychActorUtil struct {
-	t   *testing.T
+	*testing.T
 	ctx context.Context
 	*mock.Runtime
-	*pcActorHarness
+	*PcActorHarness
 	PaychAddr, PaychIDAddr, Client, ClientID, Miner address.Address
+	SendErr                                         error
 	result                                          MsgResult
 }
 
 // NewFakePaychActorUtil intializes a FakePaychActorUtil
 func NewFakePaychActorUtil(ctx context.Context, t *testing.T, paychBal abi.TokenAmount) *FakePaychActorUtil {
 	fai := &FakePaychActorUtil{
-		t:              t,
 		ctx:            ctx,
 		PaychAddr:      spect.NewActorAddr(t, "paychactor"),
 		PaychIDAddr:    spect.NewIDAddr(t, 999),
 		Client:         spect.NewActorAddr(t, "clientactor"),
 		ClientID:       spect.NewIDAddr(t, 980),
 		Miner:          spect.NewActorAddr(t, "mineractor"),
-		pcActorHarness: new(pcActorHarness),
+		PcActorHarness: new(PcActorHarness),
 	}
-	fai.constructPaychActor(paychBal)
+	fai.ConstructPaychActor(t, paychBal)
 	return fai
 }
 
-// constructPaychActor creates a mock.Runtime and constructs a payment channel harness + Actor
-func (fai *FakePaychActorUtil) constructPaychActor(paychBal abi.TokenAmount) {
+// ConstructPaychActor creates a mock.Runtime and constructs a payment channel harness + Actor
+func (fai *FakePaychActorUtil) ConstructPaychActor(t *testing.T, paychBal abi.TokenAmount) {
+	versig := func(sig crypto.Signature, signer address.Address, plaintext []byte) error {
+		return nil
+	}
+	hasher := func(data []byte) [32]byte { return [32]byte{} }
+
 	builder := mock.NewBuilder(fai.ctx, fai.PaychAddr).
 		WithBalance(paychBal, big.Zero()).
 		WithEpoch(abi.ChainEpoch(42)).
 		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
 		WithActorType(fai.PaychIDAddr, builtin.AccountActorCodeID).
-		WithActorType(fai.ClientID, builtin.AccountActorCodeID)
+		WithActorType(fai.ClientID, builtin.AccountActorCodeID).
+		WithVerifiesSig(versig).
+		WithHasher(hasher)
 
-	fai.Runtime = builder.Build(fai.t)
+	fai.T = t
+	fai.Runtime = builder.Build(fai.T)
 	fai.Runtime.AddIDAddress(fai.PaychAddr, fai.PaychIDAddr)
 	fai.Runtime.AddIDAddress(fai.Client, fai.ClientID)
-	fai.pcActorHarness.constructAndVerify(fai.t, fai.Runtime, fai.Client, fai.PaychAddr)
+	fai.PcActorHarness.constructAndVerify(fai.T, fai.Runtime, fai.Client, fai.PaychAddr)
 }
 
 // Send stubs a message Sender
@@ -73,24 +84,49 @@ func (fai *FakePaychActorUtil) Send(ctx context.Context,
 	method abi.MethodNum,
 	params interface{}) (out cid.Cid, pubErrCh chan error, err error) {
 
-	return cid.Undef, nil, nil
+	if fai.SendErr == nil {
+		fai.doSend(from, value)
+	}
+	return fai.result.MsgCid, nil, fai.SendErr
 }
 
 // Wait stubs a message Waiter
 func (fai *FakePaychActorUtil) Wait(_ context.Context, msgCid cid.Cid, cb func(*block.Block, *types.SignedMessage, *vm.MessageReceipt) error) error {
-	require.Equal(fai.t, msgCid, fai.result.MsgCid)
 	res := fai.result
 	return cb(res.Block, res.Msg, res.Rcpt)
 }
 
-type pcActorHarness struct {
+// StubSendFundsMessage sets expectations for a message that just sends funds to the actor
+func (fai *FakePaychActorUtil) StubSendFundsResponse(from address.Address, amt abi.TokenAmount, code exitcode.ExitCode, height int64) cid.Cid {
+	newCID := shared_testutil.GenerateCids(1)[0]
+
+	msg := types.NewUnsignedMessage(from, fai.PaychAddr, 1, amt, builtin.MethodSend, []byte{})
+	msg.GasPrice = abi.NewTokenAmount(100)
+	msg.GasLimit = gas.NewGas(5000)
+
+	emptySig := crypto.Signature{Type: crypto.SigTypeBLS, Data: []byte{'0'}}
+	fai.result = MsgResult{
+		Block:         &block.Block{Height: abi.ChainEpoch(height)},
+		Msg:           &types.SignedMessage{Message: *msg, Signature: emptySig},
+		DecodedParams: nil,
+		MsgCid:        newCID,
+		Rcpt:          &vm.MessageReceipt{ExitCode: code},
+	}
+	return newCID
+}
+
+func (fai *FakePaychActorUtil) doSend(caller address.Address, amt abi.TokenAmount) {
+	require.Equal(fai, amt, fai.result.Msg.Message.Value)
+	fai.Runtime.SetReceived(amt)
+}
+
+type PcActorHarness struct {
 	paych.Actor
 	t testing.TB
 }
 
-func (h *pcActorHarness) constructAndVerify(t *testing.T, rt *mock.Runtime, sender, receiver address.Address) {
+func (h *PcActorHarness) constructAndVerify(t *testing.T, rt *mock.Runtime, sender, receiver address.Address) {
 	params := &paych.ConstructorParams{To: receiver, From: sender}
-
 	rt.ExpectValidateCallerType(builtin.InitActorCodeID)
 	ret := rt.Call(h.Actor.Constructor, params)
 	assert.Nil(h.t, ret)

--- a/internal/app/go-filecoin/paymentchannel/testing/fake_paych_actor_util.go
+++ b/internal/app/go-filecoin/paymentchannel/testing/fake_paych_actor_util.go
@@ -65,8 +65,6 @@ func (fai *FakePaychActorUtil) Send(ctx context.Context,
 	method abi.MethodNum,
 	params interface{}) (mcid cid.Cid, pubErrCh chan error, err error) {
 
-	err = fai.SendErr
-
 	if fai.result != msgRcptsUndef {
 		mcid = fai.result.MsgCid
 	}

--- a/internal/app/go-filecoin/paymentchannel/testing/fake_paych_actor_util.go
+++ b/internal/app/go-filecoin/paymentchannel/testing/fake_paych_actor_util.go
@@ -37,9 +37,6 @@ type FakePaychActorUtil struct {
 
 // ConstructPaychActor creates a mock.Runtime and constructs a payment channel harness + Actor
 func (fai *FakePaychActorUtil) ConstructPaychActor(t *testing.T, paychBal abi.TokenAmount) {
-	versig := func(sig crypto.Signature, signer address.Address, plaintext []byte) error {
-		return nil
-	}
 	hasher := func(data []byte) [32]byte { return [32]byte{} }
 
 	builder := mock.NewBuilder(fai.ctx, fai.PaychAddr).
@@ -48,7 +45,6 @@ func (fai *FakePaychActorUtil) ConstructPaychActor(t *testing.T, paychBal abi.To
 		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
 		WithActorType(fai.PaychIDAddr, builtin.AccountActorCodeID).
 		WithActorType(fai.ClientID, builtin.AccountActorCodeID).
-		WithVerifiesSig(versig).
 		WithHasher(hasher)
 
 	fai.T = t

--- a/internal/app/go-filecoin/paymentchannel/testing/fake_paych_actor_util.go
+++ b/internal/app/go-filecoin/paymentchannel/testing/fake_paych_actor_util.go
@@ -12,7 +12,6 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/filecoin-project/specs-actors/support/mock"
-	spect "github.com/filecoin-project/specs-actors/support/testing"
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,21 +33,6 @@ type FakePaychActorUtil struct {
 	PaychAddr, PaychIDAddr, Client, ClientID, Miner address.Address
 	SendErr                                         error
 	result                                          MsgResult
-}
-
-// NewFakePaychActorUtil intializes a FakePaychActorUtil
-func NewFakePaychActorUtil(ctx context.Context, t *testing.T, paychBal abi.TokenAmount) *FakePaychActorUtil {
-	fai := &FakePaychActorUtil{
-		ctx:            ctx,
-		PaychAddr:      spect.NewActorAddr(t, "paychactor"),
-		PaychIDAddr:    spect.NewIDAddr(t, 999),
-		Client:         spect.NewActorAddr(t, "clientactor"),
-		ClientID:       spect.NewIDAddr(t, 980),
-		Miner:          spect.NewActorAddr(t, "mineractor"),
-		PcActorHarness: new(PcActorHarness),
-	}
-	fai.ConstructPaychActor(t, paychBal)
-	return fai
 }
 
 // ConstructPaychActor creates a mock.Runtime and constructs a payment channel harness + Actor


### PR DESCRIPTION
### Motivation
The latest go-fil-markets utilizes non-blocking creation of payment channels and adds two wait functions for creating a new payment channel and adding funds.

### Proposed changes
Closes #3988 
 
Alters GetOrCreatePaymentChannel to meet new functionality requirements
Implements new Wait* API functions
Adds thread-safety to payment channel store
Updates integration test to include adding funds and uses wait functions

### Remaining issues
Please see #4045 , #4046 , and there is an upcoming proposal to decide how to address message wait vs. get state for the new go-fil-markets retrieval api.