### PR TITLE
rand bytes should match

### DIFF
--- a/internal/app/go-filecoin/plumbing/cst/chain_state.go
+++ b/internal/app/go-filecoin/plumbing/cst/chain_state.go
@@ -167,7 +167,7 @@ func (chn *ChainStateReadWriter) SampleChainRandomness(ctx context.Context, head
 	if err != nil {
 		return nil, err
 	}
-	rnd := crypto.ChainRandomnessSource{Sampler: chain.NewSamplerAtHead(chn.readWriter, genBlk.Ticket, head)}
+	rnd := crypto.ChainRandomnessSource{Sampler: chain.NewRandomnessSamplerAtHead(chn.readWriter, genBlk.Ticket, head)}
 	return rnd.Randomness(ctx, tag, epoch, entropy)
 }
 

--- a/internal/pkg/consensus/election.go
+++ b/internal/pkg/consensus/election.go
@@ -162,7 +162,7 @@ func (em ElectionMachine) VerifyWinningPoSt(ctx context.Context, ep EPoStVerifie
 }
 
 type ChainSampler interface {
-	Sample(ctx context.Context, head block.TipSetKey, epoch abi.ChainEpoch) (crypto.RandomSeed, error)
+	SampleTicket(ctx context.Context, head block.TipSetKey, epoch abi.ChainEpoch) (block.Ticket, error)
 }
 
 // TicketMachine uses a VRF and VDF to generate deterministic, unpredictable
@@ -213,11 +213,11 @@ func (tm TicketMachine) ticketVRFRandomness(ctx context.Context, base block.TipS
 		return nil, err
 	}
 	if !newPeriod { // resample previous ticket and add to entropy
-		ticketSeed, err := tm.sampler.Sample(ctx, base, epoch)
+		ticket, err := tm.sampler.SampleTicket(ctx, base, epoch)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to sample previous ticket")
 		}
-		_, err = entropyBuf.Write(ticketSeed)
+		_, err = entropyBuf.Write(ticket.VRFProof)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/consensus/testing.go
+++ b/internal/pkg/consensus/testing.go
@@ -177,6 +177,8 @@ type FakeSampler struct {
 	Seed uint
 }
 
-func (s *FakeSampler) Sample(_ context.Context, _ block.TipSetKey, epoch abi.ChainEpoch) (crypto.RandomSeed, error) {
-	return []byte(fmt.Sprintf("s=%d,e=%d", s.Seed, epoch)), nil
+func (s *FakeSampler) SampleTicket(_ context.Context, _ block.TipSetKey, epoch abi.ChainEpoch) (block.Ticket, error) {
+	return block.Ticket{
+		VRFProof: []byte(fmt.Sprintf("s=%d,e=%d", s.Seed, epoch)),
+	}, nil
 }


### PR DESCRIPTION
### Motivation
Randomness is underspecced and ambiguous

Through agreement with lotus gfc is moving to lotus's current strategy of taking undigested ticket bytes as input to the randomness mixer.  Tests against latest lotus interopnet confirm this passes validation.

### Proposed changes

Slight refactor to sample ticket rather than mixed ticket.  Turned out to be pretty simple because of the previous change giving the ticket machine direct access to chain sampler.

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

