### PR TITLE
Pipe mac-build.sh to bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A mining node requires significant RAM and GPU resources, depending on the secto
 
 ### Install from Source on MacOS
 ```sh
-curl -fsSL https://raw.githubusercontent.com/filecoin-project/go-filecoin/master/scripts/build/mac-build.sh
+curl -fsSL https://raw.githubusercontent.com/filecoin-project/go-filecoin/master/scripts/build/mac-build.sh | bash
 ```
 
 ### Install from Source


### PR DESCRIPTION
As written, running the curl command just prints to stdout.

### Motivation

Make it easier for most people to install on MacOS

### Proposed changes

Pipe the script to bash directly instead of just printing it to stdout.