### PR TITLE
Restore faucet test as an in-process integration test

### DIFF
--- a/functional-tests/common.go
+++ b/functional-tests/common.go
@@ -4,23 +4,36 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-
-	"github.com/filecoin-project/go-filecoin/internal/pkg/drand"
-
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/stretchr/testify/require"
+
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/drand"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	gengen "github.com/filecoin-project/go-filecoin/tools/gengen/util"
-	"github.com/stretchr/testify/require"
 )
+
+// setup presealed sectors and use these paths to run test against sectors with larger sector size
+//genCfgPath := filepath.Join("./512", "setup.json")
+//presealPath := "./512"
+func fixtureGenCfg() string {
+	wd, _ := os.Getwd()
+	return filepath.Join(wd, "..", "fixtures/setup.json")
+}
+
+func fixturePresealPath() string {
+	wd, _ := os.Getwd()
+	return filepath.Join(wd, "..", "fixtures/genesis-sectors")
+}
 
 func loadGenesisConfig(t *testing.T, path string) *gengen.GenesisCfg {
 	configFile, err := os.Open(path)

--- a/functional-tests/drand_test.go
+++ b/functional-tests/drand_test.go
@@ -2,8 +2,6 @@ package functional
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -21,18 +19,15 @@ func TestDrandPublic(t *testing.T) {
 	t.Skip(("requires local drand setup"))
 
 	ctx := context.Background()
-	wd, _ := os.Getwd()
-	genCfgPath := filepath.Join(wd, "..", "fixtures/setup.json")
 	genTime := int64(1000000000)
 	blockTime := 30 * time.Second
 	// The clock is intentionally set some way ahead of the genesis time so the miner can produce
 	// catch-up blocks as quickly as possible.
 	fakeClock := clock.NewFake(time.Unix(genTime, 0).Add(4 * time.Hour))
 
-	// Load genesis config fixture.
 	// The fixture is needed in order to use the presealed genesis sectors fixture.
 	// Future code could decouple the whole setup.json from the presealed information.
-	genCfg := loadGenesisConfig(t, genCfgPath)
+	genCfg := loadGenesisConfig(t, fixtureGenCfg())
 	seed := node.MakeChainSeed(t, genCfg)
 	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, fakeClock)
 

--- a/functional-tests/plege_sector_test.go
+++ b/functional-tests/plege_sector_test.go
@@ -2,8 +2,6 @@ package functional
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -24,15 +22,11 @@ func TestMiningPledgeSector(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	wd, _ := os.Getwd()
-	genCfgPath := filepath.Join(wd, "..", "fixtures/setup.json")
-	presealPath := filepath.Join(wd, "..", "fixtures/genesis-sectors")
 	genTime := int64(1000000000)
 	blockTime := 1 * time.Second
 	fakeClock := clock.NewFake(time.Unix(genTime, 0))
 
-	// Load genesis config fixture.
-	genCfg := loadGenesisConfig(t, genCfgPath)
+	genCfg := loadGenesisConfig(t, fixtureGenCfg())
 	genCfg.Miners = append(genCfg.Miners, &gengen.CreateStorageMinerConfig{
 		Owner:         1,
 		SealProofType: constants.DevSealProofType,
@@ -46,7 +40,7 @@ func TestMiningPledgeSector(t *testing.T) {
 	}
 
 	bootstrapMiner := makeNode(ctx, t, seed, chainClock, drandImpl)
-	_, _, err := initNodeGenesisMiner(ctx, t, bootstrapMiner, seed, genCfg.Miners[0].Owner, presealPath)
+	_, _, err := initNodeGenesisMiner(ctx, t, bootstrapMiner, seed, genCfg.Miners[0].Owner, fixturePresealPath())
 	require.NoError(t, err)
 
 	newMiner := makeNode(ctx, t, seed, chainClock, drandImpl)

--- a/internal/app/go-filecoin/node/block_propagate_test.go
+++ b/internal/app/go-filecoin/node/block_propagate_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestBlockPropsManyNodes(t *testing.T) {
-	tf.UnitTest(t)
+	tf.IntegrationTest(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -68,7 +68,7 @@ func TestBlockPropsManyNodes(t *testing.T) {
 }
 
 func TestChainSyncA(t *testing.T) {
-	tf.UnitTest(t)
+	tf.IntegrationTest(t)
 
 	ctx := context.Background()
 	_, nodes, fakeClock, blockTime := makeNodesBlockPropTests(t, 2)
@@ -102,7 +102,7 @@ func TestChainSyncA(t *testing.T) {
 }
 
 func TestChainSyncWithMessages(t *testing.T) {
-	tf.UnitTest(t)
+	tf.IntegrationTest(t)
 	ctx := context.Background()
 
 	/* setup */

--- a/tools/faucet/main.go
+++ b/tools/faucet/main.go
@@ -81,12 +81,12 @@ func main() {
 			return
 		}
 
-		reqStr := fmt.Sprintf("http://%s/api/message/send?arg=%s&value=%d&from=%s&gas-price=1&gas-limit=0", *filapi, addr, *faucetval, *filwal)
+		reqStr := fmt.Sprintf("http://%s/api/message/send?arg=%s&value=%d&from=%s&gas-price=0.0001&gas-limit=1000", *filapi, addr, *faucetval, *filwal)
 		log.Infof("Request URL: %s", reqStr)
 
 		resp, err := http.Post(reqStr, "application/json", nil)
 		if err != nil {
-			log.Errorf("failed to Post request. Status: %s Error: %s", resp.Status, err)
+			log.Errorf("failed to Post request: %s", err)
 			http.Error(w, err.Error(), 500)
 			return
 		}


### PR DESCRIPTION
### Motivation
I decided to bring back some tests. I chose this one because it's the last thing pinning `testhelpers/iptbtester`, which we can delete after this PR in favour of in-process or daemon tests.

### Proposed changes
Rewrite faucet test as in-process.

- [x] Rebase on #4062

