### PR TITLE
Set gas limit to 100mm

### DIFF
--- a/internal/pkg/types/message.go
+++ b/internal/pkg/types/message.go
@@ -28,8 +28,8 @@ import (
 
 const MessageVersion = 0
 
-// BlockGasLimit is the maximum amount of gas that can be used to execute messages in a single block
-var BlockGasLimit = gas.NewGas(10000000)
+// BlockGasLimit is the maximum amount of gas that can be used to execute messages in a single block.
+var BlockGasLimit = gas.NewGas(100e6)
 
 // EmptyMessagesCID is the cid of an empty collection of messages.
 var EmptyMessagesCID cid.Cid


### PR DESCRIPTION
### Motivation
Lotus sends some messages with this gas limit, and we're not confident that 10m is high enough to not cause problems until we work out what a good value is.

This is only used as a message syntax validation check. Neither go-filecoin nor Lotus actually enforce a block-level gas limit.

### Proposed changes
Set BlockGasLimit to 100 million.
