### PR TITLE
remove channel from worker mine

### DIFF
--- a/functional-tests/common.go
+++ b/functional-tests/common.go
@@ -75,14 +75,17 @@ func initNodeGenesisMiner(ctx context.Context, t *testing.T, nd *node.Node, seed
 }
 
 func simulateBlockMining(ctx context.Context, t *testing.T, fakeClock clock.Fake, blockTime time.Duration, node *node.Node) {
+	var err error
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			fakeClock.Advance(blockTime)
-			_, err := node.BlockMining.BlockMiningAPI.MiningOnce(ctx)
+			// check error from previous loop (but only if not done)
 			require.NoError(t, err)
+
+			fakeClock.Advance(blockTime)
+			_, err = node.BlockMining.BlockMiningAPI.MiningOnce(ctx)
 		}
 	}
 }

--- a/internal/app/go-filecoin/internal/submodule/block_mining_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/block_mining_submodule.go
@@ -29,7 +29,7 @@ type BlockMiningSubmodule struct {
 	PoStGenerator postgenerator.PoStGenerator
 }
 
-type newBlockFunc func(context.Context, mining.Output)
+type newBlockFunc func(context.Context, mining.FullBlock)
 
 // NewBlockMiningSubmodule creates a new block mining submodule.
 func NewBlockMiningSubmodule(ctx context.Context, gen postgenerator.PoStGenerator) (BlockMiningSubmodule, error) {

--- a/internal/app/go-filecoin/node/block.go
+++ b/internal/app/go-filecoin/node/block.go
@@ -15,7 +15,7 @@ import (
 )
 
 // AddNewBlock receives a newly mined block and stores, validates and propagates it to the network.
-func (node *Node) AddNewBlock(ctx context.Context, o mining.Output) (err error) {
+func (node *Node) AddNewBlock(ctx context.Context, o mining.FullBlock) (err error) {
 	b := o.Header
 	ctx, span := trace.StartSpan(ctx, "Node.AddNewBlock")
 	span.AddAttributes(trace.StringAttribute("block", b.Cid().String()))

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -237,15 +237,15 @@ func (node *Node) handleNewMiningOutput(ctx context.Context, miningOutCh <-chan 
 				log.Errorf("scheduler stopped. stopping mining.")
 				node.StopMining(context.Background())
 				return
-			} else {
-				node.BlockMining.MiningDoneWg.Add(1)
-				go func() {
-					if node.IsMining() {
-						node.BlockMining.AddNewlyMinedBlock(ctx, output)
-					}
-					node.BlockMining.MiningDoneWg.Done()
-				}()
 			}
+
+			node.BlockMining.MiningDoneWg.Add(1)
+			go func() {
+				if node.IsMining() {
+					node.BlockMining.AddNewlyMinedBlock(ctx, output)
+				}
+				node.BlockMining.MiningDoneWg.Done()
+			}()
 		}
 	}
 

--- a/internal/app/go-filecoin/node/test/setup.go
+++ b/internal/app/go-filecoin/node/test/setup.go
@@ -79,7 +79,14 @@ func MustCreateNodesWithBootstrap(ctx context.Context, t *testing.T, additionalN
 func RequireMineOnce(ctx context.Context, t *testing.T, fakeClock clock.Fake, node *node.Node) {
 	fakeClock.Advance(blockTime)
 	_, err := node.BlockMining.BlockMiningAPI.MiningOnce(ctx)
-	require.NoError(t, err)
+
+	// fail only if ctx not done
+	select {
+	case <-ctx.Done():
+		return
+	default:
+		require.NoError(t, err)
+	}
 }
 
 func CreateBootstrapSetup(t *testing.T) (*node.ChainSeed, *gengen.GenesisCfg, clock.Fake, clock.ChainEpochClock) {

--- a/internal/app/go-filecoin/node/test/setup.go
+++ b/internal/app/go-filecoin/node/test/setup.go
@@ -7,9 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-filecoin/build/project"

--- a/internal/pkg/mining/block_generate.go
+++ b/internal/pkg/mining/block_generate.go
@@ -21,7 +21,6 @@ import (
 )
 
 // Generate returns a new block created from the messages in the pool.
-// The resulting output is not empty: it has either a block or an error.
 func (w *DefaultWorker) Generate(
 	ctx context.Context,
 	baseTipSet block.TipSet,
@@ -30,7 +29,7 @@ func (w *DefaultWorker) Generate(
 	nullBlockCount abi.ChainEpoch,
 	posts []block.PoStProof,
 	drandEntries []*drand.Entry,
-) (*block.Block, []*types.SignedMessage, []*types.SignedMessage, error) {
+) (*FullBlock, error) {
 
 	generateTimer := time.Now()
 	defer func() {
@@ -39,12 +38,12 @@ func (w *DefaultWorker) Generate(
 
 	weight, err := w.getWeight(ctx, baseTipSet)
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "get weight")
+		return nil, errors.Wrap(err, "get weight")
 	}
 
 	baseHeight, err := baseTipSet.Height()
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "get base tip set height")
+		return nil, errors.Wrap(err, "get base tip set height")
 	}
 
 	blockHeight := baseHeight + nullBlockCount + 1
@@ -56,7 +55,7 @@ func (w *DefaultWorker) Generate(
 	candidateMsgs := orderMessageCandidates(mq.Drain(block.BlockMessageLimit))
 	candidateMsgs = w.filterPenalizableMessages(ctx, candidateMsgs)
 	if len(candidateMsgs) > block.BlockMessageLimit {
-		return nil, nil, nil, errors.Errorf("too many messages returned from mq.Drain: %d", len(candidateMsgs))
+		return nil, errors.Errorf("too many messages returned from mq.Drain: %d", len(candidateMsgs))
 	}
 
 	var blsAccepted []*types.SignedMessage
@@ -75,24 +74,24 @@ func (w *DefaultWorker) Generate(
 	// Create an aggregage signature for messages
 	unwrappedBLSMessages, blsAggregateSig, err := aggregateBLS(blsAccepted)
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "could not aggregate bls messages")
+		return nil, errors.Wrap(err, "could not aggregate bls messages")
 	}
 
 	// Persist messages to ipld storage
 	txMetaCid, err := w.messageStore.StoreMessages(ctx, secpAccepted, unwrappedBLSMessages)
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "error persisting messages")
+		return nil, errors.Wrap(err, "error persisting messages")
 	}
 
 	// get tipset state root and receipt root
 	baseStateRoot, err := w.tsMetadata.GetTipSetStateRoot(baseTipSet.Key())
 	if err != nil {
-		return nil, nil, nil, errors.Wrapf(err, "error retrieving state root for tipset %s", baseTipSet.Key().String())
+		return nil, errors.Wrapf(err, "error retrieving state root for tipset %s", baseTipSet.Key().String())
 	}
 
 	baseReceiptRoot, err := w.tsMetadata.GetTipSetReceiptsRoot(baseTipSet.Key())
 	if err != nil {
-		return nil, nil, nil, errors.Wrapf(err, "error retrieving receipt root for tipset %s", baseTipSet.Key().String())
+		return nil, errors.Wrapf(err, "error retrieving receipt root for tipset %s", baseTipSet.Key().String())
 	}
 
 	// Set the block timestamp to be exactly the start of the target epoch, regardless of the current time.
@@ -125,24 +124,26 @@ func (w *DefaultWorker) Generate(
 
 	view, err := w.api.PowerStateView(baseTipSet.Key())
 	if err != nil {
-		return nil, nil, nil, errors.Wrapf(err, "failed to read state view")
+		return nil, errors.Wrapf(err, "failed to read state view")
 	}
 	_, workerAddr, err := view.MinerControlAddresses(ctx, w.minerAddr)
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "failed to read workerAddr during block generation")
+		return nil, errors.Wrap(err, "failed to read workerAddr during block generation")
 	}
 	workerSigningAddr, err := view.AccountSignerAddress(ctx, workerAddr)
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "failed to convert worker address to signing address")
+		return nil, errors.Wrap(err, "failed to convert worker address to signing address")
 	}
 	blockSig, err := w.workerSigner.SignBytes(ctx, next.SignatureData(), workerSigningAddr)
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "failed to sign block")
+		return nil, errors.Wrap(err, "failed to sign block")
 	}
 	next.BlockSig = &blockSig
 
