### PR TITLE
derive default address from first imported key

### DIFF
--- a/cmd/go-filecoin/main.go
+++ b/cmd/go-filecoin/main.go
@@ -75,9 +75,6 @@ const (
 	// WithMiner when set, creates a custom genesis block with a pre generated miner account, requires to run the daemon using dev mode (--dev)
 	WithMiner = "with-miner"
 
-	// DefaultAddress when set, sets the daemons's default address to the provided address
-	DefaultAddress = "default-address"
-
 	// MinerActorAddress when set, sets the daemons's miner address to the provided address
 	MinerActorAddress = "miner-actor-address"
 

--- a/internal/pkg/message/pool_test.go
+++ b/internal/pkg/message/pool_test.go
@@ -64,9 +64,10 @@ func TestMessagePoolValidate(t *testing.T) {
 	tf.UnitTest(t)
 
 	t.Run("message pool rejects messages after it reaches its limit", func(t *testing.T) {
-		// pull the default size from the default config value
+		// alter the config to have a max size that can be quickly tested
 		mpoolCfg := config.NewDefaultConfig().Mpool
-		maxMessagePoolSize := mpoolCfg.MaxPoolSize
+		maxMessagePoolSize := uint(100)
+		mpoolCfg.MaxPoolSize = maxMessagePoolSize
 		ctx := context.Background()
 		pool := message.NewPool(mpoolCfg, th.NewMockMessagePoolValidator())
 

--- a/internal/pkg/testhelpers/test_daemon.go
+++ b/internal/pkg/testhelpers/test_daemon.go
@@ -721,10 +721,6 @@ func NewDaemon(t *testing.T, options ...func(*TestDaemon)) *TestDaemon {
 		initopts = append(initopts, fmt.Sprintf("--with-miner=%s", td.withMiner))
 	}
 
-	if td.defaultAddress != address.Undef {
-		initopts = append(initopts, fmt.Sprintf("--default-address=%s", td.defaultAddress))
-	}
-
 	if td.autoSealInterval != "" {
 		initopts = append(initopts, fmt.Sprintf("--auto-seal-interval-seconds=%s", td.autoSealInterval))
 	}


### PR DESCRIPTION
### Motivation

Some changes in the way we initialize the node broke the `default-address` init option. The address would still be set in config, but it would be immediately overridden by the address of a new key generated by the node. There are really a few problems:

1. `default-address` is ignored.
2. A new key pair is generated whether or not key files are imported.
3. The new key pair address is always the default address.

I started down the path of fixing `default-address` by tying it to an imported key pair and ensuring it gets set in config, but `default-address` has a few problems:

1. It makes no sense to set a default address that isn't tied to an imported key.
2. It's not easy to determine the default address from a key file prior to node initialization.
3. Addresses, especially BLS addresses, are long and make for messy initialization parameters.

The simpler solution and the one I think makes the most sense is to set the address associated with the first imported key file as the default address.

### Proposed changes

1. Import the first key file specified for init as the `DefaultKey`. This ensures its address will be set as the wallet.defaultAddress in node config.
2. Remove the `default-address` init option which hasn't worked for some time.
3. Fix the message pool test which was creating a million signed messages and taking far too long for a unit test.