### PR TITLE
Config support for monkey-patching constants in specs-actors at daemon boot

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Heartbeat     *HeartbeatConfig     `json:"heartbeat"`
 	Mining        *MiningConfig        `json:"mining"`
 	Mpool         *MessagePoolConfig   `json:"mpool"`
+	NetworkParams *NetworkParamsConfig `json:"parameters"`
 	Observability *ObservabilityConfig `json:"observability"`
 	SectorBase    *SectorBaseConfig    `json:"sectorbase"`
 	Swarm         *SwarmConfig         `json:"swarm"`
@@ -244,6 +245,16 @@ func newDefaultMessagePoolConfig() *MessagePoolConfig {
 	}
 }
 
+type NetworkParamsConfig struct {
+	ConsensusMinerMinPower uint64 // uint64 goes up to 18 EiB
+}
+
+func newDefaultNetworkParamsConfig() *NetworkParamsConfig {
+	return &NetworkParamsConfig{
+		ConsensusMinerMinPower: 0, // 0 means don't override the value
+	}
+}
+
 // SectorBaseConfig holds all configuration options related to the node's
 // sector storage.
 type SectorBaseConfig struct {
@@ -272,13 +283,14 @@ func NewDefaultConfig() *Config {
 		Bootstrap:     newDefaultBootstrapConfig(),
 		Datastore:     newDefaultDatastoreConfig(),
 		Drand:         newDefaultDrandConfig(),
-		Swarm:         newDefaultSwarmConfig(),
-		Mining:        newDefaultMiningConfig(),
-		Wallet:        newDefaultWalletConfig(),
 		Heartbeat:     newDefaultHeartbeatConfig(),
+		Mining:        newDefaultMiningConfig(),
 		Mpool:         newDefaultMessagePoolConfig(),
-		SectorBase:    newDefaultSectorbaseConfig(),
+		NetworkParams: newDefaultNetworkParamsConfig(),
 		Observability: newDefaultObservabilityConfig(),
+		SectorBase:    newDefaultSectorbaseConfig(),
+		Swarm:         newDefaultSwarmConfig(),
+		Wallet:        newDefaultWalletConfig(),
 	}
 }
 

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -36,90 +37,17 @@ func TestWriteFile(t *testing.T) {
 
 	cfg := NewDefaultConfig()
 
+	cfgJSON, err := json.MarshalIndent(*cfg, "", "\t")
+	require.NoError(t, err)
+	expected := string(cfgJSON)
+
+	SanityCheck(t, expected)
+
 	assert.NoError(t, cfg.WriteFile(filepath.Join(dir, "config.json")))
 	content, err := ioutil.ReadFile(filepath.Join(dir, "config.json"))
 	assert.NoError(t, err)
 
-	assert.Equal(t,
-		`{
-	"api": {
-		"address": "/ip4/127.0.0.1/tcp/3453",
-		"accessControlAllowOrigin": [
-			"http://localhost:8080",
-			"https://localhost:8080",
-			"http://127.0.0.1:8080",
-			"https://127.0.0.1:8080"
-		],
-		"accessControlAllowCredentials": false,
-		"accessControlAllowMethods": [
-			"GET",
-			"POST",
-			"PUT"
-		]
-	},
-	"bootstrap": {
-		"addresses": [],
-		"minPeerThreshold": 0,
-		"period": "1m"
-	},
-	"datastore": {
-		"type": "badgerds",
-		"path": "badger"
-	},
-	"drand": {
-		"addresses": [
-			"localhost:8080",
-			"localhost:8081",
-			"localhost:8082",
-			"localhost:8083",
-			"localhost:8084"
-		],
-		"secure": false,
-		"distKey": [],
-		"startTimeUnix": 0,
-		"roundSeconds": 30
-	},
-	"heartbeat": {
-		"beatTarget": "",
-		"beatPeriod": "3s",
-		"reconnectPeriod": "10s",
-		"nickname": ""
-	},
-	"mining": {
-		"minerAddress": "\u003cempty\u003e",
-		"autoSealIntervalSeconds": 120,
-		"storagePrice": "0"
-	},
-	"mpool": {
-		"maxPoolSize": 1000000,
-		"maxNonceGap": 100
-	},
-	"observability": {
-		"metrics": {
-			"prometheusEnabled": false,
-			"reportInterval": "5s",
-			"prometheusEndpoint": "/ip4/0.0.0.0/tcp/9400"
-		},
-		"tracing": {
-			"jaegerTracingEnabled": false,
-			"probabilitySampler": 1,
-			"jaegerEndpoint": "http://localhost:14268/api/traces"
-		}
-	},
-	"sectorbase": {
-		"rootdir": "",
-		"preSealedSectorsDir": ""
-	},
-	"swarm": {
-		"address": "/ip4/0.0.0.0/tcp/6000"
-	},
-	"wallet": {
-		"defaultAddress": "\u003cempty\u003e"
-	}
-}`,
-		string(content),
-	)
-
+	assert.Equal(t, expected, string(content))
 	assert.NoError(t, os.Remove(filepath.Join(dir, "config.json")))
 }
 