-	return next, blsAccepted, secpAccepted, nil
+	return NewfullBlock(next, blsAccepted, secpAccepted), nil
 }
+
+// The resulting output is not empty: it has either a block or an error.
 
 func aggregateBLS(blsMessages []*types.SignedMessage) ([]*types.UnsignedMessage, crypto.Signature, error) {
 	var sigs []bls.Signature

--- a/internal/pkg/mining/testing.go
+++ b/internal/pkg/mining/testing.go
@@ -10,7 +10,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
-type miningFunc func(runCtx context.Context, base block.TipSet, nullBlkCount uint64) (*block.Block, []*types.SignedMessage, []*types.SignedMessage, error)
+type miningFunc func(runCtx context.Context, base block.TipSet, nullBlkCount uint64) (*FullBlock, error)
 
 // TestWorker is a worker with a customizable work function to facilitate
 // easy testing.
@@ -21,7 +21,7 @@ type TestWorker struct {
 
 // Mine is the TestWorker's Work function.  It simply calls the WorkFunc
 // field.
-func (w *TestWorker) Mine(ctx context.Context, ts block.TipSet, nullBlockCount uint64) (*block.Block, []*types.SignedMessage, []*types.SignedMessage, error) {
+func (w *TestWorker) Mine(ctx context.Context, ts block.TipSet, nullBlockCount uint64) (*FullBlock, error) {
 	require.NotNil(w.t, w.WorkFunc)
 	return w.WorkFunc(ctx, ts, nullBlockCount)
 }

--- a/internal/pkg/mining/testing.go
+++ b/internal/pkg/mining/testing.go
@@ -10,23 +10,25 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/types"
 )
 
+type miningFunc func(runCtx context.Context, base block.TipSet, nullBlkCount uint64) (*block.Block, []*types.SignedMessage, []*types.SignedMessage, error)
+
 // TestWorker is a worker with a customizable work function to facilitate
 // easy testing.
 type TestWorker struct {
-	WorkFunc func(context.Context, block.TipSet, uint64, chan<- Output) bool
+	WorkFunc miningFunc
 	t        *testing.T
 }
 
 // Mine is the TestWorker's Work function.  It simply calls the WorkFunc
 // field.
-func (w *TestWorker) Mine(ctx context.Context, ts block.TipSet, nullBlockCount uint64, outCh chan<- Output) bool {
+func (w *TestWorker) Mine(ctx context.Context, ts block.TipSet, nullBlockCount uint64) (*block.Block, []*types.SignedMessage, []*types.SignedMessage, error) {
 	require.NotNil(w.t, w.WorkFunc)
-	return w.WorkFunc(ctx, ts, nullBlockCount, outCh)
+	return w.WorkFunc(ctx, ts, nullBlockCount)
 }
 
 // NewTestWorker creates a worker that calls the provided input
 // function when Mine() is called.
-func NewTestWorker(t *testing.T, f func(context.Context, block.TipSet, uint64, chan<- Output) bool) *TestWorker {
+func NewTestWorker(t *testing.T, f miningFunc) *TestWorker {
 	return &TestWorker{
 		WorkFunc: f,
 		t:        t,

--- a/internal/pkg/mining/worker.go
+++ b/internal/pkg/mining/worker.go
@@ -30,31 +30,10 @@ import (
 
 var log = logging.Logger("mining")
 
-// Output is the result of a single mining attempt. It may have a new block header (with included messages),
-// an error, or zero-value fields indicating that the miner did not win the necessary election.
-type Output struct {
-	Header       *block.Block
-	BLSMessages  []*types.SignedMessage
-	SECPMessages []*types.SignedMessage
-	Err          error
-}
-
-func NewOutput(b *block.Block, BLSMessages, SECPMessages []*types.SignedMessage) Output {
-	return Output{Header: b, BLSMessages: BLSMessages, SECPMessages: SECPMessages, Err: nil}
-}
-
-func NewOutputEmpty() Output {
-	return Output{}
-}
-
-func NewOutputErr(e error) Output {
-	return Output{Err: e}
-}
-
 // Worker is the interface called by the Scheduler to run the mining work being
 // scheduled.
 type Worker interface {
-	Mine(runCtx context.Context, base block.TipSet, nullBlkCount uint64, outCh chan<- Output) bool
+	Mine(runCtx context.Context, base block.TipSet, nullBlkCount uint64) (*block.Block, []*types.SignedMessage, []*types.SignedMessage, error)
 }
 
 // GetStateTree is a function that gets the aggregate state tree of a TipSet. It's
@@ -179,37 +158,33 @@ func NewDefaultWorker(parameters WorkerParameters) *DefaultWorker {
 
 // Mine implements the DefaultWorkers main mining function..
 // The returned bool indicates if this miner created a new block or not.
-func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCount uint64, outCh chan<- Output) (won bool) {
+func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCount uint64) (blk *block.Block, bls []*types.SignedMessage, secp []*types.SignedMessage, err error) {
 	log.Info("Worker.Mine")
 	if !base.Defined() {
 		log.Warn("Worker.Mine returning because it can't mine on an empty tipset")
-		outCh <- NewOutputErr(errors.New("bad input tipset with no blocks sent to Mine()"))
-		return
+		return nil, nil, nil, errors.New("bad input tipset with no blocks sent to Mine()")
 	}
 	baseEpoch, err := base.Height()
 	if err != nil {
 		log.Warnf("Worker.Mine couldn't read base height %s", err)
-		outCh <- NewOutputErr(err)
-		return
+		return nil, nil, nil, err
 	}
 	currEpoch := baseEpoch + abi.ChainEpoch(1) + abi.ChainEpoch(nullBlkCount)
 
 	log.Debugf("Mining on tipset %s, at epoch %d with %d null blocks.", base.String(), baseEpoch, nullBlkCount)
 	if ctx.Err() != nil {
 		log.Warnf("Worker.Mine returning with ctx error %s", ctx.Err().Error())
-		return
+		return nil, nil, nil, ctx.Err()
 	}
 
 	// Read uncached worker address
 	keyView, err := w.api.PowerStateView(base.Key())
 	if err != nil {
-		outCh <- NewOutputErr(err)
-		return
+		return nil, nil, nil, err
 	}
 	_, workerAddr, err := keyView.MinerControlAddresses(ctx, w.minerAddr)
 	if err != nil {
-		outCh <- NewOutputErr(err)
-		return
+		return nil, nil, nil, err
 	}
 
 	// Look-back for the election ticket.
@@ -220,31 +195,27 @@ func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCoun
 
 	workerSignerAddr, err := keyView.AccountSignerAddress(ctx, workerAddr)
 	if err != nil {
-		outCh <- NewOutputErr(err)
-		return
+		return nil, nil, nil, err
 	}
 
 	drandEntries, err := w.drandEntriesForEpoch(ctx, base, nullBlkCount)
 	if err != nil {
 		log.Errorf("Worker.Mine failed to collect drand entries for block %s", err)
-		outCh <- NewOutputErr(err)
-		return
+		return nil, nil, nil, err
 	}
 
 	// Determine if we've won election
 	electionEntry, err := w.electionEntry(ctx, base, drandEntries)
 	if err != nil {
 		log.Errorf("Worker.Mine failed to calculate drand entry for election randomness %s", err)
-		outCh <- NewOutputErr(err)
-		return
+		return nil, nil, nil, err
 	}
 
 	newPeriod := len(drandEntries) > 0
 	nextTicket, err := w.ticketGen.MakeTicket(ctx, base.Key(), lookbackEpoch, w.minerAddr, electionEntry, newPeriod, workerSignerAddr, w.workerSigner)
 	if err != nil {
 		log.Warnf("Worker.Mine couldn't generate next ticket %s", err)
-		outCh <- NewOutputErr(err)
-		return
+		return nil, nil, nil, err
 	}
 
 	electionVRFProof, err := w.election.GenerateElectionProof(ctx, electionEntry, currEpoch, w.minerAddr, workerSignerAddr, w.workerSigner)
@@ -255,61 +226,48 @@ func (w *DefaultWorker) Mine(ctx context.Context, base block.TipSet, nullBlkCoun
 	electionPowerAncestor, err := w.lookbackTipset(ctx, base, nullBlkCount, consensus.ElectionPowerTableLookback)
 	if err != nil {
 		log.Errorf("Worker.Mine couldn't get ancestor tipset: %s", err.Error())
-		outCh <- NewOutputErr(err)
-		return
+		return nil, nil, nil, err
 	}
 	electionPowerTable, err := w.getPowerTable(electionPowerAncestor.Key(), base.Key())
 	if err != nil {
 		log.Errorf("Worker.Mine couldn't get snapshot for tipset: %s", err.Error())
-		outCh <- NewOutputErr(err)
-		return
+		return nil, nil, nil, err
 	}
 	networkPower, err := electionPowerTable.NetworkTotalPower(ctx)
 	if err != nil {
 		log.Errorf("failed to get network power: %s", err)
-		outCh <- NewOutputErr(err)
-		return
+		return nil, nil, nil, err
 	}
 	minerPower, err := electionPowerTable.MinerClaimedPower(ctx, w.minerAddr)
 	if err != nil {
 		log.Errorf("failed to get power claim for miner: %s", err)
-		outCh <- NewOutputErr(err)
-		return
+		return nil, nil, nil, err
 	}
 	wins := w.election.IsWinner(electionVRFDigest[:], minerPower, networkPower)
 	if !wins {
 		// no winners we are done
-		won = false
-		return
+		return nil, nil, nil, nil
 	}
 
 	// we have a winning block
 	sectorSetAncestor, err := w.lookbackTipset(ctx, base, nullBlkCount, consensus.WinningPoStSectorSetLookback)
 	if err != nil {
 		log.Errorf("Worker.Mine couldn't get ancestor tipset: %s", err.Error())
-		outCh <- NewOutputErr(err)
-		return
+		return nil, nil, nil, err
 	}
 	sectorStateView, err := w.api.PowerStateView(sectorSetAncestor.Key())
 	if err != nil {
 		log.Errorf("Worker.Mine couldn't get snapshot for tipset: %s", err.Error())
-		outCh <- NewOutputErr(err)
-		return
+		return nil, nil, nil, err
 	}
 
 	posts, err := w.election.GenerateWinningPoSt(ctx, electionEntry, currEpoch, w.poster, w.minerAddr, sectorStateView)
 	if err != nil {
 		log.Warnf("Worker.Mine failed to generate post")
-		outCh <- NewOutputErr(err)
-		return
+		return nil, nil, nil, err
 	}
 
-	next := w.Generate(ctx, base, nextTicket, electionVRFProof, abi.ChainEpoch(nullBlkCount), posts, drandEntries)
-	if next.Err == nil {
-		log.Debugf("Worker.Mine generates new winning block! %s", next.Header.Cid().String())
-	}
-	outCh <- next
-	return true
+	return w.Generate(ctx, base, nextTicket, electionVRFProof, abi.ChainEpoch(nullBlkCount), posts, drandEntries)
 }
 
 func (w *DefaultWorker) getPowerTable(powerKey, faultsKey block.TipSetKey) (consensus.PowerTableView, error) {

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -89,11 +89,11 @@ func TestLookbackElection(t *testing.T) {
 			Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 		})
 
-		header, _, _, err := worker.Mine(ctx, head, 0)
+		blk, err := worker.Mine(ctx, head, 0)
 		assert.NoError(t, err)
 
 		expectedTicket := makeExpectedTicket(ctx, t, rnd, mockSigner, head, miner.ElectionLookback, minerAddr, minerOwnerAddr)
-		assert.Equal(t, expectedTicket, header.Ticket)
+		assert.Equal(t, expectedTicket, blk.Header.Ticket)
 	})
 }
 
@@ -144,11 +144,11 @@ func Test_Mine(t *testing.T) {
 			Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 		})
 
-		header, _, _, err := worker.Mine(ctx, tipSet, 0)
+		blk, err := worker.Mine(ctx, tipSet, 0)
 		assert.NoError(t, err)
 
 		expectedTicket := makeExpectedTicket(ctx, t, rnd, mockSigner, tipSet, miner.ElectionLookback, minerAddr, minerOwnerAddr)
-		assert.Equal(t, expectedTicket, header.Ticket)
+		assert.Equal(t, expectedTicket, blk.Header.Ticket)
 	})
 
 	t.Run("Block generation fails", func(t *testing.T) {
@@ -174,7 +174,7 @@ func Test_Mine(t *testing.T) {
 			Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 		})
 
-		_, _, _, err := worker.Mine(ctx, tipSet, 0)
+		_, err := worker.Mine(ctx, tipSet, 0)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "test error retrieving state root")
 	})
