### PR TITLE
Work around go static initialization confusion for network configs

### DIFF
--- a/cmd/go-filecoin/init.go
+++ b/cmd/go-filecoin/init.go
@@ -136,19 +136,20 @@ func setConfigFromOptions(cfg *config.Config, options cmdkit.OptMap) error {
 		cfg.SectorBase.PreSealedSectorsDirPath = dir
 	}
 
-	netName, _ := options[Network].(string)
-
 	// Setup devnet specific config options.
+	netName, _ := options[Network].(string)
+	var netcfg *networks.NetworkConf
 	if netName == "interop" {
-		cfg.Bootstrap = &networks.InteropNet.Bootstrap
-		cfg.Drand = &networks.InteropNet.Drand
-		cfg.NetworkParams = &networks.InteropNet.Network
+		netcfg = networks.Interop()
 	} else if netName == "testnet" {
-		cfg.Bootstrap = &networks.TestNet.Bootstrap
-		cfg.Drand = &networks.TestNet.Drand
-		cfg.NetworkParams = &networks.TestNet.Network
+		netcfg = networks.Testnet()
 	} else if netName != "" {
 		return fmt.Errorf("unknown network name %s", netName)
+	}
+	if netcfg != nil {
+		cfg.Bootstrap = &netcfg.Bootstrap
+		cfg.Drand = &netcfg.Drand
+		cfg.NetworkParams = &netcfg.Network
 	}
 
 	return nil

--- a/fixtures/networks/interop.go
+++ b/fixtures/networks/interop.go
@@ -14,68 +14,67 @@ type NetworkConf struct {
 	Network   config.NetworkParamsConfig
 }
 
