### PR TITLE
Add msg syntax validation during sync

### DIFF
--- a/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
@@ -57,7 +57,10 @@ func NewSyncerSubmodule(ctx context.Context, config syncerConfig, blockstore *Bl
 	// setup validation
 	blkValid := consensus.NewDefaultBlockValidator(config.ChainClock())
 	msgValid := consensus.NewMessageSyntaxValidator()
-	syntax := consensus.WrappedSyntaxValidator{blkValid, msgValid}
+	syntax := consensus.WrappedSyntaxValidator{
+		BlockSyntaxValidator:   blkValid,
+		MessageSyntaxValidator: msgValid,
+	}
 
 	// register block validation on pubsub
 	btv := blocksub.NewBlockTopicValidator(blkValid)

--- a/internal/pkg/chainsync/fetcher/graphsync_fetcher_test.go
+++ b/internal/pkg/chainsync/fetcher/graphsync_fetcher_test.go
@@ -818,7 +818,9 @@ func TestRealWorldGraphsyncFetchOnlyHeaders(t *testing.T) {
 
 	bv := consensus.NewDefaultBlockValidator(chainClock)
 	msgV := &consensus.FakeMessageValidator{}
-	syntax := consensus.WrappedSyntaxValidator{bv, msgV}
+	syntax := consensus.WrappedSyntaxValidator{BlockSyntaxValidator: bv,
+		MessageSyntaxValidator: msgV,
+	}
 	pt := discovery.NewPeerTracker(peer.ID(""))
 	pt.Track(block.NewChainInfo(host2.ID(), host2.ID(), block.TipSetKey{}, 0))
 
@@ -911,7 +913,10 @@ func TestRealWorldGraphsyncFetchAcrossNetwork(t *testing.T) {
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 	bv := th.NewFakeBlockValidator()
 	msgV := &consensus.FakeMessageValidator{}
-	syntax := consensus.WrappedSyntaxValidator{bv, msgV}
+	syntax := consensus.WrappedSyntaxValidator{
+		BlockSyntaxValidator:   bv,
+		MessageSyntaxValidator: msgV,
+	}
 	fc := clock.NewFake(time.Now())
 	pt := discovery.NewPeerTracker(peer.ID(""))
 	pt.Track(block.NewChainInfo(host2.ID(), host2.ID(), block.TipSetKey{}, 0))

--- a/internal/pkg/chainsync/fetcher/graphsync_fetcher_test.go
+++ b/internal/pkg/chainsync/fetcher/graphsync_fetcher_test.go
@@ -62,7 +62,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 	fc, chainClock := clock.NewFakeChain(1234567890, 5*time.Second, time.Now().Unix())
 	bv := consensus.NewDefaultBlockValidator(chainClock)
-	msgV := consensus.NewMessageSyntaxValidator()
+	msgV := &consensus.FakeMessageValidator{}
 	syntax := consensus.WrappedSyntaxValidator{bv, msgV}
 
 	pid0 := th.RequireIntPeerID(t, 0)
@@ -657,7 +657,7 @@ func TestHeadersOnlyGraphsyncFetch(t *testing.T) {
 	genTime := uint64(1234567890)
 	chainClock := clock.NewChainClockFromClock(genTime, 5*time.Second, fc)
 	bv := consensus.NewDefaultBlockValidator(chainClock)
-	msgV := consensus.NewMessageSyntaxValidator()
+	msgV := &consensus.FakeMessageValidator{}
 	syntax := consensus.WrappedSyntaxValidator{bv, msgV}
 	pid0 := th.RequireIntPeerID(t, 0)
 	builder := chain.NewBuilderWithDeps(t, address.Undef, &chain.FakeStateBuilder{}, chain.NewClockTimestamper(chainClock))
@@ -811,7 +811,7 @@ func TestRealWorldGraphsyncFetchOnlyHeaders(t *testing.T) {
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 
 	bv := consensus.NewDefaultBlockValidator(chainClock)
-	msgV := consensus.NewMessageSyntaxValidator()
+	msgV := &consensus.FakeMessageValidator{}
 	syntax := consensus.WrappedSyntaxValidator{bv, msgV}
 	pt := discovery.NewPeerTracker(peer.ID(""))
 	pt.Track(block.NewChainInfo(host2.ID(), host2.ID(), block.TipSetKey{}, 0))
@@ -904,7 +904,7 @@ func TestRealWorldGraphsyncFetchAcrossNetwork(t *testing.T) {
 
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 	bv := th.NewFakeBlockValidator()
-	msgV := consensus.NewMessageSyntaxValidator()
+	msgV := &consensus.FakeMessageValidator{}
 	syntax := consensus.WrappedSyntaxValidator{bv, msgV}
 	fc := clock.NewFake(time.Now())
 	pt := discovery.NewPeerTracker(peer.ID(""))

--- a/internal/pkg/chainsync/fetcher/graphsync_fetcher_test.go
+++ b/internal/pkg/chainsync/fetcher/graphsync_fetcher_test.go
@@ -63,7 +63,10 @@ func TestGraphsyncFetcher(t *testing.T) {
 	fc, chainClock := clock.NewFakeChain(1234567890, 5*time.Second, time.Now().Unix())
 	bv := consensus.NewDefaultBlockValidator(chainClock)
 	msgV := &consensus.FakeMessageValidator{}
-	syntax := consensus.WrappedSyntaxValidator{bv, msgV}
+	syntax := consensus.WrappedSyntaxValidator{
+		BlockSyntaxValidator:   bv,
+		MessageSyntaxValidator: msgV,
+	}
 
 	pid0 := th.RequireIntPeerID(t, 0)
 	builder := chain.NewBuilderWithDeps(t, address.Undef, &chain.FakeStateBuilder{}, chain.NewClockTimestamper(chainClock))
@@ -658,7 +661,10 @@ func TestHeadersOnlyGraphsyncFetch(t *testing.T) {
 	chainClock := clock.NewChainClockFromClock(genTime, 5*time.Second, fc)
 	bv := consensus.NewDefaultBlockValidator(chainClock)
 	msgV := &consensus.FakeMessageValidator{}
-	syntax := consensus.WrappedSyntaxValidator{bv, msgV}
+	syntax := consensus.WrappedSyntaxValidator{
+		BlockSyntaxValidator:   bv,
+		MessageSyntaxValidator: msgV,
+	}
 	pid0 := th.RequireIntPeerID(t, 0)
 	builder := chain.NewBuilderWithDeps(t, address.Undef, &chain.FakeStateBuilder{}, chain.NewClockTimestamper(chainClock))
 	keys := types.MustGenerateKeyInfo(1, 42)

--- a/internal/pkg/chainsync/fetcher/graphsync_helpers_test.go
+++ b/internal/pkg/chainsync/fetcher/graphsync_helpers_test.go
@@ -397,11 +397,11 @@ func (mv mockSyntaxValidator) ValidateSyntax(ctx context.Context, blk *block.Blo
 	return nil
 }
 
-func (mv mockSyntaxValidator) ValidateMessagesSyntax(ctx context.Context, messages []*types.SignedMessage) error {
+func (mv mockSyntaxValidator) ValidateSignedMessageSyntax(ctx context.Context, message *types.SignedMessage) error {
 	return mv.validateMessagesError
 }
 
-func (mv mockSyntaxValidator) ValidateUnsignedMessagesSyntax(ctx context.Context, messages []*types.UnsignedMessage) error {
+func (mv mockSyntaxValidator) ValidateUnsignedMessageSyntax(ctx context.Context, message *types.UnsignedMessage) error {
 	return nil
 }
 

--- a/internal/pkg/consensus/block_validation.go
+++ b/internal/pkg/consensus/block_validation.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
 // BlockValidator defines an interface used to validate a blocks syntax and
@@ -19,6 +20,7 @@ type BlockValidator interface {
 // syntax of constituent messages
 type SyntaxValidator interface {
 	BlockSyntaxValidator
+	MessageSyntaxValidator
 }
 
 // BlockSemanticValidator defines an interface used to validate a blocks
@@ -33,9 +35,22 @@ type BlockSyntaxValidator interface {
 	ValidateSyntax(ctx context.Context, blk *block.Block) error
 }
 
+// MessageSyntaxValidator defines an interface used to validate a message's
+// syntax.
+type MessageSyntaxValidator interface {
+	ValidateSignedMessageSyntax(ctx context.Context, smsg *types.SignedMessage) error
+	ValidateUnsignedMessageSyntax(ctx context.Context, msg *types.UnsignedMessage) error
+}
+
 // DefaultBlockValidator implements the BlockValidator interface.
 type DefaultBlockValidator struct {
 	clock.ChainEpochClock
+}
+
+// WrappedSyntaxValidator implements syntax validator interface
+type WrappedSyntaxValidator struct {
+	BlockSyntaxValidator
+	MessageSyntaxValidator
 }
 
 // NewDefaultBlockValidator returns a new DefaultBlockValidator. It uses `blkTime`

--- a/internal/pkg/consensus/testing.go
+++ b/internal/pkg/consensus/testing.go
@@ -18,7 +18,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/postgenerator"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/state"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/actor"
 )
 
 // RequireNewTipSet instantiates and returns a new tipset of the given blocks
@@ -47,8 +46,11 @@ func (f *FakeConsensusStateViewer) FaultStateView(root cid.Cid) FaultStateView {
 // FakeMessageValidator is a validator that doesn't validate to simplify message creation in tests.
 type FakeMessageValidator struct{}
 
-// Validate always returns nil
-func (tsmv *FakeMessageValidator) Validate(ctx context.Context, msg *types.UnsignedMessage, fromActor *actor.Actor) error {
+func (mv *FakeMessageValidator) ValidateSignedMessageSyntax(ctx context.Context, smsg *types.SignedMessage) error {
+	return nil
+}
+
+func (mv *FakeMessageValidator) ValidateUnsignedMessageSyntax(ctx context.Context, msg *types.UnsignedMessage) error {
 	return nil
 }
 

--- a/internal/pkg/consensus/validation_test.go
+++ b/internal/pkg/consensus/validation_test.go
@@ -116,7 +116,7 @@ func TestMessageSyntaxValidator(t *testing.T) {
 	alice := addresses[0]
 	bob := addresses[1]
 
-	validator := consensus.NewMessageSyntaxValidator()
+	validator := consensus.NewDefaultMessageSyntaxValidator()
 	ctx := context.Background()
 
 	t.Run("Actor not found is not an error", func(t *testing.T) {

--- a/internal/pkg/consensus/validation_test.go
+++ b/internal/pkg/consensus/validation_test.go
@@ -116,31 +116,31 @@ func TestMessageSyntaxValidator(t *testing.T) {
 	alice := addresses[0]
 	bob := addresses[1]
 
-	validator := consensus.NewDefaultMessageSyntaxValidator()
+	validator := consensus.NewMessageSyntaxValidator()
 	ctx := context.Background()
 
 	t.Run("Actor not found is not an error", func(t *testing.T) {
 		msg, err := types.NewSignedMessage(ctx, *newMessage(t, bob, alice, 0, 0, 1, 5000), signer)
 		require.NoError(t, err)
-		assert.NoError(t, validator.Validate(ctx, msg))
+		assert.NoError(t, validator.ValidateSignedMessageSyntax(ctx, msg))
 	})
 
 	t.Run("self send passes", func(t *testing.T) {
 		msg, err := types.NewSignedMessage(ctx, *newMessage(t, alice, alice, 100, 5, 1, 5000), signer)
 		require.NoError(t, err)
-		assert.NoError(t, validator.Validate(ctx, msg), "self")
+		assert.NoError(t, validator.ValidateSignedMessageSyntax(ctx, msg), "self")
 	})
 
 	t.Run("negative value fails", func(t *testing.T) {
 		msg, err := types.NewSignedMessage(ctx, *newMessage(t, alice, alice, 100, -5, 1, 5000), signer)
 		require.NoError(t, err)
-		assert.Errorf(t, validator.Validate(ctx, msg), "negative")
+		assert.Errorf(t, validator.ValidateSignedMessageSyntax(ctx, msg), "negative")
 	})
 
 	t.Run("block gas limit fails", func(t *testing.T) {
 		msg, err := types.NewSignedMessage(ctx, *newMessage(t, alice, bob, 100, 5, 1, types.BlockGasLimit+1), signer)
 		require.NoError(t, err)
-		assert.Errorf(t, validator.Validate(ctx, msg), "block limit")
+		assert.Errorf(t, validator.ValidateSignedMessageSyntax(ctx, msg), "block limit")
 	})
 
 }

--- a/internal/pkg/message/outbox.go
+++ b/internal/pkg/message/outbox.go
@@ -47,7 +47,7 @@ type Outbox struct {
 
 type messageValidator interface {
 	// Validate checks a message for validity.
-	Validate(ctx context.Context, msg *types.SignedMessage) error
+	ValidateSignedMessageSyntax(ctx context.Context, msg *types.SignedMessage) error
 }
 
 type actorProvider interface {
@@ -138,7 +138,7 @@ func (ob *Outbox) SendEncoded(ctx context.Context, from, to address.Address, val
 
 	// Slightly awkward: it would be better validate before signing but the MeteredMessage construction
 	// is hidden inside NewSignedMessage.
-	err = ob.validator.Validate(ctx, signed)
+	err = ob.validator.ValidateSignedMessageSyntax(ctx, signed)
 	if err != nil {
 		return cid.Undef, nil, errors.Wrap(err, "invalid message")
 	}

--- a/internal/pkg/message/pool.go
+++ b/internal/pkg/message/pool.go
@@ -18,7 +18,7 @@ var mpSize = metrics.NewInt64Gauge("message_pool_size", "The size of the message
 
 // PoolValidator defines a validator that ensures a message can go through the pool.
 type PoolValidator interface {
-	Validate(ctx context.Context, msg *types.SignedMessage) error
+	ValidateSignedMessageSyntax(ctx context.Context, msg *types.SignedMessage) error
 }
 
 // Pool keeps an unordered, de-duplicated set of Messages and supports removal by CID.
@@ -169,5 +169,5 @@ func (pool *Pool) validateMessage(ctx context.Context, message *types.SignedMess
 	}
 
 	// check that the message is likely to succeed in processing
-	return pool.validator.Validate(ctx, message)
+	return pool.validator.ValidateSignedMessageSyntax(ctx, message)
 }

--- a/internal/pkg/message/testing.go
+++ b/internal/pkg/message/testing.go
@@ -100,7 +100,7 @@ type FakeValidator struct {
 }
 
 // Validate returns an error only if `RejectMessages` is true.
-func (v FakeValidator) Validate(ctx context.Context, msg *types.SignedMessage) error {
+func (v FakeValidator) ValidateSignedMessageSyntax(ctx context.Context, msg *types.SignedMessage) error {
 	if v.RejectMessages {
 		return errors.New("rejected for testing")
 	}

--- a/internal/pkg/net/msgsub/validator.go
+++ b/internal/pkg/net/msgsub/validator.go
@@ -24,7 +24,7 @@ type MessageTopicValidator struct {
 
 // NewMessageTopicValidator returns a MessageTopicValidator using the input
 // signature and syntax validators.
-func NewMessageTopicValidator(syntaxVal *consensus.MessageSyntaxValidator, sigVal *consensus.MessageSignatureValidator, opts ...pubsub.ValidatorOpt) *MessageTopicValidator {
+func NewMessageTopicValidator(syntaxVal consensus.MessageSyntaxValidator, sigVal *consensus.MessageSignatureValidator, opts ...pubsub.ValidatorOpt) *MessageTopicValidator {
 	return &MessageTopicValidator{
 		opts: opts,
 		validator: func(ctx context.Context, p peer.ID, msg *pubsub.Message) bool {
@@ -34,7 +34,7 @@ func NewMessageTopicValidator(syntaxVal *consensus.MessageSyntaxValidator, sigVa
 				mDecodeMsgFail.Inc(ctx, 1)
 				return false
 			}
-			if err := syntaxVal.Validate(ctx, unmarshaled); err != nil {
+			if err := syntaxVal.ValidateSignedMessageSyntax(ctx, unmarshaled); err != nil {
 				mCid, _ := unmarshaled.Cid()
 				messageTopicLogger.Debugf("message %s from peer: %s failed to syntax validate: %s", mCid.String(), p.String(), err.Error())
 				mInvalidMsg.Inc(ctx, 1)

--- a/internal/pkg/testhelpers/core.go
+++ b/internal/pkg/testhelpers/core.go
@@ -157,7 +157,7 @@ func NewMockMessagePoolValidator() *MockMessagePoolValidator {
 }
 
 // Validate returns true if the mock validator is set to validate the message
-func (v *MockMessagePoolValidator) Validate(ctx context.Context, msg *types.SignedMessage) error {
+func (v *MockMessagePoolValidator) ValidateSignedMessageSyntax(ctx context.Context, msg *types.SignedMessage) error {
 	if v.Valid {
 		return nil
 	}


### PR DESCRIPTION
### Motivation
We need to reject blocks that have messages with invalid syntax.  cc @arajasek 

### Proposed changes
Add message syntax validation during graphsync fetching and propagate changes.

Closes #3312

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

