### PR TITLE
implement FiniteStateMachineBackEnd#UnsealSector

### DIFF
--- a/internal/app/go-filecoin/connectors/retrieval_market/provider_test.go
+++ b/internal/app/go-filecoin/connectors/retrieval_market/provider_test.go
@@ -24,6 +24,7 @@ import (
 	pch "github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/paymentchannel"
 	paychtest "github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/paymentchannel/testing"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/constants"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/encoding"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/piecemanager"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
@@ -34,12 +35,13 @@ import (
 func TestNewRetrievalProviderNodeConnector(t *testing.T) {
 	tf.UnitTest(t)
 	rmnet := gfmtut.NewTestRetrievalMarketNetwork(gfmtut.TestNetworkParams{})
-	pm := piecemanager.NewFiniteStateMachineBackEnd(nil, nil)
+	ma := specst.NewIDAddr(t, 100)
+	pm := piecemanager.NewFiniteStateMachineBackEnd(ma, constants.DevSectorSize, nil, nil, nil)
 	bs := blockstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 
 	pchMgr, _ := makePaychMgr(context.Background(), t,
 		specst.NewIDAddr(t, 99),
-		specst.NewIDAddr(t, 100),
+		ma,
 		specst.NewActorAddr(t, "foobar"))
 	rpc := NewRetrievalProviderConnector(rmnet, &pm, bs, pchMgr, nil)
 	assert.NotZero(t, rpc)
@@ -107,7 +109,8 @@ func TestRetrievalProviderConnector_SavePaymentVoucher(t *testing.T) {
 	ctx := context.Background()
 
 	rmnet := gfmtut.NewTestRetrievalMarketNetwork(gfmtut.TestNetworkParams{})
-	pm := piecemanager.NewFiniteStateMachineBackEnd(nil, nil)
+	ma := specst.NewIDAddr(t, 100)
+	pm := piecemanager.NewFiniteStateMachineBackEnd(ma, constants.DevSectorSize, nil, nil, nil)
 
 	bs := blockstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 	pchan := specst.NewIDAddr(t, 100)

--- a/internal/pkg/piecemanager/interface.go
+++ b/internal/pkg/piecemanager/interface.go
@@ -28,7 +28,7 @@ type PieceManager interface {
 	// UnsealSector produces a reader to the unsealed bytes associated with the
 	// provided sector id, or an error if no such sealed sector exists. The
 	// bytes produced by the Reader will not include any bit-padding.
-	UnsealSector(ctx context.Context, sectorID uint64) (io.ReadCloser, error)
+	UnsealSector(ctx context.Context, sectorNumber uint64) (io.ReadCloser, error)
 
 	// LocatePieceForDealWithinSector produces information about the location of
 	// a deal's piece within a sealed sector, or an error if that piece does not


### PR DESCRIPTION
@shannonwells - This PR should serve as a starting point for getting end-to-end retrieval over the finish line. This PR is blocked on an [upstream change to sector-storage](https://github.com/filecoin-project/sector-storage/pull/34). Once that PR merges, this PR can be tested and integrated with the rest of the go-filecoin retrieval flow.