-var InteropNet = NetworkConf{
-	Bootstrap: config.BootstrapConfig{
-		Addresses: []string{
-			interopBootstrap0,
-			interopBootstrap1,
-			interopBootstrap2,
-			interopBootstrap3,
-			interopBootstrap4,
-			interopBootstrap5,
-		},
-		MinPeerThreshold: 1,
-		Period:           "10s",
-	},
-	Drand: config.DrandConfig{
-		Addresses: []string{
-			"gabbi.drand.fil-test.net:443",
-			"linus.drand.fil-test.net:443",
-			"nicolas.drand.fil-test.net:443",
-			"mathilde.drand.fil-test.net:443",
-			"jeff.drand.fil-test.net:443",
-			"philipp.drand.fil-test.net:443",
-			"ludovic.drand.fil-test.net:443",
-		},
-		Secure:        true,
-		DistKey:       interopDrandDistKey,
-		StartTimeUnix: 1588221360,
-		RoundSeconds:  30,
-	},
-	Network: config.NetworkParamsConfig{
-		ConsensusMinerMinPower: 2 << 30,
-		ReplaceProofTypes: []int64{
-			int64(abi.RegisteredProof_StackedDRG512MiBSeal),
-			int64(abi.RegisteredProof_StackedDRG32GiBSeal),
-			int64(abi.RegisteredProof_StackedDRG64GiBSeal),
-		},
-	},
-}
+func Interop() *NetworkConf {
+	const (
+		interopBootstrap0 string = "/dns4/t01000.miner.interopnet.kittyhawk.wtf/tcp/1347/p2p/12D3KooWQfrGdBE8N2RzcnuHfyWZ4MBKMYZ6z1oPdhEbFxSNo1du"
+		interopBootstrap1 string = "/ip4/34.217.110.132/tcp/1347/p2p/12D3KooWQfrGdBE8N2RzcnuHfyWZ4MBKMYZ6z1oPdhEbFxSNo1du"
+		interopBootstrap2 string = "/dns4/peer0.interopnet.kittyhawk.wtf/tcp/1347/p2p/12D3KooWKmHh5mQofRhFr6f6qsT4ksL7qUtd2BWC24wPHVFL9gej"
+		interopBootstrap3 string = "/ip4/54.187.182.170/tcp/1347/p2p/12D3KooWKmHh5mQofRhFr6f6qsT4ksL7qUtd2BWC24wPHVFL9gej"
+		interopBootstrap4 string = "/dns4/peer1.interopnet.kittyhawk.wtf/tcp/1347/p2p/12D3KooWCWWtn3GMFVSn2PY7k9K7QkQTVA6p6wojUr5PgS5h1xtK"
+		interopBootstrap5 string = "/ip4/52.24.84.39/tcp/1347/p2p/12D3KooWCWWtn3GMFVSn2PY7k9K7QkQTVA6p6wojUr5PgS5h1xtK"
+	)
 
-const (
-	interopBootstrap0 string = "/dns4/t01000.miner.interopnet.kittyhawk.wtf/tcp/1347/p2p/12D3KooWQfrGdBE8N2RzcnuHfyWZ4MBKMYZ6z1oPdhEbFxSNo1du"
-	interopBootstrap1 string = "/ip4/34.217.110.132/tcp/1347/p2p/12D3KooWQfrGdBE8N2RzcnuHfyWZ4MBKMYZ6z1oPdhEbFxSNo1du"
-	interopBootstrap2 string = "/dns4/peer0.interopnet.kittyhawk.wtf/tcp/1347/p2p/12D3KooWKmHh5mQofRhFr6f6qsT4ksL7qUtd2BWC24wPHVFL9gej"
-	interopBootstrap3 string = "/ip4/54.187.182.170/tcp/1347/p2p/12D3KooWKmHh5mQofRhFr6f6qsT4ksL7qUtd2BWC24wPHVFL9gej"
-	interopBootstrap4 string = "/dns4/peer1.interopnet.kittyhawk.wtf/tcp/1347/p2p/12D3KooWCWWtn3GMFVSn2PY7k9K7QkQTVA6p6wojUr5PgS5h1xtK"
-	interopBootstrap5 string = "/ip4/52.24.84.39/tcp/1347/p2p/12D3KooWCWWtn3GMFVSn2PY7k9K7QkQTVA6p6wojUr5PgS5h1xtK"
-)
+	var interopDrandKeys = []string{
+		"gsJ5zOdERQ5o3pjuCPlpigHdOPjjvjxT8rhA+50JrWKgtrh5geF54bFLyaLShMmF",
+		"gtUTCK00bGhvgbgJRVFZfXuWMpXL8xNAGpPfm69S1a6YqHdFvucIOaTW5lw0K9Fb",
+		"lO6/1T9LpqO4MEI2QAoS5ziF5aeBUJpcjUHS6LR2kj2OpgUmSbPBcoL1liF/lsXe",
+		"jcQjHkK07fOehu8VeUAWkkgGR5GCddp2fT5VjFINY3WtlTUwYQ/Sfa8RAYeHemXQ",
+	}
 
-var interopDrandKeys = []string{
-	"gsJ5zOdERQ5o3pjuCPlpigHdOPjjvjxT8rhA+50JrWKgtrh5geF54bFLyaLShMmF",
-	"gtUTCK00bGhvgbgJRVFZfXuWMpXL8xNAGpPfm69S1a6YqHdFvucIOaTW5lw0K9Fb",
-	"lO6/1T9LpqO4MEI2QAoS5ziF5aeBUJpcjUHS6LR2kj2OpgUmSbPBcoL1liF/lsXe",
-	"jcQjHkK07fOehu8VeUAWkkgGR5GCddp2fT5VjFINY3WtlTUwYQ/Sfa8RAYeHemXQ",
-}
-
-var interopDrandDistKey [][]byte
-
-func init() {
+	var distKey [][]byte
 	for _, key := range interopDrandKeys {
 		bs, err := base64.StdEncoding.DecodeString(key)
 		if err != nil {
 			panic(err)
 		}
-		interopDrandDistKey = append(interopDrandDistKey, bs)
+		distKey = append(distKey, bs)
+	}
+
+	return &NetworkConf{
+		Bootstrap: config.BootstrapConfig{
+			Addresses: []string{
+				interopBootstrap0,
+				interopBootstrap1,
+				interopBootstrap2,
+				interopBootstrap3,
+				interopBootstrap4,
+				interopBootstrap5,
+			},
+			MinPeerThreshold: 1,
+			Period:           "10s",
+		},
+		Drand: config.DrandConfig{
+			Addresses: []string{
+				"gabbi.drand.fil-test.net:443",
+				"linus.drand.fil-test.net:443",
+				"nicolas.drand.fil-test.net:443",
+				"mathilde.drand.fil-test.net:443",
+				"jeff.drand.fil-test.net:443",
+				"philipp.drand.fil-test.net:443",
+				"ludovic.drand.fil-test.net:443",
+			},
+			Secure:        true,
+			DistKey:       distKey,
+			StartTimeUnix: 1588221360,
+			RoundSeconds:  30,
+		},
+		Network: config.NetworkParamsConfig{
+			ConsensusMinerMinPower: 2 << 30,
+			ReplaceProofTypes: []int64{
+				int64(abi.RegisteredProof_StackedDRG512MiBSeal),
+				int64(abi.RegisteredProof_StackedDRG32GiBSeal),
+				int64(abi.RegisteredProof_StackedDRG64GiBSeal),
+			},
+		},
 	}
 }

--- a/fixtures/networks/testnet.go
+++ b/fixtures/networks/testnet.go
@@ -8,79 +8,78 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/config"
 )
 
