### PR TITLE
mine block before epoch

### DIFF
--- a/cmd/go-filecoin/daemon.go
+++ b/cmd/go-filecoin/daemon.go
@@ -36,7 +36,7 @@ var daemonCmd = &cmds.Command{
 		cmdkit.BoolOption(OfflineMode, "start the node without networking"),
 		cmdkit.BoolOption(ELStdout),
 		cmdkit.BoolOption(IsRelay, "advertise and allow filecoin network traffic to be relayed through this node"),
-		cmdkit.StringOption(BlockTime, "period a node waits between mining successive blocks").WithDefault(clock.DefaultEpochDuration.String()),
+		cmdkit.StringOption(BlockTime, "period a node waits between mining successive blocks").WithDefault(clock.DefaultEpochDuration),
 		cmdkit.StringOption(PropagationDelay, "time a node waits after the start of an epoch for blocks to arrive").WithDefault(clock.DefaultPropagationDelay.String()),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {

--- a/cmd/go-filecoin/main.go
+++ b/cmd/go-filecoin/main.go
@@ -66,6 +66,9 @@ const (
 	// with testing as we won't be able to set blocktime in production.
 	BlockTime = "block-time"
 
+	// PropagationDelay is the duration the miner will wait for blocks to arrive before attempting to mine a new one
+	PropagationDelay = "prop-delay"
+
 	// PeerKeyFile is the path of file containing key to use for new nodes libp2p identity
 	PeerKeyFile = "peerkeyfile"
 

--- a/functional-tests/drand_test.go
+++ b/functional-tests/drand_test.go
@@ -21,6 +21,7 @@ func TestDrandPublic(t *testing.T) {
 	ctx := context.Background()
 	genTime := int64(1000000000)
 	blockTime := 30 * time.Second
+	propDelay := 6 * time.Second
 	// The clock is intentionally set some way ahead of the genesis time so the miner can produce
 	// catch-up blocks as quickly as possible.
 	fakeClock := clock.NewFake(time.Unix(genTime, 0).Add(4 * time.Hour))
@@ -29,7 +30,7 @@ func TestDrandPublic(t *testing.T) {
 	// Future code could decouple the whole setup.json from the presealed information.
 	genCfg := loadGenesisConfig(t, fixtureGenCfg())
 	seed := node.MakeChainSeed(t, genCfg)
-	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, fakeClock)
+	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, propDelay, fakeClock)
 
 	nd := makeNode(ctx, t, seed, chainClock, nil)
 

--- a/functional-tests/faucet_test.go
+++ b/functional-tests/faucet_test.go
@@ -38,12 +38,13 @@ func TestFaucetSendFunds(t *testing.T) {
 	ctx := context.Background()
 	genTime := int64(1000000000)
 	blockTime := 30 * time.Second
+	propDelay := 6 * time.Second
 	// Set clock ahead so the miner can produce catch-up blocks as quickly as possible.
 	fakeClock := clock.NewFake(time.Unix(genTime, 0).Add(1 * time.Hour))
 
 	genCfg := loadGenesisConfig(t, fixtureGenCfg())
 	seed := node.MakeChainSeed(t, genCfg)
-	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, fakeClock)
+	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, propDelay, fakeClock)
 	drandImpl := &drand.Fake{
 		GenesisTime:   time.Unix(genTime, 0).Add(-1 * blockTime),
 		FirstFilecoin: 0,

--- a/functional-tests/mining_chain_test.go
+++ b/functional-tests/mining_chain_test.go
@@ -26,6 +26,7 @@ func TestSingleMiner(t *testing.T) {
 	ctx := context.Background()
 	genTime := int64(1000000000)
 	blockTime := 30 * time.Second
+	propDelay := 6 * time.Second
 	// The clock is intentionally set some way ahead of the genesis time so the miner can produce
 	// catch-up blocks as quickly as possible.
 	fakeClock := clock.NewFake(time.Unix(genTime, 0).Add(4 * time.Hour))
@@ -34,7 +35,7 @@ func TestSingleMiner(t *testing.T) {
 	// Future code could decouple the whole setup.json from the presealed information.
 	genCfg := loadGenesisConfig(t, fixtureGenCfg())
 	seed := node.MakeChainSeed(t, genCfg)
-	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, fakeClock)
+	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, propDelay, fakeClock)
 
 	drandImpl := &drand.Fake{
 		GenesisTime:   time.Unix(genTime, 0).Add(-1 * blockTime),
@@ -84,6 +85,7 @@ func TestSyncFromSingleMiner(t *testing.T) {
 
 	genTime := int64(1000000000)
 	blockTime := 30 * time.Second
+	propDelay := 6 * time.Second
 	fakeClock := clock.NewFake(time.Unix(genTime, 0))
 
 	drandImpl := &drand.Fake{
@@ -93,7 +95,7 @@ func TestSyncFromSingleMiner(t *testing.T) {
 
 	genCfg := loadGenesisConfig(t, fixtureGenCfg())
 	seed := node.MakeChainSeed(t, genCfg)
-	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, fakeClock)
+	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, propDelay, fakeClock)
 	assert.Equal(t, fakeClock.Now(), chainClock.Now())
 
 	ndMiner := makeNode(ctx, t, seed, chainClock, drandImpl)
@@ -139,6 +141,7 @@ func TestBootstrapWindowedPoSt(t *testing.T) {
 
 	genTime := int64(1000000000)
 	blockTime := 30 * time.Second
+	propDelay := 6 * time.Second
 	fakeClock := clock.NewFake(time.Unix(genTime, 0))
 
 	// Load genesis config fixture.
@@ -151,7 +154,7 @@ func TestBootstrapWindowedPoSt(t *testing.T) {
 
 	// fake proofs so we can run through a proving period quickly
 	miner := test.NewNodeBuilder(t).
-		WithBuilderOpt(node.ChainClockConfigOption(clock.NewChainClockFromClock(uint64(genTime), blockTime, fakeClock))).
+		WithBuilderOpt(node.ChainClockConfigOption(clock.NewChainClockFromClock(uint64(genTime), blockTime, propDelay, fakeClock))).
 		WithGenesisInit(seed.GenesisInitFunc).
 		WithBuilderOpt(node.DrandConfigOption(&drand.Fake{
 			GenesisTime:   time.Unix(genTime, 0).Add(-1 * blockTime),

--- a/functional-tests/plege_sector_test.go
+++ b/functional-tests/plege_sector_test.go
@@ -27,6 +27,7 @@ func TestMiningPledgeSector(t *testing.T) {
 
 	genTime := int64(1000000000)
 	blockTime := 1 * time.Second
+	propDelay := 200 * time.Millisecond
 	fakeClock := clock.NewFake(time.Unix(genTime, 0))
 
 	genCfg := loadGenesisConfig(t, fixtureGenCfg())
@@ -35,7 +36,7 @@ func TestMiningPledgeSector(t *testing.T) {
 		SealProofType: constants.DevSealProofType,
 	})
 	seed := node.MakeChainSeed(t, genCfg)
-	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, fakeClock)
+	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, propDelay, fakeClock)
 
 	drandImpl := &drand.Fake{
 		GenesisTime:   time.Unix(genTime, 0).Add(-1 * blockTime),

--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	google.golang.org/api v0.13.0 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
+	gopkg.in/src-d/go-log.v1 v1.0.1
 	gopkg.in/urfave/cli.v2 v2.0.0-20180128182452-d3ae77c26ac8
 	gotest.tools v2.2.0+incompatible
 	howett.net/plist v0.0.0-20200419221736-3b63eb3a43b5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -117,7 +117,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	google.golang.org/api v0.13.0 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
-	gopkg.in/src-d/go-log.v1 v1.0.1
 	gopkg.in/urfave/cli.v2 v2.0.0-20180128182452-d3ae77c26ac8
 	gotest.tools v2.2.0+incompatible
 	howett.net/plist v0.0.0-20200419221736-3b63eb3a43b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,6 @@ github.com/filecoin-project/specs-actors v0.2.0 h1:bKxloHLegeYJttIJbQjl4/tdsKOUt
 github.com/filecoin-project/specs-actors v0.2.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=
 github.com/filecoin-project/specs-actors v0.3.0 h1:QxgAuTrZr5TPqjyprZk0nTYW5o0JWpzbb5v+4UHHvN0=
 github.com/filecoin-project/specs-actors v0.3.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=
-github.com/filecoin-project/specs-actors v0.4.1-0.20200509020627-3c96f54f3d7d h1:xK1KzVM6DAJABSnP5GhBMIk5zCDnJR5LSkxKJW1zFzA=
-github.com/filecoin-project/specs-actors v0.4.1-0.20200509020627-3c96f54f3d7d/go.mod h1:UW3ft23q6VS8wQoNqLWjENsu9gu1uh6lxOd+H8cwhT8=
 github.com/filecoin-project/specs-actors v0.5.1 h1:uBPdtCnGRuBo/BNw9nrnf5NCdsaVJB/8FdfIpee1HZg=
 github.com/filecoin-project/specs-actors v0.5.1/go.mod h1:r5btrNzZD0oBkEz1pohv80gSCXQnqGrD0kYwOTiExyE=
 github.com/filecoin-project/specs-actors v0.5.3 h1:fdq8Gx0izhnUKl6sYEtI4SUEjT2U6W2w06HeqLz5vmw=
@@ -962,6 +960,7 @@ github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/miekg/dns v1.1.12/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.28/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
@@ -1218,6 +1217,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.5.0 h1:GpsTwfsQ27oS/Aha/6d1oD7tpKIqWnOA6tgOX9HHkt4=
 github.com/spf13/viper v1.5.0/go.mod h1:AkYRkVJF8TkSG/xet6PzXX+l39KhhXa2pdqVSxnTcn4=
+github.com/src-d/envconfig v1.0.0 h1:/AJi6DtjFhZKNx3OB2qMsq7y4yT5//AeSZIe7rk+PX8=
 github.com/src-d/envconfig v1.0.0/go.mod h1:Q9YQZ7BKITldTBnoxsE5gOeB5y66RyPXeue/R4aaNBc=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -1298,6 +1298,7 @@ github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 h1:
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.mod h1:X2c0RVCI1eSUFI8eLcY3c0423ykwiUdxLJtkDvruhjI=
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee h1:lYbXeSvJi5zk5GLKVuid9TVjS9a0OmLIDKTfoZBL6Ow=
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee/go.mod h1:m2aV4LZI4Aez7dP5PMyVKEHhUyEJ/RjmPEDOpDvudHg=
+github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
 github.com/x448/float16 v0.8.3 h1:i2Y5SfvnmNqonyrBxsp8I1AuTm+MW+kyxLES3w9dikk=
 github.com/x448/float16 v0.8.3/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
@@ -1587,6 +1588,7 @@ gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/src-d/go-cli.v0 v0.0.0-20181105080154-d492247bbc0d/go.mod h1:z+K8VcOYVYcSwSjGebuDL6176A1XskgbtNl64NSg+n8=
+gopkg.in/src-d/go-log.v1 v1.0.1 h1:heWvX7J6qbGWbeFS/aRmiy1eYaT+QMV6wNvHDyMjQV4=
 gopkg.in/src-d/go-log.v1 v1.0.1/go.mod h1:GN34hKP0g305ysm2/hctJ0Y8nWP3zxXXJ8GFabTyABE=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/go.sum
+++ b/go.sum
@@ -208,7 +208,6 @@ github.com/filecoin-project/specs-actors v0.2.0 h1:bKxloHLegeYJttIJbQjl4/tdsKOUt
 github.com/filecoin-project/specs-actors v0.2.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=
 github.com/filecoin-project/specs-actors v0.3.0 h1:QxgAuTrZr5TPqjyprZk0nTYW5o0JWpzbb5v+4UHHvN0=
 github.com/filecoin-project/specs-actors v0.3.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=
-github.com/filecoin-project/specs-actors v0.5.1 h1:uBPdtCnGRuBo/BNw9nrnf5NCdsaVJB/8FdfIpee1HZg=
 github.com/filecoin-project/specs-actors v0.5.1/go.mod h1:r5btrNzZD0oBkEz1pohv80gSCXQnqGrD0kYwOTiExyE=
 github.com/filecoin-project/specs-actors v0.5.3 h1:fdq8Gx0izhnUKl6sYEtI4SUEjT2U6W2w06HeqLz5vmw=
 github.com/filecoin-project/specs-actors v0.5.3/go.mod h1:r5btrNzZD0oBkEz1pohv80gSCXQnqGrD0kYwOTiExyE=

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,7 @@ github.com/filecoin-project/specs-actors v0.2.0 h1:bKxloHLegeYJttIJbQjl4/tdsKOUt
 github.com/filecoin-project/specs-actors v0.2.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=
 github.com/filecoin-project/specs-actors v0.3.0 h1:QxgAuTrZr5TPqjyprZk0nTYW5o0JWpzbb5v+4UHHvN0=
 github.com/filecoin-project/specs-actors v0.3.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=
+github.com/filecoin-project/specs-actors v0.4.1-0.20200509020627-3c96f54f3d7d/go.mod h1:UW3ft23q6VS8wQoNqLWjENsu9gu1uh6lxOd+H8cwhT8=
 github.com/filecoin-project/specs-actors v0.5.1/go.mod h1:r5btrNzZD0oBkEz1pohv80gSCXQnqGrD0kYwOTiExyE=
 github.com/filecoin-project/specs-actors v0.5.3 h1:fdq8Gx0izhnUKl6sYEtI4SUEjT2U6W2w06HeqLz5vmw=
 github.com/filecoin-project/specs-actors v0.5.3/go.mod h1:r5btrNzZD0oBkEz1pohv80gSCXQnqGrD0kYwOTiExyE=

--- a/internal/app/go-filecoin/node/block_propagate_test.go
+++ b/internal/app/go-filecoin/node/block_propagate_test.go
@@ -117,7 +117,8 @@ func TestChainSyncWithMessages(t *testing.T) {
 	genTime := time.Unix(genUnixSeconds, 0)
 	fakeClock := clock.NewFake(genTime)
 	blockTime := 30 * time.Second
-	c := clock.NewChainClockFromClock(uint64(genUnixSeconds), blockTime, fakeClock)
+	propDelay := 6 * time.Second
+	c := clock.NewChainClockFromClock(uint64(genUnixSeconds), blockTime, propDelay, fakeClock)
 
 	// first node is the message sender.
 	builder1 := test.NewNodeBuilder(t).
@@ -213,7 +214,8 @@ func makeNodesBlockPropTests(t *testing.T, numNodes int) (address.Address, []*No
 	genTime := time.Unix(genUnixSeconds, 0)
 	fc := clock.NewFake(genTime)
 	blockTime := 30 * time.Second
-	c := clock.NewChainClockFromClock(1234567890, blockTime, fc)
+	propDelay := 5 * time.Second
+	c := clock.NewChainClockFromClock(1234567890, blockTime, propDelay, fc)
 
 	builder := test.NewNodeBuilder(t).
 		WithGenesisInit(seed.GenesisInitFunc).

--- a/internal/app/go-filecoin/node/block_propagate_test.go
+++ b/internal/app/go-filecoin/node/block_propagate_test.go
@@ -214,7 +214,7 @@ func makeNodesBlockPropTests(t *testing.T, numNodes int) (address.Address, []*No
 	genTime := time.Unix(genUnixSeconds, 0)
 	fc := clock.NewFake(genTime)
 	blockTime := 30 * time.Second
-	propDelay := 5 * time.Second
+	propDelay := 6 * time.Second
 	c := clock.NewChainClockFromClock(1234567890, blockTime, propDelay, fc)
 
 	builder := test.NewNodeBuilder(t).

--- a/internal/app/go-filecoin/node/builder.go
+++ b/internal/app/go-filecoin/node/builder.go
@@ -40,6 +40,7 @@ type Builder struct {
 	offlineMode bool
 	verifier    ffiwrapper.Verifier
 	postGen     postgenerator.PoStGenerator
+	propDelay   time.Duration
 	repo        repo.Repo
 	journal     journal.Journal
 	isRelay     bool
@@ -71,6 +72,14 @@ func IsRelay() BuilderOpt {
 func BlockTime(blockTime time.Duration) BuilderOpt {
 	return func(c *Builder) error {
 		c.blockTime = blockTime
+		return nil
+	}
+}
+
+// PropagationDelay sets the time the node needs to wait for blocks to arrive before mining.
+func PropagationDelay(propDelay time.Duration) BuilderOpt {
+	return func(c *Builder) error {
+		c.propDelay = propDelay
 		return nil
 	}
 }
@@ -163,6 +172,7 @@ func New(ctx context.Context, opts ...BuilderOpt) (*Node, error) {
 	n := &Builder{
 		offlineMode: false,
 		blockTime:   clock.DefaultEpochDuration,
+		propDelay:   clock.DefaultPropagationDelay,
 		verifier:    ffiwrapper.ProofVerifier,
 	}
 
@@ -253,7 +263,7 @@ func (b *Builder) build(ctx context.Context) (*Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		b.chainClock = clock.NewChainClock(geneBlk.Timestamp, b.blockTime)
+		b.chainClock = clock.NewChainClock(geneBlk.Timestamp, b.blockTime, b.propDelay)
 	}
 	nd.ChainClock = b.chainClock
 

--- a/internal/app/go-filecoin/node/node_test.go
+++ b/internal/app/go-filecoin/node/node_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/proofs"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/repo"
 	tf "github.com/filecoin-project/go-filecoin/internal/pkg/testhelpers/testflags"
-	"github.com/filecoin-project/go-filecoin/tools/gengen/util"
+	gengen "github.com/filecoin-project/go-filecoin/tools/gengen/util"
 )
 
 func TestNodeConstruct(t *testing.T) {
@@ -208,10 +208,12 @@ func TestNodeConfig(t *testing.T) {
 	verifier := &proofs.FakeVerifier{}
 
 	configBlockTime := 99
+	configPropagationDelay := 20
 
 	builderOptions := []node.BuilderOpt{
 		node.VerifierConfigOption(verifier),
 		node.BlockTime(time.Duration(configBlockTime)),
+		node.PropagationDelay(time.Duration(configPropagationDelay)),
 	}
 
 	initOpts := []node.InitOpt{}

--- a/internal/app/go-filecoin/node/test/setup.go
+++ b/internal/app/go-filecoin/node/test/setup.go
@@ -36,6 +36,7 @@ func MustCreateNodesWithBootstrap(ctx context.Context, t *testing.T, additionalN
 	require.NoError(t, err)
 	genTime := int64(1000000000)
 	blockTime := 30 * time.Second
+	propDelay := 6 * time.Second
 	fakeClock := clock.NewFake(time.Unix(genTime, 0))
 
 	// Load genesis config fixture.
@@ -45,7 +46,7 @@ func MustCreateNodesWithBootstrap(ctx context.Context, t *testing.T, additionalN
 		SealProofType: constants.DevSealProofType,
 	})
 	seed := node.MakeChainSeed(t, genCfg)
-	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, fakeClock)
+	chainClock := clock.NewChainClockFromClock(uint64(genTime), blockTime, propDelay, fakeClock)
 
 	// create bootstrap miner
 	bootstrapMiner := NewNodeBuilder(t).

--- a/internal/pkg/chainsync/fetcher/graphsync_fetcher_test.go
+++ b/internal/pkg/chainsync/fetcher/graphsync_fetcher_test.go
@@ -60,7 +60,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 	tf.UnitTest(t)
 	ctx := context.Background()
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
-	fc, chainClock := clock.NewFakeChain(1234567890, 5*time.Second, time.Now().Unix())
+	fc, chainClock := clock.NewFakeChain(1234567890, 5*time.Second, time.Second, time.Now().Unix())
 	bv := consensus.NewDefaultBlockValidator(chainClock)
 	msgV := &consensus.FakeMessageValidator{}
 	syntax := consensus.WrappedSyntaxValidator{
@@ -658,7 +658,7 @@ func TestHeadersOnlyGraphsyncFetch(t *testing.T) {
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 	fc := clock.NewFake(time.Now())
 	genTime := uint64(1234567890)
-	chainClock := clock.NewChainClockFromClock(genTime, 5*time.Second, fc)
+	chainClock := clock.NewChainClockFromClock(genTime, 5*time.Second, time.Second, fc)
 	bv := consensus.NewDefaultBlockValidator(chainClock)
 	msgV := &consensus.FakeMessageValidator{}
 	syntax := consensus.WrappedSyntaxValidator{
@@ -768,7 +768,7 @@ func TestRealWorldGraphsyncFetchOnlyHeaders(t *testing.T) {
 	tf.IntegrationTest(t)
 	ctx := context.Background()
 	// setup a chain
-	fc, chainClock := clock.NewFakeChain(1234567890, 5*time.Second, time.Now().Unix())
+	fc, chainClock := clock.NewFakeChain(1234567890, 5*time.Second, time.Second, time.Now().Unix())
 	builder := chain.NewBuilderWithDeps(t, address.Undef, &chain.FakeStateBuilder{}, chain.NewClockTimestamper(chainClock))
 	keys := types.MustGenerateKeyInfo(2, 42)
 	mm := vm.NewMessageMaker(t, keys)

--- a/internal/pkg/clock/chainclock.go
+++ b/internal/pkg/clock/chainclock.go
@@ -17,6 +17,7 @@ type ChainEpochClock interface {
 	EpochRangeAtTimestamp(t uint64) (abi.ChainEpoch, abi.ChainEpoch)
 	StartTimeOfEpoch(e abi.ChainEpoch) time.Time
 	WaitForEpoch(ctx context.Context, e abi.ChainEpoch)
+	WaitForEpochOffset(ctx context.Context, e abi.ChainEpoch, offset time.Duration)
 	WaitNextEpoch(ctx context.Context) abi.ChainEpoch
 	Clock
 }
@@ -86,9 +87,9 @@ func (cc *chainClock) WaitNextEpoch(ctx context.Context) abi.ChainEpoch {
 	return nextEpoch
 }
 
-// WaitNextEpoch returns when an epoch is due to start, or ctx is done.
-func (cc *chainClock) WaitForEpoch(ctx context.Context, e abi.ChainEpoch) {
-	epochStart := cc.StartTimeOfEpoch(e)
+// WaitNextEpochOffset returns when time is offset past the start of the epoch, or ctx is done.
+func (cc *chainClock) WaitForEpochOffset(ctx context.Context, e abi.ChainEpoch, offset time.Duration) {
+	epochStart := cc.StartTimeOfEpoch(e).Add(offset)
 	nowB4 := cc.Now()
 	waitDur := epochStart.Sub(nowB4)
 	if waitDur > 0 {
@@ -98,4 +99,9 @@ func (cc *chainClock) WaitForEpoch(ctx context.Context, e abi.ChainEpoch) {
 		case <-ctx.Done():
 		}
 	}
+}
+
+// WaitNextEpoch returns when an epoch is due to start, or ctx is done.
+func (cc *chainClock) WaitForEpoch(ctx context.Context, e abi.ChainEpoch) {
+	cc.WaitForEpochOffset(ctx, e, 0)
 }

--- a/internal/pkg/clock/chainclock_test.go
+++ b/internal/pkg/clock/chainclock_test.go
@@ -16,7 +16,8 @@ func TestChainEpochClock(t *testing.T) {
 
 	now := int64(123456789)
 	bt := clock.DefaultEpochDuration
-	cec := clock.NewChainClock(uint64(now), bt)
+	pd := clock.DefaultPropagationDelay
+	cec := clock.NewChainClock(uint64(now), bt, pd)
 
 	epoch0Start := time.Unix(now, 0)
 	epoch1Start := epoch0Start.Add(bt)

--- a/internal/pkg/clock/testing.go
+++ b/internal/pkg/clock/testing.go
@@ -6,9 +6,9 @@ import (
 )
 
 // Creates a new fake clock and chain clock wrapping it.
-func NewFakeChain(genesis uint64, epochDuration time.Duration, now int64) (Fake, ChainEpochClock) {
+func NewFakeChain(genesis uint64, epochDuration time.Duration, propDelay time.Duration, now int64) (Fake, ChainEpochClock) {
 	fake := NewFake(time.Unix(now, 0))
-	return fake, NewChainClockFromClock(genesis, epochDuration, fake)
+	return fake, NewChainClockFromClock(genesis, epochDuration, propDelay, fake)
 }
 
 // Fake provides an interface for a clock which can be manually advanced.

--- a/internal/pkg/consensus/block_validation_test.go
+++ b/internal/pkg/consensus/block_validation_test.go
@@ -26,7 +26,7 @@ func TestBlockValidSemantic(t *testing.T) {
 	blockTime := clock.DefaultEpochDuration
 	ts := time.Unix(1234567890, 0)
 	genTime := ts
-	mclock := clock.NewChainClockFromClock(uint64(genTime.Unix()), blockTime, clock.NewFake(ts))
+	mclock := clock.NewChainClockFromClock(uint64(genTime.Unix()), blockTime, clock.DefaultPropagationDelay, clock.NewFake(ts))
 	ctx := context.Background()
 
 	validator := consensus.NewDefaultBlockValidator(mclock)
@@ -54,7 +54,7 @@ func TestMismatchedTime(t *testing.T) {
 	blockTime := clock.DefaultEpochDuration
 	genTime := time.Unix(1234567890, 1234567890%int64(time.Second))
 	fc := clock.NewFake(genTime)
-	mclock := clock.NewChainClockFromClock(uint64(genTime.Unix()), blockTime, fc)
+	mclock := clock.NewChainClockFromClock(uint64(genTime.Unix()), blockTime, clock.DefaultPropagationDelay, fc)
 	validator := consensus.NewDefaultBlockValidator(mclock)
 
 	fc.Advance(blockTime)
@@ -76,7 +76,7 @@ func TestFutureEpoch(t *testing.T) {
 	blockTime := clock.DefaultEpochDuration
 	genTime := time.Unix(1234567890, 1234567890%int64(time.Second))
 	fc := clock.NewFake(genTime)
-	mclock := clock.NewChainClockFromClock(uint64(genTime.Unix()), blockTime, fc)
+	mclock := clock.NewChainClockFromClock(uint64(genTime.Unix()), blockTime, clock.DefaultPropagationDelay, fc)
 	validator := consensus.NewDefaultBlockValidator(mclock)
 
 	// Fails in future epoch
@@ -92,7 +92,7 @@ func TestBlockValidSyntax(t *testing.T) {
 	blockTime := clock.DefaultEpochDuration
 	ts := time.Unix(1234567890, 0)
 	mclock := clock.NewFake(ts)
-	chainClock := clock.NewChainClockFromClock(uint64(ts.Unix()), blockTime, mclock)
+	chainClock := clock.NewChainClockFromClock(uint64(ts.Unix()), blockTime, clock.DefaultPropagationDelay, mclock)
 	ctx := context.Background()
 	mclock.Advance(blockTime)
 

--- a/internal/pkg/consensus/expected_test.go
+++ b/internal/pkg/consensus/expected_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	vmaddr "github.com/filecoin-project/go-filecoin/internal/pkg/vm/address"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/vm/state"
-	"github.com/filecoin-project/go-filecoin/tools/gengen/util"
+	gengen "github.com/filecoin-project/go-filecoin/tools/gengen/util"
 )
 
 type TestChainReader struct{}
@@ -55,7 +55,8 @@ func TestExpected_RunStateTransition_validateMining(t *testing.T) {
 	mockSigner, kis := types.NewMockSignersAndKeyInfo(3)
 	fc := clock.NewFake(time.Unix(1234567890, 0))
 	blockTime := 30 * time.Second
-	cl := clock.NewChainClockFromClock(1234567890, blockTime, fc)
+	propDelay := 5 * time.Second
+	cl := clock.NewChainClockFromClock(1234567890, blockTime, propDelay, fc)
 	drand := &drand.Fake{}
 
 	t.Run("passes the validateMining section when given valid mining blocks", func(t *testing.T) {

--- a/internal/pkg/mining/scheduler.go
+++ b/internal/pkg/mining/scheduler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/pkg/errors"
+	"gopkg.in/src-d/go-log.v1"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
@@ -70,7 +71,7 @@ func (s *timingScheduler) Start(miningCtx context.Context) (<-chan Output, *sync
 	return outCh, &doneWg
 }
 
-func (s *timingScheduler) mineLoop(miningCtx context.Context, outCh chan Output, doneWg *sync.WaitGroup) error {
+func (s *timingScheduler) mineLoop(miningCtx context.Context, outCh chan Output, doneWg *sync.WaitGroup) {
 	// The main event loop for the timing scheduler.
 	// Waits for a new epoch to start, polls the heaviest head, includes the correct number
 	// of null blocks and starts a mining job async.
@@ -80,15 +81,18 @@ func (s *timingScheduler) mineLoop(miningCtx context.Context, outCh chan Output,
 	// The scheduler will skip mining jobs if the skipping flag is set
 	prevBase, err := s.pollHeadFunc()
 	if err != nil {
-		return errors.Wrap(err, "error polling head from mining scheduler")
+		log.Errorf("error polling head from mining scheduler %s", err)
+		// FIXME return error
 	}
 	nullCount := uint64(0)
 
+	workContext, workCancel := context.WithCancel(miningCtx)
 	for {
 		// Check for a new base tipset, and reset null count if one is found.
 		base, err := s.pollHeadFunc()
 		if err != nil {
-			return errors.Wrap(err, "error polling head from mining scheduler")
+			log.Errorf("error polling head from mining scheduler %s", err)
+			// FIXME return error
 		}
 		if !base.Key().Equals(prevBase.Key()) {
 			nullCount = 0
@@ -105,7 +109,7 @@ func (s *timingScheduler) mineLoop(miningCtx context.Context, outCh chan Output,
 			// There appears to be a gap at the end of the chain.
 			// Rather than leave the gap, attempt to mine blocks to fill it.
 			doneWg.Add(1)
-			s.worker.Mine(miningCtx, base, nullCount, outCh)
+			s.worker.Mine(workContext, base, nullCount, outCh)
 			doneWg.Done()
 
 			// The use of a channel output prevents this code from knowing whether the block it may have just produced
@@ -117,9 +121,10 @@ func (s *timingScheduler) mineLoop(miningCtx context.Context, outCh chan Output,
 			select { // check for interrupt during waiting
 			case <-miningCtx.Done():
 				s.isStarted = false
-				return nil
+				return // nolint:govet
 			default:
 			}
+			workCancel() // cancel any late work from last epoch
 		}
 
 		// check if we are skipping and don't mine if so
@@ -128,9 +133,12 @@ func (s *timingScheduler) mineLoop(miningCtx context.Context, outCh chan Output,
 			continue
 		}
 
+		workContext, workCancel = context.WithCancel(miningCtx) // nolint: govet
 		doneWg.Add(1)
-		s.worker.Mine(miningCtx, base, nullCount, outCh)
-		doneWg.Done()
+		go func(ctx context.Context) {
+			s.worker.Mine(ctx, base, nullCount, outCh)
+			doneWg.Done()
+		}(workContext)
 	}
 }
 

--- a/internal/pkg/mining/scheduler_test.go
+++ b/internal/pkg/mining/scheduler_test.go
@@ -33,14 +33,14 @@ func TestWorkerCalled(t *testing.T) {
 		return true
 	})
 
-	fakeClock, chainClock, blockTime := testClock(t)
+	fakeClock, chainClock := clock.NewFakeChain(1234567890, epochDuration, 1234567890)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	scheduler := NewScheduler(w, headFunc(ts), chainClock)
 	scheduler.Start(ctx)
 	fakeClock.BlockUntil(1)
-	fakeClock.Advance(blockTime)
+	fakeClock.Advance(epochDuration)
 
 	wg.Wait()
 	assert.True(t, called)
@@ -52,13 +52,13 @@ func TestCorrectNullBlocksGivenEpoch(t *testing.T) {
 	h, err := ts.Height()
 	require.NoError(t, err)
 
-	fakeClock, chainClock, blockTime := testClock(t)
+	fakeClock, chainClock := clock.NewFakeChain(1234567890, epochDuration, 1234567890)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Move forward 20 epochs
 	for i := 0; i < 19; i++ {
-		fakeClock.Advance(blockTime)
+		fakeClock.Advance(epochDuration)
 	}
 
 	var wg sync.WaitGroup
@@ -73,7 +73,7 @@ func TestCorrectNullBlocksGivenEpoch(t *testing.T) {
 	scheduler.Start(ctx)
 	fakeClock.BlockUntil(1)
 	// Move forward 1 epoch for a total of 21
-	fakeClock.Advance(blockTime)
+	fakeClock.Advance(epochDuration)
 
 	wg.Wait()
 }
@@ -84,7 +84,7 @@ func TestWaitsForEpochStart(t *testing.T) {
 	tf.UnitTest(t)
 	ts := testHead(t)
 
-	fakeClock, chainClock, blockTime := testClock(t)
+	fakeClock, chainClock := clock.NewFakeChain(1234567890, epochDuration, 1234567890)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -99,7 +99,7 @@ func TestWaitsForEpochStart(t *testing.T) {
 	}()
 	w := NewTestWorker(t, func(_ context.Context, workHead block.TipSet, _ uint64, _ chan<- Output) bool {
 		// This doesn't get called until the clock has advanced one blocktime
-		assert.Equal(t, genTime.Add(blockTime), chainClock.Now())
+		assert.Equal(t, genTime.Add(epochDuration), chainClock.Now())
 		wg.Done()
 		return true
 	})
@@ -107,7 +107,7 @@ func TestWaitsForEpochStart(t *testing.T) {
 	scheduler := NewScheduler(w, headFunc(ts), chainClock)
 	scheduler.Start(ctx)
 	fakeClock.BlockUntil(1)
-	fakeClock.Advance(blockTime / time.Duration(2)) // advance half a blocktime
+	fakeClock.Advance(epochDuration / time.Duration(2)) // advance half a blocktime
 	// Test relies on race, that this sleep would be enough time for the mining job
 	// to hit wg.Done() if it was triggered partway through the epoch
 	time.Sleep(300 * time.Millisecond)
@@ -118,7 +118,7 @@ func TestWaitsForEpochStart(t *testing.T) {
 	default:
 	}
 
-	fakeClock.Advance(blockTime / time.Duration(2))
+	fakeClock.Advance(epochDuration / time.Duration(2))
 	wg.Wait()
 }
 
@@ -127,7 +127,7 @@ func TestCancelsLateWork(t *testing.T) {
 	tf.UnitTest(t)
 	ts := testHead(t)
 
-	fakeClock, chainClock, blockTime := testClock(t)
+	fakeClock, chainClock := clock.NewFakeChain(1234567890, epochDuration, 1234567890)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -147,9 +147,9 @@ func TestCancelsLateWork(t *testing.T) {
 	scheduler := NewScheduler(w, headFunc(ts), chainClock)
 	scheduler.Start(ctx)
 	fakeClock.BlockUntil(1)
-	fakeClock.Advance(blockTime) // schedule first work item
+	fakeClock.Advance(epochDuration) // schedule first work item
 	fakeClock.BlockUntil(1)
-	fakeClock.Advance(blockTime) // enter next epoch, should cancel first work item
+	fakeClock.Advance(epochDuration) // enter next epoch, should cancel first work item
 
 	wg.Wait()
 }
@@ -195,7 +195,7 @@ func TestSkips(t *testing.T) {
 	tf.UnitTest(t)
 	ts := testHead(t)
 
-	fakeClock, chainClock, blockTime := testClock(t)
+	fakeClock, chainClock := clock.NewFakeChain(1234567890, epochDuration, 1234567890)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -216,10 +216,10 @@ func TestSkips(t *testing.T) {
 	scheduler.Pause()
 	scheduler.Start(ctx)
 	fakeClock.BlockUntil(1)
-	fakeClock.Advance(blockTime)
+	fakeClock.Advance(epochDuration)
 	fakeClock.BlockUntil(1)
 	scheduler.Continue()
-	fakeClock.Advance(blockTime)
+	fakeClock.Advance(epochDuration)
 	wg.Wait()
 }
 
@@ -230,17 +230,6 @@ func testHead(t *testing.T) block.TipSet {
 	ts, err := block.NewTipSet(baseBlock)
 	require.NoError(t, err)
 	return ts
-}
-
-func testClock(t *testing.T) (clock.Fake, clock.ChainEpochClock, time.Duration) {
-	// return a fake clock for running tests a ChainEpochClock for
-	// using in the scheduler, and the testing blocktime
-	gt := time.Unix(1234567890, 1234567890%1000000000)
-	fc := clock.NewFake(gt)
-	DefaultEpochDurationTest := 1 * time.Second
-	chainClock := clock.NewChainClockFromClock(uint64(gt.Unix()), DefaultEpochDurationTest, fc)
-
-	return fc, chainClock, DefaultEpochDurationTest
 }
 
 func headFunc(ts block.TipSet) func() (block.TipSet, error) {

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -315,7 +315,6 @@ func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCoun
 		log.Debugf("Worker.Mine generates new winning block! %s", next.Header.Cid().String())
 	}
 	outCh <- next
-	won = true
 	return
 }
 

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -315,7 +315,7 @@ func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCoun
 		log.Debugf("Worker.Mine generates new winning block! %s", next.Header.Cid().String())
 	}
 	outCh <- next
-	return
+	return true
 }
 
 func (w *DefaultWorker) getPowerTable(powerKey, faultsKey block.TipSetKey) (consensus.PowerTableView, error) {

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -87,7 +87,7 @@ func TestLookbackElection(t *testing.T) {
 			MessageQualifier: &mining.NoMessageQualifier{},
 			Blockstore:       bs,
 			MessageStore:     messages,
-			Clock:            clock.NewChainClock(100000000, 30*time.Second),
+			Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 		})
 
 		go worker.Mine(ctx, head, 0, outCh)
@@ -144,7 +144,7 @@ func Test_Mine(t *testing.T) {
 			MessageQualifier: &mining.NoMessageQualifier{},
 			Blockstore:       bs,
 			MessageStore:     messages,
-			Clock:            clock.NewChainClock(100000000, 30*time.Second),
+			Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 		})
 
 		go worker.Mine(ctx, tipSet, 0, outCh)
@@ -175,7 +175,7 @@ func Test_Mine(t *testing.T) {
 			MessageQualifier: &mining.NoMessageQualifier{},
 			Blockstore:       bs,
 			MessageStore:     messages,
-			Clock:            clock.NewChainClock(100000000, 30*time.Second),
+			Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 		})
 		outCh := make(chan mining.Output)
 
@@ -205,7 +205,7 @@ func Test_Mine(t *testing.T) {
 			MessageQualifier: &mining.NoMessageQualifier{},
 			Blockstore:       bs,
 			MessageStore:     messages,
-			Clock:            clock.NewChainClock(100000000, 30*time.Second),
+			Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 		})
 		input := block.TipSet{}
 		outCh := make(chan mining.Output)
@@ -366,7 +366,7 @@ func TestApplyBLSMessages(t *testing.T) {
 		MessageQualifier: &mining.NoMessageQualifier{},
 		Blockstore:       bs,
 		MessageStore:     msgStore,
-		Clock:            clock.NewChainClock(100000000, 30*time.Second),
+		Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 	})
 
 	outCh := make(chan mining.Output)
@@ -464,7 +464,7 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 		MessageQualifier: &mining.NoMessageQualifier{},
 		Blockstore:       bs,
 		MessageStore:     messages,
-		Clock:            clock.NewChainClock(100000000, 30*time.Second),
+		Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 	})
 
 	builder := chain.NewBuilder(t, address.Undef)
@@ -527,7 +527,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		MessageQualifier: &mining.NoMessageQualifier{},
 		Blockstore:       bs,
 		MessageStore:     messages,
-		Clock:            clock.NewChainClock(100000000, 30*time.Second),
+		Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 	})
 
 	// addr3 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
@@ -631,7 +631,7 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 		MessageQualifier: &mining.NoMessageQualifier{},
 		Blockstore:       bs,
 		MessageStore:     messages,
-		Clock:            clock.NewChainClock(100000000, 30*time.Second),
+		Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 	})
 
 	h := abi.ChainEpoch(100)
@@ -690,7 +690,7 @@ func TestGenerateWithoutMessages(t *testing.T) {
 		MessageQualifier: &mining.NoMessageQualifier{},
 		Blockstore:       bs,
 		MessageStore:     messages,
-		Clock:            clock.NewChainClock(100000000, 30*time.Second),
+		Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 	})
 
 	assert.Len(t, pool.Pending(), 0)
@@ -743,7 +743,7 @@ func TestGenerateError(t *testing.T) {
 		MessageQualifier: &mining.NoMessageQualifier{},
 		Blockstore:       bs,
 		MessageStore:     messages,
-		Clock:            clock.NewChainClock(100000000, 30*time.Second),
+		Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 	})
 
 	// This is actually okay and should result in a receipt

--- a/internal/pkg/net/blocksub/validator_test.go
+++ b/internal/pkg/net/blocksub/validator_test.go
@@ -67,9 +67,10 @@ func TestBlockPubSubValidation(t *testing.T) {
 	mclock := clock.NewFake(now)
 	// block time will be 1 second
 	blocktime := time.Second * 1
+	propDelay := 200 * time.Millisecond
 
 	// setup a block validator and a topic validator
-	chainClock := clock.NewChainClockFromClock(uint64(now.Unix()), blocktime, mclock)
+	chainClock := clock.NewChainClockFromClock(uint64(now.Unix()), blocktime, propDelay, mclock)
 	bv := consensus.NewDefaultBlockValidator(chainClock)
 	btv := blocksub.NewBlockTopicValidator(bv)
 


### PR DESCRIPTION
### Motivation

Our scheduling for block mining is a bit off. Miners are allowed to send blocks as soon as the epoch begins, which means they should mine the block in the previous epoch. Since mining requires parent blocks to arrive from other miners, we need a configurable propagation delay to trade off between waiting long enough for all the blocks to arrive and providing sufficient time to mine the block

We also had a problem where mining in the scheduler was run in a go routine. This would allow overlapping attempts to mine when the timing is off. This potentially causes a panic.

### Proposed changes

1. Schedule mining synchronously.
2. Add propagation delay parameter alongside related block delay parameter
3. Give chain clock ability to wait for epoch + propagation delay
4. Modify scheduler to wait for propagation delay, then fetch the head, then mine, then wait for the start of the target epoch, then send the block.
5. Fix some tests and remove others that are no longer relevant.


<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

