### PR TITLE
Implement deals list & client verify-deal

### DIFF
--- a/cmd/go-filecoin/client.go
+++ b/cmd/go-filecoin/client.go
@@ -230,40 +230,35 @@ format is specified with the --enc flag.
 
 // VerifyStorageDealResult wraps the success in an interface type
 type VerifyStorageDealResult struct {
-	validPip bool // nolint: structcheck
 }
 
 var clientVerifyStorageDealCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Verify a storage deal",
 		ShortDescription: `
-Returns an error if the deal is not in the Complete state or the Piece Inclusion Proof
-is invalid.  Returns nil otherwise.
+Returns an error if the deal is not in the Complete state.  Returns nil otherwise.
 `,
 	},
 	Arguments: []cmdkit.Argument{
 		cmdkit.StringArg("id", true, false, "CID of deal to query"),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
-		panic("not implemented pending full storage market integration")
+		dealCID, err := cid.Decode(req.Arguments[0])
+		if err != nil {
+			return errors.Wrap(err, "could not decode deal cid")
+		}
 
-		//proposalCid, err := cid.Decode(req.Arguments[0])
-		//if err != nil {
-		//	return err
-		//}
-		//
-		//resp, err := GetStorageAPI(env).QueryStorageDeal(req.Context, proposalCid)
-		//if err != nil {
-		//	return err
-		//}
-		//
-		//if resp.State != storagedeal.Complete {
-		//	return errors.New("storage deal not in Complete state")
-		//}
-		//
-		//validateError := GetPorcelainAPI(env).ClientValidateDeal(req.Context, proposalCid, resp.ProofInfo)
-		//
-		//return re.Emit(VerifyStorageDealResult{validateError == nil})
+		deal, err := GetStorageAPI(env).GetStorageDeal(req.Context, dealCID)
+		if err != nil {
+			return err
+		}
+
+		if deal.State != storagemarket.StorageDealActive {
+			return errors.New("storage deal not in Active state")
+		}
+
+		// TODO: Check for slashes
+		return re.Emit(&VerifyStorageDealResult{})
 	},
 	Type: &VerifyStorageDealResult{},
 }

--- a/cmd/go-filecoin/deals.go
+++ b/cmd/go-filecoin/deals.go
@@ -1,7 +1,10 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
 	"github.com/ipfs/go-cid"
@@ -31,7 +34,9 @@ type DealsListResult struct {
 	Miner       address.Address `json:"minerAddress"`
 	PieceCid    cid.Cid         `json:"pieceCid"`
 	ProposalCid cid.Cid         `json:"proposalCid"`
+	IsMiner     bool            `json:"isMiner"`
 	State       string          `json:"state"`
+	Message     string          `json:"message"`
 }
 
 var dealsListCmd = &cmds.Command{
@@ -47,10 +52,47 @@ deals, active deals, finished deals and cancelled deals.
 		cmdkit.BoolOption(minerOnly, "m", "only return deals made as a miner"),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
-		//minerAddress, _ := GetPorcelainAPI(env).ConfigGet("mining.minerAddress")
-		panic("implement me in terms of the storage market module")
+		isClientOnly, _ := req.Options[clientOnly].(bool)
+		isMinerOnly, _ := req.Options[minerOnly].(bool)
+		var clientDeals []storagemarket.ClientDeal
+		var minerDeals []storagemarket.MinerDeal
+		var err error
+		if !isMinerOnly {
+			clientDeals, err = GetStorageAPI(env).GetClientDeals(req.Context)
+			if err != nil {
+				return fmt.Errorf("error reading client deals: %w", err)
+			}
+		}
+		if !isClientOnly {
+			minerDeals, err = GetStorageAPI(env).GetProviderDeals(req.Context)
+			if err != nil {
+				return fmt.Errorf("error reading miner deals: %w", err)
+			}
+		}
+		var formattedDeals []DealsListResult
+		for _, deal := range clientDeals {
+			formattedDeals = append(formattedDeals, DealsListResult{
+				Miner:       deal.Proposal.Provider,
+				PieceCid:    deal.Proposal.PieceCID,
+				ProposalCid: deal.ProposalCid,
+				IsMiner:     false,
+				State:       storagemarket.DealStates[deal.State],
+				Message:     deal.Message,
+			})
+		}
+		for _, deal := range minerDeals {
+			formattedDeals = append(formattedDeals, DealsListResult{
+				Miner:       deal.Proposal.Provider,
+				PieceCid:    deal.Proposal.PieceCID,
+				ProposalCid: deal.ProposalCid,
+				IsMiner:     true,
+				State:       storagemarket.DealStates[deal.State],
+				Message:     deal.Message,
+			})
+		}
+		return re.Emit(formattedDeals)
 	},