-var TestNet = NetworkConf{
-	Bootstrap: config.BootstrapConfig{
-		Addresses: []string{
-			testnetBootstrap0,
-			testnetBootstrap1,
-			testnetBootstrap2,
-			testnetBootstrap3,
-			testnetBootstrap4,
-			testnetBootstrap5,
-			testnetBootstrap6,
-			testnetBootstrap7,
-			testnetBootstrap8,
-			testnetBootstrap9,
-			testnetBootstrap10,
-			testnetBootstrap11,
-		},
-		MinPeerThreshold: 1,
-		Period:           "10s",
-	},
-	Drand: config.DrandConfig{
-		Addresses: []string{
-			"gabbi.drand.fil-test.net:443",
-			"linus.drand.fil-test.net:443",
-			"nicolas.drand.fil-test.net:443",
-			"mathilde.drand.fil-test.net:443",
-			"jeff.drand.fil-test.net:443",
-			"philipp.drand.fil-test.net:443",
-			"ludovic.drand.fil-test.net:443",
-		},
-		Secure:        true,
-		DistKey:       testnetDrandDistKey,
-		StartTimeUnix: 1588221360,
-		RoundSeconds:  30,
-	},
-	Network: config.NetworkParamsConfig{
-		ConsensusMinerMinPower: 1024 << 30,
-		ReplaceProofTypes: []int64{
-			int64(abi.RegisteredProof_StackedDRG32GiBSeal),
-			int64(abi.RegisteredProof_StackedDRG64GiBSeal),
-		},
-	},
-}
+func Testnet() *NetworkConf {
+	const (
+		testnetBootstrap0  string = "/dns4/bootstrap-0-sin.fil-test.net/tcp/1347/p2p/12D3KooWKNF7vNFEhnvB45E9mw2B5z6t419W3ziZPLdUDVnLLKGs"
+		testnetBootstrap1  string = "/ip4/86.109.15.57/tcp/1347/p2p/12D3KooWKNF7vNFEhnvB45E9mw2B5z6t419W3ziZPLdUDVnLLKGs"
+		testnetBootstrap2  string = "/dns4/bootstrap-0-dfw.fil-test.net/tcp/1347/p2p/12D3KooWECJTm7RUPyGfNbRwm6y2fK4wA7EB8rDJtWsq5AKi7iDr"
+		testnetBootstrap3  string = "/ip4/139.178.84.45/tcp/1347/p2p/12D3KooWECJTm7RUPyGfNbRwm6y2fK4wA7EB8rDJtWsq5AKi7iDr"
+		testnetBootstrap4  string = "/dns4/bootstrap-0-fra.fil-test.net/tcp/1347/p2p/12D3KooWC7MD6m7iNCuDsYtNr7xVtazihyVUizBbhmhEiyMAm9ym"
+		testnetBootstrap5  string = "/ip4/136.144.49.17/tcp/1347/p2p/12D3KooWC7MD6m7iNCuDsYtNr7xVtazihyVUizBbhmhEiyMAm9ym"
+		testnetBootstrap6  string = "/dns4/bootstrap-1-sin.fil-test.net/tcp/1347/p2p/12D3KooWD8eYqsKcEMFax6EbWN3rjA7qFsxCez2rmN8dWqkzgNaN"
+		testnetBootstrap7  string = "/ip4/86.109.15.55/tcp/1347/p2p/12D3KooWD8eYqsKcEMFax6EbWN3rjA7qFsxCez2rmN8dWqkzgNaN"
+		testnetBootstrap8  string = "/dns4/bootstrap-1-dfw.fil-test.net/tcp/1347/p2p/12D3KooWLB3RR8frLAmaK4ntHC2dwrAjyGzQgyUzWxAum1FxyyqD"
+		testnetBootstrap9  string = "/ip4/139.178.84.41/tcp/1347/p2p/12D3KooWLB3RR8frLAmaK4ntHC2dwrAjyGzQgyUzWxAum1FxyyqD"
+		testnetBootstrap10 string = "/dns4/bootstrap-1-fra.fil-test.net/tcp/1347/p2p/12D3KooWGPDJAw3HW4uVU3JEQBfFaZ1kdpg4HvvwRMVpUYbzhsLQ"
+		testnetBootstrap11 string = "/ip4/136.144.49.131/tcp/1347/p2p/12D3KooWGPDJAw3HW4uVU3JEQBfFaZ1kdpg4HvvwRMVpUYbzhsLQ"
+	)
 
-const (
-	testnetBootstrap0  string = "/dns4/bootstrap-0-sin.fil-test.net/tcp/1347/p2p/12D3KooWKNF7vNFEhnvB45E9mw2B5z6t419W3ziZPLdUDVnLLKGs"
-	testnetBootstrap1  string = "/ip4/86.109.15.57/tcp/1347/p2p/12D3KooWKNF7vNFEhnvB45E9mw2B5z6t419W3ziZPLdUDVnLLKGs"
-	testnetBootstrap2  string = "/dns4/bootstrap-0-dfw.fil-test.net/tcp/1347/p2p/12D3KooWECJTm7RUPyGfNbRwm6y2fK4wA7EB8rDJtWsq5AKi7iDr"
-	testnetBootstrap3  string = "/ip4/139.178.84.45/tcp/1347/p2p/12D3KooWECJTm7RUPyGfNbRwm6y2fK4wA7EB8rDJtWsq5AKi7iDr"
-	testnetBootstrap4  string = "/dns4/bootstrap-0-fra.fil-test.net/tcp/1347/p2p/12D3KooWC7MD6m7iNCuDsYtNr7xVtazihyVUizBbhmhEiyMAm9ym"
-	testnetBootstrap5  string = "/ip4/136.144.49.17/tcp/1347/p2p/12D3KooWC7MD6m7iNCuDsYtNr7xVtazihyVUizBbhmhEiyMAm9ym"
-	testnetBootstrap6  string = "/dns4/bootstrap-1-sin.fil-test.net/tcp/1347/p2p/12D3KooWD8eYqsKcEMFax6EbWN3rjA7qFsxCez2rmN8dWqkzgNaN"
-	testnetBootstrap7  string = "/ip4/86.109.15.55/tcp/1347/p2p/12D3KooWD8eYqsKcEMFax6EbWN3rjA7qFsxCez2rmN8dWqkzgNaN"
-	testnetBootstrap8  string = "/dns4/bootstrap-1-dfw.fil-test.net/tcp/1347/p2p/12D3KooWLB3RR8frLAmaK4ntHC2dwrAjyGzQgyUzWxAum1FxyyqD"
-	testnetBootstrap9  string = "/ip4/139.178.84.41/tcp/1347/p2p/12D3KooWLB3RR8frLAmaK4ntHC2dwrAjyGzQgyUzWxAum1FxyyqD"
-	testnetBootstrap10 string = "/dns4/bootstrap-1-fra.fil-test.net/tcp/1347/p2p/12D3KooWGPDJAw3HW4uVU3JEQBfFaZ1kdpg4HvvwRMVpUYbzhsLQ"
-	testnetBootstrap11 string = "/ip4/136.144.49.131/tcp/1347/p2p/12D3KooWGPDJAw3HW4uVU3JEQBfFaZ1kdpg4HvvwRMVpUYbzhsLQ"
-)
+	var testnetDrandKeys = []string{
+		"gsJ5zOdERQ5o3pjuCPlpigHdOPjjvjxT8rhA+50JrWKgtrh5geF54bFLyaLShMmF",
+		"gtUTCK00bGhvgbgJRVFZfXuWMpXL8xNAGpPfm69S1a6YqHdFvucIOaTW5lw0K9Fb",
+		"lO6/1T9LpqO4MEI2QAoS5ziF5aeBUJpcjUHS6LR2kj2OpgUmSbPBcoL1liF/lsXe",
+		"jcQjHkK07fOehu8VeUAWkkgGR5GCddp2fT5VjFINY3WtlTUwYQ/Sfa8RAYeHemXQ",
+	}
 
-var testnetDrandKeys = []string{
-	"gsJ5zOdERQ5o3pjuCPlpigHdOPjjvjxT8rhA+50JrWKgtrh5geF54bFLyaLShMmF",
-	"gtUTCK00bGhvgbgJRVFZfXuWMpXL8xNAGpPfm69S1a6YqHdFvucIOaTW5lw0K9Fb",
-	"lO6/1T9LpqO4MEI2QAoS5ziF5aeBUJpcjUHS6LR2kj2OpgUmSbPBcoL1liF/lsXe",
-	"jcQjHkK07fOehu8VeUAWkkgGR5GCddp2fT5VjFINY3WtlTUwYQ/Sfa8RAYeHemXQ",
-}
-
-var testnetDrandDistKey [][]byte
-
-func init() {
+	var distKey [][]byte
 	for _, key := range testnetDrandKeys {
 		bs, err := base64.StdEncoding.DecodeString(key)
 		if err != nil {
 			panic(err)
 		}
-		testnetDrandDistKey = append(testnetDrandDistKey, bs)
+		distKey = append(distKey, bs)
+	}
+
+	return &NetworkConf{
+		Bootstrap: config.BootstrapConfig{
+			Addresses: []string{
+				testnetBootstrap0,
+				testnetBootstrap1,
+				testnetBootstrap2,
+				testnetBootstrap3,
+				testnetBootstrap4,
+				testnetBootstrap5,
+				testnetBootstrap6,
+				testnetBootstrap7,
+				testnetBootstrap8,
+				testnetBootstrap9,
+				testnetBootstrap10,
+				testnetBootstrap11,
+			},
+			MinPeerThreshold: 1,
+			Period:           "10s",
+		},
+		Drand: config.DrandConfig{
+			Addresses: []string{
+				"gabbi.drand.fil-test.net:443",
+				"linus.drand.fil-test.net:443",
+				"nicolas.drand.fil-test.net:443",
+				"mathilde.drand.fil-test.net:443",
+				"jeff.drand.fil-test.net:443",
+				"philipp.drand.fil-test.net:443",
+				"ludovic.drand.fil-test.net:443",
+			},
+			Secure:        true,
+			DistKey:       distKey,
+			StartTimeUnix: 1588221360,
+			RoundSeconds:  30,
+		},
+		Network: config.NetworkParamsConfig{
+			ConsensusMinerMinPower: 1024 << 30,
+			ReplaceProofTypes: []int64{
+				int64(abi.RegisteredProof_StackedDRG32GiBSeal),
+				int64(abi.RegisteredProof_StackedDRG64GiBSeal),
+			},
+		},
 	}
 }

--- a/functional-tests/network-deployment/relay_check_test.go
+++ b/functional-tests/network-deployment/relay_check_test.go
@@ -304,7 +304,7 @@ func networkBootstrapPeers(network string) []string {
 
 	switch network {
 	case "interop":
-		return networks.InteropNet.Bootstrap.Addresses
+		return networks.Interop().Bootstrap.Addresses
 	}
 
 	return []string{}

--- a/internal/pkg/drand/drand_grpc.go
+++ b/internal/pkg/drand/drand_grpc.go
@@ -136,6 +136,9 @@ func (d *GRPC) updateLocalState(entry *Entry) {
 
 // VerifyEntry verifies that the child's signature is a valid signature of the previous entry.
 func (d *GRPC) VerifyEntry(parent, child *Entry) (bool, error) {
+	if len(d.key.Coefficients) == 0 {
+		return false, fmt.Errorf("no dist key configured")
+	}
 	msg := beacon.Message(uint64(child.Round), parent.Data)
 	err := key.Scheme.VerifyRecovered(d.key.Coefficients[0], msg, child.Data)
 	if err != nil {


### PR DESCRIPTION
### Motivation
The `init` command was writing null `drand.distKey` causing an index out of bounds panic when verifying a drand entry.
 
### Proposed changes
Re-work network parameters to avoid being static at all so I don't have to think about it.