### PR TITLE
Add dummy drand entry to genesis block in gengen

### DIFF
--- a/tools/gengen/util/generator.go
+++ b/tools/gengen/util/generator.go
@@ -272,7 +272,7 @@ func (g *GenesisGenerator) genBlock(ctx context.Context) (cid.Cid, error) {
 	geneblk := &block.Block{
 		Miner:           builtin.SystemActorAddr,
 		Ticket:          genesis.Ticket,
-		BeaconEntries:   []*drand.Entry{},
+		BeaconEntries:   []*drand.Entry{&drand.Entry{Data: []byte{0xca, 0xfe, 0xfa, 0xce}}},
 		PoStProofs:      []block.PoStProof{},
 		Parents:         block.NewTipSetKey(),
 		ParentWeight:    big.Zero(),

--- a/tools/gengen/util/generator.go
+++ b/tools/gengen/util/generator.go
@@ -272,7 +272,7 @@ func (g *GenesisGenerator) genBlock(ctx context.Context) (cid.Cid, error) {
 	geneblk := &block.Block{
 		Miner:           builtin.SystemActorAddr,
 		Ticket:          genesis.Ticket,
-		BeaconEntries:   []*drand.Entry{&drand.Entry{Data: []byte{0xca, 0xfe, 0xfa, 0xce}}},
+		BeaconEntries:   []*drand.Entry{{Data: []byte{0xca, 0xfe, 0xfa, 0xce}}},
 		PoStProofs:      []block.PoStProof{},
 		Parents:         block.NewTipSetKey(),
 		ParentWeight:    big.Zero(),


### PR DESCRIPTION
### Motivation
Small change that shouldn't affect much.  This way gengen puts something in the drand entries field to keep lotus happy during interop.  Gfc won't ever read this value because it special cases genesis when handling drand.

### Proposed changes

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