-	Type: DealsListResult{},
+	Type: []DealsListResult{},
 }
 
 // DealsShowResult contains Deal output with Payment Vouchers.

--- a/cmd/go-filecoin/deals_integration_test.go
+++ b/cmd/go-filecoin/deals_integration_test.go
@@ -1,0 +1,131 @@
+package commands_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-fil-markets/storagemarket"
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+
+	commands "github.com/filecoin-project/go-filecoin/cmd/go-filecoin"
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
+	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
+	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
+)
+
+func TestDealsList(t *testing.T) {
+	tf.IntegrationTest(t)
+
+	ctx := context.Background()
+	nodes, cancel := test.MustCreateNodesWithBootstrap(ctx, t, 1)
+	defer cancel()
+
+	miner := nodes[0]
+	minerAPI, minerStop := test.RunNodeAPI(ctx, miner, t)
+	defer minerStop()
+
+	maddr, err := miner.BlockMining.BlockMiningAPI.MinerAddress()
+	require.NoError(t, err)
+
+	client := nodes[1]
+	clientAPI, clientStop := test.RunNodeAPI(ctx, client, t)
+	defer clientStop()
+
+	clientAddr, err := client.PorcelainAPI.WalletDefaultAddress()
+	require.NoError(t, err)
+
+	// Add enough funds (1 FIL) for client and miner to to cover deal
+	provider, err := miner.StorageProtocol.Provider()
+	require.NoError(t, err)
+
+	err = provider.AddStorageCollateral(ctx, types.NewAttoFILFromFIL(1))
+	require.NoError(t, err)
+	err = client.StorageProtocol.Client().AddPaymentEscrow(ctx, clientAddr, types.NewAttoFILFromFIL(1))
+	require.NoError(t, err)
+
+	// import some data to create first piece
+	input1 := bytes.NewBuffer([]byte("HODLHODLHODL"))
+	node1, err := client.PorcelainAPI.DAGImportData(ctx, input1)
+	require.NoError(t, err)
+
+	// import some data to create second piece
+	input2 := bytes.NewBuffer([]byte("FREEASINBEER"))
+	node2, err := client.PorcelainAPI.DAGImportData(ctx, input2)
+	require.NoError(t, err)
+
+	// propose 2 deals
+	var result storagemarket.ProposeStorageDealResult
+	clientAPI.RunMarshaledJSON(ctx, &result, "client", "propose-storage-deal",
+		"--peerid", miner.Host().ID().String(),
+		maddr.String(),
+		node1.Cid().String(),
+		"1000",
+		"2000",
+		".0000000000001",
+		"1",
+	)
+	require.NotEqual(t, cid.Undef, result.ProposalCid)
+	deal1Cid := result.ProposalCid
+
+	clientAPI.RunMarshaledJSON(ctx, &result, "client", "propose-storage-deal",
+		"--peerid", miner.Host().ID().String(),
+		maddr.String(),
+		node2.Cid().String(),
+		"1000",
+		"2000",
+		".0000000000001",
+		"1",
+	)
+	require.NotEqual(t, cid.Undef, result.ProposalCid)
+	deal2Cid := result.ProposalCid
+
+	var dealResults []commands.DealsListResult
+	var cidsInList [2]cid.Cid
+	t.Run("with no filters", func(t *testing.T) {
+		// Client fails cause no miner is started for the client
+		clientAPI.RunFail(ctx, "Error: error reading miner deals: Mining has not been started so storage provider is not available", "deals", "list")
+
+		// Miner sees the deal
+		minerAPI.RunMarshaledJSON(ctx, &dealResults, "deals", "list")
+		require.Len(t, dealResults, 2)
+		cidsInList[0] = dealResults[0].ProposalCid
+		cidsInList[1] = dealResults[1].ProposalCid
+		require.Contains(t, cidsInList, deal1Cid)
+		require.Contains(t, cidsInList, deal2Cid)
+	})
+
+	t.Run("with --miner", func(t *testing.T) {
+		// Client fails cause no miner is started for the client
+		clientAPI.RunFail(ctx, "Error: error reading miner deals: Mining has not been started so storage provider is not available", "deals", "list")
+
+		// Miner sees the deal
+		minerAPI.RunMarshaledJSON(ctx, &dealResults, "deals", "list", "--miner")
+		require.Len(t, dealResults, 2)
+		cidsInList[0] = dealResults[0].ProposalCid
+		cidsInList[1] = dealResults[1].ProposalCid
+		require.Contains(t, cidsInList, deal1Cid)
+		require.Contains(t, cidsInList, deal2Cid)
+	})
+
+	t.Run("with --client", func(t *testing.T) {
+		// Client sees both deals
+		clientAPI.RunMarshaledJSON(ctx, &dealResults, "deals", "list", "--client")
+		require.Len(t, dealResults, 2)
+		cidsInList[0] = dealResults[0].ProposalCid
+		cidsInList[1] = dealResults[1].ProposalCid
+		require.Contains(t, cidsInList, deal1Cid)
+		require.Contains(t, cidsInList, deal2Cid)
+
+		// Miner sees no client deals, but does not error
+		minerOutput := minerAPI.RunSuccessFirstLine(ctx, "deals", "list", "--client")
+		require.Equal(t, minerOutput, "null")
+	})
+
+	t.Run("with --help", func(t *testing.T) {
+		clientOutput := clientAPI.RunSuccess(ctx, "deals", "list", "--help").ReadStdoutTrimNewlines()
+		require.Contains(t, clientOutput, "only return deals made as a client")
+		require.Contains(t, clientOutput, "only return deals made as a miner")
+	})
+}

--- a/internal/pkg/protocol/storage/api.go
+++ b/internal/pkg/protocol/storage/api.go
@@ -76,3 +76,17 @@ func (api *API) ProposeStorageDeal(
 func (api *API) GetStorageDeal(ctx context.Context, c cid.Cid) (storagemarket.ClientDeal, error) {
 	return api.storage.Client().GetLocalDeal(ctx, c)
 }
+
+// GetClientDeals retrieves information about a in-progress deals on th miner side
+func (api *API) GetClientDeals(ctx context.Context) ([]storagemarket.ClientDeal, error) {
+	return api.storage.Client().ListLocalDeals(ctx)
+}
+
+// GetProviderDeals retrieves information about a in-progress deals on th miner side
+func (api *API) GetProviderDeals(ctx context.Context) ([]storagemarket.MinerDeal, error) {
+	provider, err := api.storage.Provider()
+	if err != nil {
+		return nil, err
+	}
+	return provider.ListLocalDeals()
+}


### PR DESCRIPTION

### Motivation

Flesh out deals command line

### Proposed changes

- Implement two new commands, write integration test for deals list
- add methods to StorageAPI to get Client & Miner deals

### FYI

- haven't implemented verify-deal integration test cause at the moment, we have no way to get deal to completion

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

