### PR TITLE
Add Testnet connection steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,13 +143,12 @@ For a complete step-by-step tutorial, see [Getting Started](https://go.filecoin.
 # Remove any existing symlink to a repo directory
 rm ~/.filecoin
 
-# Initialize a new repository, downloading a genesis file and setting network parameters for the "interop" developer network
-./go-filecoin init --genesisfile=https://gateway.ipfs.io/ipfs/QmZ7ENWU2TYBuRfdXRjoEFvF6mNpYzyALPHexcgnonUeoK/interop.car --devnet-interop
+# Initialize a new repository, downloading a genesis file and setting network parameters (in this case, for the Testnet network)
+./go-filecoin init --genesisfile=https://ipfs.io/ipfs/QmXZQeezX1x8uRQX9EUaYxnyivUpTfJqQTvszk3c8SnFPN/testnet.car --network=testnet
 
 # Run the daemon
 ./go-filecoin daemon
 ```
-> Note: This connects you to the "interop" developer network. To connect to a different network, replace the URL after `--genesisfile=` and update the last flag.
 
 Your node should now be connected to some peers, and begin downloading and validating the blockchain.
 

--- a/README.md
+++ b/README.md
@@ -144,10 +144,16 @@ For a complete step-by-step tutorial, see [Getting Started](https://go.filecoin.
 rm ~/.filecoin
 
 # Initialize a new repository, downloading a genesis file and setting network parameters (in this case, for the Testnet network)
-./go-filecoin init --genesisfile=https://ipfs.io/ipfs/QmXZQeezX1x8uRQX9EUaYxnyivUpTfJqQTvszk3c8SnFPN/testnet.car --network=testnet
+go-filecoin init --genesisfile=https://ipfs.io/ipfs/QmXZQeezX1x8uRQX9EUaYxnyivUpTfJqQTvszk3c8SnFPN/testnet.car --network=testnet
 
-# Run the daemon
-./go-filecoin daemon
+# Start the daemon
+go-filecoin daemon
+
+# Print a list of bootstrap node addresses
+go-filecoin config bootstrap.addresses
+
+# Choose any address from the list you just printed, and connect to it (Automatic peer discovery and connection coming soon.)
+go-filecoin swarm connect <any-filecoin-node-mulitaddr>
 ```
 
 Your node should now be connected to some peers, and begin downloading and validating the blockchain.
@@ -156,10 +162,10 @@ Open a new terminal to interact with your node:
 
 ```sh
 # Print the node's connection information
-./go-filecoin id
+go-filecoin id
 
 # Show chain sync status
-./go-filecoin chain status
+go-filecoin chain status
 ```
 
 To see a full list of commands, run `./go-filecoin --help`.


### PR DESCRIPTION
- Updates the stuff after the `init` command
- Adds back the manual bootstrapping steps I removed in #4120, including more details and moving it to the correct section (thx @ZenGround0)

Please review lines 140-169 very carefully, including punctuation.