### PR TITLE
Removing redundant `with-miner` flag

### DIFF
--- a/cmd/go-filecoin/init.go
+++ b/cmd/go-filecoin/init.go
@@ -40,7 +40,6 @@ var initCmd = &cmds.Command{
 		cmdkit.StringOption(GenesisFile, "path of file or HTTP(S) URL containing archive of genesis block DAG data"),
 		cmdkit.StringOption(PeerKeyFile, "path of file containing key to use for new node's libp2p identity"),
 		cmdkit.StringOption(WalletKeyFile, "path of file containing keys to import into the wallet on initialization"),
-		cmdkit.StringOption(WithMiner, "when set, creates a custom genesis block  a pre generated miner account, requires running the daemon using dev mode (--dev)"),
 		cmdkit.StringOption(OptionSectorDir, "path of directory into which staged and sealed sectors will be written"),
 		cmdkit.StringOption(MinerActorAddress, "when set, sets the daemons's miner actor address to the provided address"),
 		cmdkit.UintOption(AutoSealIntervalSeconds, "when set to a number > 0, configures the daemon to check for and seal any staged sectors on an interval.").WithDefault(uint(120)),
@@ -112,12 +111,6 @@ func setConfigFromOptions(cfg *config.Config, options cmdkit.OptMap) error {
 		cfg.SectorBase.RootDirPath = dir
 	}
 
-	if m, ok := options[WithMiner].(string); ok {
-		if cfg.Mining.MinerAddress, err = address.NewFromString(m); err != nil {
-			return err
-		}
-	}
-
 	if autoSealIntervalSeconds, ok := options[AutoSealIntervalSeconds]; ok {
 		cfg.Mining.AutoSealIntervalSeconds = autoSealIntervalSeconds.(uint)
 	}
@@ -130,7 +123,7 @@ func setConfigFromOptions(cfg *config.Config, options cmdkit.OptMap) error {
 
 	if dir, ok := options[OptionPresealedSectorDir].(string); ok {
 		if cfg.Mining.MinerAddress == address.Undef {
-			return fmt.Errorf("if --%s is provided, --%s or --%s must also be provided", OptionPresealedSectorDir, MinerActorAddress, WithMiner)
+			return fmt.Errorf("if --%s is provided, --%s must also be provided", OptionPresealedSectorDir, MinerActorAddress)
 		}
 
 		cfg.SectorBase.PreSealedSectorsDirPath = dir

--- a/cmd/go-filecoin/main.go
+++ b/cmd/go-filecoin/main.go
@@ -75,9 +75,6 @@ const (
 	// WalletKeyFile is the path of file containing wallet keys that may be imported on initialization
 	WalletKeyFile = "wallet-keyfile"
 
-	// WithMiner when set, creates a custom genesis block with a pre generated miner account, requires to run the daemon using dev mode (--dev)
-	WithMiner = "with-miner"
-
 	// MinerActorAddress when set, sets the daemons's miner address to the provided address
 	MinerActorAddress = "miner-actor-address"
 


### PR DESCRIPTION
### Motivation
The `with-miner` flag has been rendered redundant by `MinerActorAddress` and needs to be removed/deprecated 

### Proposed changes
Remove the `WithMiner` option corresponding to the `with-miner` flag and all references to it from `cmd/go-filecoin/init.go`

Closes #4002 

