### PR TITLE
make inaccurate prooftype look less wrong

### DIFF
--- a/cmd/go-filecoin/client.go
+++ b/cmd/go-filecoin/client.go
@@ -189,9 +189,7 @@ be 2, 1 hour would be 120, and 1 day would be 2880.
 			abi.ChainEpoch(end),
 			price,
 			collateral,
-			// This constant represents StackedDRG encoding for the piece commitment computation.
-			// It's sector size and proof type are irrelevant.
-			abi.RegisteredProof_StackedDRG64GiBSeal,
+			status.MinerInfo.SealProofType,
 		)
 		if err != nil {
 			return err

--- a/cmd/go-filecoin/client.go
+++ b/cmd/go-filecoin/client.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/constants"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/pkg/errors"
@@ -190,8 +189,9 @@ be 2, 1 hour would be 120, and 1 day would be 2880.
 			abi.ChainEpoch(end),
 			price,
 			collateral,
-			// proof version (not circuit or size) should be all that is important here
-			constants.DevRegisteredWindowPoStProof,
+			// This constant represents StackedDRG encoding for the piece commitment computation.
+			// It's sector size and proof type are irrelevant.
+			abi.RegisteredProof_StackedDRG64GiBSeal,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
### Motivation

The propose-deal command had been passing in a test registered proof type. This proof only specified the proof version (StackedDRG) so the piece commitment could be calculated correctly. This looks wrong, and it would be wrong once the network supports different proof versions.

### Proposed changes

Use the miner's registered proof type for piece commitment calculation, which ensures they will be in sync.

Closes #4127


