### PR TITLE
resolve miner address before using it to derive seal randomness

### DIFF
--- a/internal/app/go-filecoin/connectors/fsm_node/connector.go
+++ b/internal/app/go-filecoin/connectors/fsm_node/connector.go
@@ -254,18 +254,8 @@ func (f *FiniteStateMachineNodeConnector) ChainGetTicket(ctx context.Context, to
 
 	randomEpoch := epoch - miner.ChainFinalityish
 
-	// resolve miner address if it is not already
-	view, err := f.stateViewer.StateView(ts.Key())
-	if err != nil {
-		return abi.SealRandomness{}, 0, err
-	}
-	minerIDAddr, err := view.InitResolveAddress(ctx, f.minerAddr)
-	if err != nil {
-		return abi.SealRandomness{}, 0, err
-	}
-
 	buf := new(bytes.Buffer)
-	err = minerIDAddr.MarshalCBOR(buf)
+	err = f.minerAddr.MarshalCBOR(buf)
 	if err != nil {
 		return abi.SealRandomness{}, 0, err
 	}

--- a/internal/app/go-filecoin/connectors/fsm_node/connector.go
+++ b/internal/app/go-filecoin/connectors/fsm_node/connector.go
@@ -254,8 +254,18 @@ func (f *FiniteStateMachineNodeConnector) ChainGetTicket(ctx context.Context, to
 
 	randomEpoch := epoch - miner.ChainFinalityish
 
+	// resolve miner address if it is not already
+	view, err := f.stateViewer.StateView(ts.Key())
+	if err != nil {
+		return abi.SealRandomness{}, 0, err
+	}
+	minerIDAddr, err := view.InitResolveAddress(ctx, f.minerAddr)
+	if err != nil {
+		return abi.SealRandomness{}, 0, err
+	}
+
 	buf := new(bytes.Buffer)
-	err = f.minerAddr.MarshalCBOR(buf)
+	err = minerIDAddr.MarshalCBOR(buf)
 	if err != nil {
 		return abi.SealRandomness{}, 0, err
 	}


### PR DESCRIPTION
### Motivation

A miner address may be a stable actor address or an ID address. When deriving seal randomness, the entropy must be derived from an ID address, so we should resolve the ID address before passing it into the connector.

The first pass at this would resolve the address just prior to use. This is more correct, because it accounts for the possibility that the ID address changes between the time the connector is constructed and the time the address is used due to a re-org. Unfortunately, this won't work because it would cause the miner address to go out of sync with the storage-fsm. I looked into fixing the storage fsm, but it would touch almost the entire interface between it and the node connector. 

For now I'll leave this simpler solution and miners will need to wait some period of time between creating a miner and starting the mining process.

### Proposed changes

1. Resolve ID address before constructing connector.

Closes #4126

