### PR TITLE
Use latest go-fil-markets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v0.3.0
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
-	github.com/filecoin-project/go-fil-markets v0.2.5
+	github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520170426-0b21b9191ba5
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200505180321-973f8949ea8e
 	github.com/filecoin-project/go-statestore v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v0.3.0
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
-	github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520213537-19255befc605
+	github.com/filecoin-project/go-fil-markets v0.2.7
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200505180321-973f8949ea8e
 	github.com/filecoin-project/go-statestore v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v0.3.0
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
-	github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520170426-0b21b9191ba5
+	github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520213537-19255befc605
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200505180321-973f8949ea8e
 	github.com/filecoin-project/go-statestore v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,7 @@ github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
 github.com/filecoin-project/go-fil-markets v0.2.5 h1:JKNYUUHPIXyCaqj98/15Toz0X6w/z5KchaaQr6JGVFQ=
 github.com/filecoin-project/go-fil-markets v0.2.5/go.mod h1:LI3VFHse33aU0djAmFQ8+Hg39i0J8ibAoppGu6TbgkA=
+github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520170426-0b21b9191ba5/go.mod h1:LI3VFHse33aU0djAmFQ8+Hg39i0J8ibAoppGu6TbgkA=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543 h1:aMJGfgqe1QDhAVwxRg5fjCRF533xHidiKsugk7Vvzug=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543/go.mod h1:mjrHv1cDGJWDlGmC0eDc1E5VJr8DmL9XMUcaFwiuKg8=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:92PET+sx1Hb4W/8CgFwGuxaKbttwY+UNspYZTvXY0vs=

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,6 @@ github.com/filecoin-project/go-data-transfer v0.3.0 h1:BwBrrXu9Unh9JjjX4GAc5FfzU
 github.com/filecoin-project/go-data-transfer v0.3.0/go.mod h1:cONglGP4s/d+IUQw5mWZrQK+FQATQxr3AXzi4dRh0l4=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1:yvQJCW9mmi9zy+51xA01Ea2X7/dL7r8eKDPuGUjRmbo=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
-github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520170426-0b21b9191ba5 h1:exWXvmLZ4nG1EzYLDPYgi3l5jK2QdNLpvSoEZzphF70=
-github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520170426-0b21b9191ba5/go.mod h1:LI3VFHse33aU0djAmFQ8+Hg39i0J8ibAoppGu6TbgkA=
 github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520213537-19255befc605 h1:V5BjLBZgTWYESlgApL7Jpuiyb/OntLgJxG4gAwf0WwM=
 github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520213537-19255befc605/go.mod h1:LI3VFHse33aU0djAmFQ8+Hg39i0J8ibAoppGu6TbgkA=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543 h1:aMJGfgqe1QDhAVwxRg5fjCRF533xHidiKsugk7Vvzug=

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/filecoin-project/go-data-transfer v0.3.0 h1:BwBrrXu9Unh9JjjX4GAc5FfzU
 github.com/filecoin-project/go-data-transfer v0.3.0/go.mod h1:cONglGP4s/d+IUQw5mWZrQK+FQATQxr3AXzi4dRh0l4=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1:yvQJCW9mmi9zy+51xA01Ea2X7/dL7r8eKDPuGUjRmbo=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
-github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520213537-19255befc605 h1:V5BjLBZgTWYESlgApL7Jpuiyb/OntLgJxG4gAwf0WwM=
-github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520213537-19255befc605/go.mod h1:LI3VFHse33aU0djAmFQ8+Hg39i0J8ibAoppGu6TbgkA=
+github.com/filecoin-project/go-fil-markets v0.2.7 h1:bgdK/e+xW15aVZLtdFLzAHdrx1hqtGF9veg2lstLK6o=
+github.com/filecoin-project/go-fil-markets v0.2.7/go.mod h1:LI3VFHse33aU0djAmFQ8+Hg39i0J8ibAoppGu6TbgkA=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543 h1:aMJGfgqe1QDhAVwxRg5fjCRF533xHidiKsugk7Vvzug=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543/go.mod h1:mjrHv1cDGJWDlGmC0eDc1E5VJr8DmL9XMUcaFwiuKg8=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:92PET+sx1Hb4W/8CgFwGuxaKbttwY+UNspYZTvXY0vs=

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,8 @@ github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
 github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520170426-0b21b9191ba5 h1:exWXvmLZ4nG1EzYLDPYgi3l5jK2QdNLpvSoEZzphF70=
 github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520170426-0b21b9191ba5/go.mod h1:LI3VFHse33aU0djAmFQ8+Hg39i0J8ibAoppGu6TbgkA=
