### PR TITLE
add lookback parameter to message wait command

### DIFF
--- a/internal/app/go-filecoin/plumbing/api.go
+++ b/internal/app/go-filecoin/plumbing/api.go
@@ -253,8 +253,8 @@ func (api *API) SignedMessageSend(ctx context.Context, smsg *types.SignedMessage
 // the case that it appears in a newly mined block. An error is returned if one is
 // encountered or if the context is canceled. Otherwise, it waits forever for the message
 // to appear on chain.
-func (api *API) MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*block.Block, *types.SignedMessage, *vm.MessageReceipt) error) error {
-	return api.msgWaiter.Wait(ctx, msgCid, msg.DefaultMessageWaitLookback, cb)
+func (api *API) MessageWait(ctx context.Context, msgCid cid.Cid, lookback uint64, cb func(*block.Block, *types.SignedMessage, *vm.MessageReceipt) error) error {
+	return api.msgWaiter.Wait(ctx, msgCid, lookback, cb)
 }
 
 // NetworkGetBandwidthStats gets stats on the current bandwidth usage of the network

--- a/internal/app/go-filecoin/porcelain/message.go
+++ b/internal/app/go-filecoin/porcelain/message.go
@@ -3,6 +3,8 @@ package porcelain
 import (
 	"context"
 
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/plumbing/msg"
+
 	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/internal/pkg/block"
@@ -12,14 +14,14 @@ import (
 )
 
 type waitPlumbing interface {
-	MessageWait(context.Context, cid.Cid, func(*block.Block, *types.SignedMessage, *vm.MessageReceipt) error) error
+	MessageWait(context.Context, cid.Cid, uint64, func(*block.Block, *types.SignedMessage, *vm.MessageReceipt) error) error
 }
 
 // MessageWaitDone blocks until the given message cid appears on chain
 func MessageWaitDone(ctx context.Context, plumbing waitPlumbing, msgCid cid.Cid) (*vm.MessageReceipt, error) {
 	l := moresync.NewLatch(1)
 	var ret *vm.MessageReceipt
-	err := plumbing.MessageWait(ctx, msgCid, func(_ *block.Block, _ *types.SignedMessage, rcpt *vm.MessageReceipt) error {
+	err := plumbing.MessageWait(ctx, msgCid, msg.DefaultMessageWaitLookback, func(_ *block.Block, _ *types.SignedMessage, rcpt *vm.MessageReceipt) error {
 		ret = rcpt
 		l.Done()
 		return nil

--- a/internal/app/go-filecoin/porcelain/miner.go
+++ b/internal/app/go-filecoin/porcelain/miner.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/filecoin-project/go-filecoin/internal/app/go-filecoin/plumbing/msg"
+
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 
 	address "github.com/filecoin-project/go-address"
@@ -28,7 +30,7 @@ type mcAPI interface {
 	ConfigGet(dottedPath string) (interface{}, error)
 	ConfigSet(dottedPath string, paramJSON string) error
 	MessageSend(ctx context.Context, from, to address.Address, value types.AttoFIL, gasPrice types.AttoFIL, gasLimit gas.Unit, method abi.MethodNum, params interface{}) (cid.Cid, chan error, error)
-	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*block.Block, *types.SignedMessage, *vm.MessageReceipt) error) error
+	MessageWait(ctx context.Context, msgCid cid.Cid, lookback uint64, cb func(*block.Block, *types.SignedMessage, *vm.MessageReceipt) error) error
 	WalletDefaultAddress() (address.Address, error)
 }
 
@@ -94,7 +96,7 @@ func MinerCreate(
 	}
 
 	var result power.CreateMinerReturn
-	err = plumbing.MessageWait(ctx, smsgCid, func(blk *block.Block, smsg *types.SignedMessage, receipt *vm.MessageReceipt) (err error) {
+	err = plumbing.MessageWait(ctx, smsgCid, msg.DefaultMessageWaitLookback, func(blk *block.Block, smsg *types.SignedMessage, receipt *vm.MessageReceipt) (err error) {
 		if receipt.ExitCode != exitcode.Ok {
 			// Dragons: do we want to have this back?
 			return fmt.Errorf("Error executing actor code (exitcode: %d)", receipt.ExitCode)

--- a/internal/app/go-filecoin/porcelain/miner_test.go
+++ b/internal/app/go-filecoin/porcelain/miner_test.go
@@ -69,7 +69,7 @@ func (mpc *minerCreate) MessageSend(ctx context.Context, from, to address.Addres
 	return mpc.msgCid, nil, nil
 }
 
-func (mpc *minerCreate) MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*block.Block, *types.SignedMessage, *vm.MessageReceipt) error) error {
+func (mpc *minerCreate) MessageWait(ctx context.Context, msgCid cid.Cid, lookback uint64, cb func(*block.Block, *types.SignedMessage, *vm.MessageReceipt) error) error {
 	assert.Equal(mpc.testing, msgCid, msgCid)
 	midAddr, err := address.NewIDAddress(100)
 	if err != nil {


### PR DESCRIPTION
### Motivation

We have changed the behavior of message wait so that it will, by default, only look back a couple of tipsets for messages that have landed on chain. This makes it a lot safer, but it means that we no longer have anyway to search for messages that we know have landed on chain more than a couple tipsets back. This PR adds a `lookback` parameter to the message wait command so users can search for messages before waiting. We may want a variant that searches and does not wait, but this parameter is useful nonetheless.

This parameter needed to be tested, but our message wait integration tests were skipped. This PR also does some infrastructure work to get those tests working with new testing patterns and unskips the tests.

### Proposed changes

1. Introduce new `lookback` parameter to `message wait` command.
2. Refactor command in-process test infrastructure to support single node with deterministic mining.
3. Restore integration tests as in-process tests.