@@ -202,7 +202,7 @@ func Test_Mine(t *testing.T) {
 			Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 		})
 		input := block.TipSet{}
-		_, _, _, err := worker.Mine(ctx, input, 0)
+		_, err := worker.Mine(ctx, input, 0)
 		assert.EqualError(t, err, "bad input tipset with no blocks sent to Mine()")
 	})
 }
@@ -361,11 +361,11 @@ func TestApplyBLSMessages(t *testing.T) {
 		Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 	})
 
-	block, _, _, err := worker.Mine(ctx, tipSet, 0)
+	block, err := worker.Mine(ctx, tipSet, 0)
 	require.NoError(t, err)
 
 	t.Run("messages are divided into bls and secp messages", func(t *testing.T) {
-		secpMessages, blsMessages, err := msgStore.LoadMessages(ctx, block.Messages.Cid)
+		secpMessages, blsMessages, err := msgStore.LoadMessages(ctx, block.Header.Messages.Cid)
 		require.NoError(t, err)
 
 		assert.Len(t, secpMessages, 5)
@@ -381,7 +381,7 @@ func TestApplyBLSMessages(t *testing.T) {
 	})
 
 	t.Run("all 10 messages are stored", func(t *testing.T) {
-		secpMessages, blsMessages, err := msgStore.LoadMessages(ctx, block.Messages.Cid)
+		secpMessages, blsMessages, err := msgStore.LoadMessages(ctx, block.Header.Messages.Cid)
 		require.NoError(t, err)
 
 		assert.Len(t, secpMessages, 5)
@@ -392,7 +392,7 @@ func TestApplyBLSMessages(t *testing.T) {
 		digests := []bls.Digest{}
 		keys := []bls.PublicKey{}
 
-		_, blsMessages, err := msgStore.LoadMessages(ctx, block.Messages.Cid)
+		_, blsMessages, err := msgStore.LoadMessages(ctx, block.Header.Messages.Cid)
 		require.NoError(t, err)
 		for _, msg := range blsMessages {
 			msgBytes, err := msg.Marshal()
@@ -405,7 +405,7 @@ func TestApplyBLSMessages(t *testing.T) {
 		}
 
 		blsSig := bls.Signature{}
-		copy(blsSig[:], block.BLSAggregateSig.Data)
+		copy(blsSig[:], block.Header.BLSAggregateSig.Data)
 		valid := bls.Verify(&blsSig, digests, keys)
 
 		assert.True(t, valid)
@@ -463,24 +463,24 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 	baseTipset := builder.AppendOn(parentTipset, 2)
 	assert.Equal(t, 2, baseTipset.Len())
 
-	header, _, _, err := worker.Generate(ctx, baseTipset, block.Ticket{VRFProof: []byte{2}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
+	blk, err := worker.Generate(ctx, baseTipset, block.Ticket{VRFProof: []byte{2}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
 	assert.NoError(t, err)
 
-	txMeta, err := messages.LoadTxMeta(ctx, header.Messages.Cid)
+	txMeta, err := messages.LoadTxMeta(ctx, blk.Header.Messages.Cid)
 	require.NoError(t, err)
 	assert.Equal(t, types.EmptyMessagesCID, txMeta.SecpRoot.Cid)
 
 	expectedStateRoot, err := meta.GetTipSetStateRoot(parentTipset.Key())
 	require.NoError(t, err)
-	assert.Equal(t, expectedStateRoot, header.StateRoot.Cid)
+	assert.Equal(t, expectedStateRoot, blk.Header.StateRoot.Cid)
 
 	expectedReceipts, err := meta.GetTipSetReceiptsRoot(parentTipset.Key())
 	require.NoError(t, err)
-	assert.Equal(t, expectedReceipts, header.MessageReceipts.Cid)
+	assert.Equal(t, expectedReceipts, blk.Header.MessageReceipts.Cid)
 
-	assert.Equal(t, uint64(101), header.Height)
-	assert.Equal(t, fbig.NewInt(120), header.ParentWeight)
-	assert.Equal(t, block.Ticket{VRFProof: []byte{2}}, header.Ticket)
+	assert.Equal(t, uint64(101), blk.Header.Height)
+	assert.Equal(t, fbig.NewInt(120), blk.Header.ParentWeight)
+	assert.Equal(t, block.Ticket{VRFProof: []byte{2}}, blk.Header.Ticket)
 }
 
 // After calling Generate, do the new block and new state of the message pool conform to our expectations?
@@ -567,7 +567,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		StateRoot: e.NewCid(stateRoot),
 	}
 
-	header, _, _, err := worker.Generate(ctx, block.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
+	blk, err := worker.Generate(ctx, block.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
 	assert.NoError(t, err)
 
 	// This is the temporary failure + the good message,
@@ -578,7 +578,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 
 	// message and receipts can be loaded from message store and have
 	// length 1.
-	msgs, _, err := messages.LoadMessages(ctx, header.Messages.Cid)
+	msgs, _, err := messages.LoadMessages(ctx, blk.Header.Messages.Cid)
 	require.NoError(t, err)
 	assert.Len(t, msgs, 1) // This is the good message
 }
@@ -632,19 +632,19 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 	}
 	baseTipSet := block.RequireNewTipSet(t, &baseBlock)
 	ticket := mining.NthTicket(7)
-	header, _, _, err := worker.Generate(ctx, baseTipSet, ticket, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
+	blk, err := worker.Generate(ctx, baseTipSet, ticket, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, h+1, header.Height)
-	assert.Equal(t, minerAddr, header.Miner)
-	assert.Equal(t, ticket, header.Ticket)
+	assert.Equal(t, h+1, blk.Header.Height)
+	assert.Equal(t, minerAddr, blk.Header.Miner)
+	assert.Equal(t, ticket, blk.Header.Ticket)
 
-	header, _, _, err = worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 1, consensus.MakeFakePoStsForTest(), nil)
+	blk, err = worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 1, consensus.MakeFakePoStsForTest(), nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, h+2, header.Height)
-	assert.Equal(t, fbig.Add(w, fbig.NewInt(10.0)), header.ParentWeight)
-	assert.Equal(t, minerAddr, header.Miner)
+	assert.Equal(t, h+2, blk.Header.Height)
+	assert.Equal(t, fbig.Add(w, fbig.NewInt(10.0)), blk.Header.ParentWeight)
+	assert.Equal(t, minerAddr, blk.Header.Miner)
 }
 
 func TestGenerateWithoutMessages(t *testing.T) {
@@ -688,11 +688,11 @@ func TestGenerateWithoutMessages(t *testing.T) {
 		Height:    100,
 		StateRoot: e.NewCid(newCid()),
 	}
-	header, _, _, err := worker.Generate(ctx, block.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
+	blk, err := worker.Generate(ctx, block.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
 	assert.NoError(t, err)
 
 	assert.Len(t, pool.Pending(), 0) // This is the temporary failure.
-	txMeta, err := messages.LoadTxMeta(ctx, header.Messages.Cid)
+	txMeta, err := messages.LoadTxMeta(ctx, blk.Header.Messages.Cid)
 	require.NoError(t, err)
 	assert.Equal(t, types.EmptyMessagesCID, txMeta.SecpRoot.Cid)
 	assert.Equal(t, types.EmptyMessagesCID, txMeta.BLSRoot.Cid)
@@ -749,9 +749,9 @@ func TestGenerateError(t *testing.T) {
 		StateRoot: e.NewCid(newCid()),
 	}
 	baseTipSet := block.RequireNewTipSet(t, &baseBlock)
-	header, _, _, err := worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
+	blk, err := worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
 	assert.Error(t, err, "boom")
-	assert.Nil(t, header)
+	assert.Nil(t, blk.Header)
 
 	assert.Len(t, pool.Pending(), 1) // No messages are removed from the pool.
 }

--- a/internal/pkg/mining/worker_test.go
+++ b/internal/pkg/mining/worker_test.go
@@ -69,7 +69,6 @@ func TestLookbackElection(t *testing.T) {
 	t.Run("Election sees ticket lookback ancestors back", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		outCh := make(chan mining.Output)
 		worker := mining.NewDefaultWorker(mining.WorkerParameters{
 			API: th.NewDefaultFakeWorkerPorcelainAPI(blockSignerAddr, rnd),
 
@@ -90,12 +89,11 @@ func TestLookbackElection(t *testing.T) {
 			Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 		})
 
-		go worker.Mine(ctx, head, 0, outCh)
-		r := <-outCh
-		assert.NoError(t, r.Err)
+		header, _, _, err := worker.Mine(ctx, head, 0)
+		assert.NoError(t, err)
 
 		expectedTicket := makeExpectedTicket(ctx, t, rnd, mockSigner, head, miner.ElectionLookback, minerAddr, minerOwnerAddr)
-		assert.Equal(t, expectedTicket, r.Header.Ticket)
+		assert.Equal(t, expectedTicket, header.Ticket)
 	})
 }
 
@@ -126,7 +124,6 @@ func Test_Mine(t *testing.T) {
 	t.Run("Trivial success case", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		outCh := make(chan mining.Output)
 		worker := mining.NewDefaultWorker(mining.WorkerParameters{
 			API: th.NewDefaultFakeWorkerPorcelainAPI(blockSignerAddr, rnd),
 
@@ -147,12 +144,11 @@ func Test_Mine(t *testing.T) {
 			Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 		})
 
-		go worker.Mine(ctx, tipSet, 0, outCh)
-		r := <-outCh
-		assert.NoError(t, r.Err)
+		header, _, _, err := worker.Mine(ctx, tipSet, 0)
+		assert.NoError(t, err)
 
 		expectedTicket := makeExpectedTicket(ctx, t, rnd, mockSigner, tipSet, miner.ElectionLookback, minerAddr, minerOwnerAddr)
-		assert.Equal(t, expectedTicket, r.Header.Ticket)
+		assert.Equal(t, expectedTicket, header.Ticket)
 	})
 
 	t.Run("Block generation fails", func(t *testing.T) {
@@ -177,12 +173,10 @@ func Test_Mine(t *testing.T) {
 			MessageStore:     messages,
 			Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 		})
-		outCh := make(chan mining.Output)
 
-		go worker.Mine(ctx, tipSet, 0, outCh)
-		r := <-outCh
-		require.Error(t, r.Err)
-		assert.Contains(t, r.Err.Error(), "test error retrieving state root")
+		_, _, _, err := worker.Mine(ctx, tipSet, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "test error retrieving state root")
 	})
 
 	t.Run("Sent empty tipset", func(t *testing.T) {
@@ -208,10 +202,8 @@ func Test_Mine(t *testing.T) {
 			Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 		})
 		input := block.TipSet{}
-		outCh := make(chan mining.Output)
-		go worker.Mine(ctx, input, 0, outCh)
-		r := <-outCh
-		assert.EqualError(t, r.Err, "bad input tipset with no blocks sent to Mine()")
+		_, _, _, err := worker.Mine(ctx, input, 0)
+		assert.EqualError(t, err, "bad input tipset with no blocks sent to Mine()")
 	})
 }
 
@@ -369,11 +361,8 @@ func TestApplyBLSMessages(t *testing.T) {
 		Clock:            clock.NewChainClock(100000000, 30*time.Second, 6*time.Second),
 	})
 
-	outCh := make(chan mining.Output)
-	go worker.Mine(ctx, tipSet, 0, outCh)
-	r := <-outCh
-	require.NoError(t, r.Err)
-	block := r.Header
+	block, _, _, err := worker.Mine(ctx, tipSet, 0)
+	require.NoError(t, err)
 
 	t.Run("messages are divided into bls and secp messages", func(t *testing.T) {
 		secpMessages, blsMessages, err := msgStore.LoadMessages(ctx, block.Messages.Cid)
@@ -474,24 +463,24 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 	baseTipset := builder.AppendOn(parentTipset, 2)
 	assert.Equal(t, 2, baseTipset.Len())
 
-	out := worker.Generate(ctx, baseTipset, block.Ticket{VRFProof: []byte{2}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
-	assert.NoError(t, out.Err)
+	header, _, _, err := worker.Generate(ctx, baseTipset, block.Ticket{VRFProof: []byte{2}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
+	assert.NoError(t, err)
 
-	txMeta, err := messages.LoadTxMeta(ctx, out.Header.Messages.Cid)
+	txMeta, err := messages.LoadTxMeta(ctx, header.Messages.Cid)
 	require.NoError(t, err)
 	assert.Equal(t, types.EmptyMessagesCID, txMeta.SecpRoot.Cid)
 
 	expectedStateRoot, err := meta.GetTipSetStateRoot(parentTipset.Key())
 	require.NoError(t, err)
-	assert.Equal(t, expectedStateRoot, out.Header.StateRoot.Cid)
+	assert.Equal(t, expectedStateRoot, header.StateRoot.Cid)
 
 	expectedReceipts, err := meta.GetTipSetReceiptsRoot(parentTipset.Key())
 	require.NoError(t, err)
-	assert.Equal(t, expectedReceipts, out.Header.MessageReceipts.Cid)
+	assert.Equal(t, expectedReceipts, header.MessageReceipts.Cid)
 
-	assert.Equal(t, uint64(101), out.Header.Height)
-	assert.Equal(t, fbig.NewInt(120), out.Header.ParentWeight)
-	assert.Equal(t, block.Ticket{VRFProof: []byte{2}}, out.Header.Ticket)
+	assert.Equal(t, uint64(101), header.Height)
+	assert.Equal(t, fbig.NewInt(120), header.ParentWeight)
+	assert.Equal(t, block.Ticket{VRFProof: []byte{2}}, header.Ticket)
 }
 
 // After calling Generate, do the new block and new state of the message pool conform to our expectations?
@@ -578,8 +567,8 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 		StateRoot: e.NewCid(stateRoot),
 	}
 
-	out := worker.Generate(ctx, block.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
-	assert.NoError(t, out.Err)
+	header, _, _, err := worker.Generate(ctx, block.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
+	assert.NoError(t, err)
 
 	// This is the temporary failure + the good message,
 	// which will be removed by the node if this block is accepted.
@@ -589,7 +578,7 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 
 	// message and receipts can be loaded from message store and have
 	// length 1.
-	msgs, _, err := messages.LoadMessages(ctx, out.Header.Messages.Cid)
+	msgs, _, err := messages.LoadMessages(ctx, header.Messages.Cid)
 	require.NoError(t, err)
 	assert.Len(t, msgs, 1) // This is the good message
 }
@@ -643,19 +632,19 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 	}
 	baseTipSet := block.RequireNewTipSet(t, &baseBlock)
 	ticket := mining.NthTicket(7)
-	out := worker.Generate(ctx, baseTipSet, ticket, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
-	assert.NoError(t, out.Err)
+	header, _, _, err := worker.Generate(ctx, baseTipSet, ticket, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
+	assert.NoError(t, err)
 
-	assert.Equal(t, h+1, out.Header.Height)
-	assert.Equal(t, minerAddr, out.Header.Miner)
-	assert.Equal(t, ticket, out.Header.Ticket)
+	assert.Equal(t, h+1, header.Height)
+	assert.Equal(t, minerAddr, header.Miner)
+	assert.Equal(t, ticket, header.Ticket)
 
-	out = worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 1, consensus.MakeFakePoStsForTest(), nil)
-	assert.NoError(t, out.Err)
+	header, _, _, err = worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 1, consensus.MakeFakePoStsForTest(), nil)
+	assert.NoError(t, err)
 
-	assert.Equal(t, h+2, out.Header.Height)
-	assert.Equal(t, fbig.Add(w, fbig.NewInt(10.0)), out.Header.ParentWeight)
-	assert.Equal(t, minerAddr, out.Header.Miner)
+	assert.Equal(t, h+2, header.Height)
+	assert.Equal(t, fbig.Add(w, fbig.NewInt(10.0)), header.ParentWeight)
+	assert.Equal(t, minerAddr, header.Miner)
 }
 
 func TestGenerateWithoutMessages(t *testing.T) {
@@ -699,11 +688,11 @@ func TestGenerateWithoutMessages(t *testing.T) {
 		Height:    100,
 		StateRoot: e.NewCid(newCid()),
 	}
-	out := worker.Generate(ctx, block.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
-	assert.NoError(t, out.Err)
+	header, _, _, err := worker.Generate(ctx, block.RequireNewTipSet(t, &baseBlock), block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
+	assert.NoError(t, err)
 
 	assert.Len(t, pool.Pending(), 0) // This is the temporary failure.
-	txMeta, err := messages.LoadTxMeta(ctx, out.Header.Messages.Cid)
+	txMeta, err := messages.LoadTxMeta(ctx, header.Messages.Cid)
 	require.NoError(t, err)
 	assert.Equal(t, types.EmptyMessagesCID, txMeta.SecpRoot.Cid)
 	assert.Equal(t, types.EmptyMessagesCID, txMeta.BLSRoot.Cid)
@@ -760,9 +749,9 @@ func TestGenerateError(t *testing.T) {
 		StateRoot: e.NewCid(newCid()),
 	}
 	baseTipSet := block.RequireNewTipSet(t, &baseBlock)
-	out := worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
-	assert.Error(t, out.Err, "boom")
-	assert.Nil(t, out.Header)
+	header, _, _, err := worker.Generate(ctx, baseTipSet, block.Ticket{VRFProof: []byte{0}}, consensus.MakeFakeVRFProofForTest(), 0, consensus.MakeFakePoStsForTest(), nil)
+	assert.Error(t, err, "boom")
+	assert.Nil(t, header)
 
 	assert.Len(t, pool.Pending(), 1) // No messages are removed from the pool.
 }

--- a/internal/pkg/protocol/mining/mining_api.go
+++ b/internal/pkg/protocol/mining/mining_api.go
@@ -87,7 +87,7 @@ func (a *API) MiningOnce(ctx context.Context) (*block.Block, error) {
 		return nil, err
 	}
 
-	if err := a.addNewBlockFunc(ctx, res); err != nil {
+	if err := a.addNewBlockFunc(ctx, *res); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/protocol/mining/mining_api.go
+++ b/internal/pkg/protocol/mining/mining_api.go
@@ -19,7 +19,7 @@ type miningChainReader interface {
 // API provides an interface to the block mining protocol.
 type API struct {
 	minerAddress    func() (address.Address, error)
-	addNewBlockFunc func(context.Context, mining.Output) (err error)
+	addNewBlockFunc func(context.Context, mining.FullBlock) (err error)
 	chainReader     miningChainReader
 	isMiningFunc    func() bool
 	setupMiningFunc func(context.Context) error
@@ -32,7 +32,7 @@ type API struct {
 // New creates a new API instance with the provided deps
 func New(
 	minerAddr func() (address.Address, error),
-	addNewBlockFunc func(context.Context, mining.Output) (err error),
+	addNewBlockFunc func(context.Context, mining.FullBlock) (err error),
 	chainReader miningChainReader,
 	isMiningFunc func() bool,
 	setupMiningFunc func(ctx context.Context) error,
@@ -82,9 +82,9 @@ func (a *API) MiningOnce(ctx context.Context) (*block.Block, error) {
 		return nil, err
 	}
 
-	res := mining.MineOnce(ctx, *miningWorker, ts)
-	if res.Err != nil {
-		return nil, res.Err
+	res, err := mining.MineOnce(ctx, *miningWorker, ts)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := a.addNewBlockFunc(ctx, res); err != nil {


### PR DESCRIPTION
### Motivation

Block mining used to occur within nested goroutines. This was causing problems, so it has been simplified to run synchronously. This makes the channel communication it used to use to communicate errors and output unnecessary. This PR removes that channel and replaces it with simple return statements.

### Proposed changes

1. Remove channel argument from worker Generate function and return block header, messsages and error directly.
2. Move `Output` struct to scheduler (which still needs to communicate via channel) and rename to `FullBlock`.
3. Remove channel argument from `worker.MIne` and return header, messages and errors instead.
4. Have scheduler log its own errors and signal its shutdown by closing its output channel (which will trigger a shutdown of mining).
5. __Important__: The scheduler no longer treats an error in mining as unrecoverable. Instead it logs the error and continues in hopes that it will be able to recover by the next epoch. The upside is a lower chance of missing mining opportunities because due to a one off error. The downside is receiving a new error per epoch due to an unrecoverable error.

Closes #4145
