### PR TITLE
Error in propose-storage-deal when peer id option is not provided

### DIFF
--- a/cmd/go-filecoin/client.go
+++ b/cmd/go-filecoin/client.go
@@ -145,7 +145,7 @@ be 2, 1 hour would be 120, and 1 day would be 2880.
 		}
 
 		peerID := status.PeerID
-		peerIDStr := req.Options["peerid"].(string)
+		peerIDStr, _ := req.Options["peerid"].(string)
 		if peerIDStr != "" {
 			peerID, err = p2pcore.Decode(peerIDStr)
 			if err != nil {

--- a/cmd/go-filecoin/client_integration_test.go
+++ b/cmd/go-filecoin/client_integration_test.go
@@ -6,18 +6,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
 func TestProposeDeal(t *testing.T) {
-	t.Skip("fix when landing new storage miner and fsm changes")
 	tf.IntegrationTest(t)
 
 	ctx := context.Background()

--- a/internal/app/go-filecoin/connectors/storage_market/client.go
+++ b/internal/app/go-filecoin/connectors/storage_market/client.go
@@ -3,6 +3,7 @@ package storagemarketconnector
 import (
 	"context"
 	"reflect"
+	"time"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 
@@ -143,21 +144,24 @@ func (s *StorageClientNodeConnector) ListStorageProviders(ctx context.Context, t
 // ValidatePublishedDeal validates a deal has been published correctly
 // Adapted from https://github.com/filecoin-project/lotus/blob/3b34eba6124d16162b712e971f0db2ee108e0f67/markets/storageadapter/client.go#L156
 func (s *StorageClientNodeConnector) ValidatePublishedDeal(ctx context.Context, deal storagemarket.ClientDeal) (dealID abi.DealID, err error) {
-	// Fetch receipt to return dealId
+	var unsigned types.UnsignedMessage
+	var receipt *vm.MessageReceipt
+
 	// TODO: This is an inefficient way to discover a deal ID. See if we can find it uniquely on chain some other way or store the dealID when the message first lands (#4066).
+	// give the wait 30 seconds to avoid races
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Fetch receipt to return dealId
 	about2Days := uint64(24 * 60)
-	chnMsg, found, err := s.waiter.Find(ctx, about2Days, func(msg *types.SignedMessage, c cid.Cid) bool {
-		return c.Equals(*deal.PublishMessage)
+	err = s.waiter.Wait(ctx, *deal.PublishMessage, about2Days, func(_ *block.Block, msg *types.SignedMessage, rcpt *vm.MessageReceipt) error {
+		unsigned = msg.Message
+		receipt = rcpt
+		return nil
 	})
 	if err != nil {
 		return 0, err
 	}
-
-	if !found {
-		return 0, xerrors.Errorf("Could not find published deal message %s", deal.PublishMessage.String())
-	}
-
-	unsigned := chnMsg.Message.Message
 
 	tok, err := encoding.Encode(s.chainStore.Head())
 	if err != nil {
@@ -194,7 +198,7 @@ func (s *StorageClientNodeConnector) ValidatePublishedDeal(ctx context.Context, 
 	for _, proposal := range msgProposals {
 		if reflect.DeepEqual(proposal.Proposal, deal.Proposal) {
 			var ret market.PublishStorageDealsReturn
-			err := encoding.Decode(chnMsg.Receipt.ReturnValue, &ret)
+			err := encoding.Decode(receipt.ReturnValue, &ret)
 			if err != nil {
 				return 0, err
 			}


### PR DESCRIPTION
### Motivation

Our client propose-storage-deal command errors with an unhelpful message when the peer id option is not provided.

### Proposed changes

Fix this and restore the propose-storage-deal integration test (which appears to be working fine).
