### PR TITLE
Work around re-entrancy and cancellation ignorance in drand fetch

### DIFF
--- a/internal/pkg/drand/drand.go
+++ b/internal/pkg/drand/drand.go
@@ -11,7 +11,7 @@ type IFace interface {
 	VerifyEntry(parent, child *Entry) (bool, error)
 	FetchGroupConfig(addresses []string, secure bool, overrideGroupAddrs bool) ([]string, [][]byte, uint64, int, error)
 	StartTimeOfRound(round Round) time.Time
-	RoundsInInterval(ctx context.Context, startTime, endTime time.Time) []Round
+	RoundsInInterval(startTime, endTime time.Time) []Round
 	FirstFilecoinRound() Round
 }
 

--- a/internal/pkg/drand/testing.go
+++ b/internal/pkg/drand/testing.go
@@ -51,9 +51,8 @@ func (d *Fake) StartTimeOfRound(round Round) time.Time {
 
 // RoundsInInterval returns the DRAND round numbers within [startTime, endTime)
 // startTime inclusive, endTime exclusive.
-// No gaps in test DRAND so this doesn't need to consult the DRAND chain
-func (d *Fake) RoundsInInterval(ctx context.Context, startTime, endTime time.Time) []Round {
-	return roundsInIntervalWhenNoGaps(startTime, endTime, d.StartTimeOfRound, testDRANDRoundDuration)
+func (d *Fake) RoundsInInterval(startTime, endTime time.Time) []Round {
+	return roundsInInterval(startTime, endTime, d.StartTimeOfRound, testDRANDRoundDuration)
 }
 
 func (d *Fake) FirstFilecoinRound() Round {
@@ -63,25 +62,4 @@ func (d *Fake) FirstFilecoinRound() Round {
 // FetchGroupConfig returns empty group addresses and key coefficients
 func (d *Fake) FetchGroupConfig(_ []string, _, _ bool) ([]string, [][]byte, uint64, int, error) {
 	return []string{}, [][]byte{}, 0, 0, nil
-}
-
-func roundsInIntervalWhenNoGaps(startTime, endTime time.Time, startTimeOfRound func(Round) time.Time, roundDuration time.Duration) []Round {
-	// Find first round after startTime
-	genesisTime := startTimeOfRound(Round(0))
-	truncatedStartRound := Round(startTime.Sub(genesisTime) / roundDuration)
-	var round Round
-	if startTimeOfRound(truncatedStartRound).Equal(startTime) {
-		round = truncatedStartRound
-	} else {
-		round = truncatedStartRound + 1
-	}
-	roundTime := startTimeOfRound(round)
-	var rounds []Round
-	// Advance a round time until we hit endTime, adding rounds
-	for roundTime.Before(endTime) {
-		rounds = append(rounds, round)
-		round++
-		roundTime = startTimeOfRound(round)
-	}
-	return rounds
 }

--- a/internal/pkg/mining/scheduler.go
+++ b/internal/pkg/mining/scheduler.go
@@ -95,6 +95,9 @@ func (s *timingScheduler) mineLoop(miningCtx context.Context, outCh chan Output,
 		nullBlkCount := uint64(currEpoch-h) - 1
 		doneWg.Add(1)
 		go func(ctx context.Context) {
+			// Mine is not intended to be re-entrant, but using a go-routine here makes it impossible to enforce
+			// single-threaded access.
+			// Some context in https://github.com/filecoin-project/go-filecoin/issues/4065
 			s.worker.Mine(ctx, base, nullBlkCount, outCh)
 			doneWg.Done()
 		}(workContext)

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -361,7 +361,7 @@ func (w *DefaultWorker) drandEntriesForEpoch(ctx context.Context, base block.Tip
 		// and then we grab everything between this round and genesis time
 		startTime := w.drand.StartTimeOfRound(w.drand.FirstFilecoinRound())
 		endTime := w.clock.StartTimeOfEpoch(lastTargetEpoch + 1)
-		rounds = w.drand.RoundsInInterval(ctx, startTime, endTime)
+		rounds = w.drand.RoundsInInterval(startTime, endTime)
 	} else {
 		latestEntry, err := chain.FindLatestDRAND(ctx, base, w.chainState)
 		if err != nil {
@@ -372,7 +372,7 @@ func (w *DefaultWorker) drandEntriesForEpoch(ctx context.Context, base block.Tip
 		// end of interval is beginning of next epoch after lastTargetEpoch so
 		//  we add 1 to lastTargetEpoch
 		endTime := w.clock.StartTimeOfEpoch(lastTargetEpoch + 1)
-		rounds = w.drand.RoundsInInterval(ctx, startTime, endTime)
+		rounds = w.drand.RoundsInInterval(startTime, endTime)
 		// first round is round of latestEntry so omit the 0th round
 		rounds = rounds[1:]
 	}


### PR DESCRIPTION
### Motivation
We observed panics from concurrent map access coming from `GRPC.updateLocalState`, which writes to a cache. These are ultimately caused by the mining worker invoking `Mine` concurrently, but exacerbated by the context being ignored by the drand client library and our wrapper.

### Proposed changes
Skip updating local state if the context has been cancelled.

This is a work-around, but not complete fix, for #4065

