### PR TITLE
add block message validation to semantic validation

### DIFF
--- a/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
+++ b/internal/app/go-filecoin/internal/submodule/syncer_submodule.go
@@ -55,7 +55,7 @@ type nodeChainSelector interface {
 func NewSyncerSubmodule(ctx context.Context, config syncerConfig, blockstore *BlockstoreSubmodule, network *NetworkSubmodule,
 	discovery *DiscoverySubmodule, chn *ChainSubmodule, postVerifier consensus.EPoStVerifier) (SyncerSubmodule, error) {
 	// setup validation
-	blkValid := consensus.NewDefaultBlockValidator(config.ChainClock())
+	blkValid := consensus.NewDefaultBlockValidator(config.ChainClock(), chn.MessageStore, chn.State)
 	msgValid := consensus.NewMessageSyntaxValidator()
 	syntax := consensus.WrappedSyntaxValidator{
 		BlockSyntaxValidator:   blkValid,

--- a/internal/pkg/chain/testing.go
+++ b/internal/pkg/chain/testing.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/filecoin-project/go-filecoin/internal/pkg/drand"
 	"testing"
+
+	"github.com/filecoin-project/go-filecoin/internal/pkg/drand"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -456,8 +457,13 @@ func (e *FakeStateEvaluator) RunStateTransition(ctx context.Context, tip block.T
 	return e.ComputeState(stateID, blsMessages, secpMessages)
 }
 
-// ValidateSemantic is a stub that always returns no error
-func (e *FakeStateEvaluator) ValidateSemantic(_ context.Context, _ *block.Block, _ block.TipSet) error {
+// ValidateHeaderSemantic is a stub that always returns no error
+func (e *FakeStateEvaluator) ValidateHeaderSemantic(_ context.Context, _ *block.Block, _ block.TipSet) error {
+	return nil
+}
+
+// ValidateHeaderSemantic is a stub that always returns no error
+func (e *FakeStateEvaluator) ValidateMessagesSemantic(_ context.Context, _ *block.Block, _ block.TipSetKey) error {
 	return nil
 }
 

--- a/internal/pkg/chainsync/chainsync.go
+++ b/internal/pkg/chainsync/chainsync.go
@@ -28,7 +28,7 @@ type Manager struct {
 }
 
 // NewManager creates a new chain sync manager.
-func NewManager(fv syncer.FullBlockValidator, hv syncer.HeaderValidator, cs syncer.ChainSelector, s syncer.ChainReaderWriter, m *chain.MessageStore, f syncer.Fetcher, c clock.Clock, detector *slashing.ConsensusFaultDetector) (Manager, error) {
+func NewManager(fv syncer.FullBlockValidator, hv syncer.BlockValidator, cs syncer.ChainSelector, s syncer.ChainReaderWriter, m *chain.MessageStore, f syncer.Fetcher, c clock.Clock, detector *slashing.ConsensusFaultDetector) (Manager, error) {
 	syncer, err := syncer.NewSyncer(fv, hv, cs, s, m, f, status.NewReporter(), c, detector)
 	if err != nil {
 		return Manager{}, err

--- a/internal/pkg/chainsync/fetcher/graphsync_fetcher_test.go
+++ b/internal/pkg/chainsync/fetcher/graphsync_fetcher_test.go
@@ -61,7 +61,7 @@ func TestGraphsyncFetcher(t *testing.T) {
 	ctx := context.Background()
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 	fc, chainClock := clock.NewFakeChain(1234567890, 5*time.Second, time.Second, time.Now().Unix())
-	bv := consensus.NewDefaultBlockValidator(chainClock)
+	bv := consensus.NewDefaultBlockValidator(chainClock, nil, nil)
 	msgV := &consensus.FakeMessageValidator{}
 	syntax := consensus.WrappedSyntaxValidator{
 		BlockSyntaxValidator:   bv,
@@ -659,7 +659,7 @@ func TestHeadersOnlyGraphsyncFetch(t *testing.T) {
 	fc := clock.NewFake(time.Now())
 	genTime := uint64(1234567890)
 	chainClock := clock.NewChainClockFromClock(genTime, 5*time.Second, time.Second, fc)
-	bv := consensus.NewDefaultBlockValidator(chainClock)
+	bv := consensus.NewDefaultBlockValidator(chainClock, nil, nil)
 	msgV := &consensus.FakeMessageValidator{}
 	syntax := consensus.WrappedSyntaxValidator{
 		BlockSyntaxValidator:   bv,
@@ -816,7 +816,7 @@ func TestRealWorldGraphsyncFetchOnlyHeaders(t *testing.T) {
 
 	bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 
-	bv := consensus.NewDefaultBlockValidator(chainClock)
+	bv := consensus.NewDefaultBlockValidator(chainClock, nil, nil)
 	msgV := &consensus.FakeMessageValidator{}
 	syntax := consensus.WrappedSyntaxValidator{BlockSyntaxValidator: bv,
 		MessageSyntaxValidator: msgV,

--- a/internal/pkg/chainsync/internal/syncer/syncer_test.go
+++ b/internal/pkg/chainsync/internal/syncer/syncer_test.go
@@ -426,10 +426,15 @@ func (pv *poisonValidator) RunStateTransition(_ context.Context, ts block.TipSet
 	return cid.Undef, nil, nil
 }
 
-func (pv *poisonValidator) ValidateSemantic(_ context.Context, header *block.Block, _ block.TipSet) error {
+func (pv *poisonValidator) ValidateHeaderSemantic(_ context.Context, header *block.Block, _ block.TipSet) error {
 	if pv.headerFailureTS == header.Timestamp {
 		return errors.New("val semantic fails on poison timestamp")
 	}
+	return nil
+}
+
+// ValidateHeaderSemantic is a stub that always returns no error
+func (pv *poisonValidator) ValidateMessagesSemantic(_ context.Context, _ *block.Block, _ block.TipSetKey) error {
 	return nil
 }
 
@@ -546,7 +551,7 @@ func setup(ctx context.Context, t *testing.T) (*chain.Builder, *chain.Store, *sy
 	return setupWithValidator(ctx, t, eval, eval)
 }
 
-func setupWithValidator(ctx context.Context, t *testing.T, fullVal syncer.FullBlockValidator, headerVal syncer.HeaderValidator) (*chain.Builder, *chain.Store, *syncer.Syncer) {
+func setupWithValidator(ctx context.Context, t *testing.T, fullVal syncer.FullBlockValidator, headerVal syncer.BlockValidator) (*chain.Builder, *chain.Store, *syncer.Syncer) {
 	builder := chain.NewBuilder(t, address.Undef)
 	genesis := builder.NewGenesis()
 	genStateRoot, err := builder.GetTipSetStateRoot(genesis.Key())

--- a/internal/pkg/consensus/block_validation.go
+++ b/internal/pkg/consensus/block_validation.go
@@ -194,7 +194,7 @@ func (dv *DefaultBlockValidator) validateMessage(msg *types.UnsignedMessage, exp
 
 	// ensure message is in the correct order
 	if callSeq != msg.CallSeqNum {
-		return fmt.Errorf("callseqnum (%d) out of order (expected %d)", msg.CallSeqNum, callSeq)
+		return fmt.Errorf("callseqnum (%d) out of order (expected %d) from %s", msg.CallSeqNum, callSeq, msg.From)
 	}
 
 	expectedCallSeqNum[msg.From] = callSeq + 1

--- a/internal/pkg/net/blocksub/validator_test.go
+++ b/internal/pkg/net/blocksub/validator_test.go
@@ -71,7 +71,7 @@ func TestBlockPubSubValidation(t *testing.T) {
 
 	// setup a block validator and a topic validator
 	chainClock := clock.NewChainClockFromClock(uint64(now.Unix()), blocktime, propDelay, mclock)
-	bv := consensus.NewDefaultBlockValidator(chainClock)
+	bv := consensus.NewDefaultBlockValidator(chainClock, nil, nil)
 	btv := blocksub.NewBlockTopicValidator(bv)
 
 	// setup a floodsub instance on the host and register the topic validator

--- a/internal/pkg/testhelpers/consensus.go
+++ b/internal/pkg/testhelpers/consensus.go
@@ -55,8 +55,8 @@ func NewFakeBlockValidator() *FakeBlockValidator {
 	return &FakeBlockValidator{}
 }
 
-// ValidateSemantic does nothing.
-func (fbv *FakeBlockValidator) ValidateSemantic(ctx context.Context, child *block.Block, parents block.TipSet) error {
+// ValidateHeaderSemantic does nothing.
+func (fbv *FakeBlockValidator) ValidateHeaderSemantic(ctx context.Context, child *block.Block, parents block.TipSet) error {
 	return nil
 }
 
@@ -95,7 +95,7 @@ func NewStubBlockValidator() *StubBlockValidator {
 	}
 }
 
-// ValidateSemantic returns nil or error for stubbed block `child`.
+// ValidateHeaderSemantic returns nil or error for stubbed block `child`.
 func (mbv *StubBlockValidator) ValidateSemantic(ctx context.Context, child *block.Block, parents *block.TipSet, _ uint64) error {
 	return mbv.semanticStubs[child.Cid()]
 }
@@ -111,7 +111,7 @@ func (mbv *StubBlockValidator) StubSyntaxValidationForBlock(blk *block.Block, er
 	mbv.syntaxStubs[blk.Cid()] = err
 }
 
-// StubSemanticValidationForBlock stubs an error when the ValidateSemantic is called
+// StubSemanticValidationForBlock stubs an error when the ValidateHeaderSemantic is called
 // on the with the given child block.
 func (mbv *StubBlockValidator) StubSemanticValidationForBlock(child *block.Block, err error) {
 	mbv.semanticStubs[child.Cid()] = err


### PR DESCRIPTION
### Motivation

We need to check call sequence numbers and a few other things on incoming blocks before we declare the tipset ready for processing. This falls under the category of semantic validation so add a new `ValidateMessagesSemantic` function to be run on each block after messages have been fetched for the tipset. 

partially addresses #934