### PR TITLE
return empty list when no deals are present

### DIFF
--- a/cmd/go-filecoin/deals.go
+++ b/cmd/go-filecoin/deals.go
@@ -69,7 +69,7 @@ deals, active deals, finished deals and cancelled deals.
 				return fmt.Errorf("error reading miner deals: %w", err)
 			}
 		}
-		var formattedDeals []DealsListResult
+		formattedDeals := []DealsListResult{}
 		for _, deal := range clientDeals {
 			formattedDeals = append(formattedDeals, DealsListResult{
 				Miner:       deal.Proposal.Provider,

--- a/cmd/go-filecoin/deals_integration_test.go
+++ b/cmd/go-filecoin/deals_integration_test.go
@@ -120,7 +120,7 @@ func TestDealsList(t *testing.T) {
 
 		// Miner sees no client deals, but does not error
 		minerOutput := minerAPI.RunSuccessFirstLine(ctx, "deals", "list", "--client")
-		require.Equal(t, minerOutput, "null")
+		require.Equal(t, "[]", minerOutput)
 	})
 
 	t.Run("with --help", func(t *testing.T) {


### PR DESCRIPTION
### Motivation

If you have no active deals and call `deals list`, the response is JSON `null`. This looks like a bug and will require special-casing in languages other than Go.

### Proposed changes

Emit an empty list (`[]`) instead of `null`.