### PR TITLE
Update go-fil-markets & solve single host data transfer issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v0.3.0
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
-	github.com/filecoin-project/go-fil-markets v0.2.4
+	github.com/filecoin-project/go-fil-markets v0.2.5
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200505180321-973f8949ea8e
 	github.com/filecoin-project/go-statemachine v0.0.0-20200314004106-2e7830fc1948 // indirect

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/filecoin-project/go-data-transfer v0.3.0 h1:BwBrrXu9Unh9JjjX4GAc5FfzU
 github.com/filecoin-project/go-data-transfer v0.3.0/go.mod h1:cONglGP4s/d+IUQw5mWZrQK+FQATQxr3AXzi4dRh0l4=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1:yvQJCW9mmi9zy+51xA01Ea2X7/dL7r8eKDPuGUjRmbo=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
-github.com/filecoin-project/go-fil-markets v0.2.4 h1:44G7VdFmzspgyVM7ijPPGqOap268rS+m78kDUXvIkW0=
-github.com/filecoin-project/go-fil-markets v0.2.4/go.mod h1:LI3VFHse33aU0djAmFQ8+Hg39i0J8ibAoppGu6TbgkA=
+github.com/filecoin-project/go-fil-markets v0.2.5 h1:JKNYUUHPIXyCaqj98/15Toz0X6w/z5KchaaQr6JGVFQ=
+github.com/filecoin-project/go-fil-markets v0.2.5/go.mod h1:LI3VFHse33aU0djAmFQ8+Hg39i0J8ibAoppGu6TbgkA=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543 h1:aMJGfgqe1QDhAVwxRg5fjCRF533xHidiKsugk7Vvzug=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543/go.mod h1:mjrHv1cDGJWDlGmC0eDc1E5VJr8DmL9XMUcaFwiuKg8=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:92PET+sx1Hb4W/8CgFwGuxaKbttwY+UNspYZTvXY0vs=

--- a/internal/app/go-filecoin/connectors/storage_market/client.go
+++ b/internal/app/go-filecoin/connectors/storage_market/client.go
@@ -237,3 +237,8 @@ func (s *StorageClientNodeConnector) ValidateAskSignature(ctx context.Context, s
 
 	return s.VerifySignature(ctx, *signed.Signature, ask.Miner, buf, tok)
 }
+
+// EventLogger logs new events on the storage client
+func (s *StorageClientNodeConnector) EventLogger(event storagemarket.ClientEvent, deal storagemarket.ClientDeal) {
+	log.Infof("Event: %s, Proposal CID: %s, State: %s, Message: %s", storagemarket.ClientEvents[event], deal.ProposalCid, storagemarket.DealStates[deal.State], deal.Message)
+}

--- a/internal/app/go-filecoin/connectors/storage_market/common.go
+++ b/internal/app/go-filecoin/connectors/storage_market/common.go
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
+	logging "github.com/ipfs/go-log"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/connectors"
@@ -28,6 +29,8 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/gas"
 )
+
+var log = logging.Logger("storage-protocol")
 
 type chainReader interface {
 	Head() block.TipSetKey

--- a/internal/app/go-filecoin/connectors/storage_market/provider.go
+++ b/internal/app/go-filecoin/connectors/storage_market/provider.go
@@ -129,8 +129,6 @@ func (s *StorageProviderNodeConnector) ListProviderDeals(ctx context.Context, ad
 
 // OnDealComplete adds the piece to the storage provider
 func (s *StorageProviderNodeConnector) OnDealComplete(ctx context.Context, deal storagemarket.MinerDeal, pieceSize abi.UnpaddedPieceSize, pieceReader io.Reader) error {
-	// TODO: storage provider is expecting a sector ID here. This won't work. The sector ID needs to be removed from
-	// TODO: the return value, and storage provider needs to call OnDealSectorCommitted which should add Sector ID to its
 	// TODO: callback.
 	return s.pieceManager.SealPieceIntoNewSector(ctx, deal.DealID, deal.Proposal.StartEpoch, deal.Proposal.EndEpoch, pieceSize, pieceReader)
 }

--- a/internal/app/go-filecoin/connectors/storage_market/provider.go
+++ b/internal/app/go-filecoin/connectors/storage_market/provider.go
@@ -197,3 +197,8 @@ func (s *StorageProviderNodeConnector) LocatePieceForDealWithinSector(ctx contex
 	})
 	return
 }
+
+// EventLogger logs new events on the storage provider
+func (s *StorageProviderNodeConnector) EventLogger(event storagemarket.ProviderEvent, deal storagemarket.MinerDeal) {
+	log.Infof("Event: %s, Proposal CID: %s, State: %s, Message: %s", storagemarket.ProviderEvents[event], deal.ProposalCid, storagemarket.DealStates[deal.State], deal.Message)
+}

