### PR TITLE
Prevent arrays in blocks from being nil

### DIFF
--- a/internal/pkg/chain/testing.go
+++ b/internal/pkg/chain/testing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/drand"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
@@ -200,6 +201,8 @@ func (f *Builder) Build(parent block.TipSet, width int, build func(b *BlockBuild
 		b := &block.Block{
 			Ticket:          ticket,
 			Miner:           f.minerAddress,
+			BeaconEntries:   []*drand.Entry{},
+			PoStProofs:      []block.PoStProof{},
 			ParentWeight:    parentWeight,
 			Parents:         parent.Key(),
 			Height:          height,

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -96,6 +96,14 @@ func (w *DefaultWorker) Generate(
 	// The real time might actually be much later than this if catching up from a pause in chain progress.
 	epochStartTime := w.clock.StartTimeOfEpoch(blockHeight)
 
+	if drandEntries == nil {
+		drandEntries = []*drand.Entry{}
+	}
+
+	if posts == nil {
+		posts = []block.PoStProof{}
+	}
+
 	next := &block.Block{
 		Miner:           w.minerAddr,
 		Height:          blockHeight,

--- a/tools/gengen/util/generator.go
+++ b/tools/gengen/util/generator.go
@@ -3,6 +3,7 @@ package gengen
 import (
 	"context"
 	"fmt"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/drand"
 	"io"
 	mrand "math/rand"
 
@@ -271,6 +272,8 @@ func (g *GenesisGenerator) genBlock(ctx context.Context) (cid.Cid, error) {
 	geneblk := &block.Block{
 		Miner:           builtin.SystemActorAddr,
 		Ticket:          genesis.Ticket,
+		BeaconEntries:   []*drand.Entry{},
+		PoStProofs:      []block.PoStProof{},
 		Parents:         block.NewTipSetKey(),
 		ParentWeight:    big.Zero(),
 		Height:          0,


### PR DESCRIPTION
### Motivation

Lotus cannot deserialise blocks with nil arrays, so we're effectively elevating this to a spec requirement in order to achieve interop.

With this change, Lotus is able to import blocks generated by gengen. 

### Proposed changes

Outside of tests, only create blocks with empty arrays for `BeaconEntries` and `PoStProofs`.

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