+github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520213537-19255befc605 h1:V5BjLBZgTWYESlgApL7Jpuiyb/OntLgJxG4gAwf0WwM=
+github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520213537-19255befc605/go.mod h1:LI3VFHse33aU0djAmFQ8+Hg39i0J8ibAoppGu6TbgkA=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543 h1:aMJGfgqe1QDhAVwxRg5fjCRF533xHidiKsugk7Vvzug=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543/go.mod h1:mjrHv1cDGJWDlGmC0eDc1E5VJr8DmL9XMUcaFwiuKg8=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:92PET+sx1Hb4W/8CgFwGuxaKbttwY+UNspYZTvXY0vs=

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,7 @@ github.com/filecoin-project/go-data-transfer v0.3.0 h1:BwBrrXu9Unh9JjjX4GAc5FfzU
 github.com/filecoin-project/go-data-transfer v0.3.0/go.mod h1:cONglGP4s/d+IUQw5mWZrQK+FQATQxr3AXzi4dRh0l4=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1:yvQJCW9mmi9zy+51xA01Ea2X7/dL7r8eKDPuGUjRmbo=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
-github.com/filecoin-project/go-fil-markets v0.2.5 h1:JKNYUUHPIXyCaqj98/15Toz0X6w/z5KchaaQr6JGVFQ=
-github.com/filecoin-project/go-fil-markets v0.2.5/go.mod h1:LI3VFHse33aU0djAmFQ8+Hg39i0J8ibAoppGu6TbgkA=
+github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520170426-0b21b9191ba5 h1:exWXvmLZ4nG1EzYLDPYgi3l5jK2QdNLpvSoEZzphF70=
 github.com/filecoin-project/go-fil-markets v0.2.7-0.20200520170426-0b21b9191ba5/go.mod h1:LI3VFHse33aU0djAmFQ8+Hg39i0J8ibAoppGu6TbgkA=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543 h1:aMJGfgqe1QDhAVwxRg5fjCRF533xHidiKsugk7Vvzug=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543/go.mod h1:mjrHv1cDGJWDlGmC0eDc1E5VJr8DmL9XMUcaFwiuKg8=

--- a/internal/app/go-filecoin/internal/submodule/retrieval_protocol_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/retrieval_protocol_submodule.go
@@ -18,6 +18,15 @@ import (
 	"github.com/filecoin-project/go-filecoin/internal/pkg/piecemanager"
 )
 