--- a/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
@@ -8,6 +8,7 @@ import (
 	"github.com/filecoin-project/go-storedcounter"
 
 	"github.com/filecoin-project/go-address"
+	datatransfer "github.com/filecoin-project/go-data-transfer"
 	graphsyncimpl "github.com/filecoin-project/go-data-transfer/impl/graphsync"
 	"github.com/filecoin-project/go-fil-markets/filestore"
 	"github.com/filecoin-project/go-fil-markets/piecestore"
@@ -18,8 +19,10 @@ import (
 	smnetwork "github.com/filecoin-project/go-fil-markets/storagemarket/network"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
 	"github.com/ipfs/go-graphsync"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/pkg/errors"
 
@@ -32,12 +35,16 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
+var storageLog = logging.Logger("storage-protocol")
+
 // StorageProtocolSubmodule enhances the node with storage protocol
 // capabilities.
 type StorageProtocolSubmodule struct {
-	StorageClient   iface.StorageClient
-	StorageProvider iface.StorageProvider
-	pieceManager    piecemanager.PieceManager
+	StorageClient    iface.StorageClient
+	StorageProvider  iface.StorageProvider
+	dataTransfer     datatransfer.Manager
+	requestValidator *smvalid.UnifiedRequestValidator
+	pieceManager     piecemanager.PieceManager
 }
 
 // NewStorageProtocolSubmodule creates a new storage protocol submodule.
@@ -55,22 +62,27 @@ func NewStorageProtocolSubmodule(
 	stateViewer *appstate.Viewer,
 ) (*StorageProtocolSubmodule, error) {
 	cnode := storagemarketconnector.NewStorageClientNodeConnector(cborutil.NewIpldStore(bs), c.State, mw, s, m.Outbox, clientAddr, stateViewer)
-	dtStoredCounter := storedcounter.New(ds, datastore.NewKey("datatransfer/client/counter"))
+	dtStoredCounter := storedcounter.New(ds, datastore.NewKey("datatransfer/counter"))
 	dt := graphsyncimpl.NewGraphSyncDataTransfer(h, gsync, dtStoredCounter)
-	validator := smvalid.NewUnifiedRequestValidator(false, true, statestore.New(ds))
+	clientDs := namespace.Wrap(ds, datastore.NewKey("/deals/client"))
+	validator := smvalid.NewUnifiedRequestValidator(nil, statestore.New(clientDs))
 	err := dt.RegisterVoucherType(&smvalid.StorageDataTransferVoucher{}, validator)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := impl.NewClient(smnetwork.NewFromLibp2pHost(h), bs, dt, discovery.NewLocal(ds), ds, cnode)
+	client, err := impl.NewClient(smnetwork.NewFromLibp2pHost(h), bs, dt, discovery.NewLocal(ds), clientDs, cnode)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating storage client")
 	}
 
-	return &StorageProtocolSubmodule{
-		StorageClient: client,
-	}, nil
+	sm := &StorageProtocolSubmodule{
+		StorageClient:    client,
+		dataTransfer:     dt,
+		requestValidator: validator,
+	}
+	sm.StorageClient.SubscribeToEvents(sm.clientEventLogger)
+	return sm, nil
 }
 
 func (sm *StorageProtocolSubmodule) AddStorageProvider(
@@ -109,15 +121,14 @@ func (sm *StorageProtocolSubmodule) AddStorageProvider(
 		return err
 	}
 
-	dtStoredCounter := storedcounter.New(ds, datastore.NewKey("datatransfer/provider/counter"))
-	dt := graphsyncimpl.NewGraphSyncDataTransfer(h, gsync, dtStoredCounter)
-	validator := smvalid.NewUnifiedRequestValidator(true, false, statestore.New(ds))
-	err = dt.RegisterVoucherType(&smvalid.StorageDataTransferVoucher{}, validator)
-	if err != nil {
-		return err
+	providerDs := namespace.Wrap(ds, datastore.NewKey(impl.ProviderDsPrefix))
+	sm.requestValidator.SetPushDeals(statestore.New(providerDs))
+	// TODO: see https://github.com/filecoin-project/go-fil-markets/issues/251 -- this should accept providerDs so
+	// the node can configure the namespace
+	sm.StorageProvider, err = impl.NewProvider(smnetwork.NewFromLibp2pHost(h), ds, bs, fs, piecestore.NewPieceStore(ds), sm.dataTransfer, pnode, minerAddr, sealProofType)
+	if err == nil {
+		sm.StorageProvider.SubscribeToEvents(sm.providerEventLogger)
 	}
-
-	sm.StorageProvider, err = impl.NewProvider(smnetwork.NewFromLibp2pHost(h), ds, bs, fs, piecestore.NewPieceStore(ds), dt, pnode, minerAddr, sealProofType)
 	return err
 }
 
@@ -137,4 +148,20 @@ func (sm *StorageProtocolSubmodule) PieceManager() (piecemanager.PieceManager, e
 		return nil, errors.New("Mining has not been started so piece manager is not available")
 	}
 	return sm.pieceManager, nil
+}
+
+func (sm *StorageProtocolSubmodule) DataTransfer() datatransfer.Manager {
+	return sm.dataTransfer
+}
+
+func (sm *StorageProtocolSubmodule) RequestValidator() datatransfer.RequestValidator {
+	return sm.requestValidator
+}
+
+func (sm *StorageProtocolSubmodule) clientEventLogger(event iface.ClientEvent, deal iface.ClientDeal) {
+	storageLog.Infof("Event: %s, Proposal CID: %s, State: %s, Message: %s", iface.ClientEvents[event], deal.ProposalCid, iface.DealStates[deal.State], deal.Message)
+}
+
+func (sm *StorageProtocolSubmodule) providerEventLogger(event iface.ProviderEvent, deal iface.MinerDeal) {
+	storageLog.Infof("Event: %s, Proposal CID: %s, State: %s, Message: %s", iface.ProviderEvents[event], deal.ProposalCid, iface.DealStates[deal.State], deal.Message)
 }


### PR DESCRIPTION
### Motivation

Update to latest go-fil-markets and make sure we have no issues arising from having a single host

### Proposed changes

- Update fil-markets to v0.2.5
- Use facilities in v0.2.5 to share a data-transfer instance between mining and client (I suspect this would have caused making deals as a client from a node running as a miner to break -- not sure that anyone has run this)
- Add some nice event logging for what's going on with deals (storage module has a subscribable interface for getting events on deals -- this could be hooked into an actual command line or HTTP api but here it's just used to make some nice logs)
- Remove an expired TODO (this was addressed a long time ago)

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

