### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A mining node requires significant RAM and GPU resources, depending on the secto
 ```sh
 curl -fsSL https://raw.githubusercontent.com/filecoin-project/go-filecoin/master/scripts/build/mac-build.sh | bash
 ```
+Note: macOS users may need to update their git config with `git config --global core.autocrlf input`
 
 ### Install from Source
 


### PR DESCRIPTION
Fix for possible installation issue if `git config core.autocrlf` is set to `true` on macOS.

### Motivation
In my initial installation, I ran into this error:
<img width="728" alt="Screen Shot 2020-07-06 at 1 37 24 AM" src="https://user-images.githubusercontent.com/25379378/86573632-838f6a80-bf29-11ea-9ab3-3b776bb41c7c.png">

It's a big error from a tiny Windows \r line ending.

### Proposed changes
A small notice in the README (or just in this thread) will be useful if someone else runs into the same config issue.

On macOS: `git config --global core.autocrlf input` clears it up.

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