--- a/internal/pkg/config/testing.go
+++ b/internal/pkg/config/testing.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Makes some basic checks of a serialized config to ascertain that it looks kind of right.
+// This is instead of brittle hardcoded exact config expectations.
+func SanityCheck(t *testing.T, cfgJSON string) {
+	assert.True(t, strings.Contains(cfgJSON, "accessControlAllowOrigin"))
+	assert.True(t, strings.Contains(cfgJSON, "http://localhost:8080"))
+	assert.True(t, strings.Contains(cfgJSON, "bootstrap"))
+	assert.True(t, strings.Contains(cfgJSON, "bootstrap"))
+	assert.True(t, strings.Contains(cfgJSON, "\"minPeerThreshold\": 0"))
+	assert.True(t, strings.Contains(cfgJSON, "minerAddress"))
+}

--- a/internal/pkg/repo/fsrepo_test.go
+++ b/internal/pkg/repo/fsrepo_test.go
@@ -18,85 +18,6 @@ import (
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
 )
 
-const (
-	expectContent = `{
-	"api": {
-		"address": "/ip4/127.0.0.1/tcp/3453",
-		"accessControlAllowOrigin": [
-			"http://localhost:8080",
-			"https://localhost:8080",
-			"http://127.0.0.1:8080",
-			"https://127.0.0.1:8080"
-		],
-		"accessControlAllowCredentials": false,
-		"accessControlAllowMethods": [
-			"GET",
-			"POST",
-			"PUT"
-		]
-	},
-	"bootstrap": {
-		"addresses": [],
-		"minPeerThreshold": 0,
-		"period": "1m"
-	},
-	"datastore": {
-		"type": "badgerds",
-		"path": "badger"
-	},
-	"drand": {
-		"addresses": [
-			"localhost:8080",
-			"localhost:8081",
-			"localhost:8082",
-			"localhost:8083",
-			"localhost:8084"
-		],
-		"secure": false,
-		"distKey": [],
-		"startTimeUnix": 0,
-		"roundSeconds": 30
-	},
-	"heartbeat": {
-		"beatTarget": "",
-		"beatPeriod": "3s",
-		"reconnectPeriod": "10s",
-		"nickname": ""
-	},
-	"mining": {
-		"minerAddress": "\u003cempty\u003e",
-		"autoSealIntervalSeconds": 120,
-		"storagePrice": "0"
-	},
-	"mpool": {
-		"maxPoolSize": 1000000,
-		"maxNonceGap": 100
-	},
-	"observability": {
-		"metrics": {
-			"prometheusEnabled": false,
-			"reportInterval": "5s",
-			"prometheusEndpoint": "/ip4/0.0.0.0/tcp/9400"
-		},
-		"tracing": {
-			"jaegerTracingEnabled": false,
-			"probabilitySampler": 1,
-			"jaegerEndpoint": "http://localhost:14268/api/traces"
-		}
-	},
-	"sectorbase": {
-		"rootdir": "",
-		"preSealedSectorsDir": ""
-	},
-	"swarm": {
-		"address": "/ip4/0.0.0.0/tcp/6000"
-	},
-	"wallet": {
-		"defaultAddress": "\u003cempty\u003e"
-	}
-}`
-)
-
 func TestInitRepoDirect(t *testing.T) {
 	tf.UnitTest(t)
 	cfg := config.NewDefaultConfig()
@@ -416,7 +337,7 @@ func checkNewRepoFiles(t *testing.T, path string, version uint) {
 
 	// Asserting the exact content here is gonna get old real quick
 	t.Log("config file matches expected value")
-	assert.Equal(t, expectContent, string(content))
+	config.SanityCheck(t, string(content))
 
 	actualVersion, err := ioutil.ReadFile(filepath.Join(path, versionFilename))
 	assert.NoError(t, err)


### PR DESCRIPTION
### Motivation
The network parameters defined in specs-actors are not currently configurable. In lieu of some real configurability, this allows a node to override the parameters for test networks.

Note that this mechanism won't work to affect genesis state construction.

### Proposed changes
New config for overriding ConsensusMinerMinPower
