### PR TITLE
Abort with ErrSerialization when storage de/serialization fails.

### DIFF
--- a/internal/pkg/vm/internal/vmcontext/actor_store.go
+++ b/internal/pkg/vm/internal/vmcontext/actor_store.go
@@ -3,43 +3,78 @@ package vmcontext
 import (
 	"context"
 	"fmt"
+	"reflect"
+
+	specsruntime "github.com/filecoin-project/specs-actors/actors/runtime"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/gascost"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/runtime"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/storage"
-	specsruntime "github.com/filecoin-project/specs-actors/actors/runtime"
-	"github.com/ipfs/go-cid"
 )
 
-// actorStorage hides the storage methods from the actors and turns the errors into runtime panics.
-type actorStorage struct {
+type vmStorage interface {
+	Get(ctx context.Context, cid cid.Cid, obj interface{}) (int, error)
+	Put(ctx context.Context, obj interface{}) (cid.Cid, int, error)
+}
+
+// ActorStorage hides the storage methods from the actors and turns the errors into runtime panics.
+type ActorStorage struct {
 	context   context.Context
-	inner     *storage.VMStorage
+	inner     vmStorage
 	pricelist gascost.Pricelist
 	gasTank   *GasTracker
 }
 
+func NewActorStorage(ctx context.Context, inner vmStorage, gasTank *GasTracker, pricelist gascost.Pricelist) *ActorStorage {
+	return &ActorStorage{
+		context:   ctx,
+		inner:     inner,
+		pricelist: pricelist,
+		gasTank:   gasTank,
+	}
+}
+
 //
-// implement runtime.Store for actorStorage
+// implement runtime.Store for ActorStorage
 //
 
-var _ specsruntime.Store = (*actorStorage)(nil)
+var _ specsruntime.Store = (*ActorStorage)(nil)
 
-func (s actorStorage) Put(obj specsruntime.CBORMarshaler) cid.Cid {
+// Serialization technically belongs in the actor code, rather than inside the VM.
+// The true VM storage interface is in terms of raw bytes and, when we have user-defined,
+// serialization code will be directly in those contracts.
+// Our present runtime interface is at a slightly higher level for convenience, but the exit code here is the
+// actor, rather than system-level, error code.
+const serializationErr = exitcode.ErrSerialization
+
+func (s *ActorStorage) Put(obj specsruntime.CBORMarshaler) cid.Cid {
 	cid, ln, err := s.inner.Put(s.context, obj)
 	if err != nil {
-		panic(fmt.Errorf("could not put object in store. %s", err))
+		msg := fmt.Sprintf("failed to put object %s in store: %s", reflect.TypeOf(obj), err)
+		if _, ok := err.(storage.SerializationError); ok {
+			runtime.Abortf(serializationErr, msg)
+		} else {
+			panic(msg)
+		}
 	}
 	s.gasTank.Charge(s.pricelist.OnIpldPut(ln), "storage put %s %d bytes into %v", cid, ln, obj)
 	return cid
 }
 
-func (s actorStorage) Get(cid cid.Cid, obj specsruntime.CBORUnmarshaler) bool {
+func (s *ActorStorage) Get(cid cid.Cid, obj specsruntime.CBORUnmarshaler) bool {
 	ln, err := s.inner.Get(s.context, cid, obj)
 	if err == storage.ErrNotFound {
 		return false
 	}
 	if err != nil {
-		panic(fmt.Errorf("could not get obj from store. %s", err))
+		msg := fmt.Sprintf("failed to get object %s %s from store: %s", reflect.TypeOf(obj), cid, err)
+		if _, ok := err.(storage.SerializationError); ok {
+			runtime.Abortf(serializationErr, msg)
+		} else {
+			panic(msg)
+		}
 	}
 	s.gasTank.Charge(s.pricelist.OnIpldGet(ln), "storage get %s %d bytes into %v", cid, ln, obj)
 	return true

--- a/internal/pkg/vm/internal/vmcontext/actor_store_test.go
+++ b/internal/pkg/vm/internal/vmcontext/actor_store_test.go
@@ -1,0 +1,104 @@
+package vmcontext_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/filecoin-project/specs-actors/actors/runtime"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	typegen "github.com/whyrusleeping/cbor-gen"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/gascost"
+	vmr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/runtime"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/internal/vmcontext"
+)
+
+func TestActorStore(t *testing.T) {
+	ctx := context.Background()
+	raw := vm.NewStorage(blockstore.NewBlockstore(datastore.NewMapDatastore()))
+	gasTank := vmcontext.NewGasTracker(1e6)
+
+	t.Run("abort on put serialization failure", func(t *testing.T) {
+		store := vmcontext.NewActorStorage(ctx, &raw, &gasTank, gascost.PricelistByEpoch(0))
+		_, thrown := tryPut(store, cannotCBOR{})
+		abort, ok := thrown.(vmr.ExecutionPanic)
+		assert.NotNil(t, thrown)
+		assert.True(t, ok, "expected abort")
+		assert.Equal(t, exitcode.ErrSerialization, abort.Code())
+	})
+
+	t.Run("abort on get serialization failure", func(t *testing.T) {
+		store := vmcontext.NewActorStorage(ctx, &raw, &gasTank, gascost.PricelistByEpoch(0))
+		v := typegen.CborInt(0)
+
+		c, thrown := tryPut(store, &v)
+		assert.True(t, c.Defined())
+		require.Nil(t, thrown)
+
+		var v2 typegen.CborCid
+		thrown = tryGet(store, c, &v2) // Attempt decode into wrong type
+		abort, ok := thrown.(vmr.ExecutionPanic)
+		assert.NotNil(t, thrown)
+		assert.True(t, ok, "expected abort")
+		assert.Equal(t, exitcode.ErrSerialization, abort.Code())
+	})
+
+	t.Run("panic on put storage failure", func(t *testing.T) {
+		store := vmcontext.NewActorStorage(ctx, &brokenStorage{}, &gasTank, gascost.PricelistByEpoch(0))
+		v := typegen.CborInt(0)
+		_, thrown := tryPut(store, &v)
+		_, ok := thrown.(vmr.ExecutionPanic)
+		assert.NotNil(t, thrown)
+		assert.False(t, ok, "expected non-abort panic")
+	})
+
+	t.Run("panic on get storage failure", func(t *testing.T) {
+		store := vmcontext.NewActorStorage(ctx, &brokenStorage{}, &gasTank, gascost.PricelistByEpoch(0))
+		var v typegen.CborInt
+		thrown := tryGet(store, cid.Undef, &v)
+		_, ok := thrown.(vmr.ExecutionPanic)
+		assert.NotNil(t, thrown)
+		assert.False(t, ok, "expected non-abort panic")
+	})
+}
+
+func tryPut(s *vmcontext.ActorStorage, v runtime.CBORMarshaler) (c cid.Cid, thrown interface{}) {
+	defer func() {
+		thrown = recover()
+	}()
+	c = s.Put(v)
+	return
+}
+
+func tryGet(s *vmcontext.ActorStorage, c cid.Cid, v runtime.CBORUnmarshaler) (thrown interface{}) {
+	defer func() {
+		thrown = recover()
+	}()
+	s.Get(c, v)
+	return
+}
+
+type cannotCBOR struct {
+}
+
+func (c cannotCBOR) MarshalCBOR(w io.Writer) error {
+	return fmt.Errorf("no")
+}
+
+type brokenStorage struct{}
+
+func (brokenStorage) Get(_ context.Context, _ cid.Cid, _ interface{}) (int, error) {
+	return 0, fmt.Errorf("no")
+}
+
+func (brokenStorage) Put(_ context.Context, _ interface{}) (cid.Cid, int, error) {
+	return cid.Undef, 0, fmt.Errorf("no")
+}

--- a/internal/pkg/vm/internal/vmcontext/invocation_context.go
+++ b/internal/pkg/vm/internal/vmcontext/invocation_context.go
@@ -357,12 +357,7 @@ func (ctx *invocationContext) Runtime() runtime.Runtime {
 
 // Store implements runtime.Runtime.
 func (ctx *invocationContext) Store() specsruntime.Store {
-	return actorStorage{
-		context:   ctx.rt.context,
-		inner:     ctx.rt.store,
-		gasTank:   ctx.gasTank,
-		pricelist: ctx.rt.pricelist,
-	}
+	return NewActorStorage(ctx.rt.context, ctx.rt.store, ctx.gasTank, ctx.rt.pricelist)
 }
 
 // Message implements runtime.InvocationContext.


### PR DESCRIPTION
### Motivation
Technically, serialization is part of the actor code and the VM puts/gets bytes. Our runtime API is at a slightly higher level of abstraction for convenience, but serialization failures, which actor's can definitely cause, should not halt execution. E.g. when we have user contracts, serialization will live in that contract code.

See a similar change in Lotus: https://github.com/filecoin-project/lotus/pull/1627

### Proposed changes
Wrap and identify errors from the encode/decode call, then abort rather than panic in that case.

FYI @arajasek @magik6k 
