### PR TITLE
Max mpool count *= 100

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -239,7 +239,7 @@ type MessagePoolConfig struct {
 
 func newDefaultMessagePoolConfig() *MessagePoolConfig {
 	return &MessagePoolConfig{
-		MaxPoolSize: 10000,
+		MaxPoolSize: 1000000,
 		MaxNonceGap: 100,
 	}
 }

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -91,7 +91,7 @@ func TestWriteFile(t *testing.T) {
 		"storagePrice": "0"
 	},
 	"mpool": {
-		"maxPoolSize": 10000,
+		"maxPoolSize": 1000000,
 		"maxNonceGap": 100
 	},
 	"observability": {

--- a/internal/pkg/repo/fsrepo_test.go
+++ b/internal/pkg/repo/fsrepo_test.go
@@ -69,7 +69,7 @@ const (
 		"storagePrice": "0"
 	},
 	"mpool": {
-		"maxPoolSize": 10000,
+		"maxPoolSize": 1000000,
 		"maxNonceGap": 100
 	},
 	"observability": {


### PR DESCRIPTION
### Motivation
Logs spam error `message pool is full` regularly because our default is below what typically occurs on a devnet.

### Proposed changes
Increase the limit

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

