### PR TITLE
No bootstrap connections in default config

### DIFF
--- a/fixtures/networks/testnet.go
+++ b/fixtures/networks/testnet.go
@@ -24,7 +24,7 @@ var TestNet = NetworkConf{
 			testnetBootstrap10,
 			testnetBootstrap11,
 		},
-		MinPeerThreshold: 1,
+		MinPeerThreshold: 0,
 		Period:           "10s",
 	},
 	Drand: config.DrandConfig{


### PR DESCRIPTION
### Motivation
This is unfortunate but needed.  Bootstrap logic is so borked that having non-zero min peer hangs the node for ever.  Actual fix on its way but not going to make it for launch.  We are handling this by instructing users to connect directly to bootstrap peers.

need to merge now but fyi @anorth 
### Proposed changes

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

