### PR TITLE
update specs-actors and add puppet actor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/drand/drand v0.8.1
 	github.com/drand/kyber v1.0.1-0.20200331114745-30e90cc60f99
 	github.com/elastic/go-windows v1.0.1 // indirect
-	github.com/filecoin-project/chain-validation v0.0.6-0.20200506234205-5fe7d4aab7f9
+	github.com/filecoin-project/chain-validation v0.0.6-0.20200511194551-1a0e66ce8052
 	github.com/filecoin-project/filecoin-ffi v0.26.1-0.20200508175440-05b30afeb00d
 	github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be
 	github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200424220931-6263827e49f2

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,10 @@ github.com/fd/go-nat v1.0.0/go.mod h1:BTBu/CKvMmOMUPkKVef1pngt2WFH/lg7E6yQnulfp6
 github.com/filecoin-project/chain-validation v0.0.3/go.mod h1:NCEGFjcWRjb8akWFSOXvU6n2efkWIqAeOKU6o5WBGQw=
 github.com/filecoin-project/chain-validation v0.0.6-0.20200506234205-5fe7d4aab7f9 h1:CK3t79ocoF35ZFr4ohfGkpEChnZ/a7TK14Dl1Be5L9w=
 github.com/filecoin-project/chain-validation v0.0.6-0.20200506234205-5fe7d4aab7f9/go.mod h1:tyI16CI6/S0TvluPzFyopPWcR+/5l6kUjyzeIgLFVfs=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200511173903-f1c1fa65e89b h1:8w9NEgjoK9G8eZxpnunJiw7da69MuPx2ix8UNPAwVeM=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200511173903-f1c1fa65e89b/go.mod h1:tyI16CI6/S0TvluPzFyopPWcR+/5l6kUjyzeIgLFVfs=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200511194551-1a0e66ce8052 h1:Ar9t7O4ZXcYNpfkorG14/zLt8ZPsVxpdp7JAZy4+B8k=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200511194551-1a0e66ce8052/go.mod h1:tyI16CI6/S0TvluPzFyopPWcR+/5l6kUjyzeIgLFVfs=
 github.com/filecoin-project/go-address v0.0.0-20191219011437-af739c490b4f/go.mod h1:rCbpXPva2NKF9/J4X6sr7hbKBgQCxyFtRj7KOZqoIms=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5 h1:/MmWluswvDIbuPvBct4q6HeQgVm62O2DzWYTB38kt4A=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=

--- a/internal/pkg/vm/internal/vmcontext/invocation_context.go
+++ b/internal/pkg/vm/internal/vmcontext/invocation_context.go
@@ -424,6 +424,10 @@ func (ctx *invocationContext) Send(toAddr address.Address, methodNum abi.MethodN
 	from := ctx.msg.to
 	fromActor := ctx.toActor
 
+	if fromActor.Balance.LessThan(value) {
+		runtime.Abort(exitcode.SysErrInsufficientFunds)
+	}
+
 	// 2. build internal message
 	newMsg := internalMessage{
 		from:   from,


### PR DESCRIPTION
### Motivation
Test inner sends via puppet actor.
Goes-with: https://github.com/filecoin-project/chain-validation/pull/191

### Proposed changes
- update to latest specs-actors with puppet actor
- add puppet actor to dispatch builder chainval driver when creating a new VM. Allows the puppet actor to be called
- Ensure the sending actor has [sufficient balance](https://github.com/filecoin-project/go-filecoin/compare/frrist/puppet-actor?expand=1#diff-ac24da57d5301efa8c681bbe720aa2f4R427-R430) before invoking an inner send