### PR TITLE
fix Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ For a complete step-by-step tutorial, see [Getting Started](https://go.filecoin.
 rm ~/.filecoin
 
 # Initialize a new repository, downloading a genesis file and setting network parameters (in this case, for the Testnet network)
-go-filecoin init --genesisfile=https://ipfs.io/ipfs/QmXZQeezX1x8uRQX9EUaYxnyivUpTfJqQTvszk3c8SnFPN/testnet.car --network=testnet
+./go-filecoin init --genesisfile=https://ipfs.io/ipfs/QmXZQeezX1x8uRQX9EUaYxnyivUpTfJqQTvszk3c8SnFPN/testnet.car --network=testnet
 
 # Start the daemon.  It will block until it connects to at least one bootstrap peer.
-go-filecoin daemon
+./go-filecoin daemon
 ```
 
 Your node should now be connected to some peers, and begin downloading and validating the blockchain.
@@ -161,10 +161,10 @@ Open a new terminal to interact with your node:
 
 ```sh
 # Print the node's connection information
-go-filecoin id
+./go-filecoin id
 
 # Show chain sync status
-go-filecoin chain status
+./go-filecoin chain status
 ```
 
 To see a full list of commands, run `./go-filecoin --help`.


### PR DESCRIPTION
after build, go-filecoin is not in bin directory, should add ./ as prefix.

### Motivation
I have tested it in macOS Mojave, All test is ok. 
I found a little problem,  the Readme has a little error.

### Proposed changes
Should add "./" as the prefix.
Then it`s perfect.

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

