### PR TITLE
drand-config-addr init option

### DIFF
--- a/cmd/go-filecoin/main.go
+++ b/cmd/go-filecoin/main.go
@@ -37,6 +37,9 @@ const (
 	// OptionPresealedSectorDir is the name of the option for specifying the directory from which presealed sectors should be pulled when initializing.
 	OptionPresealedSectorDir = "presealed-sectordir"
 
+	// OptionDrandConfigAddr is the init option for configuring drand to a given network address at init time
+	OptionDrandConfigAddr = "drand-config-addr"
+
 	// APIPrefix is the prefix for the http version of the api.
 	APIPrefix = "/api"
 


### PR DESCRIPTION
### Motivation
This option removes operator complexity into the code.  There is now an init option that initializes the config.

`go-filecoin init --drand-config-addr=<drand addr>` will populate the config with a drand network's info.

### Proposed changes
We reuse the drand api's configure method.  Along the way we extract a small set of default drand setup calls into a free function in builder.  We also do a little bit of type massage to handle the drand api's dependence on plumbing.  We give fewer options to the user configuring on init.  In particular we only let users specify one address and force the `drand configure` defaults for transport layer security (we require it) and fetched address overwriting (we do not do it).  If users want more options they can hold off and configure drand with the fully expressive daemon command.

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

cc @travisperson 