### PR TITLE
restore address and wallet command tests

### DIFF
--- a/cmd/go-filecoin/address.go
+++ b/cmd/go-filecoin/address.go
@@ -35,7 +35,7 @@ var addrsCmd = &cmds.Command{
 	},
 }
 
-type addressResult struct {
+type AddressResult struct {
 	Address address.Address
 }
 
@@ -60,12 +60,12 @@ var addrsNewCmd = &cmds.Command{
 		if err != nil {
 			return err
 		}
-		return re.Emit(&addressResult{addr})
+		return re.Emit(&AddressResult{addr})
 	},
 	Options: []cmdkit.Option{
 		cmdkit.StringOption("type", "The type of address to create: bls or secp256k1 (default)").WithDefault("secp256k1"),
 	},
-	Type: &addressResult{},
+	Type: &AddressResult{},
 }
 
 var addrsLsCmd = &cmds.Command{
@@ -89,9 +89,9 @@ var defaultAddressCmd = &cmds.Command{
 			return err
 		}
 
-		return re.Emit(&addressResult{addr})
+		return re.Emit(&AddressResult{addr})
 	},
-	Type: &addressResult{},
+	Type: &AddressResult{},
 }
 
 var balanceCmd = &cmds.Command{

--- a/internal/app/go-filecoin/porcelain/wallet.go
+++ b/internal/app/go-filecoin/porcelain/wallet.go
@@ -3,6 +3,8 @@ package porcelain
 import (
 	"context"
 
+	initact "github.com/filecoin-project/specs-actors/actors/builtin/init"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/pkg/errors"
@@ -21,7 +23,7 @@ type wbPlumbing interface {
 // WalletBalance gets the current balance associated with an address
 func WalletBalance(ctx context.Context, plumbing wbPlumbing, addr address.Address) (abi.TokenAmount, error) {
 	act, err := plumbing.ActorGet(ctx, addr)
-	if err == types.ErrNotFound {
+	if err == types.ErrNotFound || err == initact.ErrAddressNotFound {
 		// if the account doesn't exit, the balance should be zero
 		return abi.NewTokenAmount(0), nil
 	}


### PR DESCRIPTION
### Motivation

The address and wallet tests had been skipped while some changes in the commands took place. Restore the tests that make sense and delete the ones that don't.