+// RetrievalProviderDSPrefix is a prefix for all datastore keys related to the retrieval provider
+const RetrievalProviderDSPrefix = "retrievalmarket/provider"
+
+// RetrievalCounterDSKey is the datastore key for the stored counter used by the retrieval counter
+const RetrievalCounterDSKey = "retrievalmarket/client/counter"
+
+// RetrievalClientDSPrefix is a prefix for all datastore keys related to the retrieval clients
+const RetrievalClientDSPrefix = "retrievalmarket/client"
+
 // RetrievalProtocolSubmodule enhances the node with retrieval protocol
 // capabilities.
 type RetrievalProtocolSubmodule struct {
@@ -37,23 +46,23 @@ func NewRetrievalProtocolSubmodule(
 	pieceManager piecemanager.PieceManager,
 ) (*RetrievalProtocolSubmodule, error) {
 
-	retrievalDealPieceStore := piecestore.NewPieceStore(ds)
+	retrievalDealPieceStore := piecestore.NewPieceStore(namespace.Wrap(ds, datastore.NewKey(PieceStoreDSPrefix)))
 
 	netwk := network.NewFromLibp2pHost(host)
 	pnode := retmkt.NewRetrievalProviderConnector(netwk, pieceManager, bs, pchMgrAPI, nil)
 
 	// TODO: use latest go-fil-markets with persisted deal store\
 
-	marketProvider, err := impl.NewProvider(providerAddr, pnode, netwk, retrievalDealPieceStore, bs, namespace.Wrap(ds, datastore.NewKey("/retrievalmarket/provider")))
+	marketProvider, err := impl.NewProvider(providerAddr, pnode, netwk, retrievalDealPieceStore, bs, namespace.Wrap(ds, datastore.NewKey(RetrievalProviderDSPrefix)))
 	if err != nil {
 		return nil, err
 	}
 
 	cnode := retmkt.NewRetrievalClientConnector(bs, cr, signer, pchMgrAPI)
-	counter := storedcounter.New(ds, datastore.NewKey("retrievalmarket/client/counter"))
+	counter := storedcounter.New(ds, datastore.NewKey(RetrievalCounterDSKey))
 
-	resolver := discovery.Multi(discovery.NewLocal(ds))
-	marketClient, err := impl.NewClient(netwk, bs, cnode, resolver, namespace.Wrap(ds, datastore.NewKey("retrievalmarket/client")), counter)
+	resolver := discovery.Multi(discovery.NewLocal(namespace.Wrap(ds, datastore.NewKey(DiscoveryDSPrefix))))
+	marketClient, err := impl.NewClient(netwk, bs, cnode, resolver, namespace.Wrap(ds, datastore.NewKey(RetrievalClientDSPrefix)), counter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/go-filecoin/internal/submodule/retrieval_protocol_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/retrieval_protocol_submodule.go
@@ -51,8 +51,6 @@ func NewRetrievalProtocolSubmodule(
 	netwk := network.NewFromLibp2pHost(host)
 	pnode := retmkt.NewRetrievalProviderConnector(netwk, pieceManager, bs, pchMgrAPI, nil)
 
-	// TODO: use latest go-fil-markets with persisted deal store\
-
 	marketProvider, err := impl.NewProvider(providerAddr, pnode, netwk, retrievalDealPieceStore, bs, namespace.Wrap(ds, datastore.NewKey(RetrievalProviderDSPrefix)))
 	if err != nil {
 		return nil, err

--- a/internal/app/go-filecoin/internal/submodule/retrieval_protocol_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/retrieval_protocol_submodule.go
@@ -19,13 +19,13 @@ import (
 )
 
 // RetrievalProviderDSPrefix is a prefix for all datastore keys related to the retrieval provider
-const RetrievalProviderDSPrefix = "retrievalmarket/provider"
+const RetrievalProviderDSPrefix = "/retrievalmarket/provider"
 
 // RetrievalCounterDSKey is the datastore key for the stored counter used by the retrieval counter
-const RetrievalCounterDSKey = "retrievalmarket/client/counter"
+const RetrievalCounterDSKey = "/retrievalmarket/client/counter"
 
 // RetrievalClientDSPrefix is a prefix for all datastore keys related to the retrieval clients
-const RetrievalClientDSPrefix = "retrievalmarket/client"
+const RetrievalClientDSPrefix = "/retrievalmarket/client"
 
 // RetrievalProtocolSubmodule enhances the node with retrieval protocol
 // capabilities.

--- a/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/storage_protocol_submodule.go
@@ -36,22 +36,22 @@ import (
 )
 
 // DiscoveryDSPrefix is a prefix for all datastore keys used by the local
-const DiscoveryDSPrefix = "deals/local"
+const DiscoveryDSPrefix = "/deals/local"
 
 // ClientDSPrefix is a prefix for all datastore keys used by a storage client
-const ClientDSPrefix = "deals/client"
+const ClientDSPrefix = "/deals/client"
 
 // ProviderDSPrefix is a prefix for all datastore keys used by the storage provider
-const ProviderDSPrefix = "deals/provider"
+const ProviderDSPrefix = "/deals/provider"
 
 // DTCounterDSKey is the datastore key for the stored counter used by data transfer
-const DTCounterDSKey = "datatransfer/counter"
+const DTCounterDSKey = "/datatransfer/counter"
 
 // PieceStoreDSPrefix is a prefix for all datastore keys used by the piecestore
-const PieceStoreDSPrefix = "piecestore"
+const PieceStoreDSPrefix = "/piecestore"
 
 // AskDSKey is the datastore key for the stored ask used by the storage provider
-const AskDSKey = "deals/latest-ask"
+const AskDSKey = "/deals/latest-ask"
 
 // StorageProtocolSubmodule enhances the node with storage protocol
 // capabilities.


### PR DESCRIPTION
### Motivation
Upgrade to latest go-fil-markets

### Proposed changes
Upgrade to latest go-fil-markets and make any needed changes to get it working.

Changes include:
- We've now moved prefixing datastores largely out of the markets modules, to allow node implementations to customize how they want to prefix their datastores - the module constructors have been updated minimally to stay compatible with the previous release (any greater customization such as setting up in the config file is left to node maintainers)
- The stored ask is now constructed seperately from the storage provider. We've update to constructors with a minimal implementation here, though node maintainers want to interact directly with the ask it's an option
- Per https://github.com/filecoin-project/go-fil-markets/blob/master/storagemarket/impl/provider.go#L92 there is now a mechanism to add custom decision logic to accepting deals. However, we've left it up to node maintainers to implement this, if they want

Closes #

