### PR TITLE
update ffr after live config

### DIFF
--- a/internal/pkg/drand/drand_grpc.go
+++ b/internal/pkg/drand/drand_grpc.go
@@ -82,8 +82,7 @@ func (d *GRPC) updateFirstFilecoinRound() error {
 	if len(results) != 1 {
 		return fmt.Errorf("found %d drand rounds between filecoinGenTime and filecoinGenTime - drandRountDuration, expected 1", len(results))
 	}
-	ffr := results[0]
-	d.firstFilecoin = ffr
+	d.firstFilecoin = results[0]
 	return nil
 }
 

--- a/internal/pkg/drand/drand_grpc.go
+++ b/internal/pkg/drand/drand_grpc.go
@@ -164,7 +164,10 @@ func (d *GRPC) FetchGroupConfig(addresses []string, secure bool, overrideGroupAd
 			d.addresses = drandAddresses(groupAddrs, secure)
 		}
 
-		d.updateFirstFilecoinRound() // this depends on genesis and round time so recalculate
+		err = d.updateFirstFilecoinRound() // this depends on genesis and round time so recalculate
+		if err != nil {
+			return nil, nil, 0, 0, err
+		}
 
 		return groupAddrs, keyCoeffs, genesisTime, roundSeconds, nil
 	}


### PR DESCRIPTION
### Motivation
If you call `drand configure` on a daemon and do not restart it the first filecoin round property of the in memory drand grpc construct does not get properly reset so the first filecoin round value gets set to a very high number which makes mining fail. 

### Proposed changes
To fix this we do the calculation along with other resets after fetching the config.  We take advantage of this PR to abstract that ffr calculation and setting to a subfunction of drand grpc.

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

