### PR TITLE
update fxamacker cbor to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,8 @@ require (
 	github.com/filecoin-project/sector-storage v0.0.0-20200508203401-a74812ba12f3
 	github.com/filecoin-project/specs-actors v0.5.3
 	github.com/filecoin-project/storage-fsm v0.0.0-20200508212339-4980cb4c92b1
-	github.com/fxamacker/cbor v1.5.0
+	github.com/fxamacker/cbor/v2 v2.2.0
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golangci/golangci-lint v1.21.0
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -192,7 +192,6 @@ github.com/filecoin-project/sector-storage v0.0.0-20200508203401-a74812ba12f3/go
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.0.0-20200409043918-e569f4a2f504/go.mod h1:mdJraXq5vMy0+/FqVQIrnNlpQ/Em6zeu06G/ltQ0/lA=
 github.com/filecoin-project/specs-actors v0.3.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=
-github.com/filecoin-project/specs-actors v0.4.1-0.20200509020627-3c96f54f3d7d/go.mod h1:UW3ft23q6VS8wQoNqLWjENsu9gu1uh6lxOd+H8cwhT8=
 github.com/filecoin-project/specs-actors v0.5.2/go.mod h1:r5btrNzZD0oBkEz1pohv80gSCXQnqGrD0kYwOTiExyE=
 github.com/filecoin-project/specs-actors v0.5.3 h1:fdq8Gx0izhnUKl6sYEtI4SUEjT2U6W2w06HeqLz5vmw=
 github.com/filecoin-project/specs-actors v0.5.3/go.mod h1:r5btrNzZD0oBkEz1pohv80gSCXQnqGrD0kYwOTiExyE=
@@ -202,8 +201,8 @@ github.com/filecoin-project/storage-fsm v0.0.0-20200508212339-4980cb4c92b1 h1:qs
 github.com/filecoin-project/storage-fsm v0.0.0-20200508212339-4980cb4c92b1/go.mod h1:3wZV/yMjSlKkP80kXnJSeYRGwsWKd08XGAVIQKvcyYQ=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fxamacker/cbor v1.5.0 h1:idAiyeNSq/jeG9FPbCLVZLFJjsxP+g40a3UrXFapumw=
-github.com/fxamacker/cbor v1.5.0/go.mod h1:UjdWSysJckWsChYy9I5zMbkGvK4xXDR+LmDb8kPGYgA=
+github.com/fxamacker/cbor/v2 v2.2.0 h1:6eXqdDDe588rSYAi1HfZKbx6YYQO4mxQ9eC6xYpU/JQ=
+github.com/fxamacker/cbor/v2 v2.2.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJYCFOLkIBwI7xFExG03bbkOkCvUPI=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
@@ -262,6 +261,8 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -1251,8 +1252,8 @@ github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee h1:lYbXeSv
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee/go.mod h1:m2aV4LZI4Aez7dP5PMyVKEHhUyEJ/RjmPEDOpDvudHg=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
-github.com/x448/float16 v0.8.3 h1:i2Y5SfvnmNqonyrBxsp8I1AuTm+MW+kyxLES3w9dikk=
-github.com/x448/float16 v0.8.3/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/pkg/enccid/enc_cid.go
+++ b/internal/pkg/enccid/enc_cid.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	cbor "github.com/fxamacker/cbor"
+	cbor "github.com/fxamacker/cbor/v2"
 	cid "github.com/ipfs/go-cid"
 	ipldcbor "github.com/ipfs/go-ipld-cbor"
 )
@@ -44,7 +44,7 @@ func (w Cid) MarshalCBOR() ([]byte, error) {
 	}
 	// because we need to do the cbor tag outside the byte string we are forced
 	// to write the cbor type-len value for a byte string of raw's length
-	cborLen, err := cbor.Marshal(len(raw), cbor.EncOptions{})
+	cborLen, err := cbor.Marshal(len(raw))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/enccid/enccid_test.go
+++ b/internal/pkg/enccid/enccid_test.go
@@ -3,7 +3,7 @@ package enccid_test
 import (
 	"testing"
 
-	cbor "github.com/fxamacker/cbor"
+	cbor "github.com/fxamacker/cbor/v2"
 	cid "github.com/ipfs/go-cid"
 	ipldcbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/stretchr/testify/assert"
@@ -20,7 +20,7 @@ func TestCborRoundTrip(t *testing.T) {
 	c, err := constants.DefaultCidBuilder.Sum([]byte("epigram"))
 	require.NoError(t, err)
 	w := NewCid(c)
-	cbytes, err := cbor.Marshal(w, cbor.EncOptions{})
+	cbytes, err := cbor.Marshal(w)
 	require.NoError(t, err)
 
 	olcbytes, err := ipldcbor.DumpObject(c)
@@ -40,7 +40,7 @@ func TestEmptyCid(t *testing.T) {
 	tf.UnitTest(t)
 
 	nullCid := NewCid(cid.Undef)
-	cbytes, err := cbor.Marshal(nullCid, cbor.EncOptions{})
+	cbytes, err := cbor.Marshal(nullCid)
 	require.NoError(t, err)
 
 	var retUndefCid Cid

--- a/internal/pkg/encoding/fxamacker_cbor.go
+++ b/internal/pkg/encoding/fxamacker_cbor.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"io"
 
-	cbor "github.com/fxamacker/cbor"
+	cbor "github.com/fxamacker/cbor/v2"
 )
 
 // FxamackerCborEncoder is an object encoder that encodes objects based on the CBOR standard.
@@ -123,7 +123,7 @@ func (encoder *FxamackerCborEncoder) encodeCbor(obj interface{}) error {
 	}
 
 	// get cbor encoded bytes
-	raw, err := cbor.Marshal(obj, cbor.EncOptions{})
+	raw, err := cbor.Marshal(obj)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/vm/actor/actor.go
+++ b/internal/pkg/vm/actor/actor.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	fxamackercbor "github.com/fxamacker/cbor"
+	fxamackercbor "github.com/fxamacker/cbor/v2"
 	"github.com/ipfs/go-cid"
 
 	"github.com/pkg/errors"
@@ -81,7 +81,7 @@ func (a *Actor) UnmarshalCBOR(r io.Reader) error {
 
 // MarshalCBOR must implement cbg.Marshaller to insert this into a hamt.
 func (a *Actor) MarshalCBOR(w io.Writer) error {
-	bs, err := fxamackercbor.Marshal(a, fxamackercbor.EncOptions{})
+	bs, err := fxamackercbor.Marshal(a)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Motivation
Fxamacker cbor library has been upgraded to v2 for a while now.  It seems like a good time to bring in latest version.  There were two very small breaking interface changes.

### Proposed changes
Update go mod.  Fix a few small interface changes.

Note: I tested this out against syncing latest lotus interopnet.  Haven't tested out when mining with lotus -- we should feel free to postpone merge until post mainnet to be on the extra safe side to make sure we don't introduce further incompatibilities that only show up when we produce blocks.

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

