### PR TITLE
simplify miner status so that command serializes

### DIFF
--- a/cmd/go-filecoin/client.go
+++ b/cmd/go-filecoin/client.go
@@ -156,7 +156,7 @@ be 2, 1 hour would be 120, and 1 day would be 2880.
 			Address:    maddr,
 			Owner:      status.OwnerAddress,
 			Worker:     status.WorkerAddress,
-			SectorSize: uint64(status.SectorConfiguration.SectorSize),
+			SectorSize: uint64(status.SectorSize),
 			PeerID:     peerID,
 		}
 
@@ -189,7 +189,7 @@ be 2, 1 hour would be 120, and 1 day would be 2880.
 			abi.ChainEpoch(end),
 			price,
 			collateral,
-			status.MinerInfo.SealProofType,
+			status.SealProofType,
 		)
 		if err != nil {
 			return err

--- a/internal/app/go-filecoin/node/node.go
+++ b/internal/app/go-filecoin/node/node.go
@@ -431,7 +431,7 @@ func (node *Node) setupStorageMining(ctx context.Context) error {
 		return err
 	}
 
-	sealProofType := status.SectorConfiguration.SealProofType
+	sealProofType := status.SealProofType
 
 	cborStore := node.Blockstore.CborStore
 

--- a/internal/app/go-filecoin/porcelain/miner.go
+++ b/internal/app/go-filecoin/porcelain/miner.go
@@ -181,24 +181,21 @@ type MinerProvingWindow struct {
 
 // MinerStatus contains a miners power and the total power of the network
 type MinerStatus struct {
-	ActorAddress        address.Address
-	OwnerAddress        address.Address
-	WorkerAddress       address.Address
-	PeerID              peer.ID
-	SectorConfiguration *state.MinerSectorConfiguration
-	SectorCount         uint64
+	ActorAddress  address.Address
+	OwnerAddress  address.Address
+	WorkerAddress address.Address
+	PeerID        peer.ID
 
-	RawPower             abi.StoragePower
-	QualityAdjustedPower abi.StoragePower
-	PledgeRequirement    abi.TokenAmount
-	PledgeBalance        abi.TokenAmount
+	SealProofType              abi.RegisteredProof
+	SectorSize                 abi.SectorSize
+	WindowPoStPartitionSectors uint64
+	SectorCount                uint64
+	PoStFailureCount           int
 
-	Deadlines *miner.Deadlines
-	MinerInfo miner.MinerInfo
-
-	PoStFailureCount            int
+	RawPower                    abi.StoragePower
 	NetworkRawPower             abi.StoragePower
 	NetworkQualityAdjustedPower abi.StoragePower
+	QualityAdjustedPower        abi.StoragePower
 }
 
 // MinerGetStatus queries the power of a given miner.
@@ -207,23 +204,7 @@ func MinerGetStatus(ctx context.Context, plumbing minerStatusPlumbing, minerAddr
 	if err != nil {
 		return MinerStatus{}, err
 	}
-	owner, worker, err := view.MinerControlAddresses(ctx, minerAddr)
-	if err != nil {
-		return MinerStatus{}, err
-	}
-	peerID, err := view.MinerPeerID(ctx, minerAddr)
-	if err != nil {
-		return MinerStatus{}, err
-	}
-	sectorConfig, err := view.MinerSectorConfiguration(ctx, minerAddr)
-	if err != nil {
-		return MinerStatus{}, err
-	}
 	sectorCount, err := view.MinerSectorCount(ctx, minerAddr)
-	if err != nil {
-		return MinerStatus{}, err
-	}
-	deadlines, err := view.MinerDeadlines(ctx, minerAddr)
 	if err != nil {
 		return MinerStatus{}, err
 	}
@@ -241,18 +222,18 @@ func MinerGetStatus(ctx context.Context, plumbing minerStatusPlumbing, minerAddr
 	}
 
 	return MinerStatus{
-		ActorAddress:        minerAddr,
-		OwnerAddress:        owner,
-		WorkerAddress:       worker,
-		PeerID:              peerID,
-		SectorConfiguration: sectorConfig,
-		SectorCount:         sectorCount,
+		ActorAddress:  minerAddr,
+		OwnerAddress:  minerInfo.Owner,
+		WorkerAddress: minerInfo.Worker,
+		PeerID:        minerInfo.PeerId,
 
-		RawPower:             rawPower,
-		QualityAdjustedPower: qaPower,
+		SealProofType:              minerInfo.SealProofType,
+		SectorSize:                 minerInfo.SectorSize,
+		WindowPoStPartitionSectors: minerInfo.WindowPoStPartitionSectors,
+		SectorCount:                sectorCount,
 
-		Deadlines:                   deadlines,
-		MinerInfo:                   minerInfo,
+		RawPower:                    rawPower,
+		QualityAdjustedPower:        qaPower,
 		NetworkRawPower:             totalPower.RawBytePower,
 		NetworkQualityAdjustedPower: totalPower.QualityAdjustedPower,
 	}, nil

--- a/internal/pkg/state/testing.go
+++ b/internal/pkg/state/testing.go
@@ -162,5 +162,13 @@ func (v *FakeStateView) MinerDeadlines(ctx context.Context, maddr address.Addres
 }
 
 func (v *FakeStateView) MinerInfo(ctx context.Context, maddr address.Address) (miner.MinerInfo, error) {
-	return miner.MinerInfo{}, nil
+	m, ok := v.Miners[maddr]
+	if !ok {
+		return miner.MinerInfo{}, errors.Errorf("no miner %s", maddr)
+	}
+	return miner.MinerInfo{
+		Owner:  m.Owner,
+		Worker: m.Worker,
+		PeerId: m.PeerID,
+	}, nil
 }


### PR DESCRIPTION
### Motivation

The `miner status` currently fails with a serialization error. The cause is some big.Int values were nil, and that breaks the serialization between the daemon and the client. 

This command had become a dumping ground of miner information with redundancies and no real organization. This PR simplifies the lookups required and the result. It fixes the serialization error simply by deleting the offending fields.
