### PR TITLE
resolve miner id addres before passing to storage fsm

### DIFF
--- a/functional-tests/common.go
+++ b/functional-tests/common.go
@@ -9,17 +9,13 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node"
 	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/node/test"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/clock"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/constants"
 	"github.com/filecoin-project/go-filecoin/internal/pkg/drand"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/vm"
 	gengen "github.com/filecoin-project/go-filecoin/tools/gengen/util"
 )
 
@@ -89,25 +85,4 @@ func simulateBlockMining(ctx context.Context, t *testing.T, fakeClock clock.Fake
 			require.NoError(t, err)
 		}
 	}
-}
-
-// send funds from one actor to another. The from account must be an address with a private key imported into the node.
-// This function blocks until the message to lands on chain to avoid call sequence number races.
-func transferFunds(ctx context.Context, t *testing.T, nd *node.Node, from address.Address, to address.Address, amount types.AttoFIL) {
-	mcid, errCh, err := nd.Messaging.Outbox.SendEncoded(ctx,
-		from,
-		to,
-		amount,
-		types.NewGasPrice(1),
-		10000,
-		true,
-		builtin.MethodSend,
-		nil,
-	)
-	require.NoError(t, err)
-	require.NoError(t, <-errCh)
-
-	require.NoError(t, nd.PorcelainAPI.MessageWait(ctx, mcid, func(block *block.Block, message *types.SignedMessage, receipt *vm.MessageReceipt) error {
-		return nil
-	}))
 }


### PR DESCRIPTION
### Motivation

The storage FSM uses an ID derived from the miner's address to locate sectors. This fails if the miner id is not an ID address (i.e. when it's the robust address returned from the miner create command). We need to convert this address before passing it to the fsm.

### Proposed changes

1. Resolve miner address before passing it on to storage FSM.
2. Modify pledge-sector test so that it creates a miner and sets robust address in config to replicate failure prior to change.

Closes #4126

